### PR TITLE
Allow filenames greater than 30 characters to be correctly printed to RSL log files

### DIFF
--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -1726,7 +1726,7 @@ write(0,*)__FILE__,__LINE__,' grid%id ',grid%id,' grid%oid ',grid%oid
 
    END SELECT
    IF ( wrf_dm_on_monitor() ) THEN
-     WRITE ( message , FMT = '("Writing ",A30," for domain ",I8)' )TRIM(fname),grid%id
+     WRITE ( message , FMT = '("Writing ",A," for domain ",I8)' )TRIM(fname),grid%id
      CALL end_timing ( TRIM(message) )
    END IF
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RSL, write, filename

SOURCE: internal

DESCRIPTION OF CHANGES: I discovered recently that if an output file name is longer than 30 characters, it will not fully display the filename in the "Writing" step. This was discovered when running a WRFPLUS case where "auxhist6" files are written out, like so:

```
Timing for processing lateral boundary for domain        1:    0.23379 elapsed seconds
Timing for Writing wrfout_d01_2016-10-17_12:00:00 for domain        1:    0.72086 elapsed seconds
Timing for Writing ./auxhist6_d01_2016-10-17_12:0 for domain        1:    0.49816 elapsed seconds
```

Note the end of the "auxhist" file name is cut off. The same sort of problem occurs if you use the "history_outname" namelist setting to specify a long output filename: 

```
Timing for main: time 2015-04-22_11:59:40 on domain 1: 0.20643 elapsed seconds
Timing for main: time 2015-04-22_12:00:00 on domain 1: 0.21708 elapsed seconds
Timing for Writing wrfout_long_filename_test_d01_ for domain 1: 0.50923 elapsed seconds
d01 2015-04-22_12:00:00 wrf: SUCCESS COMPLETE WRF
```

The fix is to change a fortran format statement in share/mediation_integrate.F from 'A30' to 'A'. This is in line with all the other print statements in the WRF code, and no one seems to know why it wasn't this way in the first place ¯\_(ツ)_/¯ 

After the fix, the two examples above display correctly:

```
Timing for processing lateral boundary for domain        1:    0.29357 elapsed seconds
Timing for Writing wrfout_d01_2016-10-17_12:00:00 for domain        1:    1.12513 elapsed seconds
Timing for Writing ./auxhist6_d01_2016-10-17_12:00:00 for domain        1:    0.65448 elapsed seconds

Timing for main: time 2015-04-22_11:59:40 on domain   1:    0.20501 elapsed seconds
Timing for main: time 2015-04-22_12:00:00 on domain   1:    0.21411 elapsed seconds
Timing for Writing wrfout_long_filename_test_d01_2015-04-22_12:00:00 for domain        1:    0.79716 elapsed seconds
d01 2015-04-22_12:00:00 wrf: SUCCESS COMPLETE WRF
```

LIST OF MODIFIED FILES: 
M       share/mediation_integrate.F

TESTS CONDUCTED: WTF and WRFDA regression tests both pass. Above-mentioned tests show that filenames longer than 30 characters now print out correctly.
