### PR TITLE
OpenMP number of tiles

### DIFF
--- a/frame/module_tiles.F
+++ b/frame/module_tiles.F
@@ -334,11 +334,10 @@ CONTAINS
           tile_strategy=TILE_Y
           WRITE(mess,*)'Tile Strategy is not specified. Assuming 1D-Y'
           CALL WRF_MESSAGE ( mess )
-
-         IF ( num_tiles >= (epy-spy+1)/MIN_TILE_SIZE .and. num_tiles_x == 0 .and. num_tiles_y == 0) THEN ! number of tiles is too high. Trying to adjust
+          IF ( num_tiles > (epy-spy+1)/MIN_TILE_SIZE .and. num_tiles_x == 0 .and. num_tiles_y == 0) THEN ! number of tiles is too high. Trying to adjust
             num_tiles_x=1
             num_tiles_y=(epy-spy+1)/MIN_TILE_SIZE
-            DO WHILE (num_tiles_x*num_tiles_inc*num_tiles_y <= num_tiles)
+            DO WHILE (num_tiles_x*num_tiles_inc*num_tiles_y < num_tiles)
                num_tiles_x=num_tiles_x+1
             END DO
           num_tiles_x=num_tiles_x*num_tiles_inc


### PR DESCRIPTION
### OpenMP number of tiles

__TYPE:__ bug fix

__KEYWORDS:__ OpenMP, tiling, DM+SM

__SOURCE:__ Samuel Elliot (CU)

__DESCRIPTION OF CHANGES:__
Small changes for computation of the total number of tiles.  For example, when the 
number of rows in the MPI task is 11, and the user asks for 11 OpenMP threads, the default
should be to have each row to be an OpenMP thread.  The default code misses the counting
by one, thinking that 11 threads are too many, and then does a 2d decomposition.  This will
be more of an issue now that we get reasonable timings for DM+SM builds, and now that the number
of OpenMP threads is likely to get much larger.  

The forecast simulations will not be modified, as this is just a different OpenMP decomposition.
Also, with our few OpenMP threads available, we don't really get a chance to see any timing
performance.

__LIST OF MODIFIED FILES:__ 
frame/module_tiles.F

__TESTS CONDUCTED:__ 
1) Regression test PASS

2) Able to get bit-for-bit results with 24-h simulation (Jan 2000, single domain) running DM+SM build.  The tile decomposition was unnecessarily larger than required (for example, 22 instead of 11), but the source code always correctly computed on the larger number of tiles.

2) Print-out to see the actual tile sizes.  I set up a the domain to have 11 rows in the
MPI task.  I asked for 11 OpenMP threads.  There should be 11 threads, each as a single
row.  The "WITH MODS" shows this result.  The "ORIGINAL" shows the 22 tiles (not intended).


*WITH MODS*
```
WRF V3.8.1 MODEL
 *************************************
 Parent domain
 ids,ide,jds,jde            1          74           1          61
 ims,ime,jms,jme           -4          79          44          66
 ips,ipe,jps,jpe            1          74          51          61
 *************************************
DYNAMICS OPTION: Eulerian Mass Coordinate
 alloc_space_field: domain            1 ,              42988188  bytes allocated
med_initialdata_input: calling input_input
Max map factor in domain 1 =  1.03. Scale the dt in the model accordingly.
INPUT LandUse = "USGS"
 LANDUSE TYPE = "USGS" FOUND          33  CATEGORIES           2  SEASONS WATER CATEGORY =           16  SNOW CATEGORY =           24
 Initializing OML with HML0 =    50.0000000
WRF NUMBER OF TILES FROM OMP_GET_MAX_THREADS =  11
 Tile Strategy is not specified. Assuming 1D-Y
WRF TILE   1 IS      1 IE     74 JS     51 JE     51
WRF TILE   2 IS      1 IE     74 JS     52 JE     52
WRF TILE   3 IS      1 IE     74 JS     53 JE     53
WRF TILE   4 IS      1 IE     74 JS     54 JE     54
WRF TILE   5 IS      1 IE     74 JS     55 JE     55
WRF TILE   6 IS      1 IE     74 JS     56 JE     56
WRF TILE   7 IS      1 IE     74 JS     57 JE     57
WRF TILE   8 IS      1 IE     74 JS     58 JE     58
WRF TILE   9 IS      1 IE     74 JS     59 JE     59
WRF TILE  10 IS      1 IE     74 JS     60 JE     60
WRF TILE  11 IS      1 IE     74 JS     61 JE     61
WRF NUMBER OF TILES =  11
```


*ORIGINAL*
 
```
WRF V3.8.1 MODEL
 *************************************
 Parent domain
 ids,ide,jds,jde            1          74           1          61
 ims,ime,jms,jme           -4          79          44          66
 ips,ipe,jps,jpe            1          74          51          61
 *************************************
DYNAMICS OPTION: Eulerian Mass Coordinate
 alloc_space_field: domain            1 ,              42988188  bytes allocated
med_initialdata_input: calling input_input
Max map factor in domain 1 =  1.03. Scale the dt in the model accordingly.
INPUT LandUse = "USGS"
 LANDUSE TYPE = "USGS" FOUND          33  CATEGORIES           2  SEASONS WATER CATEGORY =           16  SNOW CATEGORY =           24
 Initializing OML with HML0 =    50.0000000
WRF NUMBER OF TILES FROM OMP_GET_MAX_THREADS =  11
 Tile Strategy is not specified. Assuming 1D-Y
Total number of tiles is too big for 1D-Y tiling. Going 2D. New tiling is   2x 11
WRF TILE   1 IS      1 IE     37 JS     51 JE     51
WRF TILE   2 IS     38 IE     74 JS     51 JE     51
WRF TILE   3 IS      1 IE     37 JS     52 JE     52
WRF TILE   4 IS     38 IE     74 JS     52 JE     52
WRF TILE   5 IS      1 IE     37 JS     53 JE     53
WRF TILE   6 IS     38 IE     74 JS     53 JE     53
WRF TILE   7 IS      1 IE     37 JS     54 JE     54
WRF TILE   8 IS     38 IE     74 JS     54 JE     54
WRF TILE   9 IS      1 IE     37 JS     55 JE     55
WRF TILE  10 IS     38 IE     74 JS     55 JE     55
WRF TILE  11 IS      1 IE     37 JS     56 JE     56
WRF TILE  12 IS     38 IE     74 JS     56 JE     56
WRF TILE  13 IS      1 IE     37 JS     57 JE     57
WRF TILE  14 IS     38 IE     74 JS     57 JE     57
WRF TILE  15 IS      1 IE     37 JS     58 JE     58
WRF TILE  16 IS     38 IE     74 JS     58 JE     58
WRF TILE  17 IS      1 IE     37 JS     59 JE     59
WRF TILE  18 IS     38 IE     74 JS     59 JE     59
WRF TILE  19 IS      1 IE     37 JS     60 JE     60
WRF TILE  20 IS     38 IE     74 JS     60 JE     60
WRF TILE  21 IS      1 IE     37 JS     61 JE     61
WRF TILE  22 IS     38 IE     74 JS     61 JE     61
WRF NUMBER OF TILES =  22
```


