### PR TITLE
Fix KPP compilation problem due to non-existent empty directory after Github transition

### DIFF
--- a/chem/KPP/compile_wkc
+++ b/chem/KPP/compile_wkc
@@ -14,6 +14,7 @@ setenv WKC_HOME ${WRFC_ROOT}/chem/${WKC_DIRNAME}
 # KPP_HOME: environment variable needed by KPP
 # note: this is not plain KPP
 setenv KPP_HOME ${WKC_HOME}/kpp/kpp-2.1
+mkdir -p ${KPP_HOME}/bin
 setenv WKC_KPP ${KPP_HOME}/bin/kpp
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRF-CHEM, KPP, compile

SOURCE: internal

DESCRIPTION OF CHANGES:
The transition to git comes with a bit of a quirk: empty directories are not tracked, so cloning the repository and compiling that code can lead to some interesting failures. In this example, WRF-CHEM KPP compilation fails because the chem/KPP/kpp/kpp-2.1/bin/ directory (which was previously just an empty directory in the Subversion repository) does not exist.

A similar problem was previously solved for WRFDA (commit 6f386a3, Fri Jul 8 19:52:50 2016) by adding a .gitignore to that directory. However, since this directory only holds one file in the compiled code, that solution seems a bit pointless. Adding a `mkdir -p` command to chem/KPP/compile_wkc ensures that the directory will be made if it does not exist.

LIST OF MODIFIED FILES (annotated if not obvious, not required to be on a single line):
    M       chem/KPP/compile_wkc

TESTS CONDUCTED: WTF passes (previous KPP failures no longer exist).
