### PR TITLE
Vertical refinement eta levels, incorrect indexing for d02 and above in real

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1437,7 +1437,7 @@ integer::oops1,oops2
               DO WHILE (grid%id .GT. id)
                 id = id+1
                 ks = ks+model_config_rec%e_vert(id-1)
-                ke = ks+model_config_rec%e_vert(id)
+                ke = ks+model_config_rec%e_vert(id)-1
               ENDDO
             ENDIF
             eta_levels(1:kde) = model_config_rec%eta_levels(ks:ke)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: real, vertical, eta

SOURCE: internal

DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
The vertical refinement option in the real program has two different
methods to get the eta levels.  A user can ask the real program to
compute them, or the user can specify the eta levels for each domain.
When the second method is used, a single 1d array of the combined
eta levels is provided in the namelist.input file.

The namelist has this info:
 max_dom                             = 2,
 e_vert                              = 35,    45,
 eta_levels(1:35)                    = 1., 0.993, 0.983, 0.97, 0.954, 0.934, 0.909, 0.88, 0.8406663, 0.8013327,
                                       0.761999, 0.7226653, 0.6525755, 0.5877361, 0.5278192, 0.472514,
                                       0.4215262, 0.3745775, 0.3314044, 0.2917579, 0.2554026, 0.2221162,
                                       0.1916888, 0.1639222, 0.1386297, 0.1156351, 0.09525016, 0.07733481,
                                       0.06158983, 0.04775231, 0.03559115, 0.02490328, 0.0155102, 0.007255059, 0.
 eta_levels(36:80)                   = 1.0000, 0.9946, 0.9875, 0.9789, 0.9685, 0.9562, 0.9413, 0.9238, 0.9037, 0.8813, 0.8514,
                                       0.8210, 0.7906, 0.7602, 0.7298, 0.6812, 0.6290, 0.5796, 0.5333, 0.4901, 0.4493, 0.4109,
                                       0.3746, 0.3412, 0.3098, 0.2802, 0.2524, 0.2267, 0.2028, 0.1803, 0.1593, 0.1398, 0.1219,
                                       0.1054, 0.0904, 0.0766, 0.0645, 0.0534, 0.0433, 0.0341, 0.0259, 0.0185, 0.0118, 0.0056, 0.

The loop inside of the real program that computed the starting
and ending indices (within the large 1d array) of the specific
domain eta levels incorrectly had the loop boundary extend
too far into the 1d array.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
    modified:   dyn_em/module_initialize_real.F

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
1) The starting and ending bounds are now consistent with the namelist.input file
2) BOUND checking (in real) passes for vertical refinement
3) The eta levels are correct for d01 and d02:

ncdump -v ZNW wrfinput_d01
data:

 ZNW =
  1, 0.993, 0.983, 0.97, 0.954, 0.934, 0.909, 0.88, 0.8406663, 0.8013327,
    0.761999, 0.7226653, 0.6525755, 0.5877361, 0.5278192, 0.472514,
    0.4215262, 0.3745775, 0.3314044, 0.2917579, 0.2554026, 0.2221162,
    0.1916888, 0.1639222, 0.1386297, 0.1156351, 0.09525016, 0.07733481,
    0.06158983, 0.04775231, 0.03559115, 0.02490328, 0.0155102, 0.007255059, 0 ;

ncdump -v ZNW wrfinput_d02
data:

 ZNW =
  1, 0.9946, 0.9875, 0.9789, 0.9685, 0.9562, 0.9413, 0.9238, 0.9037, 0.8813,
    0.8514, 0.821, 0.7906, 0.7602, 0.7298, 0.6812, 0.629, 0.5796, 0.5333,
    0.4901, 0.4493, 0.4109, 0.3746, 0.3412, 0.3098, 0.2802, 0.2524, 0.2267,
    0.2028, 0.1803, 0.1593, 0.1398, 0.1219, 0.1054, 0.0904, 0.0766, 0.0645,
    0.0534, 0.0433, 0.0341, 0.0259, 0.0185, 0.0118, 0.0056, 0 ;
