### PR TITLE
Bug fix for real*8 with Intel

### DIFF
--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -153,8 +153,8 @@
     call nl_get_aer_asy_opt        ( grid%id,  aer_asy_opt        )
     call nl_get_aer_aod550_val     ( grid%id,  aer_aod550_val     )
     call nl_get_aer_angexp_val     ( grid%id,  aer_angexp_val     )
-    call nl_get_aer_ssa_opt        ( grid%id,  aer_ssa_val        )
-    call nl_get_aer_asy_opt        ( grid%id,  aer_asy_val        )
+    call nl_get_aer_ssa_val        ( grid%id,  aer_ssa_val        )
+    call nl_get_aer_asy_val        ( grid%id,  aer_asy_val        )
     call nl_get_sf_lake_physics    ( grid%id,  sf_lake_physics    )
 
 #if (EM_CORE == 1)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: real*8, intel, WTF, regression

SOURCE: Internal

DESCRIPTION OF CHANGES: 
In output_wrf.F, aer_asy_val was assigned to aer_asy_opt, and aer_ssa_val was assigned to aer_ssa_opt. Because a "val" is a real value, and an "opt" is an integer, this caused problems (NaN's) with the 64-bit tests during WTF testing. Made the correction.

LIST OF MODIFIED FILES: 
M               share/output_wrf.F

TESTS CONDUCTED: Ran a simple test with a real*8 compile to verify this corrects the problem. Regression test is now successful.
