### PR TITLE
TYPO in module_diag_afwa.F

### DIFF
--- a/phys/module_diag_afwa.F
+++ b/phys/module_diag_afwa.F
@@ -2702,7 +2702,7 @@ CONTAINS
                                               ,           lidx
 
     REAL, INTENT(IN) ::                                     dt
-    LOGICAL, INTENT(IN) ::                        do_buoy_calc  &
+    LOGICAL, INTENT(IN) ::                        do_buoy_calc
 
     ! Local
     ! -----


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile

SOURCE: internal

DESCRIPTION OF CHANGES:
Accidentally left an ampersand on the end of a line.  Removed the
ampersand, now the code compiles.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
phys/module_diag_afwa.F

TESTS CONDUCTED:
1. Code did not compile before, and compiles after change.