### PR TITLE
Add new file (p3_lookup_table_1.dat) to those removed with "./clean -a"

### DIFF
--- a/clean
+++ b/clean
@@ -61,7 +61,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  */ozone.formatted */ozone_lat.formatted */ozone_plev.formatted \
 	  */aerosol.formatted */aerosol_lat.formatted */aerosol_plev.formatted */aerosol_lon.formatted \
 	  */kernels.asc_s_0_03_0_9 */bulkradii.asc_s_0_03_0_9 */bulkdens.asc_s_0_03_0_9 \
-	  */constants.asc \
+	  */constants.asc */p3_lookup_table_1.dat \
 	  */masses.asc */kernels_z.asc */capacity.asc */termvels.asc */coeff_p.asc */coeff_q.asc \
 	  */gribmap.txt */tr??t?? */co2_trans */namelist.output ) >& /dev/null
   else if ( "$arg" == '-aa' ) then


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: clean, p3_lookup_table_1.dat

### SOURCE: internal

### DESCRIPTION OF CHANGES:
In the "./clean" script is a manually managed list of files that are linked or copied from the WRFV3/run directory into the various WRFV3/test/* directories.  Those linked and copied data files are removed from all of the WRFV3/test/* directories with the issue of the "./clean -a" command.  

A new file has been added to the WRFV3/run directory: p3_lookup_table_1.dat (361351415, PR #93).  This new data file needs to be added to the manually managed list of files to be removed.

PR | Hash | Original Developer | File Fixed
------------ | ------------- |------------ | ------------
#93 | 361351415 | @dudhia  | WRFV3/clean

### LIST OF MODIFIED FILES:
M       clean

### TESTS CONDUCTED:
- [x] When I run "./clean -a", and then do a "git status", I no longer see p3_lookup_table_1.dat as an untracked file.
- [x] My life is now happy.