### PR TITLE
NMM: Remove HWRF/NMM variable (avgPchg) from the history file.

### DIFF
--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -571,7 +571,7 @@ rconfig   real    aer_asy_val             namelist,physics      max_domains   0.
 #
 # module_IGWAVE_ADJUST.F
 
-state  real   avgPchg   -     dyn_nmm   1    -     rh    "avgPchg" "Average global change (hPa/3h)" "hPa/3h"
+state  real   avgPchg   -     dyn_nmm   1    -     r     "avgPchg" "Average global change (hPa/3h)" "hPa/3h"
 
 # module_CLDWTR.F
 #


### PR DESCRIPTION
TYPE: bugfix     
   
    KEYWORDS: NMM, HWRF 

    SOURCE: internal                      

    DESCRIPTION OF CHANGES: This variable causes some bit-for-bit errors
    for a few of the NMM regression test cases.  It is not used for non-HWRF NMM.  
    This is a work-around to avoid wrfout file diffs.
   
    LIST OF MODIFIED FILES:

        M       Registry/Registry.NMM

    TESTS CONDUCTED:

    WTF completes as expected.
