### PR TITLE
Check for VAR_SSO when using topo_wind

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1192,6 +1192,7 @@ state logical just_read_auxinput4  -      misc      -         -     r    "we_jus
 state logical just_read_boundary   -      misc      -         -     r    "we_just_d01_LBC"           "1=BOUNDARY  ALARM RINGING, 0=NO BOUNDARY  ALARM"  "-"
 state   real    mf_fft         -       misc         -         -     r        "mf_fft"                "Mass point map factor at equatorward FFT filter location"  ""
 state   real    p_top          -       misc         -         -     irh       "p_top"                "PRESSURE TOP OF THE MODEL"  "Pa"
+state logical got_var_sso	-	misc	    -	      -     i02r  "got_var_sso"		     "whether VAR_SSO was included in WPS output (beginning V3.4)" ""
 
 #BSINGH - Adding all these variables for CuP scheme[any var before t00]
 state   real    lat_ll_t       -       dyn_em       -         -     ir       "lat_ll_t"              "latitude lower left, temp point" "degrees"

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3776,6 +3776,21 @@ endif
 !     CALL wrf_debug ( 0 , '   DONE routine to add snow in high mountain peaks')
 !+---+-----------------------------------------------------------------+
 
+! checking whether var_sso exists in the domain
+      ! if so, we set got_var_sso flag to true.  This is later used in external/RSL_LITE/module_dm.F
+      ! to check for this, when the topo_wind option is used.
+      grid%got_var_sso = .FALSE.
+      DO j=jts,MIN(jde-1,jte)
+         DO i=its,MIN(ide-1,ite)
+           IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
+               IF(grid%var_sso(i,j) .NE. 0) THEN
+                    grid%got_var_sso = .true.
+               ENDIF
+         END DO
+      END DO
+#if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )
+      grid%got_var_sso = wrf_dm_lor_logical ( grid%got_var_sso )
+#endif
 
 #ifdef DM_PARALLEL
 #   include "HALO_EM_INIT_1.inc"

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -204,6 +204,10 @@
 ! here we check to see if the boundary conditions are set properly
 
    CALL boundary_condition_check( config_flags, bdyzone, error, grid%id )
+! make sure that topo_wind option has var_sso data available
+    IF ((config_flags%topo_wind .EQ. 1) .AND. (.NOT. grid%got_var_sso)) THEN
+      CALL wrf_error_fatal ("topo_wind requires VAR_SSO data")
+    ENDIF
 
 !kludge - need to stop CG from resetting precip and phys tendencies to zero
 !         when we are in here due to a nest being spawned, we want to still

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -1478,6 +1478,37 @@ CONTAINS
 #endif
    END FUNCTION wrf_dm_bxor_integer
 
+
+LOGICAL FUNCTION wrf_dm_lor_logical ( inval )
+      IMPLICIT NONE
+#ifndef STUBMPI
+      LOGICAL inval, retval
+      INTEGER comm, ierr
+      CALL wrf_get_dm_communicator(comm)
+      CALL mpi_allreduce ( inval, retval , 1, MPI_LOGICAL, MPI_LAND, comm, ierr )
+      wrf_dm_lor_logical = retval
+#else
+      LOGICAL inval
+      wrf_dm_lor_logical = inval
+#endif
+   END FUNCTION wrf_dm_lor_logical
+
+
+LOGICAL FUNCTION wrf_dm_land_logical ( inval )
+      IMPLICIT NONE
+#ifndef STUBMPI
+      LOGICAL inval, retval
+      INTEGER comm, ierr
+      CALL wrf_get_dm_communicator(comm)
+      CALL mpi_allreduce ( inval, retval , 1, MPI_LOGICAL, MPI_LAND, comm, ierr )
+      wrf_dm_land_logical = retval
+#else
+      LOGICAL inval
+      wrf_dm_land_logical = inval
+#endif
+   END FUNCTION wrf_dm_land_logical
+
+
    SUBROUTINE wrf_dm_maxval_real ( val, idex, jdex )
 # ifndef STUBMPI
       use mpi


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: VAR_SSO, topo_wind

SOURCE: Internal

DESCRIPTION OF CHANGES: 
Versions of WPS prior to V3.4 did not include VAR_SSO static data.  This is necessary for running the topo_wind option in WRF (also introduced in version 3.4).  If someone tries to use this option with a newer version of WRF, but with older WPS files, this  causes problems, and we need this to cause a fatal error.  Added a state variable to Registry.EM_COMMON called 'got_var_sso' (logical).  Added a check in module_initialize_real.F to determine if var_sso is zero anywhere in the domain.  If so, we set it to .true.  Because we need to use a function in the module_initialize_real.F check that returns an 'OR' logical when looping through multiple processors, in module_dm.F, it was necessary to create a logical function called 'wrf_dm_lor_logical' that  takes the input value and gives a return value (in the meantime, went ahead and added a similar function for an 'AND' logical in case it's needed in the future).  Finally, added a check in start_em.F to make sure if using the topo wind option, VARSSO data is available.  If not, it calls a fatal error and prints 'topo_wind requires VAR_SSO data'.

LIST OF MODIFIED FILES: 
M        Registry/Registry.EM_COMMON
M        dyn_em/module_initialize_real.F
M        dyn_em/start_em.F
M        external/RSL_LITE/module_dm.F

TESTS CONDUCTED: Ran tests to verify that when using WPS data without VAR_SSO, with the topo_wind option, I get a fatal error specifying the reason.  Regression test successful.
