### PR TITLE
 bug fix in module_surface_driver.F to consider the seaice effects

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1693,6 +1693,7 @@ CONTAINS
             (sf_sfclay_physics .EQ. QNSESFCSCHEME) )
   isisfc = ( FRACTIONAL_SEAICE .EQ. 1  .AND. (          &
             (sf_sfclay_physics .EQ. SFCLAYSCHEME ) .OR. &
+            (sf_sfclay_physics .EQ. SFCLAYREVSCHEME ) .OR. &
             (sf_sfclay_physics .EQ. PXSFCSCHEME  ) .OR. &
             (sf_sfclay_physics .EQ. MYJSFCSCHEME ) .OR. &
             (sf_sfclay_physics .EQ. QNSESFCSCHEME ) .OR. &  !emt

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -908,7 +908,7 @@ Namelist variables for controlling the adaptive time step option:
                                                 ;             =1: z0 from Davis et al (2008), zt & zq from COARE3.0
                                                 ;             =2: z0 from Davis et al (2008), zt & zq from Garratt (1992)
  fractional_seaice                   = 0        ; treat sea-ice as fractional field (1) or ice/no-ice flag (0)
-                                                  works for sf_sfclay_physics=1,2,5,or 7.
+                                                  works for sf_sfclay_physics=1,2,3,4,5,7,and 91 
                                                   If fractional_seaice = 1, also set seaice_threshold = 0.
  seaice_albedo_opt                   = 0        ; option to set albedo over sea ice
                                                 ; 0 = seaice albedo is a constant value from namelist option seaice_albedo_default


### PR DESCRIPTION
### fix for isisfc related to SFCLAYREV schemes and modify README
__TYPE:__ bug fix
__KEY WORDS:__ isisfc, seaice, sfclayrev scheme, README
__SOURCE:__ Jeffrey Willison (North Carolina State University)
__DESCRIPTION OF CHANGES:__
1) When the original SFCLAY scheme was renamed option 91, the IF tests in the surface driver for seaice interaction were not modified. With the inclusion of option 1 (SFCLAYREVSCHEME) as part of the .OR. arguments in the IF test, the flag value isisfc is set to utilize seaice. Before this modification, the sfclay scheme (now called SFCLAYREVSCHEME, numbered 1) incorrectly did not include seaice processing, resulting in incorrect values for HFX and QFX over areas where sea ice is present.This modification fixes an oversight that now allows SFCLAYREVSCHEME to continue to use seaice.

Example: the HFX term should be weighted by the percent of the fractional seaice in the grid cell:
```
hfx = hfx_sea*(1-xice) + hfx*xice
```

2)  README.namelist is updated                                                        

__LIST OF MODIFIED FILES:__
 M phys/module_surface_driver.F
 M run/README.namelist

__TESTS CONDUCTED:__
1) Standard regression test passed.
2) Separate runs were conducted to confirm the modification has impacts in a domain that includes seaice.