### PR TITLE
Change radiation scheme defaults in namelist to RRTMG

### DIFF
--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -53,8 +53,8 @@
 
  &physics
  mp_physics                          = 3,     3,     3,
- ra_lw_physics                       = 1,     1,     1,
- ra_sw_physics                       = 1,     1,     1,
+ ra_lw_physics                       = 4,     4,     4,
+ ra_sw_physics                       = 4,     4,     4,
  radt                                = 30,    30,    30,
  sf_sfclay_physics                   = 1,     1,     1,
  sf_surface_physics                  = 2,     2,     2,


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: namelist.input, RRTMG, ra_lw_physics, ra_sw_physics, default

SOURCE: Internal

DESCRIPTION OF CHANGES: We want the radiation schemes in the namelist.input file in em_real/ to default to the RRTMG scheme.  Changed this so that it would be in place for the next release.

LIST OF MODIFIED FILES: 
M      test/em_real/namelist.input

TESTS CONDUCTED: no tests necessary, as this should not affect compiling and this is a user-changeable option.
