### PR TITLE
Halo exchange for muus and muvs for trajectory

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -313,9 +313,9 @@ state    real   mub_save        ij     dyn_em      1         -      -           
 state    real   mu0             ij     dyn_em      1         -      i1          "mu0" "initial dry mass in column" "Pa"
 state    real   mudf            ij     dyn_em      1         -      -           "mudf" "" ""
 state    real   muu             ij     dyn_em      1          X     -           "muu"
-i1       real   muus            ij     dyn_em      1          -     
+state    real   muus            ij     dyn_em      1          X     -           "muus"
 state    real   muv             ij     dyn_em      1          Y     -           "muv"
-i1       real   muvs            ij     dyn_em      1          -     
+state    real   muvs            ij     dyn_em      1          Y     -           "muvs"
 state    real   mut             ij     dyn_em      1          -     -           "mut"
 state    real   muts            ij     dyn_em      1          -     -           "muts"
 i1       real   muave           ij     dyn_em      1          -     
@@ -3003,6 +3003,7 @@ period    PERIOD_EM_COUPLE_B dyn_em 3:ph_1,ph_2,w_1,w_2,t_1,t_2,u_1,u_2,v_1,v_2,
 
 #cyl for trajectory 
 halo      HALO_EM_F dyn_em  24:muu,muv,mut
+halo      HALO_EM_F_1 dyn_em  24:muus,muvs
 
 ## For moving nests
 #halo      em_shift_halo_y  dyn_em 48:imask_nostag,imask_xstag,imask_ystag,imask_xystag,u_2,v_2,t_2
@@ -3048,6 +3049,8 @@ period    PERIOD_BDY_EM_C dyn_em 2:u_2,u_save,v_2,v_save,t_2,t_save,muv,msfvx,ms
 period    PERIOD_BDY_EM_D dyn_em 3:u_2,v_2,w_2,t_2,ph_2,mu_2,tke_2
 period    PERIOD_BDY_EM_D3 dyn_em 3:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,mu_1,mu_2
 period    PERIOD_EM_DA dyn_em 2:ru_m,rv_m,ww_m,mut,muts
+period    PERIOD_EM_F dyn_em 2:muus,muvs
+period    PERIOD_EM_G dyn_em 2:msftx,msfux,msfvy
 period    PERIOD_EM_THETAM dyn_em 3:t_1,t_2,h_diabatic
 
 #

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -44,7 +44,8 @@ SUBROUTINE solve_em ( grid , config_flags  &
                  ,period_bdy_em_scalar_sub,period_bdy_em_tke_old_sub                       &
                  ,period_bdy_em_tracer2_sub,period_bdy_em_tracer_old_sub                   &
                  ,period_bdy_em_tracer_sub,period_em_da_sub,period_em_hydro_uv_sub         &
-                 ,halo_em_f_sub,halo_em_init_4_sub,halo_em_thetam_sub,period_em_thetam_sub
+                 ,period_em_f_sub,period_em_g_sub                                          &
+                 ,halo_em_f_1_sub,halo_em_init_4_sub,halo_em_thetam_sub,period_em_thetam_sub
 #endif
    USE module_utility
 ! Mediation layer modules
@@ -1109,7 +1110,7 @@ BENCH_START(small_step_prep_tim)
        CALL small_step_prep( grid%u_1,grid%u_2,grid%v_1,grid%v_2,grid%w_1,grid%w_2,   &
                              grid%t_1,grid%t_2,grid%ph_1,grid%ph_2,                   &
                              grid%mub, grid%mu_1, grid%mu_2,                          &
-                             grid%muu, muus, grid%muv, muvs,                          &
+                             grid%muu, grid%muus, grid%muv, grid%muvs,                &
                              grid%mut, grid%muts, grid%mudf,                          &
                              grid%c1h, grid%c2h, grid%c1f, grid%c2f,                  &
                              grid%c3h, grid%c4h, grid%c3f, grid%c4f,                  &
@@ -1750,7 +1751,7 @@ BENCH_END(phys_bc_tim)
 
 BENCH_START(calc_mu_uv_tim)
        CALL calc_mu_uv_1 ( config_flags,                     &
-                           grid%muts, muus, muvs,                 &
+                           grid%muts, grid%muus, grid%muvs,  &
                            ids, ide, jds, jde, kds, kde,     &
                            ims, ime, jms, jme, kms, kme,     &
                            grid%i_start(ij), grid%i_end(ij), &
@@ -1761,7 +1762,7 @@ BENCH_START(small_step_finish_tim)
        CALL small_step_finish( grid%u_2, grid%u_1, grid%v_2, grid%v_1, grid%w_2, grid%w_1,     &
                                grid%t_2, grid%t_1, grid%ph_2, grid%ph_1, grid%ww, ww1,    &
                                grid%mu_2, grid%mu_1,                       &
-                               grid%mut, grid%muts, grid%muu, muus, grid%muv, muvs,  & 
+                               grid%mut, grid%muts, grid%muu, grid%muus, grid%muv, grid%muvs,  & 
                                grid%c1h, grid%c2h, grid%c1f, grid%c2f, &
                                grid%c3h, grid%c4h, grid%c3f, grid%c4f, &
                                grid%u_save, grid%v_save, w_save,           &
@@ -3462,9 +3463,14 @@ BENCH_END(bc_end_tim)
 
    IF      ( config_flags%traj_opt .EQ. UM_TRAJECTORY ) THEN
 #ifdef DM_PARALLEL
-#    include "HALO_EM_F.inc"
+#    include "HALO_EM_F_1.inc"
 #    include "HALO_EM_D.inc"
 #    include "HALO_EM_INIT_4.inc"
+     IF( config_flags%periodic_x ) THEN
+#    include "PERIOD_EM_DA.inc"
+#    include "PERIOD_EM_F.inc"
+#    include "PERIOD_EM_G.inc"
+     ENDIF
 #endif
      !$OMP PARALLEL DO   &
      !$OMP PRIVATE ( ij )
@@ -3472,7 +3478,7 @@ BENCH_END(bc_end_tim)
 
            call trajectory (grid,config_flags,                                     &
                             grid%dt,grid%itimestep,grid%ru_m, grid%rv_m, grid%ww_m,&
-                            grid%muts,muus,muvs,                                   &
+                            grid%muts,grid%muus,grid%muvs,                         &
                             grid%c1h, grid%c2h, grid%c1f, grid%c2f,                &
                             grid%rdx, grid%rdy, grid%rdn, grid%rdnw,grid%rdzw,     &
                             grid%traj_i,grid%traj_j,grid%traj_k,                   &
@@ -3575,7 +3581,7 @@ BENCH_END(advance_ppt_tim)
    DO ij = 1 , grid%num_tiles
         CALL wrf_debug ( 200 , ' call phy_prep_part2' )
         CALL phy_prep_part2 ( config_flags,                              &
-                        grid%muts, muus, muvs,                           &
+                        grid%muts, grid%muus, grid%muvs,                 &
                         grid%c1h, grid%c2h, grid%c1f, grid%c2f,          &
                         grid%rthraten,                                   &
                         grid%rthblten, grid%rublten, grid%rvblten,       &
@@ -4372,7 +4378,7 @@ BENCH_END(bc_2d_tim)
 
      CALL wrf_debug ( 200 , ' call spec_bdy_final' )
 
-     CALL spec_bdy_final   ( grid%u_2, muus, grid%c1h, grid%c2h, grid%msfuy,     &
+     CALL spec_bdy_final   ( grid%u_2, grid%muus, grid%c1h, grid%c2h, grid%msfuy,     &
                                 grid%u_bxs, grid%u_bxe, grid%u_bys, grid%u_bye,  &
                                 grid%u_btxs,grid%u_btxe,grid%u_btys,grid%u_btye, &
                                 'u', config_flags,                               &
@@ -4385,7 +4391,7 @@ BENCH_END(bc_2d_tim)
                                 grid%j_start(ij), grid%j_end(ij),       &
                                 k_start    , k_end                     )
 
-     CALL spec_bdy_final   ( grid%v_2, muvs, grid%c1h, grid%c2h, grid%msfvx,     &
+     CALL spec_bdy_final   ( grid%v_2, grid%muvs, grid%c1h, grid%c2h, grid%msfvx,     &
                                 grid%v_bxs, grid%v_bxe, grid%v_bys, grid%v_bye,  &
                                 grid%v_btxs,grid%v_btxe,grid%v_btys,grid%v_btye, &
                                 'v', config_flags,                               &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1624,6 +1624,15 @@
       END IF
 
 !-----------------------------------------------------------------------
+! This WRF version does not support trajectories on a global domain
+!-----------------------------------------------------------------------
+      IF (  model_config_rec % polar(1) .AND. &
+            model_config_rec % fft_filter_lat .LT. 90. .AND. &
+            model_config_rec % traj_opt .NE. 0 ) THEN
+         CALL wrf_error_fatal ( '--- ERROR: Trajectories not supported on global domain' )
+      END IF
+
+!-----------------------------------------------------------------------
 ! If any CAM scheme is turned on, then there are a few shared variables.
 ! These need to be allocated when any CAM scheme is active.
 !-----------------------------------------------------------------------

--- a/share/module_trajectory.F
+++ b/share/module_trajectory.F
@@ -1021,7 +1021,6 @@ is_initial: &
 !-----------------------------------------------------------------------------
 trj_loop: &
        do trj = 1,n_traj
-         if( trjects(trj)%in_dom ) then
 pkg_loop:  do pkg = 1,pkg_max
              astat = 0
              select case( trim(pkg_tag(pkg)) )
@@ -1032,7 +1031,7 @@ pkg_loop:  do pkg = 1,pkg_max
                  if( m1 > 0 ) then
                    allocate( trj_pbf(trj)%chm_vals(vals_max,m1),stat=astat)
                    do m = 1,m1
-                     trj_msk(trj,trjects(trj)%chm_ndx(m)) = .true.
+                     trj_msk(trj,trjects(trj)%chm_ndx(m)) = trjects(trj)%in_dom
                    end do
                  endif
                case( 'dchm' )
@@ -1041,7 +1040,7 @@ pkg_loop:  do pkg = 1,pkg_max
                  if( m1 > 0 ) then
                    allocate( trj_pbf(trj)%dchm_vals(vals_max,m1),stat=astat)
                    do m = 1,m1
-                     trj_msk(trj,trjects(trj)%dchm_ndx(m)) = .true.
+                     trj_msk(trj,trjects(trj)%dchm_ndx(m)) = trjects(trj)%in_dom
                    end do
                  endif
 #endif
@@ -1051,7 +1050,7 @@ pkg_loop:  do pkg = 1,pkg_max
                  if( m1 > 0 ) then
                    allocate( trj_pbf(trj)%hyd_vals(vals_max,m1),stat=astat)
                    do m = 1,m1
-                     trj_msk(trj,trjects(trj)%hyd_ndx(m)) = .true.
+                     trj_msk(trj,trjects(trj)%hyd_ndx(m)) = trjects(trj)%in_dom
                    end do
                  endif
                case( 'trc' )
@@ -1060,7 +1059,7 @@ pkg_loop:  do pkg = 1,pkg_max
                  if( m1 > 0 ) then
                    allocate( trj_pbf(trj)%trc_vals(vals_max,m1),stat=astat)
                    do m = 1,m1
-                     trj_msk(trj,trjects(trj)%trc_ndx(m)) = .true.
+                     trj_msk(trj,trjects(trj)%trc_ndx(m)) = trjects(trj)%in_dom
                    end do
                  endif
                case( 'dyn' )
@@ -1069,7 +1068,7 @@ pkg_loop:  do pkg = 1,pkg_max
                  if( m1 > 0 ) then
                    allocate( trj_pbf(trj)%dyn_vals(vals_max,m1),stat=astat)
                    do m = 1,m1
-                     trj_msk(trj,trjects(trj)%dyn_ndx(m)) = .true.
+                     trj_msk(trj,trjects(trj)%dyn_ndx(m)) = trjects(trj)%in_dom
                    end do
                  endif
                case( 'msc' )
@@ -1078,7 +1077,7 @@ pkg_loop:  do pkg = 1,pkg_max
                  if( m1 > 0 ) then
                    allocate( trj_pbf(trj)%msc_vals(vals_max,m1),stat=astat)
                    do m = 1,m1
-                     trj_msk(trj,trjects(trj)%msc_ndx(m)) = .true.
+                     trj_msk(trj,trjects(trj)%msc_ndx(m)) = trjects(trj)%in_dom
                    end do
                  endif
              end select
@@ -1088,7 +1087,6 @@ pkg_loop:  do pkg = 1,pkg_max
                call wrf_error_fatal( trim( err_mes  ) )
              endif
            end do pkg_loop
-         endif
        end do trj_loop
 
        do pkg = 1,pkg_max


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: trajectory

SOURCE: internal

DESCRIPTION OF CHANGES:

Change muus,muvs from i1 to state variables in EM_COMMON.
Add halo exhange routine definition for muus,muvs in EM_COMMON.
Change muus,muvs from local to grid variables in solve_em.F.
Add new halo exchange routine call for muus,muvs in routine trajectory( solve_em.F ).
Fix trajectory initialization bug in routine trajectory_init( module_trajectory.F ).
Add trap to error halt if trajectories are set in global domain( module_check_a_mundo.F ).

LIST OF MODIFIED FILES:

M	dyn_em/solve_em.F
M	share/module_trajectory.F
M	share/module_check_a_mundo.F
M	Registry/Registry.EM_COMMON

TESTS CONDUCTED:

WTF reg test, version 3.06, has been successfully completed. The code has been
tested by Stacy Walters and Gabi Pfister.