### PR TITLE
Fix for VARBC failures when calculated pressure does not increases monotonically

### DIFF
--- a/var/da/da_radiance/da_get_innov_vector_crtm.inc
+++ b/var/da/da_radiance/da_get_innov_vector_crtm.inc
@@ -455,6 +455,7 @@ subroutine da_get_innov_vector_crtm ( it, grid, ob, iv )
                   ' where the pressure is not monotonic'
                call da_warning(__FILE__,__LINE__,message(1:1))
                iv%instid(inst)%tb_inv(:,n) = missing_r
+               iv%instid(inst)%info%proc_domain(:,n) = .false.
                cycle pixel_loop
             end if
          end do

--- a/var/da/da_varbc/da_varbc_coldstart.inc
+++ b/var/da/da_varbc/da_varbc_coldstart.inc
@@ -12,9 +12,7 @@
    !
    !  HISTORY: 10/26/2007 - Creation                     Tom Auligne
    !           11/03/2008 - Bug-fix: exclude HALO data for
-   !                        computation of predictor statistics    Tom/Hui-Chuan
-   !           11/03/2016 - Bug-fix: exclude missing_r data where the pressure is not monotonic for
-   !                        computation of predictor statistics    Yuanbing Wang
+   !                        computation of predictor statistics    Tom/Hui-Chuan  
    !---------------------------------------------------------------------------
 
    implicit none
@@ -43,6 +41,12 @@
 
       npredmax       = iv%instid(inst)%varbc_info%npredmax
       num_rad        = iv%instid(inst)%num_rad
+      if (num_rad > 0) then
+         num_rad_domain = COUNT(iv%instid(inst)%info%proc_domain(1,1:num_rad)) !do not count HALO
+      else
+         num_rad_domain = 0
+      end if
+      num_rad_tot    = wrf_dm_sum_integer(num_rad_domain)
       
       if (npredmax <= 0) cycle                                         !! VarBC instr only
       
@@ -64,44 +68,29 @@
 	    Allocate ( hist(nbins),  hist_tot(nbins))
             hist(:) = 0  
             mode    = 0.0
- 
+	 
            ! Accumulate statistics for histogram
            ! -----------------------------------
-            if (k==1) then
-               if (num_rad > 0) then
-                  num_rad_domain = COUNT(iv%instid(inst)%info%proc_domain(1,1:num_rad)) !do not count HALO
-               else
-                  num_rad_domain = 0
-               end if
-            end if
-
             do n = 1, num_rad      !! loop for pixel      
                if (iv%instid(inst)%info%proc_domain(1,n)) then ! do not count HALO
-                  if (iv%instid(inst)%tb_inv(k,n) /= missing_r) then
-                     ibin = NINT( (iv%instid(inst)%tb_inv(k,n)+maxhist)/zbin )
-                     if ((ibin>0).and.(ibin<=nbins)) hist(ibin) = hist(ibin) + 1
-                  else
-                     iv%instid(inst)%tb_qc(k,n) = qc_varbc_bad
-                     if (k==1) num_rad_domain = num_rad_domain - 1
-                  end if
-               end if 
-
+                  ibin = NINT( (iv%instid(inst)%tb_inv(k,n)+maxhist)/zbin )
+ 	          if ((ibin>0).AND.(ibin<=nbins)) &
+	             hist(ibin) = hist(ibin) + 1
+               end if          
             end do             ! end loop for pixels
-
-            if (k==1) num_rad_tot = wrf_dm_sum_integer(num_rad_domain)
-       
+	       
            ! Do inter-processor communication to gather statistics
            ! ------------------------------------------------------
 	    do ibin = 1, nbins
 	       hist_tot(ibin) = wrf_dm_sum_integer(hist(ibin))
 	    end do
-   
+		   
            ! Determine mode of Histogram
            !----------------------------
             if ( SUM(hist_tot(:)) > 0 ) then
-              modetmp(1:1) = MAXLOC(hist_tot(:))*zbin - maxhist
+	      modetmp(1:1) = MAXLOC(hist_tot(:))*zbin - maxhist
               mode = modetmp(1)
-            end if
+	    end if
 	 
 	   ! Use mode to initialize VarBC 
 	   !-----------------------------
@@ -112,8 +101,8 @@
             if ( satinfo(inst)%iuse(k) == 1 ) &
                write(unit=stdout,fmt='(A,A,I5,A,F5.2)') 'VARBC: Cold-starting ', &
                   trim(adjustl(iv%instid(inst)%rttovid_string)),iv%instid(inst)%ichan(k),&
-                  ' --> ',mode
-         end if
+	          ' --> ',mode			       	
+	 end if
       end do                                                              !  end loop for channels
 
     !---------------------------------------------------------------------------
@@ -123,7 +112,7 @@
       do k = 1, iv%instid(inst)%nchan 
 	 if (iv%instid(inst)%varbc(k)%npred <= 0) cycle                   !! VarBC channels only      
 	 if (ANY(iv%instid(inst)%varbc(k)%pred_use > 0)) global_cs = .false.      
-      end do
+      end do	 
     
       if (global_cs) then                                                 !! Instrument coldstart only
 
@@ -131,59 +120,53 @@
 
         ! Accumulate statistics for predictor mean/std
         ! ---------------------------------------------
-         if (num_rad > 0) then
+	 if (num_rad > 0) then
             do i = 1, npredmax
                mean(i) = SUM( iv%instid(inst)%varbc_info%pred(i,1:num_rad),    &
-                         MASK=iv%instid(inst)%info%proc_domain(1,1:num_rad) .and. &
-                         iv%instid(inst)%tb_inv(1,1:num_rad) /= missing_r)   ! do not count HALO  
+                         MASK=iv%instid(inst)%info%proc_domain(1,1:num_rad))   ! do not count HALO  
                rms(i)  = SUM( iv%instid(inst)%varbc_info%pred(i,1:num_rad)**2, &
-                         MASK=iv%instid(inst)%info%proc_domain(1,1:num_rad) .and. &
-                         iv%instid(inst)%tb_inv(1,1:num_rad) /= missing_r)   ! do not count HALO 
+                         MASK=iv%instid(inst)%info%proc_domain(1,1:num_rad))   ! do not count HALO 
             end do
-         else
-            mean = 0.0
-            rms  = 0.0
-         end if
-
+	 else
+	    mean = 0.0
+	    rms  = 0.0
+	 end if
+  
         ! Do inter-processor communication to gather statistics
         ! ------------------------------------------------------
-         call wrf_dm_sum_reals(mean, mean_tot)
-         call wrf_dm_sum_reals(rms,  rms_tot) 
- 
+	 call wrf_dm_sum_reals(mean, mean_tot)
+  	 call wrf_dm_sum_reals(rms,  rms_tot)	 
          if (num_rad_tot >= varbc_nobsmin) then
-            mean_tot = mean_tot / num_rad_tot
+	    mean_tot = mean_tot / num_rad_tot
             rms_tot  = rms_tot  / num_rad_tot
-         else
-            mean_tot = 0.0
-            rms_tot  = 1.0   
-         end if
-
+	 else
+	    mean_tot = 0.0
+	    rms_tot  = 1.0   
+	 end if
+	 
         ! Store statistics
         !------------------
-         iv%instid(inst)%varbc_info%pred_mean = mean_tot
+	 iv%instid(inst)%varbc_info%pred_mean = mean_tot
          iv%instid(inst)%varbc_info%pred_std  = sqrt(rms_tot - mean_tot**2)
-
+      
          deallocate(mean, rms, mean_tot, rms_tot)
 
       end if
-      deallocate(ipred)
+      deallocate(ipred)  	           	     	
 
     !---------------------------------------------------------------------------
     !  [3]: Normalize predictors
     !---------------------------------------------------------------------------
       do i = 1,  npredmax
          if ( iv%instid(inst)%varbc_info%pred_std(i) <= 0.0 ) cycle
-         do n = 1, num_rad
-            if (iv%instid(inst)%tb_inv(1,n) /= missing_r) then
-               iv%instid(inst)%varbc_info%pred(i,n) = &
-                    ( iv%instid(inst)%varbc_info%pred(i,n) - iv%instid(inst)%varbc_info%pred_mean(i) ) / &
-                    iv%instid(inst)%varbc_info%pred_std(i)
-            else
-               iv%instid(inst)%varbc_info%pred(i,n) = missing_r
-            end if
-         end do     
+         do n = 1, num_rad      
+            iv%instid(inst)%varbc_info%pred(i,n) = &
+          ( iv%instid(inst)%varbc_info%pred(i,n) - &
+            iv%instid(inst)%varbc_info%pred_mean(i) ) / &
+            iv%instid(inst)%varbc_info%pred_std(i)
+	 end do     
       end do
-
+      
    end do                           !  end loop for sensor
    
    if (trace_use) call da_trace_exit("da_varbc_coldstart")


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, VARBC, CRTM, runtime failure

SOURCE: Initial fix by Yuanbing Wang of NUIST (Nanjing University of Information Science and Technology), improved by Jamie Bresch

DESCRIPTION OF CHANGES:
When the pressure is not monotonic as detected by the subroutine da_get_innov_vector_crtm, we exclude it in computation of VARBC predictor statistics by setting iv%instid(inst)%info%proc_domain(:,n) = .false. Previously this flag was not set, which could cause failures in the VARBC calculation subroutines.

LIST OF MODIFIED FILES:
M var/da/da_radiance/da_get_innov_vector_crtm

TESTS CONDUCTED:
WRFDA regression tests for GNU and Intel both passed. There were differences in the results for the VARBC test, but this was expected.