### PR TITLE
Fix for SEVIRI and IASI radiance assimilation with more than one bufr file

### DIFF
--- a/var/da/da_radiance/da_read_obs_bufriasi.inc
+++ b/var/da/da_radiance/da_read_obs_bufriasi.inc
@@ -421,11 +421,11 @@ subroutine da_read_obs_bufriasi (obstype,iv,infile)
      end do read_loop
   end do
   call closbf(lnbufr)
+
+  !Deallocate temporary array for next bufrfile do loop
+  deallocate(data_all)
 end do bufrfile
 
-deallocate(data_all) ! Deallocate data arrays
-
-  
    if (thinning .and. num_iasi_global > 0 ) then
 
 #ifdef DM_PARALLEL 

--- a/var/da/da_radiance/da_read_obs_bufrseviri.inc
+++ b/var/da/da_radiance/da_read_obs_bufrseviri.inc
@@ -459,11 +459,14 @@ subroutine da_read_obs_bufrseviri (obstype,iv,infile)
      end do read_loop
   end do
   call closbf(lnbufr)
+
+  !Deallocate temporary arrays for next bufrfile do loop
+  deallocate(datasev1)
+  deallocate(datasev2)
+  deallocate(hdr)
+  deallocate(data_all)
 end do bufrfile
 
-deallocate(data_all) ! Deallocate data arrays
-
-  
    if (thinning .and. num_seviri_global > 0 ) then
 
 #ifdef DM_PARALLEL 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, SEVIRI, IASI, radiance, bufr

SOURCE: Thomas Schwitalla (University of Hohenheim)

DESCRIPTION OF CHANGES: There were some missing/misplaced deallocation statements in the subroutines for reading IASI and SEVIRI BUFR files which resulted in errors when trying to read two different files of the same observation type for these instruments. The errors were due to attempting to allocate already-allocated arrays. Moving the deallocate statements inside the file read loop, as well as adding a few more necessary deallocation statements, fixes this error.

LIST OF MODIFIED FILES:
M var/da/da_radiance/da_read_obs_bufriasi.inc
M var/da/da_radiance/da_read_obs_bufrseviri.inc

TESTS CONDUCTED: Created a new regression test for 4DVAR reading two files at once, both for IASI and SEVIRI. The test failed as expected before the fix, and now passes. For GNU the test runs successfully, for Intel there is still a failure later on in the assimilation process that still needs to be resolved (likely unrelated to this issue). Other tests all still pass as expected.
