### PR TITLE
Corrected incorrectly pasted function:  MPI_LAND -> MPI_LOR

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -1485,7 +1485,7 @@ LOGICAL FUNCTION wrf_dm_lor_logical ( inval )
       LOGICAL inval, retval
       INTEGER comm, ierr
       CALL wrf_get_dm_communicator(comm)
-      CALL mpi_allreduce ( inval, retval , 1, MPI_LOGICAL, MPI_LAND, comm, ierr )
+      CALL mpi_allreduce ( inval, retval , 1, MPI_LOGICAL, MPI_LOR, comm, ierr )
       wrf_dm_lor_logical = retval
 #else
       LOGICAL inval


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MPI_LOR, MPI_LAND, module_dm.F, wrf_dm_lor_logical

SOURCE: Internal

DESCRIPTION OF CHANGES: In a previous change (Check for VAR_SSO when using topo_wind), a function (wrf_dm_lor_logical) was added to module_dm.F.  There was one word that was incorrect in the function - MPI_LAND should have been MPI_LOR.  This is now corrected.

LIST OF MODIFIED FILES: 
M             external/RSL_LITE/module_dm.F

TESTS CONDUCTED: Tested compilation - ok.  Conducted a test to check this function, as well as the similar 'AND' function by creating 8 tests (4 for 'AND' and 4 for 'OR').  The domain was divided into X pieces.  **AND tests**:  1) all grid cells true, except 1 false - returns false, 2) all grid cells false, except 1 true - returns false, 3) all grid cells true - returns true, 4) all grid cells false - returns false.  **OR tests**:   1) all grid cells true, except 1 false - returns true, 2) all grid cells false, except 1 true - returns true, 3) all grid cells true - returns true, 4) all grid cells false - returns false.   All of these verified.  No regression test necessary, as this change was only a one-word fix that will not cause regression failures.
