### PR TITLE
Radar DA bug fix for use_radar_rhv (retrieved hydrometeors)

### DIFF
--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -280,7 +280,7 @@ END IF
                         else if (model_tc(k,n).lt.5.0 .and. model_tc(k,n).gt.-5.0 ) then
                              ! contribution from rain, snow and graupel
                              ! Ze = c * Z_Qr + (1-c) * (Z_Qs+Z_Qg)
-                             ! the factor c varies linearly bwteen 0 at t=-5C and 1 at t=5C
+                             ! the factor c varies linearly between 0 at t=-5C and 1 at t=5C
                              czr=(model_tc(k,n)+5)/10.0
                              if (model_tc(k,n).le.0.0) then
                                 czs = (1.0-czr)*zds/(zds+zg) ! dry snow


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, use_radar_rhv

SOURCE: Ki-Hong Min (Kyungpook National University, Korea) + internal

DESCRIPTION OF CHANGES:

1. Remove unnecessary call to da_radar_rf.
2. Correct the application of the factoring coefficient.
It should be
`rze = czr*10.0**(ob % radar(n) % rf(k)/10.0)`
not
`rze = 10.0**(czr*ob % radar(n) % rf(k)/10.0)`
3. Rearrange the code to have the dBZ to Z conversion appear only once.
4. Add comments.

LIST OF MODIFIED FILES:
M       var/da/da_radar/da_get_innov_vector_radar.inc

TESTS CONDUCTED:
A test case shows differences in the result.