### PR TITLE
SUSE Linux cpp, stop addition of boilerplate c-styled comments

### DIFF
--- a/configure
+++ b/configure
@@ -420,20 +420,20 @@ fi
 # a problem for ARW
 
 if [ -n "$WRF_NMM_CORE" -a "$WRF_NMM_CORE" = "1" ] ; then
-    TFL="-traditional-cpp"
-    CFL="-P"
+  TFL="-traditional-cpp"
+  CFL="-P -nostdinc"
 elif [ "$wrf_core" = "DA_CORE" -o "$wrf_core" = "4D_DA_CORE" ] ; then
   TFL="-traditional-cpp"
-  CFL="-P"
+  CFL="-P -nostdinc"
 elif [ "$vnest" = "VN" ] ; then
   TFL="-traditional-cpp"
-  CFL="-P"
+  CFL="-P -nostdinc"
 elif [ "$hyb" = "NOHYB" ] ; then
   TFL="-traditional-cpp"
-  CFL="-P"
+  CFL="-P -nostdinc"
 else
   TFL=" "
-  CFL="-P -C"
+  CFL="-P -C -nostdinc"
   compileflags="${compileflags}!-DHYBRID_COORD=1"
 fi
 


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: cpp, comments

### SOURCE: Kevin Manning (NCAR)

### DESCRIPTION OF CHANGES: 
Add the -nostdinc flag to the default set always used with the WRF build.  This is important now that we are unable to use -traditional-cpp when trying to build the hybrid vertical coordinate for ARW.

### LIST OF MODIFIED FILES: 
M       configure

### TESTS CONDUCTED: 
1. The laramie build fails without the option, and works with the option. 
2. Manual test on laramie (cpp (SUSE Linux) 4.8.5) and yellowstone (cpp (GCC) 4.4.7 20120313 (Red Hat 4.4.7-3)).
```
#if ( HYBRID_COORD==1 )
#  define mut(...) (c1f(k)*XXPCTXX(__VA_ARGS__)+c2f(k))
#  define XXPCTXX(...) mut(__VA_ARGS__)
#endif

      DO j=jts,jtf
      DO k=kts,kte
      DO i=its,itf
         rw(i,k,j)=w(i,k,j)*mut(i,j)/msft(i,j)
      ENDDO
      ENDDO
      ENDDO

print *,'This is half 1 ' // 'followed by half 2'
```
Using the command
```
cpp -DHYBRID_COORD -P -C -nostdinc foo
```
The generated files are correct:
    - The HYBRID_COORD string variables are expanded
    - The Fortran concatenate is preserved
    - There are no cpp-inserted c-style comments, such as:
```
/* Copyright (C) 1991-2014 Free Software Foundation, Inc.
   This file is part of the GNU C Library.
```