### PR TITLE
Include WENO and WENO+PD in advection kernel

### DIFF
--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -7849,7 +7849,687 @@ SUBROUTINE advect_scalar_pd   ( field, field_old, tendency,    &
   END IF
 
 END SUBROUTINE advect_scalar_pd
-#if ( !defined(ADVECT_KERNEL) )
+
+!----------------------------------------------------------------
+
+SUBROUTINE advect_scalar_weno ( field, field_old, tendency,     &
+                             ru, rv, rom,                   &
+                             mut, time_step, config_flags,  &
+                             msfux, msfuy, msfvx, msfvy,    &
+                             msftx, msfty,                  &
+                             fzm, fzp,                      &
+                             rdx, rdy, rdzw,                &
+                             ids, ide, jds, jde, kds, kde,  &
+                             ims, ime, jms, jme, kms, kme,  &
+                             its, ite, jts, jte, kts, kte  )
+!
+! 5th-order WENO (Weighted Essentially Non-Oscillatory) scheme adapted from COMMAS.  
+! See Jiang and Shu, 1996, J. Comp. Phys. v. 126, 202-223; 
+! Shu 2003, Int. J. Comp. Fluid Dyn. v. 17 107-118;  Also used by Bryan 2005, Mon. Wea. Rev.
+!
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+   
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
+                                                                      field_old, &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      rom
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   INTEGER ,                                     INTENT(IN   ) :: time_step
+
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax
+
+   INTEGER , PARAMETER :: is=0, js=0, ks=0
+
+   REAL    :: mrdx, mrdy, ub, vb, vw
+   REAL , DIMENSION(its:ite, kts:kte) :: vflux
+
+
+   REAL,  DIMENSION( its-is:ite+1, kts:kte  ) :: fqx
+!   REAL,  DIMENSION( its:ite+1, kts:kte  ) :: fqx
+   REAL,  DIMENSION( its:ite, kts:kte, 2 ) :: fqy
+
+   INTEGER :: horz_order, vert_order
+   
+   LOGICAL :: degrade_xs, degrade_ys
+   LOGICAL :: degrade_xe, degrade_ye
+
+   INTEGER :: jp1, jp0, jtmp
+
+    real            :: dir, vv
+    real            :: ue,uw,vs,vn,wb,wt
+    real, parameter :: f30 =  7./12., f31 = 1./12.
+    real, parameter :: f50 = 37./60., f51 = 2./15., f52 = 1./60.
+
+
+   integer kt,kb
+   
+    
+    real               :: qim2, qim1, qi, qip1, qip2
+    double precision               :: beta0, beta1, beta2, f0, f1, f2, wi0, wi1, wi2, sumwk
+    double precision, parameter    :: gi0 = 1.d0/10.d0, gi1 = 6.d0/10.d0, gi2 = 3.d0/10.d0, eps=1.0d-28
+    integer, parameter :: pw = 2
+
+
+! definition of flux operators, 3rd, 4th, 5th or 6th order
+
+   REAL    :: flux3, flux4, flux5, flux6
+   REAL    :: q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua, vel
+
+      flux4(q_im2, q_im1, q_i, q_ip1, ua) =                     &
+            (7./12.)*(q_i + q_im1) - (1./12.)*(q_ip1 + q_im2)
+
+      flux3(q_im2, q_im1, q_i, q_ip1, ua) =                     &
+           flux4(q_im2, q_im1, q_i, q_ip1, ua) +                &
+           sign(1.,ua)*(1./12.)*((q_ip1 - q_im2)-3.*(q_i-q_im1))
+
+      flux6(q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua) =       &
+            (37./60.)*(q_i+q_im1) - (2./15.)*(q_ip1+q_im2)      &
+            +(1./60.)*(q_ip2+q_im3)
+
+      flux5(q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua) =       &
+           flux6(q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua)    &
+            -sign(1,time_step)*sign(1.,ua)*(1./60.)*(           &
+              (q_ip2-q_im3)-5.*(q_ip1-q_im2)+10.*(q_i-q_im1) )
+
+   LOGICAL :: specified
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+! set order for the advection schemes
+
+  ktf=MIN(kte,kde-1)
+  horz_order = 5 ! config_flags%h_sca_adv_order
+  vert_order = 5 ! config_flags%v_sca_adv_order
+
+!  begin with horizontal flux divergence
+!  here is the choice of flux operators
+
+
+
+  IF( horz_order == 5 ) THEN
+
+!  determine boundary mods for flux operators
+!  We degrade the flux operators from 3rd/4th order
+!   to second order one gridpoint in from the boundaries for
+!   all boundary conditions except periodic and symmetry - these
+!   conditions have boundary zone data fill for correct application
+!   of the higher order flux stencils
+
+   degrade_xs = .true.
+   degrade_xe = .true.
+   degrade_ys = .true.
+   degrade_ye = .true.
+
+   IF( config_flags%periodic_x   .or. &
+       config_flags%symmetric_xs .or. &
+       (its > ids+3)                ) degrade_xs = .false.
+   IF( config_flags%periodic_x   .or. &
+       config_flags%symmetric_xe .or. &
+       (ite < ide-3)                ) degrade_xe = .false.
+   IF( config_flags%periodic_y   .or. &
+       config_flags%symmetric_ys .or. &
+       (jts > jds+3)                ) degrade_ys = .false.
+   IF( config_flags%periodic_y   .or. &
+       config_flags%symmetric_ye .or. &
+       (jte < jde-4)                ) degrade_ye = .false.
+
+!--------------- y - advection first
+
+      ktf=MIN(kte,kde-1)
+      i_start = its
+      i_end   = MIN(ite,ide-1)
+
+
+! check for U
+      IF ( is == 1 ) THEN
+        i_start = its
+        i_end   = ite
+        IF ( config_flags%open_xs .or. specified ) i_start = MAX(ids+1,its)
+        IF ( config_flags%open_xe .or. specified ) i_end   = MIN(ide-1,ite)
+        IF ( config_flags%periodic_x ) i_start = its
+        IF ( config_flags%periodic_x ) i_end = ite
+      ENDIF
+
+      j_start = jts
+      j_end   = MIN(jte,jde-1)
+
+!  higher order flux has a 5 or 7 point stencil, so compute
+!  bounds so we can switch to second order flux close to the boundary
+
+      j_start_f = j_start
+      j_end_f   = j_end+1
+
+      IF(degrade_ys) then
+        j_start = MAX(jts,jds+1)
+        j_start_f = jds+3
+      ENDIF
+
+      IF(degrade_ye) then
+        j_end = MIN(jte,jde-2)
+        j_end_f = jde-3
+      ENDIF
+
+      IF(config_flags%polar) j_end = MIN(jte,jde-1)
+
+!  compute fluxes, 5th or 6th order
+
+     jp1 = 2
+     jp0 = 1
+
+     j_loop_y_flux_5 : DO j = j_start, j_end+1
+
+      IF( (j >= j_start_f ) .and. (j <= j_end_f) ) THEN ! use full stencil
+
+        DO k=kts,ktf
+        DO i = i_start, i_end
+!          vel = rv(i,k,j)
+          vel = 0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )
+
+         IF ( vel .ge. 0.0 ) THEN
+            qip2 = field(i,k,j+1)
+            qip1 = field(i,k,j  )
+            qi   = field(i,k,j-1)
+            qim1 = field(i,k,j-2)
+            qim2 = field(i,k,j-3)
+          ELSE
+            qip2 = field(i,k,j-2)
+            qip1 = field(i,k,j-1)
+            qi   = field(i,k,j  )
+            qim1 = field(i,k,j+1)
+            qim2 = field(i,k,j+2)
+         ENDIF
+    
+         f0 =  1./3.*qim2 - 7./6.*qim1 + 11./6.*qi
+         f1 = -1./6.*qim1 + 5./6.*qi   + 1./3. *qip1
+         f2 =  1./3.*qi   + 5./6.*qip1 - 1./6. *qip2
+    
+         beta0 = 13./12.*(qim2 - 2.*qim1 + qi  )**2 + 1./4.*(qim2 - 4.*qim1 + 3.*qi)**2
+         beta1 = 13./12.*(qim1 - 2.*qi   + qip1)**2 + 1./4.*(qim1 - qip1)**2
+         beta2 = 13./12.*(qi   - 2.*qip1 + qip2)**2 + 1./4.*(qip2 - 4.*qip1 + 3.*qi)**2
+    
+         wi0 = gi0 / (eps + beta0)**pw
+         wi1 = gi1 / (eps + beta1)**pw
+         wi2 = gi2 / (eps + beta2)**pw
+    
+         sumwk = wi0 + wi1 + wi2
+    
+          fqy( i, k, jp1 ) = vel * (wi0*f0 + wi1*f1 + wi2*f2) / sumwk
+
+!          fqy( i, k, jp1 ) = vel*flux5(                                &
+!                  field(i,k,j-3), field(i,k,j-2), field(i,k,j-1),       &
+!                  field(i,k,j  ), field(i,k,j+1), field(i,k,j+2),  vel )
+        ENDDO
+        ENDDO
+
+
+      ELSE IF ( j == jds+1 ) THEN   ! 2nd order flux next to south boundary
+
+            DO k=kts,ktf
+            DO i = i_start, i_end
+              fqy(i,k, jp1) = 0.5*rv(i,k,j)*          &
+!              fqy(i,k, jp1) = 0.5*0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )*          &
+                     (field(i,k,j)+field(i,k,j-1))
+
+            ENDDO
+            ENDDO
+
+     ELSE IF  ( j == jds+2 ) THEN  ! third of 4th order flux 2 in from south boundary
+
+            DO k=kts,ktf
+            DO i = i_start, i_end
+!              vel = 0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )
+              vel = rv(i,k,j)
+              fqy( i, k, jp1 ) = vel*flux3(              &
+                   field(i,k,j-2),field(i,k,j-1),field(i,k,j),field(i,k,j+1),vel )
+            ENDDO
+            ENDDO
+
+     ELSE IF ( j == jde-1 ) THEN  ! 2nd order flux next to north boundary
+
+            DO k=kts,ktf
+            DO i = i_start, i_end
+!              fqy(i, k, jp1) = 0.5*0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )*      &
+              fqy(i, k, jp1) = 0.5*rv(i,k,j)*      &
+                     (field(i,k,j)+field(i,k,j-1))
+            ENDDO
+            ENDDO
+
+     ELSE IF ( j == jde-2 ) THEN  ! 3rd or 4th order flux 2 in from north boundary
+
+            DO k=kts,ktf
+            DO i = i_start, i_end
+              vel = rv(i,k,j)
+!              vel = 0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )
+              fqy( i, k, jp1) = vel*flux3(             &
+                   field(i,k,j-2),field(i,k,j-1),    &
+                   field(i,k,j),field(i,k,j+1),vel )
+            ENDDO
+            ENDDO
+
+     ENDIF
+
+!  y flux-divergence into tendency
+
+      IF ( is == 0 ) THEN
+        ! Comments on polar boundary conditions
+        ! Same process as for advect_u - tendencies run from jds to jde-1 
+        ! (latitudes are as for u grid, longitudes are displaced)
+        ! Therefore: flow is only from one side for points next to poles
+        IF ( config_flags%polar .AND. (j == jds+1) ) THEN
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdy=msftx(i,j-1)*rdy     ! see ADT eqn 48 [rho->rho*q] dividing by my, 2nd term RHS
+            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*fqy(i,k,jp1)
+          END DO
+          END DO
+        ELSE IF( config_flags%polar .AND. (j == jde) ) THEN
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdy=msftx(i,j-1)*rdy     ! see ADT eqn 48 [rho->rho*q] dividing by my, 2nd term RHS
+            tendency(i,k,j-1) = tendency(i,k,j-1) + mrdy*fqy(i,k,jp0)
+          END DO
+          END DO
+        ELSE  ! normal code
+
+        IF(j > j_start) THEN
+
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdy=msftx(i,j-1)*rdy    ! see ADT eqn 48 [rho->rho*q] dividing by my, 2nd term RHS
+            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*(fqy(i,k,jp1)-fqy(i,k,jp0))
+          ENDDO
+          ENDDO
+
+        ENDIF
+        ENDIF
+       ELSEIF ( is == 1 ) THEN
+
+        ! (j > j_start) will miss the u(,,jds) tendency
+        IF ( config_flags%polar .AND. (j == jds+1) ) THEN
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdy=msfux(i,j-1)*rdy   ! ADT eqn 44, 2nd term on RHS
+            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*fqy(i,k,jp1)
+          END DO
+          END DO
+        ! This would be seen by (j > j_start) but we need to zero out the NP tendency
+        ELSE IF( config_flags%polar .AND. (j == jde) ) THEN
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdy=msfux(i,j-1)*rdy   ! ADT eqn 44, 2nd term on RHS
+            tendency(i,k,j-1) = tendency(i,k,j-1) + mrdy*fqy(i,k,jp0)
+          END DO
+          END DO
+        ELSE  ! normal code
+
+        IF(j > j_start) THEN
+
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdy=msfux(i,j-1)*rdy   ! ADT eqn 44, 2nd term on RHS
+            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*(fqy(i,k,jp1)-fqy(i,k,jp0))
+          ENDDO
+          ENDDO
+
+        ENDIF
+
+        END IF
+       
+       ENDIF
+
+        jtmp = jp1
+        jp1 = jp0
+        jp0 = jtmp
+
+      ENDDO j_loop_y_flux_5
+
+!  next, x - flux divergence
+
+      i_start = its
+      i_end   = MIN(ite,ide-1)
+
+      j_start = jts
+      j_end   = MIN(jte,jde-1)
+
+!  higher order flux has a 5 or 7 point stencil, so compute
+!  bounds so we can switch to second order flux close to the boundary
+
+      i_start_f = i_start
+      i_end_f   = i_end+1
+
+      IF(degrade_xs) then
+        i_start = MAX(ids+1,its)
+!        i_start_f = i_start+2
+        i_start_f = MIN(i_start+2,ids+3)
+      ENDIF
+
+      IF(degrade_xe) then
+        i_end = MIN(ide-2,ite)
+        i_end_f = ide-3
+      ENDIF
+
+!  compute fluxes
+
+      DO j = j_start, j_end
+
+!  5th or 6th order flux
+
+        DO k=kts,ktf
+        DO i = i_start_f, i_end_f
+!          vel = ru(i,k,j)
+          vel = 0.5*( ru(i,k,j) + ru(i-is,k-ks,j-js) )
+
+
+         IF ( vel .ge. 0.0 ) THEN
+            qip2 = field(i+1,k,j)
+            qip1 = field(i,  k,j)
+            qi   = field(i-1,k,j)
+            qim1 = field(i-2,k,j)
+            qim2 = field(i-3,k,j)
+          ELSE
+            qip2 = field(i-2,k,j)
+            qip1 = field(i-1,k,j)
+            qi   = field(i,  k,j)
+            qim1 = field(i+1,k,j)
+            qim2 = field(i+2,k,j)
+         ENDIF
+    
+         f0 =  1./3.*qim2 - 7./6.*qim1 + 11./6.*qi
+         f1 = -1./6.*qim1 + 5./6.*qi   + 1./3. *qip1
+         f2 =  1./3.*qi   + 5./6.*qip1 - 1./6. *qip2
+    
+         beta0 = 13./12.*(qim2 - 2.*qim1 + qi  )**2 + 1./4.*(qim2 - 4.*qim1 + 3.*qi)**2
+         beta1 = 13./12.*(qim1 - 2.*qi   + qip1)**2 + 1./4.*(qim1 - qip1)**2
+         beta2 = 13./12.*(qi   - 2.*qip1 + qip2)**2 + 1./4.*(qip2 - 4.*qip1 + 3.*qi)**2
+    
+         wi0 = gi0 / (eps + beta0)**pw
+         wi1 = gi1 / (eps + beta1)**pw
+         wi2 = gi2 / (eps + beta2)**pw
+    
+         sumwk = wi0 + wi1 + wi2
+    
+         fqx(i,k) = vel * (wi0*f0 + wi1*f1 + wi2*f2) / sumwk
+
+!          fqx( i,k ) = vel*flux5( field(i-3,k,j), field(i-2,k,j),  &
+!                                         field(i-1,k,j), field(i  ,k,j),  &
+!                                         field(i+1,k,j), field(i+2,k,j),  &
+!                                         vel                             )
+        ENDDO
+        ENDDO
+
+!  lower order fluxes close to boundaries (if not periodic or symmetric)
+
+        IF( degrade_xs ) THEN
+
+          DO i=i_start,i_start_f-1
+
+            IF(i == ids+1) THEN ! second order
+              DO k=kts,ktf
+                fqx(i,k) = 0.5*(ru(i,k,j)) &
+                       *(field(i,k,j)+field(i-1,k,j))
+              ENDDO
+            ENDIF
+
+            IF(i == ids+2) THEN  ! third order
+              DO k=kts,ktf
+                vel = ru(i,k,j)
+                fqx( i,k ) = vel*flux3( field(i-2,k,j), field(i-1,k,j),  &
+                                              field(i  ,k,j), field(i+1,k,j),  &
+                                              vel                     )
+              ENDDO
+            END IF
+
+          ENDDO
+
+        ENDIF
+
+        IF( degrade_xe ) THEN
+
+          DO i = i_end_f+1, i_end+1
+
+            IF( i == ide-1 ) THEN ! second order flux next to the boundary
+              DO k=kts,ktf
+                fqx(i,k) = 0.5*(ru(i,k,j))      &
+                       *(field(i,k,j)+field(i-1,k,j))
+              ENDDO
+           ENDIF
+
+           IF( i == ide-2 ) THEN ! third order flux one in from the boundary
+             DO k=kts,ktf
+               vel = ru(i,k,j)
+               fqx( i,k ) = vel*flux3( field(i-2,k,j), field(i-1,k,j),  &
+                                       field(i  ,k,j), field(i+1,k,j),  &
+                                       vel                             )
+             ENDDO
+           ENDIF
+
+         ENDDO
+
+       ENDIF
+
+!  x flux-divergence into tendency
+
+       IF ( is == 0 ) THEN
+          DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdx=msftx(i,j)*rdx      ! see ADT eqn 48 [rho->rho*q] dividing by my, 1st term RHS
+            tendency(i,k,j) = tendency(i,k,j) - mrdx*(fqx(i+1,k)-fqx(i,k))
+          ENDDO
+          ENDDO
+       ELSEIF ( is == 1 ) THEN
+        DO k=kts,ktf
+          DO i = i_start, i_end
+            mrdx=msfux(i,j)*rdx ! ADT eqn 44, 1st term on RHS
+            tendency(i,k,j) = tendency(i,k,j) - mrdx*(fqx(i+1,k)-fqx(i,k))
+          ENDDO
+        ENDDO
+       ENDIF
+
+      ENDDO
+
+
+   ENDIF
+   
+
+!  pick up the rest of the horizontal radiation boundary conditions.
+!  (these are the computations that don't require 'cb'.
+!  first, set to index ranges
+
+      i_start = its
+      i_end   = MIN(ite,ide-1)
+      j_start = jts
+      j_end   = MIN(jte,jde-1)
+
+!  compute x (u) conditions for v, w, or scalar
+
+   IF( (config_flags%open_xs) .and. (its == ids) ) THEN
+
+       DO j = j_start, j_end
+       DO k = kts, ktf
+         ub = MIN( 0.5*(ru(its,k,j)+ru(its+1,k,j)), 0. )
+         tendency(its,k,j) = tendency(its,k,j)                     &
+               - rdx*(                                             &
+                       ub*(   field_old(its+1,k,j)                 &
+                            - field_old(its  ,k,j)   ) +           &
+                       field(its,k,j)*(ru(its+1,k,j)-ru(its,k,j))  &
+                                                                )
+       ENDDO
+       ENDDO
+
+   ENDIF
+
+   IF( (config_flags%open_xe) .and. (ite == ide) ) THEN
+
+       DO j = j_start, j_end
+       DO k = kts, ktf
+         ub = MAX( 0.5*(ru(ite-1,k,j)+ru(ite,k,j)), 0. )
+         tendency(i_end,k,j) = tendency(i_end,k,j)                   &
+               - rdx*(                                               &
+                       ub*(  field_old(i_end  ,k,j)                  &
+                           - field_old(i_end-1,k,j) ) +              &
+                       field(i_end,k,j)*(ru(ite,k,j)-ru(ite-1,k,j))  &
+                                                                    )
+       ENDDO
+       ENDDO
+
+   ENDIF
+
+   IF( (config_flags%open_ys) .and. (jts == jds) ) THEN
+
+       DO i = i_start, i_end
+       DO k = kts, ktf
+         vb = MIN( 0.5*(rv(i,k,jts)+rv(i,k,jts+1)), 0. )
+         tendency(i,k,jts) = tendency(i,k,jts)                     &
+               - rdy*(                                             &
+                       vb*(  field_old(i,k,jts+1)                  &
+                           - field_old(i,k,jts  ) ) +              &
+                       field(i,k,jts)*(rv(i,k,jts+1)-rv(i,k,jts))  &
+                                                                )
+       ENDDO
+       ENDDO
+
+   ENDIF
+
+   IF( (config_flags%open_ye) .and. (jte == jde)) THEN
+
+       DO i = i_start, i_end
+       DO k = kts, ktf
+         vb = MAX( 0.5*(rv(i,k,jte-1)+rv(i,k,jte)), 0. )
+         tendency(i,k,j_end) = tendency(i,k,j_end)                   &
+               - rdy*(                                               &
+                       vb*(   field_old(i,k,j_end  )                 &
+                            - field_old(i,k,j_end-1) ) +             &
+                       field(i,k,j_end)*(rv(i,k,jte)-rv(i,k,jte-1))  &
+                                                                    )
+       ENDDO
+       ENDDO
+
+   ENDIF
+
+
+!-------------------- vertical advection
+!     Scalar equation has 3rd term on RHS = - partial d/dz (q rho w /my)
+!     Here we have: - partial d/dz (q*rom) = - partial d/dz (q rho w / my)
+!     So we don't need to make a correction for advect_scalar
+
+      i_start = its
+      i_end   = MIN(ite,ide-1)
+      j_start = jts
+      j_end   = MIN(jte,jde-1)
+
+      DO i = i_start, i_end
+         vflux(i,kts)=0.
+         vflux(i,kte)=0.
+      ENDDO
+
+
+
+      DO j = j_start, j_end
+
+         DO k=kts+3,ktf-2
+         DO i = i_start, i_end
+!           vel = rom(i,k,j)
+           vel = 0.5*( rom(i,k,j) + rom(i-is,k-ks,j-js) )
+
+         IF( -vel .ge. 0.0 ) THEN
+            qip2 = field(i,k+1,j)
+            qip1 = field(i,k  ,j)
+            qi   = field(i,k-1,j)
+            qim1 = field(i,k-2,j)
+            qim2 = field(i,k-3,j)
+          ELSE
+            qip2 = field(i,k-2,j)
+            qip1 = field(i,k-1,j)
+            qi   = field(i,k  ,j)
+            qim1 = field(i,k+1,j)
+            qim2 = field(i,k+2,j)
+         ENDIF
+    
+         f0 =  1./3.*qim2 - 7./6.*qim1 + 11./6.*qi
+         f1 = -1./6.*qim1 + 5./6.*qi   + 1./3. *qip1
+         f2 =  1./3.*qi   + 5./6.*qip1 - 1./6. *qip2
+    
+         beta0 = 13./12.*(qim2 - 2.*qim1 + qi  )**2 + 1./4.*(qim2 - 4.*qim1 + 3.*qi)**2
+         beta1 = 13./12.*(qim1 - 2.*qi   + qip1)**2 + 1./4.*(qim1 - qip1)**2
+         beta2 = 13./12.*(qi   - 2.*qip1 + qip2)**2 + 1./4.*(qip2 - 4.*qip1 + 3.*qi)**2
+    
+         wi0 = gi0 / (eps + beta0)**pw
+         wi1 = gi1 / (eps + beta1)**pw
+         wi2 = gi2 / (eps + beta2)**pw
+    
+         sumwk = wi0 + wi1 + wi2
+    
+          vflux(i,k) = vel * (wi0*f0 + wi1*f1 + wi2*f2) / sumwk
+
+!           vflux(i,k) = vel*flux5(                                 &
+!                   field(i,k-3,j), field(i,k-2,j), field(i,k-1,j),       &
+!                   field(i,k  ,j), field(i,k+1,j), field(i,k+2,j),  -vel )
+         ENDDO
+         ENDDO
+
+         DO i = i_start, i_end
+
+           k=kts+1
+           vflux(i,k)=rom(i,k,j)*(fzm(k)*field(i,k,j)+fzp(k)*field(i,k-1,j))
+                                   
+           k = kts+2
+           vel=rom(i,k,j) 
+           vflux(i,k) = vel*flux3(               &
+                   field(i,k-2,j), field(i,k-1,j),   &
+                   field(i,k  ,j), field(i,k+1,j), -vel )
+           k = ktf-1
+           vel=rom(i,k,j)
+           vflux(i,k) = vel*flux3(               &
+                   field(i,k-2,j), field(i,k-1,j),   &
+                   field(i,k  ,j), field(i,k+1,j), -vel )
+
+           k=ktf
+           vflux(i,k)=rom(i,k,j)*(fzm(k)*field(i,k,j)+fzp(k)*field(i,k-1,j))
+         ENDDO
+
+         DO k=kts,ktf
+         DO i = i_start, i_end
+            tendency(i,k,j)=tendency(i,k,j)-rdzw(k)*(vflux(i,k+1)-vflux(i,k))
+         ENDDO
+         ENDDO
+
+      ENDDO
+
+
+
+END SUBROUTINE advect_scalar_weno
 
 !----------------------------------------------------------------
 
@@ -8748,7 +9428,6 @@ END SUBROUTINE advect_scalar_wenopd
 
 !----------------------------------------------------------------
 
-#endif
 SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                                   h_tendency, z_tendency,        & 
                                   ru, rv, rom,                   &
@@ -9735,7 +10414,7 @@ PROGRAM feeder
    INTEGER :: time_step, im
    INTEGER :: i, j, k, n, loop
 
-   config_flags%scalar_adv_opt = 2
+   config_flags%scalar_adv_opt = 3
 
    PRINT *,'Init dimensions'
    ids = 1; ide = 91; jds = 1; jde = 3; kds = 1; kde =10 
@@ -9910,6 +10589,33 @@ PROGRAM feeder
                                     ids, ide, jds, jde, kds, kde, &
                                     ims, ime, jms, jme, kms, kme, &
                                     its, ite, jts, jte, kts, kte )
+         ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
+            CALL advect_scalar_weno ( field(ims,kms,jms,im), &
+                                   field_old(ims,kms,jms,im), &
+                                   tendency(ims,kms,jms), &
+                             ru, rv, rom,                   &
+                             mut, time_step, config_flags,  &
+                             msfux, msfuy, msfvx, msfvy,    &
+                             msftx, msfty,                  &
+                             fzm, fzp,                      &
+                             rdx, rdy, rdzw,                &
+                             ids, ide, jds, jde, kds, kde,  &
+                             ims, ime, jms, jme, kms, kme,  &
+                             its, ite, jts, jte, kts, kte  )
+         ELSE IF (config_flags%scalar_adv_opt .EQ. 4 ) THEN
+            CALL advect_scalar_wenopd ( field(ims,kms,jms,im), &
+                                        field_old(ims,kms,jms,im), &
+                                        tendency(ims,kms,jms), &
+                                ru, rv, rom,                   &
+                                mut, mub, mu_old,              &
+                                time_step, config_flags,       &
+                                msfux, msfuy, msfvx, msfvy,    &
+                                msftx, msfty,                  &
+                                fzm, fzp,                      &
+                                rdx, rdy, rdzw, dt,            &
+                                ids, ide, jds, jde, kds, kde,  &
+                                ims, ime, jms, jme, kms, kme,  &
+                                its, ite, jts, jte, kts, kte  )
          END IF
          DO n = 1 , MAX_SCALARS
             field(:,:,:,n) = field_old(:,:,:,n) + dt * ( tendency(:,:,:) )
@@ -9953,6 +10659,10 @@ PROGRAM feeder
       print *,'set title "PD Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 2 ) THEN
       print *,'set title "Mono Advection" font ",20"'
+   ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
+      print *,'set title "WENO Advection" font ",20"'
+   ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
+      print *,'set title "WENO PD Advection" font ",20"'
    END IF
    print *,"set yrange[-20:120]"
    print *,"plot [0:90] '000000.txt' with lines , '000200.txt' with lines , '000400.txt' with lines , '000600.txt' with lines , '000800.txt' with lines , '001000.txt' with lines "
@@ -9961,685 +10671,6 @@ PROGRAM feeder
 END PROGRAM feeder
 #endif
 #if ( !defined(ADVECT_KERNEL) )
-
-SUBROUTINE advect_scalar_weno ( field, field_old, tendency,     &
-                             ru, rv, rom,                   &
-                             mut, time_step, config_flags,  &
-                             msfux, msfuy, msfvx, msfvy,    &
-                             msftx, msfty,                  &
-                             fzm, fzp,                      &
-                             rdx, rdy, rdzw,                &
-                             ids, ide, jds, jde, kds, kde,  &
-                             ims, ime, jms, jme, kms, kme,  &
-                             its, ite, jts, jte, kts, kte  )
-!
-! 5th-order WENO (Weighted Essentially Non-Oscillatory) scheme adapted from COMMAS.  
-! See Jiang and Shu, 1996, J. Comp. Phys. v. 126, 202-223; 
-! Shu 2003, Int. J. Comp. Fluid Dyn. v. 17 107-118;  Also used by Bryan 2005, Mon. Wea. Rev.
-!
-   IMPLICIT NONE
-   
-   ! Input data
-   
-   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
-
-   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
-                                              ims, ime, jms, jme, kms, kme, &
-                                              its, ite, jts, jte, kts, kte
-   
-   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
-                                                                      field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
-                                                                      rom
-
-   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut
-   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
-
-   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
-                                                                    msfuy,  &
-                                                                    msfvx,  &
-                                                                    msfvy,  &
-                                                                    msftx,  &
-                                                                    msfty
-
-   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
-                                                                  fzp,  &
-                                                                  rdzw
-
-   REAL ,                                        INTENT(IN   ) :: rdx,  &
-                                                                  rdy
-   INTEGER ,                                     INTENT(IN   ) :: time_step
-
-
-   ! Local data
-   
-   INTEGER :: i, j, k, itf, jtf, ktf
-   INTEGER :: i_start, i_end, j_start, j_end
-   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
-   INTEGER :: jmin, jmax, jp, jm, imin, imax
-
-   INTEGER , PARAMETER :: is=0, js=0, ks=0
-
-   REAL    :: mrdx, mrdy, ub, vb, vw
-   REAL , DIMENSION(its:ite, kts:kte) :: vflux
-
-
-   REAL,  DIMENSION( its-is:ite+1, kts:kte  ) :: fqx
-!   REAL,  DIMENSION( its:ite+1, kts:kte  ) :: fqx
-   REAL,  DIMENSION( its:ite, kts:kte, 2 ) :: fqy
-
-   INTEGER :: horz_order, vert_order
-   
-   LOGICAL :: degrade_xs, degrade_ys
-   LOGICAL :: degrade_xe, degrade_ye
-
-   INTEGER :: jp1, jp0, jtmp
-
-    real            :: dir, vv
-    real            :: ue,uw,vs,vn,wb,wt
-    real, parameter :: f30 =  7./12., f31 = 1./12.
-    real, parameter :: f50 = 37./60., f51 = 2./15., f52 = 1./60.
-
-
-   integer kt,kb
-   
-    
-    real               :: qim2, qim1, qi, qip1, qip2
-    double precision               :: beta0, beta1, beta2, f0, f1, f2, wi0, wi1, wi2, sumwk
-    double precision, parameter    :: gi0 = 1.d0/10.d0, gi1 = 6.d0/10.d0, gi2 = 3.d0/10.d0, eps=1.0d-28
-    integer, parameter :: pw = 2
-
-
-! definition of flux operators, 3rd, 4th, 5th or 6th order
-
-   REAL    :: flux3, flux4, flux5, flux6
-   REAL    :: q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua, vel
-
-      flux4(q_im2, q_im1, q_i, q_ip1, ua) =                     &
-            (7./12.)*(q_i + q_im1) - (1./12.)*(q_ip1 + q_im2)
-
-      flux3(q_im2, q_im1, q_i, q_ip1, ua) =                     &
-           flux4(q_im2, q_im1, q_i, q_ip1, ua) +                &
-           sign(1.,ua)*(1./12.)*((q_ip1 - q_im2)-3.*(q_i-q_im1))
-
-      flux6(q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua) =       &
-            (37./60.)*(q_i+q_im1) - (2./15.)*(q_ip1+q_im2)      &
-            +(1./60.)*(q_ip2+q_im3)
-
-      flux5(q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua) =       &
-           flux6(q_im3, q_im2, q_im1, q_i, q_ip1, q_ip2, ua)    &
-            -sign(1,time_step)*sign(1.,ua)*(1./60.)*(           &
-              (q_ip2-q_im3)-5.*(q_ip1-q_im2)+10.*(q_i-q_im1) )
-
-   LOGICAL :: specified
-
-   specified = .false.
-   if(config_flags%specified .or. config_flags%nested) specified = .true.
-
-! set order for the advection schemes
-
-  ktf=MIN(kte,kde-1)
-  horz_order = 5 ! config_flags%h_sca_adv_order
-  vert_order = 5 ! config_flags%v_sca_adv_order
-
-!  begin with horizontal flux divergence
-!  here is the choice of flux operators
-
-
-
-  IF( horz_order == 5 ) THEN
-
-!  determine boundary mods for flux operators
-!  We degrade the flux operators from 3rd/4th order
-!   to second order one gridpoint in from the boundaries for
-!   all boundary conditions except periodic and symmetry - these
-!   conditions have boundary zone data fill for correct application
-!   of the higher order flux stencils
-
-   degrade_xs = .true.
-   degrade_xe = .true.
-   degrade_ys = .true.
-   degrade_ye = .true.
-
-   IF( config_flags%periodic_x   .or. &
-       config_flags%symmetric_xs .or. &
-       (its > ids+3)                ) degrade_xs = .false.
-   IF( config_flags%periodic_x   .or. &
-       config_flags%symmetric_xe .or. &
-       (ite < ide-3)                ) degrade_xe = .false.
-   IF( config_flags%periodic_y   .or. &
-       config_flags%symmetric_ys .or. &
-       (jts > jds+3)                ) degrade_ys = .false.
-   IF( config_flags%periodic_y   .or. &
-       config_flags%symmetric_ye .or. &
-       (jte < jde-4)                ) degrade_ye = .false.
-
-!--------------- y - advection first
-
-      ktf=MIN(kte,kde-1)
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-
-
-! check for U
-      IF ( is == 1 ) THEN
-        i_start = its
-        i_end   = ite
-        IF ( config_flags%open_xs .or. specified ) i_start = MAX(ids+1,its)
-        IF ( config_flags%open_xe .or. specified ) i_end   = MIN(ide-1,ite)
-        IF ( config_flags%periodic_x ) i_start = its
-        IF ( config_flags%periodic_x ) i_end = ite
-      ENDIF
-
-      j_start = jts
-      j_end   = MIN(jte,jde-1)
-
-!  higher order flux has a 5 or 7 point stencil, so compute
-!  bounds so we can switch to second order flux close to the boundary
-
-      j_start_f = j_start
-      j_end_f   = j_end+1
-
-      IF(degrade_ys) then
-        j_start = MAX(jts,jds+1)
-        j_start_f = jds+3
-      ENDIF
-
-      IF(degrade_ye) then
-        j_end = MIN(jte,jde-2)
-        j_end_f = jde-3
-      ENDIF
-
-      IF(config_flags%polar) j_end = MIN(jte,jde-1)
-
-!  compute fluxes, 5th or 6th order
-
-     jp1 = 2
-     jp0 = 1
-
-     j_loop_y_flux_5 : DO j = j_start, j_end+1
-
-      IF( (j >= j_start_f ) .and. (j <= j_end_f) ) THEN ! use full stencil
-
-        DO k=kts,ktf
-        DO i = i_start, i_end
-!          vel = rv(i,k,j)
-          vel = 0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )
-
-         IF ( vel .ge. 0.0 ) THEN
-            qip2 = field(i,k,j+1)
-            qip1 = field(i,k,j  )
-            qi   = field(i,k,j-1)
-            qim1 = field(i,k,j-2)
-            qim2 = field(i,k,j-3)
-          ELSE
-            qip2 = field(i,k,j-2)
-            qip1 = field(i,k,j-1)
-            qi   = field(i,k,j  )
-            qim1 = field(i,k,j+1)
-            qim2 = field(i,k,j+2)
-         ENDIF
-    
-         f0 =  1./3.*qim2 - 7./6.*qim1 + 11./6.*qi
-         f1 = -1./6.*qim1 + 5./6.*qi   + 1./3. *qip1
-         f2 =  1./3.*qi   + 5./6.*qip1 - 1./6. *qip2
-    
-         beta0 = 13./12.*(qim2 - 2.*qim1 + qi  )**2 + 1./4.*(qim2 - 4.*qim1 + 3.*qi)**2
-         beta1 = 13./12.*(qim1 - 2.*qi   + qip1)**2 + 1./4.*(qim1 - qip1)**2
-         beta2 = 13./12.*(qi   - 2.*qip1 + qip2)**2 + 1./4.*(qip2 - 4.*qip1 + 3.*qi)**2
-    
-         wi0 = gi0 / (eps + beta0)**pw
-         wi1 = gi1 / (eps + beta1)**pw
-         wi2 = gi2 / (eps + beta2)**pw
-    
-         sumwk = wi0 + wi1 + wi2
-    
-          fqy( i, k, jp1 ) = vel * (wi0*f0 + wi1*f1 + wi2*f2) / sumwk
-
-!          fqy( i, k, jp1 ) = vel*flux5(                                &
-!                  field(i,k,j-3), field(i,k,j-2), field(i,k,j-1),       &
-!                  field(i,k,j  ), field(i,k,j+1), field(i,k,j+2),  vel )
-        ENDDO
-        ENDDO
-
-
-      ELSE IF ( j == jds+1 ) THEN   ! 2nd order flux next to south boundary
-
-            DO k=kts,ktf
-            DO i = i_start, i_end
-              fqy(i,k, jp1) = 0.5*rv(i,k,j)*          &
-!              fqy(i,k, jp1) = 0.5*0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )*          &
-                     (field(i,k,j)+field(i,k,j-1))
-
-            ENDDO
-            ENDDO
-
-     ELSE IF  ( j == jds+2 ) THEN  ! third of 4th order flux 2 in from south boundary
-
-            DO k=kts,ktf
-            DO i = i_start, i_end
-!              vel = 0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )
-              vel = rv(i,k,j)
-              fqy( i, k, jp1 ) = vel*flux3(              &
-                   field(i,k,j-2),field(i,k,j-1),field(i,k,j),field(i,k,j+1),vel )
-            ENDDO
-            ENDDO
-
-     ELSE IF ( j == jde-1 ) THEN  ! 2nd order flux next to north boundary
-
-            DO k=kts,ktf
-            DO i = i_start, i_end
-!              fqy(i, k, jp1) = 0.5*0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )*      &
-              fqy(i, k, jp1) = 0.5*rv(i,k,j)*      &
-                     (field(i,k,j)+field(i,k,j-1))
-            ENDDO
-            ENDDO
-
-     ELSE IF ( j == jde-2 ) THEN  ! 3rd or 4th order flux 2 in from north boundary
-
-            DO k=kts,ktf
-            DO i = i_start, i_end
-              vel = rv(i,k,j)
-!              vel = 0.5*( rv(i,k,j) + rv(i-is,k-ks,j-js) )
-              fqy( i, k, jp1) = vel*flux3(             &
-                   field(i,k,j-2),field(i,k,j-1),    &
-                   field(i,k,j),field(i,k,j+1),vel )
-            ENDDO
-            ENDDO
-
-     ENDIF
-
-!  y flux-divergence into tendency
-
-      IF ( is == 0 ) THEN
-        ! Comments on polar boundary conditions
-        ! Same process as for advect_u - tendencies run from jds to jde-1 
-        ! (latitudes are as for u grid, longitudes are displaced)
-        ! Therefore: flow is only from one side for points next to poles
-        IF ( config_flags%polar .AND. (j == jds+1) ) THEN
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdy=msftx(i,j-1)*rdy     ! see ADT eqn 48 [rho->rho*q] dividing by my, 2nd term RHS
-            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*fqy(i,k,jp1)
-          END DO
-          END DO
-        ELSE IF( config_flags%polar .AND. (j == jde) ) THEN
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdy=msftx(i,j-1)*rdy     ! see ADT eqn 48 [rho->rho*q] dividing by my, 2nd term RHS
-            tendency(i,k,j-1) = tendency(i,k,j-1) + mrdy*fqy(i,k,jp0)
-          END DO
-          END DO
-        ELSE  ! normal code
-
-        IF(j > j_start) THEN
-
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdy=msftx(i,j-1)*rdy    ! see ADT eqn 48 [rho->rho*q] dividing by my, 2nd term RHS
-            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*(fqy(i,k,jp1)-fqy(i,k,jp0))
-          ENDDO
-          ENDDO
-
-        ENDIF
-        ENDIF
-       ELSEIF ( is == 1 ) THEN
-
-        ! (j > j_start) will miss the u(,,jds) tendency
-        IF ( config_flags%polar .AND. (j == jds+1) ) THEN
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdy=msfux(i,j-1)*rdy   ! ADT eqn 44, 2nd term on RHS
-            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*fqy(i,k,jp1)
-          END DO
-          END DO
-        ! This would be seen by (j > j_start) but we need to zero out the NP tendency
-        ELSE IF( config_flags%polar .AND. (j == jde) ) THEN
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdy=msfux(i,j-1)*rdy   ! ADT eqn 44, 2nd term on RHS
-            tendency(i,k,j-1) = tendency(i,k,j-1) + mrdy*fqy(i,k,jp0)
-          END DO
-          END DO
-        ELSE  ! normal code
-
-        IF(j > j_start) THEN
-
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdy=msfux(i,j-1)*rdy   ! ADT eqn 44, 2nd term on RHS
-            tendency(i,k,j-1) = tendency(i,k,j-1) - mrdy*(fqy(i,k,jp1)-fqy(i,k,jp0))
-          ENDDO
-          ENDDO
-
-        ENDIF
-
-        END IF
-       
-       ENDIF
-
-        jtmp = jp1
-        jp1 = jp0
-        jp0 = jtmp
-
-      ENDDO j_loop_y_flux_5
-
-!  next, x - flux divergence
-
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-
-      j_start = jts
-      j_end   = MIN(jte,jde-1)
-
-!  higher order flux has a 5 or 7 point stencil, so compute
-!  bounds so we can switch to second order flux close to the boundary
-
-      i_start_f = i_start
-      i_end_f   = i_end+1
-
-      IF(degrade_xs) then
-        i_start = MAX(ids+1,its)
-!        i_start_f = i_start+2
-        i_start_f = MIN(i_start+2,ids+3)
-      ENDIF
-
-      IF(degrade_xe) then
-        i_end = MIN(ide-2,ite)
-        i_end_f = ide-3
-      ENDIF
-
-!  compute fluxes
-
-      DO j = j_start, j_end
-
-!  5th or 6th order flux
-
-        DO k=kts,ktf
-        DO i = i_start_f, i_end_f
-!          vel = ru(i,k,j)
-          vel = 0.5*( ru(i,k,j) + ru(i-is,k-ks,j-js) )
-
-
-         IF ( vel .ge. 0.0 ) THEN
-            qip2 = field(i+1,k,j)
-            qip1 = field(i,  k,j)
-            qi   = field(i-1,k,j)
-            qim1 = field(i-2,k,j)
-            qim2 = field(i-3,k,j)
-          ELSE
-            qip2 = field(i-2,k,j)
-            qip1 = field(i-1,k,j)
-            qi   = field(i,  k,j)
-            qim1 = field(i+1,k,j)
-            qim2 = field(i+2,k,j)
-         ENDIF
-    
-         f0 =  1./3.*qim2 - 7./6.*qim1 + 11./6.*qi
-         f1 = -1./6.*qim1 + 5./6.*qi   + 1./3. *qip1
-         f2 =  1./3.*qi   + 5./6.*qip1 - 1./6. *qip2
-    
-         beta0 = 13./12.*(qim2 - 2.*qim1 + qi  )**2 + 1./4.*(qim2 - 4.*qim1 + 3.*qi)**2
-         beta1 = 13./12.*(qim1 - 2.*qi   + qip1)**2 + 1./4.*(qim1 - qip1)**2
-         beta2 = 13./12.*(qi   - 2.*qip1 + qip2)**2 + 1./4.*(qip2 - 4.*qip1 + 3.*qi)**2
-    
-         wi0 = gi0 / (eps + beta0)**pw
-         wi1 = gi1 / (eps + beta1)**pw
-         wi2 = gi2 / (eps + beta2)**pw
-    
-         sumwk = wi0 + wi1 + wi2
-    
-         fqx(i,k) = vel * (wi0*f0 + wi1*f1 + wi2*f2) / sumwk
-
-!          fqx( i,k ) = vel*flux5( field(i-3,k,j), field(i-2,k,j),  &
-!                                         field(i-1,k,j), field(i  ,k,j),  &
-!                                         field(i+1,k,j), field(i+2,k,j),  &
-!                                         vel                             )
-        ENDDO
-        ENDDO
-
-!  lower order fluxes close to boundaries (if not periodic or symmetric)
-
-        IF( degrade_xs ) THEN
-
-          DO i=i_start,i_start_f-1
-
-            IF(i == ids+1) THEN ! second order
-              DO k=kts,ktf
-                fqx(i,k) = 0.5*(ru(i,k,j)) &
-                       *(field(i,k,j)+field(i-1,k,j))
-              ENDDO
-            ENDIF
-
-            IF(i == ids+2) THEN  ! third order
-              DO k=kts,ktf
-                vel = ru(i,k,j)
-                fqx( i,k ) = vel*flux3( field(i-2,k,j), field(i-1,k,j),  &
-                                              field(i  ,k,j), field(i+1,k,j),  &
-                                              vel                     )
-              ENDDO
-            END IF
-
-          ENDDO
-
-        ENDIF
-
-        IF( degrade_xe ) THEN
-
-          DO i = i_end_f+1, i_end+1
-
-            IF( i == ide-1 ) THEN ! second order flux next to the boundary
-              DO k=kts,ktf
-                fqx(i,k) = 0.5*(ru(i,k,j))      &
-                       *(field(i,k,j)+field(i-1,k,j))
-              ENDDO
-           ENDIF
-
-           IF( i == ide-2 ) THEN ! third order flux one in from the boundary
-             DO k=kts,ktf
-               vel = ru(i,k,j)
-               fqx( i,k ) = vel*flux3( field(i-2,k,j), field(i-1,k,j),  &
-                                       field(i  ,k,j), field(i+1,k,j),  &
-                                       vel                             )
-             ENDDO
-           ENDIF
-
-         ENDDO
-
-       ENDIF
-
-!  x flux-divergence into tendency
-
-       IF ( is == 0 ) THEN
-          DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdx=msftx(i,j)*rdx      ! see ADT eqn 48 [rho->rho*q] dividing by my, 1st term RHS
-            tendency(i,k,j) = tendency(i,k,j) - mrdx*(fqx(i+1,k)-fqx(i,k))
-          ENDDO
-          ENDDO
-       ELSEIF ( is == 1 ) THEN
-        DO k=kts,ktf
-          DO i = i_start, i_end
-            mrdx=msfux(i,j)*rdx ! ADT eqn 44, 1st term on RHS
-            tendency(i,k,j) = tendency(i,k,j) - mrdx*(fqx(i+1,k)-fqx(i,k))
-          ENDDO
-        ENDDO
-       ENDIF
-
-      ENDDO
-
-
-   ENDIF
-   
-
-!  pick up the rest of the horizontal radiation boundary conditions.
-!  (these are the computations that don't require 'cb'.
-!  first, set to index ranges
-
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-      j_start = jts
-      j_end   = MIN(jte,jde-1)
-
-!  compute x (u) conditions for v, w, or scalar
-
-   IF( (config_flags%open_xs) .and. (its == ids) ) THEN
-
-       DO j = j_start, j_end
-       DO k = kts, ktf
-         ub = MIN( 0.5*(ru(its,k,j)+ru(its+1,k,j)), 0. )
-         tendency(its,k,j) = tendency(its,k,j)                     &
-               - rdx*(                                             &
-                       ub*(   field_old(its+1,k,j)                 &
-                            - field_old(its  ,k,j)   ) +           &
-                       field(its,k,j)*(ru(its+1,k,j)-ru(its,k,j))  &
-                                                                )
-       ENDDO
-       ENDDO
-
-   ENDIF
-
-   IF( (config_flags%open_xe) .and. (ite == ide) ) THEN
-
-       DO j = j_start, j_end
-       DO k = kts, ktf
-         ub = MAX( 0.5*(ru(ite-1,k,j)+ru(ite,k,j)), 0. )
-         tendency(i_end,k,j) = tendency(i_end,k,j)                   &
-               - rdx*(                                               &
-                       ub*(  field_old(i_end  ,k,j)                  &
-                           - field_old(i_end-1,k,j) ) +              &
-                       field(i_end,k,j)*(ru(ite,k,j)-ru(ite-1,k,j))  &
-                                                                    )
-       ENDDO
-       ENDDO
-
-   ENDIF
-
-   IF( (config_flags%open_ys) .and. (jts == jds) ) THEN
-
-       DO i = i_start, i_end
-       DO k = kts, ktf
-         vb = MIN( 0.5*(rv(i,k,jts)+rv(i,k,jts+1)), 0. )
-         tendency(i,k,jts) = tendency(i,k,jts)                     &
-               - rdy*(                                             &
-                       vb*(  field_old(i,k,jts+1)                  &
-                           - field_old(i,k,jts  ) ) +              &
-                       field(i,k,jts)*(rv(i,k,jts+1)-rv(i,k,jts))  &
-                                                                )
-       ENDDO
-       ENDDO
-
-   ENDIF
-
-   IF( (config_flags%open_ye) .and. (jte == jde)) THEN
-
-       DO i = i_start, i_end
-       DO k = kts, ktf
-         vb = MAX( 0.5*(rv(i,k,jte-1)+rv(i,k,jte)), 0. )
-         tendency(i,k,j_end) = tendency(i,k,j_end)                   &
-               - rdy*(                                               &
-                       vb*(   field_old(i,k,j_end  )                 &
-                            - field_old(i,k,j_end-1) ) +             &
-                       field(i,k,j_end)*(rv(i,k,jte)-rv(i,k,jte-1))  &
-                                                                    )
-       ENDDO
-       ENDDO
-
-   ENDIF
-
-
-!-------------------- vertical advection
-!     Scalar equation has 3rd term on RHS = - partial d/dz (q rho w /my)
-!     Here we have: - partial d/dz (q*rom) = - partial d/dz (q rho w / my)
-!     So we don't need to make a correction for advect_scalar
-
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-      j_start = jts
-      j_end   = MIN(jte,jde-1)
-
-      DO i = i_start, i_end
-         vflux(i,kts)=0.
-         vflux(i,kte)=0.
-      ENDDO
-
-
-
-      DO j = j_start, j_end
-
-         DO k=kts+3,ktf-2
-         DO i = i_start, i_end
-!           vel = rom(i,k,j)
-           vel = 0.5*( rom(i,k,j) + rom(i-is,k-ks,j-js) )
-
-         IF( -vel .ge. 0.0 ) THEN
-            qip2 = field(i,k+1,j)
-            qip1 = field(i,k  ,j)
-            qi   = field(i,k-1,j)
-            qim1 = field(i,k-2,j)
-            qim2 = field(i,k-3,j)
-          ELSE
-            qip2 = field(i,k-2,j)
-            qip1 = field(i,k-1,j)
-            qi   = field(i,k  ,j)
-            qim1 = field(i,k+1,j)
-            qim2 = field(i,k+2,j)
-         ENDIF
-    
-         f0 =  1./3.*qim2 - 7./6.*qim1 + 11./6.*qi
-         f1 = -1./6.*qim1 + 5./6.*qi   + 1./3. *qip1
-         f2 =  1./3.*qi   + 5./6.*qip1 - 1./6. *qip2
-    
-         beta0 = 13./12.*(qim2 - 2.*qim1 + qi  )**2 + 1./4.*(qim2 - 4.*qim1 + 3.*qi)**2
-         beta1 = 13./12.*(qim1 - 2.*qi   + qip1)**2 + 1./4.*(qim1 - qip1)**2
-         beta2 = 13./12.*(qi   - 2.*qip1 + qip2)**2 + 1./4.*(qip2 - 4.*qip1 + 3.*qi)**2
-    
-         wi0 = gi0 / (eps + beta0)**pw
-         wi1 = gi1 / (eps + beta1)**pw
-         wi2 = gi2 / (eps + beta2)**pw
-    
-         sumwk = wi0 + wi1 + wi2
-    
-          vflux(i,k) = vel * (wi0*f0 + wi1*f1 + wi2*f2) / sumwk
-
-!           vflux(i,k) = vel*flux5(                                 &
-!                   field(i,k-3,j), field(i,k-2,j), field(i,k-1,j),       &
-!                   field(i,k  ,j), field(i,k+1,j), field(i,k+2,j),  -vel )
-         ENDDO
-         ENDDO
-
-         DO i = i_start, i_end
-
-           k=kts+1
-           vflux(i,k)=rom(i,k,j)*(fzm(k)*field(i,k,j)+fzp(k)*field(i,k-1,j))
-                                   
-           k = kts+2
-           vel=rom(i,k,j) 
-           vflux(i,k) = vel*flux3(               &
-                   field(i,k-2,j), field(i,k-1,j),   &
-                   field(i,k  ,j), field(i,k+1,j), -vel )
-           k = ktf-1
-           vel=rom(i,k,j)
-           vflux(i,k) = vel*flux3(               &
-                   field(i,k-2,j), field(i,k-1,j),   &
-                   field(i,k  ,j), field(i,k+1,j), -vel )
-
-           k=ktf
-           vflux(i,k)=rom(i,k,j)*(fzm(k)*field(i,k,j)+fzp(k)*field(i,k-1,j))
-         ENDDO
-
-         DO k=kts,ktf
-         DO i = i_start, i_end
-            tendency(i,k,j)=tendency(i,k,j)-rdzw(k)*(vflux(i,k+1)-vflux(i,k))
-         ENDDO
-         ENDDO
-
-      ENDDO
-
-
-
-END SUBROUTINE advect_scalar_weno
 
 !---------------------------------------------------------------------------------
 


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: advection, kernel, WENO

### SOURCE: internal

### DESCRIPTION OF CHANGES:
Two changes in dyn_em/module_advect_em.F
1. Re-order the subroutines inside the file.  This makes no changes to the
results, of course.  Importantly, this re-arrangement allows simple cpp directives to build source code subset that has a module that is textually prior to a main program.  Since the subroutines
for WENO and WENO+PD scalar advection came after the original main program in the
kernel, they need to be moved.  With the code re-arrangement, the cpp directives allow source
code for an executable kernel to be built successfully.
2. The advection kernel is modified to allow the use of scalar advection
options:
* 0: standard advection
* 1: Positive Definite
* 2: PD + Monotonic
* 3: Weighted Essentially Non Oscillatory
* 4: WENO + PD

### LIST OF MODIFIED FILES:
M       dyn_em/module_advect_em.F

### TESTS CONDUCTED:
1. The code built normally
2. The advection kernel manufactured reasonable looking plots.