### PR TITLE
Do not overwrite "run" directory namelist.input file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ em_fire : wrf
 	( cd test/em_fire ; /bin/sh create_links.sh )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_fire/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_fire/input_sounding . )
 	@echo "build started:   $(START_OF_COMPILE)"
@@ -188,7 +188,7 @@ em_quarter_ss : wrf
 	( cd test/em_quarter_ss ; /bin/rm -f termvels.asc ; ln -s ../../run/termvels.asc . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_quarter_ss/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_quarter_ss/input_sounding . )
 	@echo " "
@@ -221,7 +221,7 @@ em_squall2d_x : wrf
 	( cd test/em_squall2d_x ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_squall2d_x/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_squall2d_x/input_sounding . )
 	@echo "build started:   $(START_OF_COMPILE)"
@@ -256,7 +256,7 @@ em_squall2d_y : wrf
 	( cd test/em_squall2d_y ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_squall2d_y/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_squall2d_y/input_sounding . )
 	@echo " "
@@ -289,7 +289,7 @@ em_b_wave : wrf
 	( cd test/em_b_wave ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_b_wave/namelist.input . )
 	( cd run ; /bin/rm -f input_jet ; ln -s ../test/em_b_wave/input_jet . )
 	@echo " "
@@ -322,7 +322,7 @@ em_les : wrf
 	( cd test/em_les ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_les/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_les/input_sounding . )
 	@echo " "
@@ -355,7 +355,7 @@ em_seabreeze2d_x : wrf
 	( cd test/em_seabreeze2d_x ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_seabreeze2d_x/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_seabreeze2d_x/input_sounding . )
 	@echo " "
@@ -386,7 +386,7 @@ em_convrad : wrf
 	( cd test/em_convrad ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_convrad/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_convrad/input_sounding . )
 	@echo "build started:   $(START_OF_COMPILE)"
@@ -402,7 +402,7 @@ em_tropical_cyclone : wrf
 	( cd test/em_tropical_cyclone ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_tropical_cyclone/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_tropical_cyclone/input_sounding . )
 	@echo " "
@@ -435,7 +435,7 @@ em_scm_xy : wrf
 	( cd test/em_scm_xy ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_scm_xy/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_scm_xy/input_sounding . )
 	@echo " "
@@ -601,7 +601,7 @@ em_real : wrf
 	( cd run ; /bin/rm -f ndown.exe ; ln -s ../main/ndown.exe . )
 	#TEMPORARILY REMOVED ( cd run ; /bin/rm -f nup.exe ; ln -s ../main/nup.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 	@echo " "
 	@echo "=========================================================================="
@@ -634,7 +634,7 @@ em_hill2d_x : wrf
 	( cd test/em_hill2d_x ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_hill2d_x/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_hill2d_x/input_sounding . )
 	@echo " "
@@ -667,7 +667,7 @@ em_grav2d_x : wrf
 	( cd test/em_grav2d_x ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_grav2d_x/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_grav2d_x/input_sounding . )
 	@echo " "
@@ -700,7 +700,7 @@ em_heldsuarez : wrf
 	( cd test/em_heldsuarez ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_heldsuarez/namelist.input . )
 	@echo " "
 	@echo "=========================================================================="
@@ -730,7 +730,7 @@ emi_conv : wrf
 	( cd test/em_real ; /bin/rm -f convert_emiss.exe ; ln -s ../../chem/convert_emiss.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 #### emissions opt 3 converter
@@ -741,7 +741,7 @@ opt3_conv : wrf
 	( cd test/em_real ; /bin/rm -f convert_fireemiss.exe ; ln -s ../../chem/convert_fireemiss.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 #### biogenic emissions converter
@@ -752,7 +752,7 @@ bio_conv : wrf
 	( cd test/em_real ; /bin/rm -f convert_bioemiss.exe ; ln -s ../../chem/convert_bioemiss.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 bioemiss_conv_megan2 : wrf
@@ -761,7 +761,7 @@ bioemiss_conv_megan2 : wrf
 	( cd test/em_real ; /bin/rm -f convert_bioemiss_megan2.exe ; ln -s ../../chem/convert_bioemiss_megan2.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-	        /bin/cp -f namelist.input namelist.input.backup ; fi ; \
+	        /bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 	        /bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 #### DMS emissions converter
@@ -772,7 +772,7 @@ dms_conv : wrf
 	( cd test/em_real ; /bin/rm -f convert_dms.exe ; ln -s ../../chem/convert_dms.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 
@@ -784,7 +784,7 @@ dust_conv : wrf
 	( cd test/em_real ; /bin/rm -f convert_dust.exe ; ln -s ../../chem/convert_dust.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 #### GOCART background state for oh, no3 and h2o2 converter
@@ -795,7 +795,7 @@ gocart_conv : wrf
 	( cd test/em_real ; /bin/rm -f convert_gocart.exe ; ln -s ../../chem/convert_gocart.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_real/namelist.input . )
 
 
@@ -810,7 +810,7 @@ nmm_tropical_cyclone : nmm_wrf
 	( cd test/nmm_tropical_cyclone ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd run ; /bin/rm -f ideal.exe ; ln -s ../main/ideal.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/nmm_tropical_cyclone/namelist.input . )
 	@echo "build started:   $(START_OF_COMPILE)"
 	@echo "build completed:" `date`
@@ -843,7 +843,7 @@ nmm_real : nmm_wrf
 	( cd test/nmm_real ; /bin/rm -f co2_trans ; ln -s ../../run/co2_trans . )
 	( cd run ; /bin/rm -f real_nmm.exe ; ln -s ../main/real_nmm.exe . )
 	( cd run ; if test -f namelist.input ; then \
-		/bin/cp -f namelist.input namelist.input.backup ; fi ; \
+		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/nmm_real/namelist.input . )
 
 

--- a/clean
+++ b/clean
@@ -48,7 +48,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
   endif
   if ( "$arg" != '-aa' ) then
     ( cd run ; /bin/rm -f gm* out* fort* ideal* *.exe input_sounding ; \
-	  /bin/cp -f namelist.input namelist.input.backup ; \
+	  /bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; \
 	  /bin/rm -f namelist.input ) >& /dev/null
     ( cd test/exp_real ; /bin/rm -f gm* out* fort* real* )
     ( cd test ; rm -f */*.exe */ETAMPNEW_DATA* */GENPARM.TBL */LANDUSE.TBL */README.namelist \
@@ -67,7 +67,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
   else if ( "$arg" == '-aa' ) then
     /bin/rm -f configure.wrf.backup
     /bin/rm -f Registry/Registry.backup
-    /bin/rm -f run/namelist.input.backup
+    /bin/rm -f run/namelist.input.backup.*
   endif
 endif
 


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: namelist.input

### SOURCE: internal

### DESCRIPTION OF CHANGES:
When copying in the namelist.input file into the "run" directory, add a date string the existing namelist file.  For users that prefer the "run" directory, this will stop the overwriting of their valid (and likely inconvenient to re-construct) namelist.input file.  This is implemented for all em and nmm cores.  Because of the new naming convention, the clean script is also updated.

### LIST OF MODIFIED FILES:
M       clean
M       Makefile

### TESTS CONDUCTED:
1. Did a few simple tests, and the namelist.input files get renamed as expected.
2. The namelist.input file is renamed with "clean -a"
3. The namelist.input.backup.*some-date-string* is removed with "clean -aa"