### PR TITLE
Modifications for reading ASCII observations with large numbers of levels (>1001)

### DIFF
--- a/var/da/da_obs_io/da_read_obs_ascii.inc
+++ b/var/da/da_obs_io/da_read_obs_ascii.inc
@@ -216,6 +216,12 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
       ! ---------------
 
       do i = 1, platform%info%levels
+         if (i > max_ob_levels) then
+            ! platform%each only has size "max_ob_levels", so if we exceed this limit
+            ! we should just read past these lines and not assign them to platform%each
+            read (unit = iunit, fmt = trim (fmt_each))
+            cycle
+         end if
          platform%each (i) = each_level_type(missing_r, missing, -1.0, & ! height
             field_type(missing_r, missing, missing_r, missing, missing_r), & ! u
             field_type(missing_r, missing, missing_r, missing, missing_r), & ! v
@@ -354,28 +360,6 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
       nlevels = platform%info%levels
       if (nlevels > max_ob_levels) then
          nlevels = max_ob_levels
-         write(unit=message(1), fmt='(4(2a,2x),a,2f8.2,2x,2(a,f9.2,2x),2(a,i4,2x))') &
-            'Station: ', trim(platform%info%name), &
-            'ID: ', trim(platform%info%id), &
-            'Platform: ', trim(platform%info%platform), &
-            'Date: ', trim(platform%info%date_char), &
-            'At Loc(lat, lon): ', platform%info%lat, platform%info%lon, &
-            'At elv: ', platform%info%elv, &
-            'with pstar: ', platform%info%pstar, &
-            'Has level: ', platform%info%levels, &
-            'which is great than max_ob_levels: ', max_ob_levels
-
-         write (unit=message(2), fmt = '(A,1X,A,1X,A,1X,I4,2f9.3,f9.1,1X,A)') &
-            platform%info%name,        &
-            platform%info%platform,    &
-            platform%info%date_char,   &
-            platform%info%levels,      &
-            platform%info%lat,         &
-            platform%info%lon,         &
-            platform%info%elv,         &
-            platform%info%id
-         call da_warning(__FILE__,__LINE__,message(1:2))
-
          platform%info%levels = nlevels
       else if (nlevels < 1) then
          ! Not GPSPW and GPSZD data:

--- a/var/da/da_obs_io/da_scan_obs_ascii.inc
+++ b/var/da/da_obs_io/da_scan_obs_ascii.inc
@@ -150,8 +150,41 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
       ! read each level
 
       nlevels= platform%info%levels 
+      if (nlevels > max_ob_levels) then
+         write(unit=message(1), fmt='(4(2a,2x),a,2f8.2,2x,2(a,f9.2,2x),2(a,i0,2x))') &
+            'Station: ', trim(platform%info%name), &
+            'ID: ', trim(platform%info%id), &
+            'Platform: ', trim(platform%info%platform), &
+            'Date: ', trim(platform%info%date_char), &
+            'At Location (lat, lon): ', platform%info%lat, platform%info%lon, &
+            'At elevation: ', platform%info%elv, &
+            'with pstar: ', platform%info%pstar, &
+            'Has ', platform%info%levels, &
+            'levels, which is greater than max_ob_levels: ', max_ob_levels
+
+         write (unit=message(2), fmt = '(A,1X,A,1X,A,1X,I4,2f9.3,f9.1,1X,A)') &
+            platform%info%name,        &
+            platform%info%platform,    &
+            platform%info%date_char,   &
+            platform%info%levels,      &
+            platform%info%lat,         &
+            platform%info%lon,         &
+            platform%info%elv,         &
+            platform%info%id
+
+         write (unit=message(3), fmt = '(A,I4,A)')'Only the first ',max_ob_levels,' levels will be used!'
+
+         call da_warning(__FILE__,__LINE__,message(1:3))
+      end if
 
       do i = 1, platform%info%levels
+         if (i > max_ob_levels) then
+            ! platform%each only has size "max_ob_levels", so if we exceed this limit
+            ! we should just read past these lines and not assign them to platform%each
+            read (unit = iunit, fmt = trim (fmt_each))
+            cycle
+         end if
+
          platform%each (i) = each_level_type(missing_r, missing, -1.0, & ! height
             field_type(missing_r, missing, missing_r, missing, missing_r), & ! u
             field_type(missing_r, missing, missing_r, missing, missing_r), & ! v


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, ASCII observations, max_ob_levels, runtime error, write format

SOURCE: Internal

DESCRIPTION OF CHANGES: 

A user was attempting to assimilate some very detailed soundings with more than 2000 vertical levels. This was hitting a hard-coded maximum "max_ob_levels=1001", which is intended to print a warning message and then ignore all levels past the first 1001. However, there was a runtime error when code block containing the warning message was reached, which presented in strange ways (gfortran claimed it was reaching the "End of file", ifort claimed "too many records in I/O statement"). I traced this down to the inclusion of slashes (/) in the fmt specification of this write statement. The inital fix was to remove the slashes, which allowed the code to run normally.

When testing this fix, I found that assimilation of these large observations still failed in debug mode. This is because, in da_scan_obs_ascii.inc, the ASCII observations are read and stored in the "platform" structure. Each level is stored in "platform%each(i)", where "i" is the level number. platform%each is defined as having "max_ob_levels" (1001) levels, which is why the limit check in da_read_obs_ascii.inc exists. However, to avoid writing past the end of the array in da_scan_obs_ascii.inc, we need to add this check here as well. We add an if check to each do loop over the number of observation levels in these two subroutines, and move the warning message to da_scan_obs_ascii since that is the first instance of this exception.

LIST OF MODIFIED FILES: 
M       var/da/da_obs_io/da_read_obs_ascii.inc
M       var/da/da_obs_io/da_scan_obs_ascii.inc

TESTS CONDUCTED: Ran test with a large sounding observation with a greater amount of levels than max_ob_levels. This case failed at runtime originally, and succeeded with the fix (for both gnu and intel). WRFDA Regression tests passed as expected. Added new large observation to existing WRFDA regression tests to check for similar problems in the future; these fail before the test and succeed afterwards, even in debug mode. 
