### PR TITLE
Grell CU bit-for-bit fix, mentrd_rate no longer re-assigned in I-loop

### DIFF
--- a/phys/module_cu_gf.F
+++ b/phys/module_cu_gf.F
@@ -1333,9 +1333,8 @@ CONTAINS
 ! calculate downdraft mass terms
 !
             do ki=jmin(i)-1,1,-1
-               mentrd_rate=mentrd_rate_2d(i,ki)
                dzo=zo_cup(i,ki+1)-zo_cup(i,ki)
-               dd_massentro(i,ki)=mentrd_rate*dzo*zdo(i,ki+1)
+               dd_massentro(i,ki)=mentrd_rate_2d(i,ki)*dzo*zdo(i,ki+1)
                dd_massdetro(i,ki)=cdd(i,ki)*dzo*zdo(i,ki+1)
                zdo(i,ki)=zdo(i,ki+1)+dd_massentro(i,ki)-dd_massdetro(i,ki)
             enddo


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Grell, GF, CU, cumulus, bit

SOURCE: internal

DESCRIPTION OF CHANGES:

Inside CUP_gf, outside of an I-loop, the variable mentrd_rate is initialized:

 850 !
 851 !--- entrainment of mass
 852 !
 853       mentrd_rate=entr_rate ! 0.

In a number of places within the larger I-loop, the variable mentrd_rate is
used on the RHS as some sort of initialization:

1290       do i=its,itf
1291           bud(i)=0.
1292           IF(ierr(I).eq.0)then
1293             mentrd_rate_2d(i,:)=mentrd_rate

Also used to reset values:

1313             if(kstart.lt.jmin(i)-levadj-1)then
1314               do ki=jmin(i)-levadj-1,kstart,-1
1315                 dz=z_cup(i,ki+1)-z_cup(i,ki)
1316                 mentrd_rate_2d(i,ki)=mentrd_rate

When the mentrd_rate variable is used within the I-loop on the LHS for a
computation, we have now modified the initialization value for the next I-loop.
This breaks bit-for-bit identical results for both DM and OpenMP
parallelism.

Original code (mentrd_rate re-assigned within outer I-loop):
             do ki=jmin(i)-1,1,-1
                mentrd_rate=mentrd_rate_2d(i,ki)
                dzo=zo_cup(i,ki+1)-zo_cup(i,ki)
                dd_massentro(i,ki)=mentrd_rate_dzo_zdo(i,ki+1)

The new code removes the re-assignment of the mentrd_rate variable (which
is unnecessary), and uses instead the available mentrd_rate_2d(i,ki) array
(which has the desired value anyways).

1335             do ki=jmin(i)-1,1,-1
1336                dzo=zo_cup(i,ki+1)-zo_cup(i,ki)
1337                dd_massentro(i,ki)=mentrd_rate_2d(i,ki)_dzo_zdo(i,ki+1)

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M       phys/module_cu_gf.F

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
1. 12-h bit-for-bit results on the GSD RAP domain with the fix,
and non-bit-for-bit results without the fix
