### PR TITLE
Revert accidental overwriting of Stochastic initialization

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -26,7 +26,7 @@
    USE module_physics_init
    USE module_lightning_driver, ONLY : lightning_init
    USE module_fr_fire_driver_wrf, ONLY : fire_driver_em_init
-   USE module_stoch, ONLY : setup_rand_perturb, rand_seed, update_stoch
+   USE module_stoch, ONLY : setup_rand_perturb, rand_seed, update_stoch, initialize_stoch
 #if (WRF_CHEM == 1)
    USE module_aerosols_sorgam, ONLY: sum_pm_sorgam
    USE module_gocart_aerosols, ONLY: sum_pm_gocart
@@ -248,107 +248,31 @@
 
 !   --- SETUP AND INITIALIZE STOCHASTIC PERTURBATION SCHEMES ---
 
-   IF ( first_trip_for_this_domain ) THEN
-     grid%did_stoch = .FALSE.
+   IF ( grid%itimestep .EQ. 0 ) THEN
+      first_trip_for_this_domain = .TRUE.
+   ELSE
+      first_trip_for_this_domain = .FALSE.
    END IF
 
-   IF ((( grid%id == 1) .AND. (.NOT. grid%did_stoch)) .AND. &
-       (( grid%skebs_on== 1) .OR.( grid%sppt_on== 1) .OR. ( grid%rand_perturb_on== 1))) THEN
+   IF ( .not. ( config_flags%restart .or. grid%moved .or. config_flags%hrrr_cycling) ) THEN
+       grid%itimestep=0
+   ENDIF
 
-     grid%did_stoch = .TRUE.
+   IF ( config_flags%restart .or. grid%moved .or. config_flags%hrrr_cycling) THEN 
+       first_trip_for_this_domain = .TRUE.
+   ENDIF
 
-     IF (grid%skebs_on==1) then
+   CALL INITIALIZE_STOCH  (grid, config_flags,                  &    
+                           first_trip_for_this_domain,          &    
+                           ips, ipe, jps, jpe, kps, kpe,        &    
+                           ids, ide, jds, jde, kds, kde,        &    
+                           ims, ime, jms, jme, kms, kme,        &    
+                           its, ite, jts, jte, kts, kte,        &    
+                           imsx, imex, jmsx, jmex, kmsx, kmex,  &
+                           ipsx, ipex, jpsx, jpex, kpsx, kpex,  &
+                           imsy, imey, jmsy, jmey, kmsy, kmey,  &
+                           ipsy, ipey, jpsy, jpey, kpsy, kpey   )
 
-! Initialize SKEBS
-!    Initialize streamfunction (1)
-     if (.not.config_flags%restart) then 
-         call rand_seed (config_flags, grid%ISEED_SKEBS, grid%iseedarr_skebs , kms, kme)
-     endif
-     call SETUP_RAND_PERTURB('W',                                         &
-                       grid%skebs_vertstruc,config_flags%restart,         &
-                       grid%SPSTREAM_AMP,                                 &
-                       grid%SPSTREAMFORCS,grid%SPSTREAMFORCC,grid%ALPH_PSI,&
-                       grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPUV,     &
-                       grid%KMINFORCT,grid%KMAXFORCT,                     &
-                       grid%LMINFORCT,grid%LMAXFORCT,                     &
-                       grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
-                       grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_sppt,                           &
-                       grid%lengthscale_sppt,                             &
-                       grid%timescale_sppt,                               &
-                       grid%TOT_BACKSCAT_PSI,grid%ZTAU_PSI,               &
-                       grid%REXPONENT_PSI,                                &
-                       ids, ide, jds, jde, kds, kde,                      &
-                       ims, ime, jms, jme, kms, kme,                      &
-                       its, ite, jts, jte, kts, kte                       )
-!    Initialize potential temperature (2)
-     call SETUP_RAND_PERTURB('T',                                         &
-                       grid%skebs_vertstruc,config_flags%restart,     &
-                       grid%SPT_AMP,                                      &
-                       grid%SPTFORCS,grid%SPTFORCC,grid%ALPH_T,           &
-                       grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT,     &
-                       grid%KMINFORCT,grid%KMAXFORCT,                     &
-                       grid%LMINFORCT,grid%LMAXFORCT,                     &
-                       grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
-                       grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_sppt,                           &
-                       grid%lengthscale_sppt,                             &
-                       grid%timescale_sppt,                               &
-                       grid%TOT_BACKSCAT_T,grid%ZTAU_T,                   &
-                       grid%REXPONENT_T,                                  &
-                       ids, ide, jds, jde, kds, kde,                      &
-                       ims, ime, jms, jme, kms, kme,                      &
-                       its, ite, jts, jte, kts, kte                       )
-     ENDIF
-
-IF (grid%sppt_on==1) then
-! Initialize SPPT (3)
-     if (.not.config_flags%restart) then ! set random number seed (else  iseedarray is read in from restart files)
-         call rand_seed (config_flags, grid%ISEED_SPPT, grid%iseedarr_sppt  , kms, kme)
-     endif
-     call SETUP_RAND_PERTURB('P',                                         &
-                       grid%sppt_vertstruc,config_flags%restart,          &
-                       grid%SPPT_AMP,                                     &
-                       grid%SPPTFORCC,grid%SPPTFORCS,grid%ALPH_SPPT,      &
-                       grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT,     &
-                       grid%KMINFORCT,grid%KMAXFORCT,                     &
-                       grid%LMINFORCT,grid%LMAXFORCT,                     &
-                       grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
-                       grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_sppt,                           &
-                       grid%lengthscale_sppt,                             &
-                       grid%timescale_sppt,                               &
-                       grid%TOT_BACKSCAT_PSI,grid%ZTAU_PSI,               &
-                       grid%REXPONENT_PSI,                                &
-                       ids, ide, jds, jde, kds, kde,                      &
-                       ims, ime, jms, jme, kms, kme,                      &
-                       its, ite, jts, jte, kts, kte                       )
-     ENDIF
-
-! Initialize RAND_PERTURB (4)
-     IF (grid%rand_perturb_on==1) then
-     if (.not.config_flags%restart) then ! set random number seed (else  iseedarray is read in from restart files)
-         call rand_seed (config_flags, grid%ISEED_RAND_PERT, grid%iseedarr_rand_pert  , kms, kme)
-     endif
-     call SETUP_RAND_PERTURB('R',                                         &
-                       grid%rand_pert_vertstruc,config_flags%restart,     &
-                       grid%SP_AMP,                                       &
-                       grid%SPFORCC,grid%SPFORCS,grid%ALPH_RAND,          &
-                       grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT,     &
-                       grid%KMINFORCT,grid%KMAXFORCT,                     &
-                       grid%LMINFORCT,grid%LMAXFORCT,                     &
-                       grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
-                       grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_rand_pert,                      &
-                       grid%lengthscale_rand_pert,                        &
-                       grid%timescale_rand_pert,                          &
-                       grid%TOT_BACKSCAT_PSI,grid%ZTAU_PSI,               &
-                       grid%REXPONENT_PSI,                                &
-                       ids, ide, jds, jde, kds, kde,                      &
-                       ims, ime, jms, jme, kms, kme,                      &
-                       its, ite, jts, jte, kts, kte                       )
-     ENDIF
-     ENDIF ! skebs or sppt or rand_perturb
 !   --- END SETUP STOCHASTIC PERTURBATION SCHEMES ----------
 
 


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: Stochastic initialization

### SOURCE: internal - thanks Jamie

### DESCRIPTION OF CHANGES:
The original mods (put in PR #65) were accidentally removed in
PR #101.  We are putting the code from PR #65 back in, along
with the required groundwater/crop mods from PR #101.

Here is what I did to see what was going on:

Groundwater #101
```
git checkout f512eb9
git diff --name-status 38edf4572090e
git diff 38edf4572090e dyn_em/start_em.F
```

What we want:

Stochastic SPP #65
```
git checkout fffa034
git diff --name-status 8e0927924
git diff 8e0927924 dyn_em/start_em.F
```

Other than a couple of intended lines, most of the mods in dyn_em/start_em.F PR #101 reverted the mods in PR #65 (in that same file).

### LIST OF MODIFIED FILES:
M       dyn_em/start_em.F

### TESTS CONDUCTED:
1. No regression test yet, getting quite backed up on things to do!