### PR TITLE
Fix WRFDA compilation error after RASM Diagnostics commit 43da3a4

### DIFF
--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -2174,6 +2174,7 @@ SUBROUTINE open_hist_w ( grid , config_flags, stream, alarm_id, &
    IF ( adjust ) THEN 
      CALL adjust_io_timestr( grid%io_intervals( alarm_id ), CT, ST, timestr )
    ENDIF
+#if (DA_CORE != 1)
 !----------------------------------------------------------------------
 ! RASM Climate Diagnostics - JR, AS, MS  - October 2016
 !----------------------------------------------------------------------
@@ -2193,6 +2194,7 @@ SUBROUTINE open_hist_w ( grid , config_flags, stream, alarm_id, &
 !----------------------------------------------------------------------
 ! end RASM Climate Diagnostics
 !----------------------------------------------------------------------
+#endif
    CALL construct_filename2a ( fname , hist_outname, &
                                grid%id , 2 , timestr )
    stream_l = stream-auxhist1_only+1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, compile, DA_CORE, rasm_diag

SOURCE: internal

DESCRIPTION OF CHANGES:
WRFDA failed to compile after the RASM Diagnostics commit 43da3a4.
Exclude the RASM diagnostics in open_hist_w for DA_CORE.

LIST OF MODIFIED FILES:
M       share/mediation_integrate.F

TESTS CONDUCTED:
WRFDA compiles after the fix.
WRF-ARW still compiles.