### PR TITLE
Remove MPI ifdef checks in NSSL 2MOM

### DIFF
--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -1537,20 +1537,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
                               its,ite, jts,jte, kts,kte)                                   ! tile dims
 
 
-#if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )
-#define MPI
-      USE module_dm, ONLY : &
-         local_communicator, mytask
-! keep a spacing line here to keep Apple cpp from adding a space in front of the endif
-#endif
-
       implicit none
-
-#if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) ) || defined(MPI)
-      INCLUDE 'mpif.h'
-#else
-      integer :: mytask = 0
-#endif
 
  !Subroutine arguments:
 
@@ -1660,15 +1647,6 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
       double precision :: timesed,timesed1,timesed2,timesed3, timegs, timenucond, timedbz,zmaxsed
       double precision :: timevtcalc,timesetvt
       
-#ifdef MPI
-
-#if defined(MPI) 
-      integer, parameter :: ntot = 50
-      double precision  mpitotindp(ntot), mpitotoutdp(ntot)
-      INTEGER :: mpi_error_code = 1
-#endif
-#endif
-
 
 ! -------------------------------------------------------------------
 
@@ -5780,9 +5758,7 @@ END SUBROUTINE nssl_2mom_driver
         kgs(ngscnt) = kz
         if ( ngscnt .eq. ngs ) goto 1100
         end if
-!#ifndef MPI
         end do !!ix
-!#endif
         nxmpb = 1
        end do !! kz
 


### PR DESCRIPTION
either this one XOR #87
### TYPE: enhancement

### KEYWORDS: NSSL, MPI

### SOURCE: internal

### DESCRIPTION OF CHANGES: 
There is no need to MPI at all in the module_mp_nssl_2mom.F file.  All of the several ifdef tests specifically for MPI processing are removed.

### LIST OF MODIFIED FILES: 
phys/module_mp_nssl_2mom.F

### TESTS CONDUCTED:
1. Code builds
