### PR TITLE
HVC check_a_mundo bullet-proofing

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1382,7 +1382,9 @@
      END DO 
 
 !-----------------------------------------------------------------------
-!  The hybrid vertical coordinate requires the code to be built.
+!  The hybrid vertical coordinate (HVC) namelist.input option (hybrid_opt=2) 
+!  requires the code to be built with the HVC code enabled.  This is a run-time
+!  test to make sure the correct compile-time capabilities are available.
 !-----------------------------------------------------------------------
 #if ( HYBRID_COORD==1 )
 #else


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: hybrid, HVC, check_a_mundo

### SOURCE: internal

### DESCRIPTION OF CHANGES:
Add an "if test" to verify that ( ( hybrid_opt != 0) .and. ( non-HVC build ) ) is a fatal error.  Clean up other HVC "if test" with the incrementing fatal error count.

### LIST OF MODIFIED FILES:
M       share/module_check_a_mundo.F

### TESTS CONDUCTED:
1. When built without the HVC option,the code correctly stops.

configure.wrf - code not built with hybrid option
```
# configure.wrf
#
# Original configure options used:
# configure  -d
# Compiler choice: 32
# Nesting option: 1
```

namelist.input file requests the hybrid option:
```
 &dynamics
 hybrid_opt=2
 etac= 0.2
 /
```

Attempting to run real.exe or wrf.exe gives:
```
--- ERROR: The code was not built with hybrid vertical coordinate enabled
---        Either set hybrid_opt=0, or re-compile with HVC enabled
```