### PR TITLE
Fixed restart problem for tmn_update option

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1674,7 +1674,7 @@ state    real  TMN              ij      misc        1         -     i012rhd=(int
 state    real  TYR              ij      misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TYR"        "ANNUAL MEAN SFC TEMPERATURE"           "K"
 state    real  TYRA             ij      misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TYRA"   "ACCUMULATED YEARLY SFC TEMPERATURE FOR CURRENT YEAR"  "K"
 state    real  TDLY             ij      misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TDLY"     "ACCUMULATED DAILY SFC TEMPERATURE FOR CURRENT DAY"  "K"
-state    real  TLAG             i&j     misc        1         -     d=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TLAG"         "DAILY MEAN SFC TEMPERATURE OF PRIOR DAYS"       "K"
+state    real  TLAG             i&j     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TLAG"         "DAILY MEAN SFC TEMPERATURE OF PRIOR DAYS"       "K"
 state    integer NYEAR          -       misc        1         -     r        "NYEAR"                  "ACCUM DAYS IN A YEAR"                         ""
 state    real    NDAY           -       misc        1         -     r        "NDAY"                  "ACCUM TIMESTEPS IN A DAY"                      ""
 state    real  XLAND            ij      misc        1         -     i02rhd=(interp_fcnm_imask)u=(copy_fcnm)       "XLAND"                 "LAND MASK (1 FOR LAND, 2 FOR WATER)"          ""      


### PR DESCRIPTION
TYPE: bug fix - posted

KEYWORDS: tmn_update, restart, Registry, Registry.EM_COMMON, regional climate

SOURCE: Heimo Truhetz of University of Graz, Austria

DESCRIPTION OF CHANGES:
Added a "r" in the registry line for TLAG to add variable to restart files.  Since TLAG was left out of the restart file, any restart using the tmn_update option started with 0 K as the lower boundary condition for the land model. When running long simulations (i.e, regional climate runs), this caused the soil temperature to cool gradually, eventually affecting the skin and atmospheric temperature. This change corrects the problem.

This has been an issue since Version 3.7. 

LIST OF MODIFIED FILES : Registry/Registry.EM_COMMON

TESTS CONDUCTED : Tests conducted to ensure problem is corrected.  Regression test is pending.
