### PR TITLE
Update new Tiedtke scheme to the latest version from Hawaii

### DIFF
--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -107,7 +107,7 @@ module module_cu_ntiedtke
 !     isequil: representing equilibrium and nonequilibrium convection
 !     ( .false. [default]; .true. [experimental]. Ref. Bechtold et al. 2014 JAS )
 ! 
-      parameter(isequil = .false. )
+      parameter(isequil = .true. )
 !
 !--------------------
 !     switches for deep, mid, shallow convections, downdraft, and momentum transport
@@ -939,7 +939,7 @@ contains
         ztauc(jl)  = (zgeoh(jl,ikt)-zgeoh(jl,ikb)) / &
                    ((2.+ min(15.0,wup(jl)))*g)
         if(lndj(jl) .eq. 0) then 
-          upbl(jl) = 10.+ upbl(jl)/(paph(jl,klev+1)-paph(jl,ikb))
+          upbl(jl) = 2.+ upbl(jl)/(paph(jl,klev+1)-paph(jl,ikb))
           ztaubl(jl) = (zgeoh(jl,ikb)-zgeoh(jl,klev+1))/(g*upbl(jl))
           ztaubl(jl) = min(300., ztaubl(jl))
         else
@@ -978,7 +978,7 @@ contains
            ikt = kctop(jl)
            ztau = ztauc(jl) * (1.+1.33e-5*dx)
            ztau = max(ztmst,ztau)
-           ztau = max(720.,ztau)
+           ztau = max(360.,ztau)
            ztau = min(10800.,ztau)
            if(isequil) then
              zcape2(jl)= max(0.,zcape2(jl))


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: new Tiedtke, non-equilibrium convection

SOURCE: Chunxi Zhang, Univ of Hawaii

DESCRIPTION OF CHANGES:
By reducing the minimum allowed value for convective adjustment time scale from 720 to 360 sec and tuning the coupling, the scheme's non-equilibrium convection between boundary layer forcing and free atmosphere is working well, and it hence becomes default option (isequil = true). This is intended to improve diurnal convection over land. 

LIST OF MODIFIED FILES:
phys/module_cu_ntiedtke.F

TESTS CONDUCTED:
Reg tested. 
