### PR TITLE
Reduce computational patch size for intermediate domain for vertical nesting

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -4217,24 +4217,17 @@ endif
       
          !  Uncouple the variables moist and t_2 that are used to calculate ph_2
 
-         DO j = MAX(jds,jps),MIN(jde-1,jps)
-            DO i = MAX(ids,ips),MIN(ide-1,ips)
+         DO j = MAX(jds,jps),MIN(jde-1,jpe)
+            DO i = MAX(ids,ips),MIN(ide-1,ipe)
                DO k=kds,kde-1
-if((grid%mub(i,j) + grid%mu_2(i,j)).lt.0.01)then
-print *,'DAVE i,j,k=',i,j,k
-print *,'t_2 = ',grid%t_2(i,k,j)
-print *,'Qv  = ',moist(i,k,j,P_qv)
-print *,'mu_2= ',grid%mu_2(i,j)
-print *,'mub= ',grid%mub(i,j)
-endif
                   grid%t_2(i,k,j) = grid%t_2(i,k,j)/(grid%mub(i,j) + grid%mu_2(i,j))
                   moist(i,k,j,P_QV) = moist(i,k,j,P_QV)/(grid%mub(i,j) + grid%mu_2(i,j))
                END DO
             END DO
          END DO
     
-         DO j = MAX(jds,jps),MIN(jde-1,jps)
-            DO i = MAX(ids,ips),MIN(ide-1,ips)
+         DO j = MAX(jds,jps),MIN(jde-1,jpe)
+            DO i = MAX(ids,ips),MIN(ide-1,ipe)
 
                DO k = 1, kpe-1
                   grid%pb(i,k,j) = ngrid%znu(k)*grid%mub(i,j)+ngrid%p_top
@@ -4278,8 +4271,8 @@ endif
          ALLOCATE( p (ips:ipe, kps:kpe, jps:jpe) )
          ALLOCATE( al(ips:ipe, kps:kpe, jps:jpe) )
 
-         DO j = MAX(jds,jps),MIN(jde-1,jps)
-            DO i = MAX(ids,ips),MIN(ide-1,ips)
+         DO j = MAX(jds,jps),MIN(jde-1,jpe)
+            DO i = MAX(ids,ips),MIN(ide-1,ipe)
 
                !  Integrate the hydrostatic equation (from the RHS of the bigstep vertical momentum
                !  equation) down from the top to get the pressure perturbation.  First get the pressure
@@ -4346,15 +4339,15 @@ endif
          DEALLOCATE(al)
       
          ! Couple the variables moist and t_2, and the newly calculated ph_2
-         DO j = MAX(jds,jps),MIN(jde-1,jps)
-            DO i = MAX(ids,ips),MIN(ide-1,ips)
+         DO j = MAX(jds,jps),MIN(jde-1,jpe)
+            DO i = MAX(ids,ips),MIN(ide-1,ipe)
                DO k=kps,kpe
                grid%ph_2(i,k,j) = grid%ph_2(i,k,j)*(grid%mub(i,j) + grid%mu_2(i,j))
                END DO
             END DO
          END DO
-         DO j = MAX(jds,jps),MIN(jde-1,jps)
-            DO i = MAX(ids,ips),MIN(ide-1,ips)
+         DO j = MAX(jds,jps),MIN(jde-1,jpe)
+            DO i = MAX(ids,ips),MIN(ide-1,ipe)
                DO k=kps,kpe-1
                grid%t_2(i,k,j) = grid%t_2(i,k,j)*(grid%mub(i,j) + grid%mu_2(i,j))
                moist(i,k,j,P_QV) = moist(i,k,j,P_QV)*(grid%mub(i,j) + grid%mu_2(i,j))


### PR DESCRIPTION
TYPE: bug fix
    
KEYWORDS: vertical refinement, intermediate domain, patch
    
SOURCE: internal
    
DESCRIPTION OF CHANGES: 
The vertical refinement option rebalances the fine grid to
account for the horizontal and vertical interpolation.  The
intermediate domain value are coupled with total column pressure.
When the allocated (but initialized to zero) portions of the patch
are part of the computations, floating point errors show up
when using the FPE traps.  These values are never used, but the
uninitialized values throw FPEs when we are doing division.
    
The solution is to require that the computations be entirely
enclosed with the more restrictive of either the patch or domain dimensions 
(for the intermediate domain, "patch" and "domain" sizes are not
as intuitive as on a parent or child domain).

LIST OF MODIFIED FILES: 
external/RSL_LITE/module_dm.F
    
TESTS CONDUCTED: 
1) With the mods, the vertical refinement code successfully runs through several time
steps with the FPE flags activated, and the code was not able to 
do so without these mods.
2) WTF passes (including the several dozen vertical refinement tests)
3) The results (with the restrictive index bounds) are bit-for-bit identical with the master results (the
restricted index computations are INDEED giving the same results).  This
is a comparison of the 1798 regression tests (with and without vertical
nesting).  

I WILL REMOVE THE FOLLOWING IN THE FINAL COMMIT:
1) As an FYI, HWRF test 3 is not reproducible.  It should be fixed XOR removed.
2) I will squash the fix for the incorrect indexing in the first of two commits.
3) This bug fix is yet another requirement to get the hybrid coordinate ready to go
