### PR TITLE
Fix failures for IASI radiance assimilation with PGI compiler

### DIFF
--- a/var/da/da_radiance/da_qc_iasi.inc
+++ b/var/da/da_radiance/da_qc_iasi.inc
@@ -14,8 +14,7 @@ subroutine da_qc_iasi (it, i, nchan, ob, iv)
 
 
    ! local variables
-   logical   :: lmix,lcould_read
-   real    :: satzen
+   logical   :: lmix
    integer   :: n,k,isflg,ios,fgat_rad_unit,sensor_id
    integer :: scanpos
    integer   :: ngood(nchan),nrej(nchan),nrej_omb_abs(nchan), &
@@ -23,13 +22,12 @@ subroutine da_qc_iasi (it, i, nchan, ob, iv)
                 nrej_landsurface,nrej_windowchshort,nrej_windowchlong,    &
                 nrej_clw,nrej_sst,nrej_eccloud, num_proc_domain, nrej_mixsurface
 
-   real      :: SST_model, SST_airs, SST_pred, diffSST, diffSST2
    real      :: inv_grosscheck
 
    character(len=30)  :: filename
 
    ! iasi Cloud Detection Variables
-   integer              :: kmin, kmax, ndim, iunit
+   integer              :: kmin, kmax, ndim
    integer, allocatable  :: k_cloud_flag(:) ! cloud flags   
    ! mmr Cloud Detection Variables
    integer              :: kts_100hPa(1), kte_surf,kts_200hPa(1)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, IASI, PGI

SOURCE: internal

DESCRIPTION OF CHANGES: In the `da_qc_iasi` routine, there is an extra, ambiguous "close(iunit)" statement at the end. Not only is this not paired with an equivalent "open(iunit)" statement, but iunit is not even defined in this subroutine! Yet, for some strange reason, the only compiler I can find that fails due to this is PGI 15.1.

Removing the rogue "close" statement fixes the error. In addition, I took this opportunity to remove a number of other variables in this subroutine that are declared but never defined or used, presumably due to copy-pasting of another routine as a template.

LIST OF MODIFIED FILES:
```
M       var/da/da_radiance/da_qc_iasi.inc
```

TESTS CONDUCTED: WRFDA regtest compiled with PGI 15.1 failed before this fix for IASI assimilation test. This fix, on top of the fix in PR #108, allows the test to run successfully. gfortran and intel tests did not exhibit this error, and show no impact. WRFDA Regression tests now all pass for PGI 15.1! (except for one known 4DVAR failure)
