### PR TITLE
Add -hyb info to the "configure -h" output

### DIFF
--- a/configure
+++ b/configure
@@ -50,7 +50,7 @@ if [ -n "$print_usage" ] ; then
   echo '-d    build with debugging information and no optimization'
   echo '-D    build with -d AND floating traps, traceback, uninitialized variables'
   echo '-r8   build with 8 byte reals'
-  echo '-vn   build with vertical nesting (no hybrid option for ARW)'
+  echo '-hyb  build with hybrid vertical coordinate (HVC) for ARW only'
   echo '-help print this message'
   echo '*****************************************************************************'
   echo ' '


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: hybrid, HVC, configure, help

### SOURCE: internal

### DESCRIPTION OF CHANGES: 
Add a single line to the output of the "configure -h" output.  Let users know how to build for the hybrid vertical coordinate.  I also removed the info for the "-vn" option.  No need to specifically build for vertical nesting, as that is the default.

### LIST OF MODIFIED FILES:
M       configure

### TESTS CONDUCTED: 
1. "configure -h" does indeed print out info for the hybrid coordinate.  Woot