### PR TITLE
Make ARW ocean coupler flexible

### DIFF
--- a/frame/module_cpl.F
+++ b/frame/module_cpl.F
@@ -437,7 +437,7 @@ CONTAINS
       DO jext = 1, max_edom
          lltorcv = lltorcv .OR. cpl_toreceive( kdomwrf, jext, ifldid )
       END DO
-      IF( lltorcv == .false. ) return
+      IF( .not.lltorcv ) return
          
       IF( PRESENT(pdataobs) ) THEN
          pdatacpl(ips:ipe,jps:jpe) = pdataobs(ips:ipe,jps:jpe) * ( 1.0 - SUM( pcplmask(ips:ipe,1:max_edom,jps:jpe), dim = 2 ) )


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: ARW ocean coupler interface

SOURCE: Sebastien Masson, LOCEAN - IPSL, Univ. Pierre et Marie Curie, France

DESCRIPTION OF CHANGES: To accommodate users who may not want to couple all variables.

LIST OF MODIFIED FILES:

frame/module_cpl.F

TESTS CONDUCTED: reg tested.