### PR TITLE
Moist potential temperature lateral boundary fixes: use_theta_m=1

### DIFF
--- a/dyn_em/module_bc_em.F
+++ b/dyn_em/module_bc_em.F
@@ -1389,6 +1389,19 @@ CONTAINS
       REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ), INTENT(IN   ) :: moist_bdy_tend_ys, moist_bdy_tend_ye
 
       !  Local variables
+#ifdef _OPENMP
+      INTEGER, EXTERNAL :: omp_get_thread_num
+#endif
+
+      REAL,  DIMENSION( jms:jme , kds:kde , spec_bdy_width ) :: t_bdy_xs, t_bdy_xe
+      REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ) :: t_bdy_ys, t_bdy_ye
+      REAL,  DIMENSION( jms:jme , kds:kde , spec_bdy_width ) :: t_bdy_tend_xs, t_bdy_tend_xe
+      REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ) :: t_bdy_tend_ys, t_bdy_tend_ye
+
+      REAL,  DIMENSION( jms:jme , kds:kde , spec_bdy_width ) :: new_t_bdy_xs, new_t_bdy_xe
+      REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ) :: new_t_bdy_ys, new_t_bdy_ye
+      REAL,  DIMENSION( jms:jme , kds:kde , spec_bdy_width ) :: new_t_bdy_tend_xs, new_t_bdy_tend_xe
+      REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ) :: new_t_bdy_tend_ys, new_t_bdy_tend_ye
 
       INTEGER    :: i, j, k, ii, jj
 
@@ -1412,11 +1425,6 @@ CONTAINS
       REAL :: moist_new_bdy_ys      , moist_new_bdy_ye
       REAL :: moist_old_bdy_tend_xs , moist_old_bdy_tend_xe
       REAL :: moist_old_bdy_tend_ys , moist_old_bdy_tend_ye
-
-      REAL,  DIMENSION( jms:jme , kds:kde , spec_bdy_width ) :: t_bdy_xs, t_bdy_xe
-      REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ) :: t_bdy_ys, t_bdy_ye
-      REAL,  DIMENSION( jms:jme , kds:kde , spec_bdy_width ) :: t_bdy_tend_xs, t_bdy_tend_xe
-      REAL,  DIMENSION( ims:ime , kds:kde , spec_bdy_width ) :: t_bdy_tend_ys, t_bdy_tend_ye
 
       INTEGER :: i_min, i_max, j_min, j_max
 
@@ -1449,8 +1457,27 @@ CONTAINS
       !  passed in, this will either be dry potential temperature or moist potential
       !  temperature.
 
-      i_min = its
-      i_max = ite
+      !  The i_min, i_max for the south and north boundaries depends on if we are doing
+      !  serial, OpenMP, or MPI.  For OpenMP, we do not want any overlap between tiles that
+      !  are on the same task (either OpenMP only, or OpenMP+MPI).
+
+      IF      ( its .EQ. ids ) THEN
+         i_min = its
+      ELSE IF ( its .EQ. ips ) THEN
+         i_min = ims
+      ELSE
+         i_min = its
+      END IF
+      i_min = MAX(ids,i_min)
+
+      IF      ( ite .EQ. ide ) THEN
+         i_max = ite
+      ELSE IF ( ite .EQ. ipe ) THEN
+         i_max = ime
+      ELSE
+         i_max = ite
+      END IF
+      i_max = MIN(i_max,ide-1)
 
       !  South and north lateral boundaries.  This is the i-extent of its through ite, but j only
       !  goes to within spec_bdy_width of the top and bottom (north and south) boundaries.
@@ -1461,7 +1488,7 @@ CONTAINS
       DO jj = MAX(jts,1) , MIN(jte,jde-1,spec_bdy_width)
          j = jj
          DO k = kts , kte-1
-            DO i = MAX(1,i_min) , MIN(i_max,ide-1)
+            DO i = i_min , i_max
               t_bdy_ys     (i,k,j) = orig_t_bdy_ys     (i,k,j)
               t_bdy_tend_ys(i,k,j) = orig_t_bdy_tend_ys(i,k,j)
             END DO
@@ -1470,7 +1497,7 @@ CONTAINS
       DO jj = MAX(jts,1) , MIN(jte,jde-1,spec_bdy_width)
          j = jj
          DO k = kts , kte-1
-            DO i = MAX(1,i_min) , MIN(i_max,ide-1)
+            DO i = i_min , i_max
                mu_old_bdy_ys         =   mu_bdy_ys(i,1,j)    + mub(i,jj)
                t_old_bdy_ys          = ( t_bdy_ys(i,k,j)                                            ) / mu_old_bdy_ys
                moist_old_bdy_ys      = ( moist_bdy_ys(i,k,j)                                        ) / mu_old_bdy_ys
@@ -1480,12 +1507,12 @@ CONTAINS
                t_old_bdy_tend_ys     = ( t_new_bdy_ys        - t_old_bdy_ys                         ) / dt_interval
                moist_old_bdy_tend_ys = ( moist_new_bdy_ys    - moist_old_bdy_ys                     ) / dt_interval
                IF ( theta_to_thetam ) THEN
-                  t_bdy_ys(i,k,j) = ( ( ( t_old_bdy_ys + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_ys ) ) - T0 ) * mu_old_bdy_ys
-                  t_bdy_tend_ys(i,k,j) = ( ( mu_new_bdy_ys * ( ( t_new_bdy_ys + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_ys ) - T0 ) ) - &
+                  new_t_bdy_ys(i,k,j) = ( ( ( t_old_bdy_ys + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_ys ) ) - T0 ) * mu_old_bdy_ys
+                  new_t_bdy_tend_ys(i,k,j) = ( ( mu_new_bdy_ys * ( ( t_new_bdy_ys + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_ys ) - T0 ) ) - &
                                            ( mu_old_bdy_ys * ( ( t_old_bdy_ys + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_ys ) - T0 ) ) ) / dt_interval
                ELSE
-                  t_bdy_ys(i,k,j) = ( ( ( t_old_bdy_ys + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_ys ) ) - T0 ) * mu_old_bdy_ys
-                  t_bdy_tend_ys(i,k,j) = ( ( mu_new_bdy_ys * ( ( t_new_bdy_ys + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_ys ) - T0 ) ) - &
+                  new_t_bdy_ys(i,k,j) = ( ( ( t_old_bdy_ys + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_ys ) ) - T0 ) * mu_old_bdy_ys
+                  new_t_bdy_tend_ys(i,k,j) = ( ( mu_new_bdy_ys * ( ( t_new_bdy_ys + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_ys ) - T0 ) ) - &
                                            ( mu_old_bdy_ys * ( ( t_old_bdy_ys + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_ys ) - T0 ) ) ) / dt_interval
                END IF
             END DO
@@ -1498,7 +1525,7 @@ CONTAINS
       DO jj = MIN(jde-1,jte) , MAX(jde-spec_bdy_width,jts) , -1
          j = jde-jj
          DO k = kts , kte-1
-            DO i = MAX(1,i_min) , MIN(i_max,ide-1)
+            DO i = i_min , i_max
                t_bdy_ye     (i,k,j) = orig_t_bdy_ye     (i,k,j)
                t_bdy_tend_ye(i,k,j) = orig_t_bdy_tend_ye(i,k,j)
             END DO
@@ -1507,7 +1534,7 @@ CONTAINS
       DO jj = MIN(jde-1,jte) , MAX(jde-spec_bdy_width,jts) , -1
          j = jde-jj
          DO k = kts , kte-1
-            DO i = MAX(1,i_min) , MIN(i_max,ide-1)
+            DO i = i_min , i_max
                mu_old_bdy_ye         =   mu_bdy_ye(i,1,j)    + mub(i,jj)
                t_old_bdy_ye          = ( t_bdy_ye(i,k,j)                                            ) / mu_old_bdy_ye
                moist_old_bdy_ye      = ( moist_bdy_ye(i,k,j)                                        ) / mu_old_bdy_ye
@@ -1517,20 +1544,39 @@ CONTAINS
                t_old_bdy_tend_ye     = ( t_new_bdy_ye        - t_old_bdy_ye                         ) / dt_interval
                moist_old_bdy_tend_ye = ( moist_new_bdy_ye    - moist_old_bdy_ye                     ) / dt_interval
                IF ( theta_to_thetam ) THEN
-                  t_bdy_ye(i,k,j) = ( ( ( t_old_bdy_ye + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_ye ) ) - T0 ) * mu_old_bdy_ye
-                  t_bdy_tend_ye(i,k,j) = ( ( mu_new_bdy_ye * ( ( t_new_bdy_ye + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_ye ) - T0 ) ) - &
+                  new_t_bdy_ye(i,k,j) = ( ( ( t_old_bdy_ye + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_ye ) ) - T0 ) * mu_old_bdy_ye
+                  new_t_bdy_tend_ye(i,k,j) = ( ( mu_new_bdy_ye * ( ( t_new_bdy_ye + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_ye ) - T0 ) ) - &
                                            ( mu_old_bdy_ye * ( ( t_old_bdy_ye + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_ye ) - T0 ) ) ) / dt_interval
                ELSE
-                  t_bdy_ye(i,k,j) = ( ( ( t_old_bdy_ye + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_ye ) ) - T0 ) * mu_old_bdy_ye
-                  t_bdy_tend_ye(i,k,j) = ( ( mu_new_bdy_ye * ( ( t_new_bdy_ye + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_ye ) - T0 ) ) - &
+                  new_t_bdy_ye(i,k,j) = ( ( ( t_old_bdy_ye + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_ye ) ) - T0 ) * mu_old_bdy_ye
+                  new_t_bdy_tend_ye(i,k,j) = ( ( mu_new_bdy_ye * ( ( t_new_bdy_ye + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_ye ) - T0 ) ) - &
                                            ( mu_old_bdy_ye * ( ( t_old_bdy_ye + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_ye ) - T0 ) ) ) / dt_interval
                END IF
             END DO
          END DO
       END DO
 
-      j_min = jts
-      j_max = jte
+      !  The j_min, j_max for the west and east boundaries depends on if we are doing
+      !  serial, OpenMP, or MPI.  For OpenMP, we do not want any overlap between tiles that
+      !  are on the same task (either OpenMP only, or OpenMP+MPI).
+
+      IF      ( jts .EQ. jds ) THEN
+         j_min = jts
+      ELSE IF ( jts .EQ. jps ) THEN
+         j_min = jms
+      ELSE
+         j_min = jts
+      END IF
+      j_min = MAX(jds,j_min)
+
+      IF      ( jte .EQ. jde ) THEN
+         j_max = jte
+      ELSE IF ( jte .EQ. jpe ) THEN
+         j_max = jme
+      ELSE
+         j_max = jte
+      END IF
+      j_max = MIN(j_max,jde-1)
 
       !  West and east lateral boundaries.  This is the j-extent of jts through jte, but i only
       !  goes to within spec_bdy_width of the left and right (west and east) boundaries.
@@ -1541,7 +1587,7 @@ CONTAINS
       DO ii = MAX(its,1) , MIN(ite,ide-1,spec_bdy_width)
          i = ii
          DO k = kts , kte-1
-            DO j = MAX(1,j_min) , MIN(j_max,jde-1)
+            DO j = j_min , j_max
                t_bdy_xs     (j,k,i) = orig_t_bdy_xs     (j,k,i)
                t_bdy_tend_xs(j,k,i) = orig_t_bdy_tend_xs(j,k,i)
             END DO
@@ -1550,7 +1596,7 @@ CONTAINS
       DO ii = MAX(its,1) , MIN(ite,ide-1,spec_bdy_width)
          i = ii
          DO k = kts , kte-1
-            DO j = MAX(1,j_min) , MIN(j_max,jde-1)
+            DO j = j_min , j_max
                mu_old_bdy_xs         =   mu_bdy_xs(j,1,i)    + mub(ii,j)
                t_old_bdy_xs          = ( t_bdy_xs(j,k,i)                                            ) / mu_old_bdy_xs
                moist_old_bdy_xs      = ( moist_bdy_xs(j,k,i)                                        ) / mu_old_bdy_xs
@@ -1560,12 +1606,12 @@ CONTAINS
                t_old_bdy_tend_xs     = ( t_new_bdy_xs        - t_old_bdy_xs                         ) / dt_interval
                moist_old_bdy_tend_xs = ( moist_new_bdy_xs    - moist_old_bdy_xs                     ) / dt_interval
                IF ( theta_to_thetam ) THEN
-                  t_bdy_xs(j,k,i) = ( ( ( t_old_bdy_xs + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_xs ) ) - T0 ) * mu_old_bdy_xs
-                  t_bdy_tend_xs(j,k,i) = ( ( mu_new_bdy_xs * ( ( t_new_bdy_xs + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_xs ) - T0 ) ) - &
+                  new_t_bdy_xs(j,k,i) = ( ( ( t_old_bdy_xs + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_xs ) ) - T0 ) * mu_old_bdy_xs
+                  new_t_bdy_tend_xs(j,k,i) = ( ( mu_new_bdy_xs * ( ( t_new_bdy_xs + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_xs ) - T0 ) ) - &
                                            ( mu_old_bdy_xs * ( ( t_old_bdy_xs + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_xs ) - T0 ) ) ) / dt_interval
                ELSE
-                  t_bdy_xs(j,k,i) = ( ( ( t_old_bdy_xs + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_xs ) ) - T0 ) * mu_old_bdy_xs
-                  t_bdy_tend_xs(j,k,i) = ( ( mu_new_bdy_xs * ( ( t_new_bdy_xs + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_xs ) - T0 ) ) - &
+                  new_t_bdy_xs(j,k,i) = ( ( ( t_old_bdy_xs + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_xs ) ) - T0 ) * mu_old_bdy_xs
+                  new_t_bdy_tend_xs(j,k,i) = ( ( mu_new_bdy_xs * ( ( t_new_bdy_xs + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_xs ) - T0 ) ) - &
                                            ( mu_old_bdy_xs * ( ( t_old_bdy_xs + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_xs ) - T0 ) ) ) / dt_interval
                END IF
             END DO
@@ -1578,7 +1624,7 @@ CONTAINS
       DO ii = MIN(ide-1,ite) , MAX(ide-spec_bdy_width,its) , -1
          i = ide-ii
          DO k = kts , kte-1
-            DO j = MAX(1,j_min) , MIN(j_max,jde-1)
+            DO j = j_min , j_max
                t_bdy_xe     (j,k,i) = orig_t_bdy_xe     (j,k,i)
                t_bdy_tend_xe(j,k,i) = orig_t_bdy_tend_xe(j,k,i)
             END DO
@@ -1587,7 +1633,7 @@ CONTAINS
       DO ii = MIN(ide-1,ite) , MAX(ide-spec_bdy_width,its) , -1
          i = ide-ii
          DO k = kts , kte-1
-            DO j = MAX(1,j_min) , MIN(j_max,jde-1)
+            DO j = j_min , j_max
                mu_old_bdy_xe         =   mu_bdy_xe(j,1,i)    + mub(ii,j)
                t_old_bdy_xe          = ( t_bdy_xe(j,k,i)                                            ) / mu_old_bdy_xe
                moist_old_bdy_xe      = ( moist_bdy_xe(j,k,i)                                        ) / mu_old_bdy_xe
@@ -1597,12 +1643,12 @@ CONTAINS
                t_old_bdy_tend_xe     = ( t_new_bdy_xe        - t_old_bdy_xe                         ) / dt_interval
                moist_old_bdy_tend_xe = ( moist_new_bdy_xe    - moist_old_bdy_xe                     ) / dt_interval
                IF ( theta_to_thetam ) THEN
-                  t_bdy_xe(j,k,i) = ( ( ( t_old_bdy_xe + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_xe ) ) - T0 ) * mu_old_bdy_xe
-                  t_bdy_tend_xe(j,k,i) = ( ( mu_new_bdy_xe * ( ( t_new_bdy_xe + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_xe ) - T0 ) ) - &
+                  new_t_bdy_xe(j,k,i) = ( ( ( t_old_bdy_xe + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_xe ) ) - T0 ) * mu_old_bdy_xe
+                  new_t_bdy_tend_xe(j,k,i) = ( ( mu_new_bdy_xe * ( ( t_new_bdy_xe + T0 ) * ( 1. + (R_v/R_d) * moist_new_bdy_xe ) - T0 ) ) - &
                                            ( mu_old_bdy_xe * ( ( t_old_bdy_xe + T0 ) * ( 1. + (R_v/R_d) * moist_old_bdy_xe ) - T0 ) ) ) / dt_interval
                ELSE
-                  t_bdy_xe(j,k,i) = ( ( ( t_old_bdy_xe + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_xe ) ) - T0 ) * mu_old_bdy_xe
-                  t_bdy_tend_xe(j,k,i) = ( ( mu_new_bdy_xe * ( ( t_new_bdy_xe + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_xe ) - T0 ) ) - &
+                  new_t_bdy_xe(j,k,i) = ( ( ( t_old_bdy_xe + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_xe ) ) - T0 ) * mu_old_bdy_xe
+                  new_t_bdy_tend_xe(j,k,i) = ( ( mu_new_bdy_xe * ( ( t_new_bdy_xe + T0 ) / ( 1. + (R_v/R_d) * moist_new_bdy_xe ) - T0 ) ) - &
                                            ( mu_old_bdy_xe * ( ( t_old_bdy_xe + T0 ) / ( 1. + (R_v/R_d) * moist_old_bdy_xe ) - T0 ) ) ) / dt_interval
                END IF
             END DO
@@ -1612,15 +1658,45 @@ CONTAINS
       !  Put the final values for the tendencies into the arrays that get passed 
       !  back out to the calling routine.
 
-      orig_t_bdy_xs ( jts:jte , kds:kde , 1:spec_bdy_width ) = t_bdy_xs ( jts:jte , kds:kde , 1:spec_bdy_width )
-      orig_t_bdy_xe ( jts:jte , kds:kde , 1:spec_bdy_width ) = t_bdy_xe ( jts:jte , kds:kde , 1:spec_bdy_width )
-      orig_t_bdy_tend_xs ( jts:jte , kds:kde , 1:spec_bdy_width ) = t_bdy_tend_xs ( jts:jte , kds:kde , 1:spec_bdy_width )
-      orig_t_bdy_tend_xe ( jts:jte , kds:kde , 1:spec_bdy_width ) = t_bdy_tend_xe ( jts:jte , kds:kde , 1:spec_bdy_width )
+      DO jj = MAX(jts,1) , MIN(jte,jde-1,spec_bdy_width)
+         j = jj
+         DO k = kts , kte-1
+            DO i = i_min , i_max
+              orig_t_bdy_ys     (i,k,j) = new_t_bdy_ys     (i,k,j)
+              orig_t_bdy_tend_ys(i,k,j) = new_t_bdy_tend_ys(i,k,j)
+            END DO
+         END DO
+      END DO
 
-      orig_t_bdy_ys ( its:ite , kds:kde , 1:spec_bdy_width ) = t_bdy_ys ( its:ite , kds:kde , 1:spec_bdy_width )
-      orig_t_bdy_ye ( its:ite , kds:kde , 1:spec_bdy_width ) = t_bdy_ye ( its:ite , kds:kde , 1:spec_bdy_width )
-      orig_t_bdy_tend_ys ( its:ite , kds:kde , 1:spec_bdy_width ) = t_bdy_tend_ys ( its:ite , kds:kde , 1:spec_bdy_width )
-      orig_t_bdy_tend_ye ( its:ite , kds:kde , 1:spec_bdy_width ) = t_bdy_tend_ye ( its:ite , kds:kde , 1:spec_bdy_width )
+      DO jj = MIN(jde-1,jte) , MAX(jde-spec_bdy_width,jts) , -1
+         j = jde-jj
+         DO k = kts , kte-1
+            DO i = i_min , i_max
+               orig_t_bdy_ye     (i,k,j) = new_t_bdy_ye     (i,k,j)
+               orig_t_bdy_tend_ye(i,k,j) = new_t_bdy_tend_ye(i,k,j)
+            END DO
+         END DO
+      END DO
+
+      DO ii = its , MIN(ite,ide-1,spec_bdy_width)
+         i = ii
+         DO k = kts , kte-1
+            DO j = j_min , j_max
+               orig_t_bdy_xs     (j,k,i) = new_t_bdy_xs     (j,k,i)
+               orig_t_bdy_tend_xs(j,k,i) = new_t_bdy_tend_xs(j,k,i)
+            END DO
+         END DO
+      END DO
+
+      DO ii = MIN(ide-1,ite) , MAX(ide-spec_bdy_width,its) , -1
+         i = ide-ii
+         DO k = kts , kte-1
+            DO j = j_min , j_max
+               orig_t_bdy_xe     (j,k,i) = new_t_bdy_xe     (j,k,i)
+               orig_t_bdy_tend_xe(j,k,i) = new_t_bdy_tend_xe(j,k,i)
+            END DO
+         END DO
+      END DO
 
    END SUBROUTINE theta_and_thetam_lbc_only
 


### PR DESCRIPTION
### Moist potential temperature lateral boundary fixes: use_theta_m=1

### TYPE: bug fix

### KEYWORDS: use_theta_m, moist, theta, BC, boundary

### SOURCE: Bug hunt prompted by Bill Gustafson (PNNL)

### DESCRIPTION OF CHANGES: 
There are two modifications that are fixing bugs in the same subroutine:
theta_and_thetam_lbc_only.  This routine computes the lateral boundary tendencies
for potential temperature for specified or for nested boundary conditions.  When
dry potential temperature comes in, the moist theta BCs are computed.  Similarly, 
when moist theta is input, the output is the tendencies for the dry theta.

1. The horizontal indexes for the computation of the lateral boundary condition for
potential temperature do _NOT_ need to be anything other than the ususal its->ite, and
jts->jte.  The machinations with +4 and -4, depending on OpenMP or MPI was all wrong.
The potential temperature field is on mass points, the mu-coupling is on mass points,
there is no averaging, so no need for any stencil at all.  This should be a computation
only on a single column, and that is what the indexing now does.

2. Two fields, t_bdy and t_bdy_tend, were originally INOUT variables.  They are both used on the
right hand side of the equal sign, and they are used on the LHS also.  Because of 
this usage, care needed to be taken that an updated value was not subsequently (and
incorrectly) used on the RHS of the equations.  Unfortunately, that care was not taken.
What is done now is to hold on to the original values (orig_t_bdy, orig_t_bdy_tend), and then ahead of each loop that uses the arrays, assign the copies t_bdy and t_by_tend to be used on the RHS of the statements.  When computed, the values are stored in new_t_bdy and new_t_bdy_tend.  At the end of the routine, the new_t_bdy and new_t_bdy_tend are put into the orig_t_bdy and orig_t_bdy_tend arrays.

### LIST OF MODIFIED FILES: 
M       dyn_em/module_bc_em.F

### TESTS CONDUCTED:
1) Old regression test passes with mods
2) New extended regression test that has use_theta_m=1 passes for serial, OpenMP, and MPI
