### PR TITLE
Correct a dimension bug

### DIFF
--- a/phys/module_ltng_iccg.F
+++ b/phys/module_ltng_iccg.F
@@ -194,7 +194,7 @@
 ! Inputs
  INTEGER, DIMENSION( ims:ime,          jms:jme ), INTENT(IN   ) :: kLNB
  REAL,                                            INTENT(IN   ) :: cldtop_adjustment
- REAL,    DIMENSION( ims:ims, kms:kme, jms:jme ), INTENT(IN   ) :: t, z
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN   ) :: t, z
 
 ! Order dependent args for domain, mem, and tile dims
  INTEGER, INTENT(IN   )    ::       ids,ide, jds,jde, kds,kde


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: dimension error, iccg_pr93

SOURCE: Josh Laughner, UC Berkeley

DESCRIPTION OF CHANGES: A dimension error for t and z was found in subroutine iccg_pr93, module_ltng_iccg.F. The arrays should be dimensioned by ims:ime, ins
tead it is dimensioned by ims:ims.

LIST OF MODIFIED FILES:
phys/module_ltng_iccg.F

TESTS CONDUCTED:
Reg tested.
