### PR TITLE
 bug fix for FLG radiation scheme

### DIFF
--- a/phys/module_ra_flg.F
+++ b/phys/module_ra_flg.F
@@ -11341,7 +11341,7 @@ MODULE module_ra_FLG
       i1 = 1
       do i = 1, nv1
 ! -test
-        if (pt(i).gt.320.) then
+        if (pt(i).gt.345.) then
           pt(i) = 345.
         endif
         if (pt(i).lt.180.) then


### PR DESCRIPTION
Type:            Bug fix

Keywords:    FLG radiation scheme

Source:         Yu Gu ( UCLA)

Description of changes:  the threshold value for maximum pt(i) is reset to 345 (unit: K).  In the previous code, this value is set to 320. If the temperature simulated by WRF is somehow higher than 320, the previous value will cause errors in the simulation.    

List of modified codes: 

M  ./phys/module_ra_flg.F

Test conducted:  regression test is done.  
