### PR TITLE
Remove the use of MUT in a few physics routines

### DIFF
--- a/phys/module_bl_gwdo.F
+++ b/phys/module_bl_gwdo.F
@@ -10,7 +10,7 @@ contains
                   rublten,rvblten,                                             &
                   dtaux3d,dtauy3d,dusfcg,dvsfcg,                               &
                   var2d,oc12d,oa2d1,oa2d2,oa2d3,oa2d4,ol2d1,ol2d2,ol2d3,ol2d4, &
-                  znu,znw,mut,p_top,                                           &
+                  znu,znw,p_top,                                               &
                   cp,g,rd,rv,ep1,pi,                                           &
                   dt,dx,kpbl2d,itimestep,                                      &
                   ids,ide, jds,jde, kds,kde,                                   &
@@ -96,9 +96,6 @@ contains
                                                                         oc12d, &
                                                       oa2d1,oa2d2,oa2d3,oa2d4, &
                                                       ol2d1,ol2d2,ol2d3,ol2d4
-  real,     dimension( ims:ime, jms:jme )                                    , &
-            optional                                                         , &
-            intent(in  )   ::                                             mut
 !
   real,     dimension( kms:kme )                                             , &
             optional                                                         , &
@@ -121,22 +118,12 @@ contains
    enddo
 !
    do j = jts,jte
-      if(present(mut))then
-! For ARW we will replace p and p8w with dry hydrostatic pressure
-        do k = kts,kte+1
-          do i = its,ite
-             if(k.le.kte)pdh(i,k) = mut(i,j)*znu(k) + p_top
-             pdhi(i,k) = mut(i,j)*znw(k) + p_top
-          enddo
+      do k = kts,kte+1
+        do i = its,ite
+           if(k.le.kte)pdh(i,k) = p3d(i,k,j)
+           pdhi(i,k) = p3di(i,k,j)
         enddo
-      else
-        do k = kts,kte+1
-          do i = its,ite
-             if(k.le.kte)pdh(i,k) = p3d(i,k,j)
-             pdhi(i,k) = p3di(i,k,j)
-          enddo
-        enddo
-      endif
+      enddo
 !
       do k = kts,kte
         do i = its,ite

--- a/phys/module_bl_shinhong.F
+++ b/phys/module_bl_shinhong.F
@@ -11,7 +11,7 @@ contains
                   rqvblten,rqcblten,rqiblten,flag_qi,                          &
                   cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
                   dz8w,psfc,                                                   &
-                  znu,znw,mut,p_top,                                           &
+                  znu,znw,p_top,                                               &
                   znt,ust,hpbl,psim,psih,                                      &
                   xland,hfx,qfx,wspd,br,                                       &
                   dt,kpbl2d,                                                   &
@@ -66,7 +66,6 @@ contains
 !-- psfc        pressure at the surface (pa)
 !-- znu         eta values on half (mass) levels  
 !-- znw         eta values on full (w) levels
-!-- mut         mass in column (pa)
 !-- p_top       pressure top of the model (pa)
 !-- znt         roughness length (m)
 !-- ust	        u* in similarity theory (m/s)
@@ -178,8 +177,6 @@ contains
              intent(inout), optional    ::                             regime
 !
    real,     dimension( ims:ime, jms:jme )                                   , &
-             intent(in   ), optional    ::                                mut
-   real,     dimension( ims:ime, jms:jme )                                   , &
              intent(in   ), optional    ::                              ctopo, &
                                                                        ctopo2
 !
@@ -205,24 +202,12 @@ contains
    qv2d(its:ite,:) = 0.0
 !
    do j = jts,jte
-     if(present(mut))then
-!
-! For ARW we will replace p and p8w with dry hydrostatic pressure
-!
-       do k = kts,kte+1
-         do i = its,ite
-           if(k.le.kte)pdh(i,k) = mut(i,j)*znu(k) + p_top
-           pdhi(i,k) = mut(i,j)*znw(k) + p_top
-         enddo
+     do k = kts,kte+1
+       do i = its,ite
+         if(k.le.kte)pdh(i,k) = p3d(i,k,j)
+         pdhi(i,k) = p3di(i,k,j)
        enddo
-     else
-       do k = kts,kte+1
-         do i = its,ite
-           if(k.le.kte)pdh(i,k) = p3d(i,k,j)
-           pdhi(i,k) = p3di(i,k,j)
-         enddo
-       enddo
-     endif
+     enddo
      do k = kts,kte
        do i = its,ite
          qv2d(i,k) = qv3d(i,k,j)

--- a/phys/module_bl_temf.F
+++ b/phys/module_bl_temf.F
@@ -13,7 +13,7 @@ contains
                   rqvblten,rqcblten,rqiblten,flag_qi,                          &
                   g,cp,rcp,r_d,r_v,cpv,                                   &
                   z,xlv,psfc,                                          &
-                  mut,p_top,                                           &
+                  p_top,                                               &
                   znt,ht,ust,zol,hol,hpbl,psim,psih,                         &
                   xland,hfx,qfx,tsk,qsfc,gz1oz0,wspd,br,                    &
                   dt,dtmin,kpbl2d,                                             &
@@ -200,10 +200,6 @@ contains
 !   real,     dimension( ims:ime, kms:kme, jms:jme ), &
 !             optional                              , &
 !             intent(inout)   ::      rqiblten
-!
-   real,     dimension( ims:ime, jms:jme )                                   , &
-             optional                                                        , &
-             intent(in   )   ::      mut
 !
    real,     optional, intent(in   )   ::  p_top
 !

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -17,7 +17,7 @@ contains
                   rqvblten,rqcblten,rqiblten,flag_qi,                          &
                   cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
                   dz8w,psfc,                                                   &
-                  znu,znw,mut,p_top,                                           &
+                  znu,znw,p_top,                                               &
                   znt,ust,hpbl,psim,psih,                                      &
                   xland,hfx,qfx,wspd,br,                                       &
                   dt,kpbl2d,                                                   &
@@ -192,9 +192,6 @@ contains
              intent(in   )   ::                                           znu, &
                                                                           znw
 !
-   real,     dimension( ims:ime, jms:jme )                                   , &
-             optional                                                        , &
-             intent(in   )   ::                                           mut
 !
    real,     optional, intent(in   )   ::                               p_top
 !
@@ -217,24 +214,12 @@ contains
    qv2d(its:ite,:) = 0.0
 !
    do j = jts,jte
-     if(present(mut))then
-!
-! For ARW we will replace p and p8w with dry hydrostatic pressure
-!
-        do k = kts,kte+1
-          do i = its,ite
-             if(k.le.kte)pdh(i,k) = mut(i,j)*znu(k) + p_top
-             pdhi(i,k) = mut(i,j)*znw(k) + p_top
-          enddo
+      do k = kts,kte+1
+        do i = its,ite
+          if(k.le.kte)pdh(i,k) = p3d(i,k,j)
+          pdhi(i,k) = p3di(i,k,j)
         enddo
-      else
-        do k = kts,kte+1
-          do i = its,ite
-            if(k.le.kte)pdh(i,k) = p3d(i,k,j)
-            pdhi(i,k) = p3di(i,k,j)
-          enddo
-        enddo
-      endif
+      enddo
       do k = kts,kte
         do i = its,ite
           qv2d(i,k) = qv3d(i,k,j)

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -1098,7 +1098,7 @@ CONTAINS
               ,FLAG_QI=flag_qi                                      &
               ,g=g,cp=cp,rcp=rcp,r_d=r_d,r_v=r_v,cpv=cpv                    &
               ,Z=z,XLV=XLV,PSFC=PSFC               &
-              ,MUT=mut,P_TOP=p_top                  &
+              ,P_TOP=p_top                                          &
               ,ZNT=znt,HT=ht,UST=ust,ZOL=zol,HOL=hol,HPBL=pblh      &
               ,PSIM=psim,PSIH=psih,XLAND=xland                      &
               ,HFX=hfx,QFX=qfx,TSK=tskold,QSFC=qsfc,GZ1OZ0=gz1oz0   &
@@ -1142,7 +1142,7 @@ CONTAINS
               ,FLAG_QI=flag_qi                                      &
               ,CP=cp,G=g,ROVCP=rcp,RD=r_D,ROVG=rovg                 &
               ,DZ8W=dz8w,XLV=XLV,RV=r_v,PSFC=PSFC                   &
-              ,ZNU=znu,ZNW=znw,MUT=mut,P_TOP=p_top                  &
+              ,ZNU=znu,ZNW=znw,P_TOP=p_top                          &
               ,ZNT=znt,UST=ust,HPBL=pblh                            &
               ,PSIM=fm,PSIH=fhh,XLAND=xland                         &
               ,HFX=hfx,QFX=qfx                                      &
@@ -1219,7 +1219,7 @@ CONTAINS
               ,FLAG_QI=flag_qi                                      &
               ,CP=cp,G=g,ROVCP=rcp,RD=r_D,ROVG=rovg                 &
               ,DZ8W=dz8w,XLV=XLV,RV=r_v,PSFC=PSFC                   &
-              ,ZNU=znu,ZNW=znw,MUT=mut,P_TOP=p_top                  &
+              ,ZNU=znu,ZNW=znw,P_TOP=p_top                          &
               ,ZNT=znt,UST=ust,HPBL=pblh                            &
               ,PSIM=fm,PSIH=fhh,XLAND=xland                         &
               ,HFX=hfx,QFX=qfx                                      &
@@ -1892,7 +1892,7 @@ CONTAINS
               ,VAR2D=var2d,OC12D=oc12d     &
               ,OA2D1=oa1,OA2D2=oa2,OA2D3=oa3,OA2D4=oa4  &
               ,OL2D1=ol1,OL2D2=ol2,OL2D3=ol3,OL2D4=ol4  &
-              ,ZNU=znu,ZNW=znw,MUT=mut,P_TOP=p_top                  &
+              ,ZNU=znu,ZNW=znw,P_TOP=p_top                &
               ,CP=cp,G=g,RD=r_d                           &
               ,RV=r_v,EP1=ep_1,PI=3.141592653                        &
               ,DT=dtbl,DX=dx,KPBL2D=kpbl,ITIMESTEP=itimestep      &


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: mut, YSU, Shin-Hong PBL, GWDO

SOURCE: internal

DESCRIPTION OF CHANGES: Due to the upcoming vertical coordinate modification, the definition of mut will change, and hence the usage in the physics routines modified here will be wrong. Instead of using dry hydrostatic pressure, these routines will now use hydrostatic pressure. The developer for YSU, Shin-Hong PBL and GWDO routines have agreed to the changes. In the case of TEMF PBL, mut was never used.

LIST OF MODIFIED FILES:
phys/module_bl_ysu.F
phys/module_bl_shinhong.F
phys/module_bl_gwdo.F
phys/module_bl_temf.F
phys/module_pbl_driver.F

TESTS CONDUCTED:
Reg tested. A case test over East Asia is conducted. Small changes are found.
