### PR TITLE
Changing printout of scanpos for OMA radiance diagnostic files from I3 to I6

### DIFF
--- a/var/da/da_monitor/da_rad_diags.f90
+++ b/var/da/da_monitor/da_rad_diags.f90
@@ -341,15 +341,10 @@ ntime_loop: do itime = 1, ntime
 
          npixel_loop: do ipixel = ips, ipe
 
-            read(unit=iunit(iproc),fmt='(7x,i7,2x,a19,i3,i3,f6.0,4f8.2,f8.3)',iostat=ios)  &
+            read(unit=iunit(iproc),fmt='(7x,i7,2x,a19,i6,i3,f6.0,4f8.2,f8.3)',iostat=ios)  &
                n, datestr2(ipixel), scanpos(ipixel), landsea_mask(ipixel), elv(ipixel), &
                lat(ipixel), lon(ipixel), satzen(ipixel), satazi(ipixel), ret_clw(ipixel)
-            if ( scanpos(ipixel) > 360 .or. scanpos(ipixel) == 0 ) then
-               backspace(iunit(iproc))
-               read(unit=iunit(iproc),fmt='(7x,i7,2x,a19,i6,i3,f6.0,4f8.2,f8.3)',iostat=ios) &
-               n, datestr2(ipixel), scanpos(ipixel), landsea_mask(ipixel), elv(ipixel), &
-               lat(ipixel), lon(ipixel), satzen(ipixel), satazi(ipixel), ret_clw(ipixel)
-            end if
+
             read(unit=iunit(iproc),fmt='(14x,9f10.2,3i3,3f10.2)',iostat=ios)  &
                t2m(ipixel), mr2m(ipixel), u10(ipixel), v10(ipixel), ps(ipixel), ts(ipixel), &
                smois(ipixel), tslb(ipixel), snowh(ipixel), isflg(ipixel), soiltyp(ipixel),  &

--- a/var/da/da_radiance/da_write_oa_rad_ascii.inc
+++ b/var/da/da_radiance/da_write_oa_rad_ascii.inc
@@ -77,7 +77,7 @@ subroutine da_write_oa_rad_ascii (it, ob, iv, re )
                                    iv%instid(i)%satazi(n),         &
                                    iv%instid(i)%clw(n)
             else !no clw info
-               write(unit=oma_rad_unit,fmt='(a,i7,2x,a,2i3,f6.0,4f8.2)') 'INFO : ', ndomain, &
+               write(unit=oma_rad_unit,fmt='(a,i7,2x,a,i6,i3,f6.0,4f8.2)') 'INFO : ', ndomain, &
                                    iv%instid(i)%info%date_char(n), &
                                    iv%instid(i)%scanpos(n),        &
                                    iv%instid(i)%landsea_mask(n),   &


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, radiance, OMA diagnostics, AMSR2

SOURCE: Yuanbing Wang (NUIST)

DESCRIPTION OF CHANGES: Changing printout of "scanpos" (scan position) for OMA radiance diagnostic files from I3 to I6. Most instruments have a scanpos value of far less than 1000, so originally this field only needed I3. However, some newer instruments (such as AMSR2) have >1000 scan positions, so this field needs to be upped to I6, otherwise the diags files can have "***" due to the way fortran handles write format errors. 

The original AMSR2 radiance capability had an if statement exception to write I6 for scan position, however, it accidentally left an inconsistency between two different types of diagnostic files (OMA in da_write_oa_rad_ascii.inc vs INV in da_write_iv_rad_ascii.inc), where one file would write I6 output for all files and the other would write I3 output for non-AMSR2 files. Now all instruments follow the same print behavior for all diagnostic output files.

The change is made in the routine for printing the radiance OMA diagnostic files, as well as da_rad_diags.f90 which is a stand-alone utility for reading radiance assimilation diagnostic information and converting into netCDF format.

LIST OF MODIFIED FILES: 
M       var/da/da_monitor/da_rad_diags.f90
M       var/da/da_radiance/da_write_oa_rad_ascii.inc

TESTS CONDUCTED: WRFDA Regtest passed (GNU 4.8.2 and Intel 12.1.5). Log files now all display scanpos as I6 as expected.