### PR TITLE
Fix runtime errors for certain cases with observation error inflation

### DIFF
--- a/var/da/da_synop/da_get_innov_vector_synop.inc
+++ b/var/da/da_synop/da_get_innov_vector_synop.inc
@@ -133,7 +133,7 @@ subroutine da_get_innov_vector_synop( it,num_qcstat_conv, grid, ob, iv)
                end if
             end if
 
-            if ( it == 1 .and. obs_err_inflate ) then
+            if ( (it == 1) .and. (obs_err_inflate) .and. (abs(hd) <= Max_StHeight_Diff) ) then
                err_inflate_fac = MIN(exp(abs(hd)/stn_ht_diff_scale),100.)
                !iv%synop(n)%u%error = iv%synop(n)%u%error * err_inflate_fac
                !iv%synop(n)%v%error = iv%synop(n)%v%error * err_inflate_fac


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, observation error inflation

SOURCE: internal

DESCRIPTION OF CHANGES: For the new capability "obs_err_inflate=.true.", if the difference between the model and observation elevations is too large, the error inflation factor can be so large that it will cause errors when printing the "gts_omb_oma" statistics files, eventually leading to a runtime error in some cases. This can be fixed by adding two checks to the observation error inflation capability:

 - Do not inflate the observation error if the height difference is greater than the namelist-specified value "max_stheight_diff"
 - Cap the error inflation value at 100., inflating errors more than this has essentially no impact.

Between these two checks it should cover all error cases, and indeed, every test I've run shows no errors with this fix.

LIST OF MODIFIED FILES:
M       var/da/da_synop/da_get_innov_vector_synop.inc

TESTS CONDUCTED: WRFDA Regression test (with the new options enabled) now runs successfully for GNU, intel test pending.
