### PR TITLE
Change option numbers to option names in cumulus driver

### DIFF
--- a/phys/module_cumulus_driver.F
+++ b/phys/module_cumulus_driver.F
@@ -283,8 +283,8 @@ CONTAINS
 !-- RTHRATEN      radiative temp forcing for Grell-Devenyi scheme
 !-- RTHBLTEN      PBL temp forcing for Grell-Devenyi scheme
 !-- RQVBLTEN      PBL moisture forcing for Grell-Devenyi scheme
-!-- RTHFTEN
-!-- RQVFTEN
+!-- RTHFTEN       Advective tendency for theta
+!-- RQVFTEN       Advective tendency for vapor
 !-- MASS_FLUX
 !-- XF_ENS
 !-- PR_ENS
@@ -794,7 +794,7 @@ CONTAINS
    END IF
 
 #if  ( EM_CORE == 1 )
-      if(cu_physics .eq. 5 .or. cu_physics .eq. 16) then
+      if(cu_physics == G3SCHEME .or. cu_physics == NTIEDTKESCHEME) then
       !$OMP PARALLEL DO   &
       !$OMP PRIVATE ( ij,i,j,k,its,ite,jts,jte )
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cumulus option numbers and names

SOURCE: internal

DESCRIPTION OF CHANGES:To follow the convention used in the code, option numbers shouldn't be used. So we change them to option names. No effect on results.

LIST OF MODIFIED FILES:
phys/module_cumulus_driver.F

TESTS CONDUCTED:
Reg tested. 