### PR TITLE
bug fix for WRF IO_QUILT

### DIFF
--- a/frame/module_io_quilt_old.F
+++ b/frame/module_io_quilt_old.F
@@ -5138,7 +5138,7 @@ SUBROUTINE get_mpi_comm_io_groups( retval, isrvr )
       RETURN
 END SUBROUTINE get_mpi_comm_io_groups
 
-SUBROUTINE get_nio_tasks_in_group( retval )
+SUBROUTINE get_nio_tasks_in_group( id, retval )
 !<DESCRIPTION>
 ! This routine returns the number of I/O server tasks in each 
 ! I/O server group.  It can be called by both clients and 
@@ -5147,6 +5147,7 @@ SUBROUTINE get_nio_tasks_in_group( retval )
 #if defined( DM_PARALLEL ) && !defined( STUBMPI )
       USE module_wrf_quilt
       IMPLICIT NONE
+      INTEGER, INTENT(IN)  :: id
       INTEGER, INTENT(OUT) :: retval
       retval = nio_tasks_in_group
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRF IO_QUILT

SOURCE: internal (Dave)

DESCRIPTION OF CHANGES: The subroutine call was missing an argument, even though the argument is not used directly. The Cray compiler usually segfaults on this line (the code was wrong, the Cray compiler just indicated the error). If the quilting option was working for a user before this modification, it will continue to work after this modification (consistent with what was found with the regression tests, which do quilting

LIST OF MODIFIED FILES: 
M       frame/module_io_quilt_old.F

TESTS CONDUCTED: A nesting run with this fix is done to confirm this fix works.  Regression is OK.  
