### PR TITLE
Fix a bug introduced in the af26bfb commit.

### DIFF
--- a/var/da/da_transfer_model/da_transfer_model.f90
+++ b/var/da/da_transfer_model/da_transfer_model.f90
@@ -42,7 +42,7 @@ module da_transfer_model
       its,ite,jts,jte,kts,kte, ips,ipe,jps,jpe,kps,kpe, qlimit, &
       update_sfcdiags, use_wrf_sfcinfo
    use da_control, only: base_pres_strat, base_lapse_strat
-   use da_control, only: c1h, c2h, c3f, c3h, c4f, c4h
+   use da_control, only: c1f, c2f, c1h, c2h, c3f, c3h, c4f, c4h
    use da_define_structures, only : xbx_type, be_type
    use da_par_util, only : da_patch_to_global
    use da_physics, only : da_check_rh_simple,da_roughness_from_lanu, &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, use statement, c1f

SOURCE: internal

DESCRIPTION OF CHANGES:
When the proposed code was modified to change c1h to c1f per review comments,
c1f should have been added in the use statement in var/da/da_transfer_model/da_transfer_model.f90.

LIST OF MODIFIED FILES:
M       var/da/da_transfer_model/da_transfer_model.f90

TESTS CONDUCTED:
WRFDA compiles after the fix.