### PR TITLE
Fix an error introduced in the #22 DA WPEC 42449c23 commit

### DIFF
--- a/var/da/da_vtox_transforms/da_transform_xtoxa.inc
+++ b/var/da/da_vtox_transforms/da_transform_xtoxa.inc
@@ -31,7 +31,7 @@ subroutine da_transform_xtoxa(grid, wpec_on)
       if ( wpec_on ) calc_wpec_term =.true.
    end if
 
-   if ( .not. var4d ) then ! for 4dvar the xa%p is come from the model
+   if ( .not. var4d ) then ! for 4dvar, xa%p comes from the model
 
    do j=jts,jte
       do i=its,ite


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, WPEC, 4DVAR, uninitialized

SOURCE: internal

DESCRIPTION OF CHANGES:
The setting of calc_wpec_term should be outside of the if ( .not. var4d ) block,
otherwise it is uninitialized when var4d=true and then it is used later
for determinging if certain calculation and halo exchange should be done or not.
The failure behavior will be compiler and compiler version dependent.

LIST OF MODIFIED FILES:
M       var/da/da_vtox_transforms/da_transform_xtoxa.inc

TESTS CONDUCTED:
Mike confirmed that the fix does allow the 4DVAR case to run successfully for gfortran 5.3.0 and 6.1.0. Other compilers still successful.