### PR TITLE
Add RASM registry diagnostics file to Chemistry

### DIFF
--- a/Registry/Registry.EM_CHEM
+++ b/Registry/Registry.EM_CHEM
@@ -16,6 +16,7 @@ include registry.ssib
 include registry.sbm
 include registry.diags
 include registry.afwa
+include registry.rasm_diag
 include registry.elec
 include registry.bdy_perturb
 include registry.new3d_gca


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: RASM, CHEM, build

### SOURCE: internal

### DESCRIPTION OF CHANGES:
Add the registry.rasm_diag file (already in Registry.EM) to the list of included files inside Registry.EM_CHEM

### LIST OF MODIFIED FILES:
M       Registry/Registry.EM_CHEM

### TESTS CONDUCTED:
1. Regression test with v3.05, all chem tests now pass.  All NMM jobs expectedly fail to compile.  That is fixed by PR #119.