### PR TITLE
Splitting the PD advection limiter loop for better performance

### DIFF
--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -6138,7 +6138,9 @@ SUBROUTINE advect_scalar_pd   ( field, field_old, tendency,    &
 
    INTEGER :: jp1, jp0, jtmp
 
-   REAL :: flux_out, ph_low, scale
+   REAL,DIMENSION( its-1:ite+2, kts:kte, jts-1:jte+2  ) :: flux_out, ph_low
+   REAL :: scale
+   !REAL :: flux_out, ph_low, scale
    REAL, PARAMETER :: eps=1.e-20
 
 
@@ -7694,13 +7696,22 @@ SUBROUTINE advect_scalar_pd   ( field, field_old, tendency,    &
 #endif
    DO i=i_start, i_end
 
-     ph_low = (mub(i,j)+mu_old(i,j))*field_old(i,k,j)        &
+     ph_low(i,k,j) = (mub(i,j)+mu_old(i,j))*field_old(i,k,j) &
                 - dt*( msftx(i,j)*msfty(i,j)*(               &
                        rdx*(fqxl(i+1,k,j)-fqxl(i,k,j)) +     &
                        rdy*(fqyl(i,k,j+1)-fqyl(i,k,j))  )    &
                       +msfty(i,j)*rdzw(k)*(fqzl(i,k+1,j)-fqzl(i,k,j)) )
 
-     flux_out = dt*( (msftx(i,j)*msfty(i,j))*(                    &
+   ENDDO
+   ENDDO
+   ENDDO
+
+   DO j=j_start, j_end
+   DO k=kts, ktf
+!DIR$ vector always
+   DO i=i_start, i_end
+
+     flux_out(i,k,j) = dt*( (msftx(i,j)*msfty(i,j))*( &
                                 rdx*(  max(0.,fqx (i+1,k,j))      &
                                       -min(0.,fqx (i  ,k,j)) )    &
                                +rdy*(  max(0.,fqy (i,k,j+1))      &
@@ -7708,9 +7719,16 @@ SUBROUTINE advect_scalar_pd   ( field, field_old, tendency,    &
                 +msfty(i,j)*rdzw(k)*(  min(0.,fqz (i,k+1,j))      &
                                       -max(0.,fqz (i,k  ,j)) )   )
 
-     IF( flux_out .gt. ph_low ) THEN
+   ENDDO
+   ENDDO
+   ENDDO
 
-       scale = max(0.,ph_low/(flux_out+eps))
+   DO j=j_start, j_end
+   DO k=kts, ktf
+!DIR$ vector always
+   DO i=i_start, i_end
+     IF( flux_out(i,k,j) .gt. ph_low(i,k,j) ) THEN
+       scale = max(0.,ph_low(i,k,j)/(flux_out(i,k,j)+eps))
        IF( fqx (i+1,k,j) .gt. 0.) fqx(i+1,k,j) = scale*fqx(i+1,k,j)
        IF( fqx (i  ,k,j) .lt. 0.) fqx(i  ,k,j) = scale*fqx(i  ,k,j)
        IF( fqy (i,k,j+1) .gt. 0.) fqy(i,k,j+1) = scale*fqy(i,k,j+1)


### PR DESCRIPTION
### Splitting the advection PD loop 

__TYPE:__ Improvement

__KEYWORDS:__ Advection, Positive Definite, Optimization

__SOURCE:__ Negin Sobhani (UIowa) | Davide Del Vento (NCAR)

__DESCRIPTION OF CHANGES:__
This is the first of the changes that I worked on with @davidedelvento .    
Tests on the advection kernel showed that PD advection limiter loop is not vectorized and is a major hotspot of the subroutine. The PD condition check loop was split and reordered to increase the vectorization for the first two sections loops and accelerate the code.  
This change showed a 100% speed-up (2X) for PD condition section of the code (the loop that has been split) and of ~17% speed-up for the advection kernel for intel compiler (-O3). For GNU compiler (-Ofast), we have 105% speed-up on the PD limiter section of the code and total of ~11% speed-up for the advection kernel. For PGI compiler with -O3, we have only 35% speed-up for the PD limiter loop and total of ~ 4% speed-up.
Depending on how much advection you have in your WRF case, this speed-up might be significant.
For example, advection might include up to 50% of the total time of the code and a 17% speed-up for advection kernel means a total of 8.5% speed-up for the whole WRF run. For an advection-heavy WRF case such as WRF-Chem with many tracers transport this speed-up is significant.


__LIST OF MODIFIED FILES:__  
dyn_em/module_advect_em.F

__TESTS CONDUCTED:__   
1) Regression tests (WTF) PASS

2) Able to get bit-for-bit results for WTF tests between modified and original codes.

3) Top-hat advection tests from the kernel show the same results.
