### PR TITLE
CPP syntax fix in NSSL 2 MOM scheme

### DIFF
--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -1537,7 +1537,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
                               its,ite, jts,jte, kts,kte)                                   ! tile dims
 
 
-#ifdef ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )
+#if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )
 #define MPI
       USE module_dm, ONLY : &
          local_communicator, mytask


### PR DESCRIPTION
either this one XOR #91 
### TYPE: bug fix

### KEYWORDS: cpp, NSSL, defined

### SOURCE: internal

### DESCRIPTION OF CHANGES: 

The cpp syntax when using an AND operator is
```#if defined(THING1) && defined(THING2)```

The original code had
```#ifdef defined(THING1) && defined(THING2)```

This caused CPP errors to be thrown during the build.  Even though the source code looks to have been built correctly, the build log had the special "_Error_" string which will always cause users (and therefore, wrfhelp) trouble.

### LIST OF MODIFIED FILES:
M       phys/module_mp_nssl_2mom.F

### TESTS CONDUCTED:
1. Code compiles cleanly