### PR TITLE
Vertical indexing loop bounds fix in module_bc.F for 't' variables

### DIFF
--- a/share/module_bc.F
+++ b/share/module_bc.F
@@ -1648,7 +1648,6 @@ CONTAINS
       IF (variable == 'u') itf = min(ite,ide)
       IF (variable == 'v') jbe = jde
       IF (variable == 'v') jtf = min(jte,jde)
-      IF (variable == 't') ktf = kte
       IF (variable == 'h') ktf = kte
 
       IF (jts - jbs .lt. spec_zone) THEN
@@ -2162,8 +2161,7 @@ CONTAINS
       IF (variable == 'u') itf = min(ite,ide)
       IF (variable == 'v') jbe = jde
       IF (variable == 'v') jtf = min(jte,jde)
-      IF (variable == 't') ktf = kte
-      IF (variable == 'm') ktf = kte
+      IF (variable == 'm') ktf = kde
       IF (variable == 'h') ktf = kde
       IF (variable == 'w') ktf = kde
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: spec_bdy_final, spec_bdy_perturb, 't', index, bound

SOURCE: problem found by Joe Olson (NOAA), internal

DESCRIPTION OF CHANGES: 

```
Two lines in the subroutine spec_bdy_final need to be modified in
the file share/module_bc.F.  Both changes relate to the vertical
indexing loop ranges.  
In subroutine spec_bdytend_perturb, the same
change for the half-level 't' variables is required.

1) The vertical indexing for the temperature-staggered variables
(t_2 (which is potential temperature - 300), moist, chem, scalar,
tracer - the actual arguments used when called from solve_em)
needs to be adjusted inside of spec_bdy_final and spec_bdytend_perturb.  There is a line
that re-assigns ktf for the 't' variables, and that needs to be
removed completely.  This is a bug that has been in the WRF
repository for a while, and testing with the use of the hybrid coordinate just
has made it more obvious that the loop index bounds are incorrect.

2) For consistency, a second change is introduced in spec_bdy_final, though this does
not cause any troubles at all.  The 2d array mu_2 (variable type
'm') needs to use all of the incoming vertical levels (i.e., all
"one" of the the levels).  Since the calling routine solve_em passes
in the "k" index as 1, the 'm' type variables should be considered
as full-level (ktf=kde NOT ktf=kde-1).  Since the 'w' and 'h'
arrays are full-levels (and they conventionally already use
ktf=kde for a loop index bound), for consistency (code readability,
etc.) the 'm' variable should also use ktf=kde.
```

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M       share/module_bc.F

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
1) Without the modification, the allocated but uninitialized values of arrays at the k=kde index are used.  This sometimes causes run-time errors.   With the mod, no run-time errors occurred, and the test print values for the vertical indexes for all variable types were correct.
