### PR TITLE
bug fix for FDDA related to FASDAS obsgrid analysis

### DIFF
--- a/phys/module_fdda_psufddagd.F
+++ b/phys/module_fdda_psufddagd.F
@@ -1258,7 +1258,7 @@ CONTAINS
      !BPR END
                           ( val_analysis - qv3d(i,k,j) )
      if(k.eq.1) then
-         SDA_QFX = RQVNDGDTEN(i,k,j)
+         SDA_QFX(i,j) = RQVNDGDTEN(i,k,j)
      else
          RQVNDGDTEN(i,k,j) = 0.0
      end if

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -648,6 +648,8 @@ CONTAINS
    HFX_PHY = 0.0   ! initialize
    QFX_PHY = 0.0
    XQNORM  = 0.0
+   XSDA_HFX = 0.0
+   XSDA_QFX = 0.0
 !
 !  END FASDAS
 !
@@ -1045,6 +1047,21 @@ CONTAINS
           SMC(NS) = 1.0
           SMAV(NS) = 1.0
        ENDDO
+!
+!  FASDAS
+!
+       IF( fasdas == 1 ) THEN
+
+         DZQ = DZ8W(I,1,J)
+         XSDA_HFX= SDA_HFX(I,J)*RHO(I,1,J)*CPM(I,J)*DZQ  ! W/m^2
+         XSDA_QFX= 0.0          ! Kg/m2/s of water
+         XQNORM = 0.0
+
+       ENDIF
+!
+!  END FASDAS
+!
+
        CALL SFLX_GLACIAL(I,J,ISICE,FFROZP,DT,ZLVL,NSOIL,SLDPTH,   &    !C
             &    LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,              &    !F
             &    TH2,Q2SAT,DQSDT2,                                &    !I
@@ -2839,6 +2856,8 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
    HFX_PHY = 0.0   ! initialize
    QFX_PHY = 0.0
    XQNORM  = 0.0
+   XSDA_HFX = 0.0
+   XSDA_QFX = 0.0
 !
 !  END FASDAS
 !


### PR DESCRIPTION
TYPE: bug fix
KEYWORDS: FASDAS, FDDA, obsgrid
SOURCE: Timothy Glotfelty (EPA)
DESCRIPTION OF CHANGES:
(1) an indexing error passing water vapor nudging tendency was fixed;  
(2) an error in adjusting the surface temperature nudging was fixed when surface land use for a grid cell is glacier. There is no FASDAS code executed for glacial lands in the previous version.
(3) The indirect moisture nudging component of the FASDAS treatment is only applicable to adjusting soil moisture. The section of code from lines 1050 to 1060 is applicable to the glacier land use type. Because there is an ice barrier in a glacier there is no direct evaporation of water from the soil and no transpiration takes place because of there is no vegetation. Thus XSDA_QFX that adjusts evapotranspiration fluxes from the soil is set to zero.
LIST OF MODIFIED FILES:
 M phys/module_fdda_psufddagd.F
 M phys/module_sf_noahdrv.F
TESTS CONDUCTED:
Standard regression test passed