### PR TITLE
GF scheme update (version 2)

### DIFF
--- a/phys/module_cu_gf_deep.F
+++ b/phys/module_cu_gf_deep.F
@@ -7,16 +7,16 @@ MODULE module_cu_gf_deep
 ! tuning constant for cloudwater/ice detrainment
      real, parameter:: c1=.001 ! .0005
 ! parameter to turn on or off evaporation of rainwater as done in SAS
-     integer, parameter :: irainevap=1
+     integer, parameter :: irainevap=0
 ! max allowed fractional coverage (frh_thresh)
-     real, parameter::frh_thresh = .7
+     real, parameter::frh_thresh = .9
 ! rh threshold. if fractional coverage ~ frh_thres, do not use cupa any further
      real, parameter::rh_thresh = .97
 ! tuning constant for J. Brown closure (Ichoice = 4,5,6)
      real, parameter::betajb=1.5
 ! tuning for shallow and mid convection. EC uses 1.5
-     integer, parameter:: use_excess=0 !1
-     real, parameter :: fluxtune=0. !1.5
+     integer, parameter:: use_excess=1
+     real, parameter :: fluxtune=1.
 ! flag to turn off or modify mom transport by downdrafts
      real, parameter :: pgcd = 1.
 !
@@ -32,7 +32,7 @@ MODULE module_cu_gf_deep
 contains
 
 
-   SUBROUTINE CUP_gf(        &
+   SUBROUTINE CUP_gf(        &          
                itf,ktf,its,ite, kts,kte  &
 
               ,dicycle       &  ! diurnal cycle flag
@@ -46,66 +46,66 @@ contains
               ,dhdt          &  ! boundary layer forcing (one closure for shallow)
               ,xland         &  ! land mask
 
-              ,zo            &   ! heights above surface
-              ,forcing       &   ! only diagnostic
-              ,T             &   ! T before forcing
-              ,Q             &   ! Q before forcing
-              ,Z1            &   ! terrain
-              ,Tn            &   ! T including forcing
-              ,QO            &   ! Q including forcing
-              ,PO            &   ! pressure (mb)
-              ,PSUR          &   ! surface pressure (mb)
-              ,US            &   ! u on mass points
-              ,VS            &   ! v on mass points
-              ,rho           &   ! density
-              ,hfx           &   ! W/M2, positive upward
-              ,qfx           &   ! W/M2, positive upward
-              ,dx            &   ! dx is grid point dependent here
-              ,mconv         &   ! integrated vertical advection of moisture
-              ,omeg          &   ! omega (Pa/s)
+              ,zo            &  ! heights above surface
+              ,forcing       &  ! only diagnostic
+              ,T             &  ! T before forcing
+              ,Q             &  ! Q before forcing
+              ,Z1            &  ! terrain
+              ,Tn            &  ! T including forcing
+              ,QO            &  ! Q including forcing
+              ,PO            &  ! pressure (mb)
+              ,PSUR          &  ! surface pressure (mb)
+              ,US            &  ! u on mass points
+              ,VS            &  ! v on mass points
+              ,rho           &  ! density
+              ,hfx           &  ! W/M2, positive upward
+              ,qfx           &  ! W/M2, positive upward
+              ,dx            &  ! dx is grid point dependent here
+              ,mconv         &  ! integrated vertical advection of moisture
+              ,omeg          &  ! omega (Pa/s)
 
-              ,csum          & ! used to implement memory, set to zero if not avail
-              ,cnvwt         & ! GFS needs this
-              ,zuo           & ! nomalized updraft mass flux
-              ,zdo           & ! nomalized downdraft mass flux
+              ,csum          &  ! used to implement memory, set to zero if not avail
+              ,cnvwt         &  ! GFS needs this
+              ,zuo           &  ! nomalized updraft mass flux
+              ,zdo           &  ! nomalized downdraft mass flux
               ,edto          &
-              ,xmb_out       & !the xmb's may be needed for dicycle
+              ,xmb_out       &  !the xmb's may be needed for dicycle
               ,xmbm_in       &
               ,xmbs_in       &
               ,pre           &
-              ,outu          & ! momentum tendencies at mass points
+              ,outu          &  ! momentum tendencies at mass points
               ,outv          &
-              ,outt          & ! temperature tendencies
-              ,outq          & ! q tendencies
-              ,outqc         & ! ql/qice tendencies
+              ,outt          &  ! temperature tendencies
+              ,outq          &  ! q tendencies
+              ,outqc         &  ! ql/qice tendencies
               ,kbcon         &
               ,ktop          &
-              ,cupclw        & ! used for direct coupling to radiation, but with tuning factors
-              ,ierr          & ! ierr flags are error flags, used for debugging
+              ,cupclw        &  ! used for direct coupling to radiation, but with tuning factors
+              ,ierr          &  ! ierr flags are error flags, used for debugging
               ,ierrc         &
 !    the following should be set to zero if not available
-              ,rand_mom      & ! for stochastics mom, if temporal and spatial patterns exist
-              ,rand_vmas     & ! for stochastics vertmass, if temporal and spatial patterns exist
-              ,rand_clos     & ! for stochastics closures, if temporal and spatial patterns exist
-              ,nranflag      & ! flag to what you want perturbed
-                               ! 1 = momentum transport
-                               ! 2 = normalized vertical mass flux profile
-                               ! 3 = closures
-                               ! more is possible, talk to developer or
-                               ! implement yourself. pattern is expected to be
-                               ! betwee -1 and +1
+              ,rand_mom      &  ! for stochastics mom, if temporal and spatial patterns exist
+              ,rand_vmas     &  ! for stochastics vertmass, if temporal and spatial patterns exist
+              ,rand_clos     &  ! for stochastics closures, if temporal and spatial patterns exist
+              ,nranflag      &  ! flag to what you want perturbed
+                                ! 1 = momentum transport 
+                                ! 2 = normalized vertical mass flux profile
+                                ! 3 = closures
+                                ! more is possible, talk to developer or
+                                ! implement yourself. pattern is expected to be
+                                ! betwee -1 and +1
 #if ( WRF_DFI_RADAR == 1 )
-              ,do_capsuppress,cap_suppress_j &
+              ,do_capsuppress,cap_suppress_j    &             
 #endif
-              ,k22           &
+              ,k22                              &
               ,jmin)
 
    IMPLICIT NONE
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
+     integer                                                &
+        ,intent (in   )                   ::                &
         nranflag,itf,ktf,its,ite, kts,kte,ipr,imid
-     integer, intent (in   )              ::                           &
+     integer, intent (in   )              ::                &
         ichoice
      real,  dimension (its:ite,4)                           &
         ,intent (in  )                   ::  rand_clos
@@ -123,7 +123,7 @@ contains
    REAL, DIMENSION( its:ite ) :: cap_suppress_j
 #endif
   !
-  !
+  ! 
   !
       real,    dimension (its:ite,1:maxens3) :: xf_ens,pr_ens
   ! outtem = output temp tendency (per s)
@@ -131,19 +131,19 @@ contains
   ! outqc  = output qc tendency (per s)
   ! pre    = output precip
      real,    dimension (its:ite,kts:kte)                              &
-        ,intent (inout  )                   ::                           &
+        ,intent (inout  )                   ::                         &
         cnvwt,outu,outv,OUTT,OUTQ,OUTQC,cupclw
      real,    dimension (its:ite)                                      &
-        ,intent (inout  )                   ::                           &
+        ,intent (inout  )                   ::                         &
         pre,xmb_out
      real,    dimension (its:ite)                                      &
-        ,intent (in  )                   ::                           &
+        ,intent (in  )                   ::                            &
         hfx,qfx,xmbm_in,xmbs_in
      integer,    dimension (its:ite)                                   &
-        ,intent (inout  )                   ::                           &
+        ,intent (inout  )                ::                            &
         kbcon,ktop
      integer,    dimension (its:ite)                                   &
-        ,intent (in  )                   ::                           &
+        ,intent (in  )                   ::                            &
         kpbl
   !
   ! basic environmental input includes moisture convergence (mconv)
@@ -153,8 +153,8 @@ contains
      real,    dimension (its:ite,kts:kte)                              &
         ,intent (in   )                   ::                           &
         dhdt,rho,T,PO,US,VS,tn
-     real,    dimension (its:ite,kts:kte)                       &
-        ,intent (inout   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                              &
+        ,intent (inout   )                ::                           &
         omeg
      real,    dimension (its:ite,kts:kte)                              &
         ,intent (inout)                   ::                           &
@@ -163,10 +163,10 @@ contains
         ,intent (in   )                   ::                           &
         dx,ccn,Z1,PSUR,xland
      real, dimension (its:ite)                                         &
-        ,intent (inout   )                   ::                           &
+        ,intent (inout   )                ::                           &
         mconv
 
-
+       
        real                                                            &
         ,intent (in   )                   ::                           &
         dtime
@@ -175,11 +175,11 @@ contains
 !
 !  local ensemble dependent variables in this routine
 !
-     real,    dimension (its:ite,1)  ::                         &
+     real,    dimension (its:ite,1)  ::                                &
         xaa0_ens
-     real,    dimension (its:ite,1) ::                         &
+     real,    dimension (its:ite,1)  ::                                &
         edtc
-     real,    dimension (its:ite,kts:kte,1) ::                 &
+     real,    dimension (its:ite,kts:kte,1) ::                         &
         dellat_ens,dellaqc_ens,dellaq_ens,pwo_ens
 !
 !
@@ -247,15 +247,15 @@ contains
   ! hc = cloud moist static energy
   ! hkb = moist static energy at originating level
 
-     real,    dimension (its:ite,kts:kte) ::                           &
-        entr_rate_2d,mentrd_rate_2d,he,hes,qes,z, heo,heso,qeso,zo,    &
-        xhe,xhes,xqes,xz,xt,xq,qes_cup,q_cup,he_cup,hes_cup,z_cup,     &
-        p_cup,gamma_cup,t_cup, qeso_cup,qo_cup,heo_cup,heso_cup,       &
-        zo_cup,po_cup,gammao_cup,tn_cup,              &
-        xqes_cup,xq_cup,xhe_cup,xhes_cup,xz_cup,     &
-        xt_cup, dby,hc,zu,clw_all,   &
-        dbyo,qco,qrcdo,pwdo,pwo,hcdo,qcdo,dbydo,hco,qrco,      &
-        xdby,xhc,xzu,            &
+     real,    dimension (its:ite,kts:kte) ::                            &
+        entr_rate_2d,mentrd_rate_2d,he,hes,qes,z, heo,heso,qeso,zo,     &                    
+        xhe,xhes,xqes,xz,xt,xq,qes_cup,q_cup,he_cup,hes_cup,z_cup,      &
+        p_cup,gamma_cup,t_cup, qeso_cup,qo_cup,heo_cup,heso_cup,        &
+        zo_cup,po_cup,gammao_cup,tn_cup,                                &    
+        xqes_cup,xq_cup,xhe_cup,xhes_cup,xz_cup,                        &
+        xt_cup, dby,hc,zu,clw_all,                                      &
+        dbyo,qco,qrcdo,pwdo,pwo,hcdo,qcdo,dbydo,hco,qrco,               &
+        dbyt,xdby,xhc,xzu,                                                   &
 
   ! cd  = detrainment function for updraft
   ! cdd = detrainment function for downdraft
@@ -263,7 +263,7 @@ contains
   ! dellaq = change of q per unit mass flux of cloud ensemble
   ! dellaqc = change of qc per unit mass flux of cloud ensemble
 
-        cd,cdd,DELLAH,DELLAQ,DELLAT,DELLAQC,          &
+        cd,cdd,DELLAH,DELLAQ,DELLAT,DELLAQC,                            &
         u_cup,v_cup,uc,vc,ucd,vcd,dellu,dellv
 
   ! aa0 cloud work function for downdraft
@@ -273,56 +273,56 @@ contains
   ! xaa0    = cloud work function with cloud effects (ensemble dependent)
   ! edt     = epsilon
 
-     real,    dimension (its:ite) ::                                   &
-       edt,edto,AA1,AA0,XAA0,HKB,                          &
-       HKBO,XHKB,                                    &
-       XMB,PWAVO,                                &
-       PWEVO,BU,BUD,cap_max,                                   &
+     real,    dimension (its:ite) ::                                     &
+       edt,edto,AA1,AA0,XAA0,HKB,                                        &
+       HKBO,XHKB,                                                        &
+       XMB,PWAVO,                                                        &
+       PWEVO,BU,BUD,cap_max,                                             &
        cap_max_increment,closure_n,psum,psumh,sig,sigd
-     real,    dimension (its:ite) ::                                   &
+     real,    dimension (its:ite) ::                                     &
         axx,edtmax,edtmin,entr_rate
-     integer,    dimension (its:ite) ::                                &
-       kzdown,KDET,K22,JMIN,kstabi,kstabm,K22x,xland1,        &
+     integer,    dimension (its:ite) ::                                  &
+       kzdown,KDET,K22,JMIN,kstabi,kstabm,K22x,xland1,                   &  
        ktopdby,KBCONx,ierr2,ierr3,KBMAX
 
      integer,  dimension (its:ite), intent(inout) :: ierr
      integer,  dimension (its:ite), intent(in) :: csum
-     integer                              ::                           &
-       iloop,nens3,ki,I,K
-     real                                 ::                           &
-      dz,dzo,mbdt,radius, &
-      zcutdown,depth_min,zkbmax,z_detr,zktop,      &
+     integer                              ::                             &
+       iloop,nens3,ki,kk,I,K
+     real                                 ::                             &
+      dz,dzo,mbdt,radius,                                                &
+      zcutdown,depth_min,zkbmax,z_detr,zktop,                            &
       dh,cap_maxs,trash,trash2,frh,sig_thresh
-     real entdo,dp,subin,detdo,entup,                &
+     real entdo,dp,subin,detdo,entup,                                    &
       detup,subdown,entdoj,entupk,detupk,totmas
 
      real, dimension (its:ite) :: lambau,flux_tun,zws,ztexec,zqexec
 
      integer :: jprnt,jmini,start_k22
      logical :: keep_going,flg(its:ite)
-
+     
      character*50 :: ierrc(its:ite)
-     real,    dimension (its:ite,kts:kte) ::                           &
-       up_massentr,up_massdetr,c1d             &
+     real,    dimension (its:ite,kts:kte) ::                              &
+       up_massentr,up_massdetr,c1d                                        &
       ,up_massentro,up_massdetro,dd_massentro,dd_massdetro
-     real,    dimension (its:ite,kts:kte) ::                           &
+     real,    dimension (its:ite,kts:kte) ::                              &
        up_massentru,up_massdetru
      real buo_flux,pgcon,pgc,blqe
-
+    
      real :: xff_mid(its:ite,2)
      integer :: iversion=1
      real :: denom,h_entr,umean,t_star,dq
      integer, intent(IN) :: DICYCLE
      real,    dimension (its:ite) :: aa1_bl,hkbo_bl,tau_bl,tau_ecmwf,wmean
-     real, dimension (its:ite,kts:kte) :: tn_bl, qo_bl, qeso_bl, heo_bl, heso_bl &
-     					 ,qeso_cup_bl,qo_cup_bl, heo_cup_bl,heso_cup_bl&
-     					 ,gammao_cup_bl,tn_cup_bl,hco_bl,DBYo_bl
+     real, dimension (its:ite,kts:kte) :: tn_bl, qo_bl, qeso_bl, heo_bl, heso_bl             &
+                                              ,qeso_cup_bl,qo_cup_bl, heo_cup_bl,heso_cup_bl &
+                                              ,gammao_cup_bl,tn_cup_bl,hco_bl,DBYo_bl
      real, dimension(its:ite) :: xf_dicycle
      real, intent(inout), dimension(its:ite,10) :: forcing
-     integer :: pmin_lev(its:ite),start_level(its:ite)
+     integer :: pmin_lev(its:ite),start_level(its:ite),ktopkeep(its:ite)
      real,    dimension (its:ite,kts:kte) :: dtempdz
-     integer, dimension (its:ite,kts:kte) ::  k_inv_layers
-
+     integer, dimension (its:ite,kts:kte) ::  k_inv_layers 
+ 
 ! rainevap from sas
      real zuh2(40)
      real, dimension (its:ite) :: rntot,delqev,delq2,qevap,rn,qcond
@@ -350,7 +350,7 @@ contains
            lambau(:)=1.5+rand_mom(:)
        endif
 ! SAS
-     lambau=0.
+!     lambau=0.
 !     pgcon=-.55
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ztexec(:)     = 0.
@@ -366,7 +366,7 @@ contains
          if(zws(i) > TINY(pgeoh)) then
             !-convective-scale velocity w*
             zws(i) = 1.2*zws(i)**.3333
-            !- temperature excess
+            !- temperature excess 
             ztexec(i)     = MAX(flux_tun(i)*hfx(i)/(rho(i,1)*zws(i)*cp),0.0)
             !- moisture  excess
             zqexec(i)     = MAX(flux_tun(i)*qfx(i)/xlv/(rho(i,1)*zws(i)),0.)
@@ -386,8 +386,8 @@ contains
         closure_n(i)=16.
         xmb_out(i)=0.
         cap_max(i)=cap_maxs
-        cap_max_increment(i)=25.
-!        if(imid.eq.1)cap_max_increment(i)=10.
+        cap_max_increment(i)=20.
+        if(imid.eq.1)cap_max_increment(i)=10.
 !
 ! for water or ice
 !
@@ -395,20 +395,19 @@ contains
         if(xland(i).gt.1.5 .or. xland(i).lt.0.5)then
             xland1(i)=0
 !            if(imid.eq.0)cap_max(i)=cap_maxs-25.
-!            if(imid.eq.1)cap_max(i)=cap_maxs-50.
-!            cap_max_increment(i)=20.
+            if(imid.eq.1)cap_max(i)=cap_maxs-50.
+            cap_max_increment(i)=20.
         else
-!            if(ztexec(i).gt.0.)cap_max(i)=cap_max(i)+15.
-!            if(ztexec(i).lt.0.)cap_max(i)=cap_max(i)-15.
+            if(ztexec(i).gt.0.)cap_max(i)=cap_max(i)+25.
+            if(ztexec(i).lt.0.)cap_max(i)=cap_max(i)-25.
         endif
         ierrc(i)=" "
 !       cap_max_increment(i)=1.
       enddo
-      if(use_excess == 0 )then
+      if(imid == 0 .or. use_excess == 0 )then
        ztexec(:)=0
        zqexec(:)=0
       endif
-
 #if ( WRF_DFI_RADAR == 1 )
   if(do_capsuppress == 1) then
       do i=its,itf
@@ -433,9 +432,8 @@ contains
          if(xland1(i) == 0)entr_rate(i)=7.e-5
          if(imid.eq.1)entr_rate(i)=1.e-4
 !         if(imid.eq.1)c1d(i,:)=c1
-!TEST         radius=.2/entr_rate(i)
-         radius=.1/entr_rate(i)
-         frh=3.14*radius*radius/dx(i)/dx(i)
+         radius=.2/entr_rate(i)
+         frh=min(1.,3.14*radius*radius/dx(i)/dx(i))
          if(frh > frh_thresh)then
             frh=frh_thresh
             radius=sqrt(frh*dx(i)*dx(i)/3.14)
@@ -445,7 +443,7 @@ contains
       enddo
       sig_thresh = (1.-frh_thresh)**2
 
-
+      
 !
 !--- entrainment of mass
 !
@@ -482,7 +480,7 @@ contains
       depth_min=1000.
       if(imid.eq.1)depth_min=500.
 !
-!--- maximum depth (mb) of capping
+!--- maximum depth (mb) of capping 
 !--- inversion (larger cap = no convection)
 !
       DO i=its,itf
@@ -512,7 +510,7 @@ contains
 !
 !--- height(m) above which no downdrafts are allowed to originate
 !
-      zcutdown=3000.
+      zcutdown=4000.
 !
 !--- depth(m) over which downdraft detrains all its mass
 !
@@ -533,27 +531,27 @@ contains
 !
 !--- calculate moist static energy, heights, qes
 !
-      call cup_env(z,qes,he,hes,t,q,po,z1, &
-           psur,ierr,tcrit,-1,   &
-           itf,ktf, &
+      call cup_env(z,qes,he,hes,t,q,po,z1,                         &
+           psur,ierr,tcrit,-1,                                     &
+           itf,ktf,                                                &
            its,ite, kts,kte)
-      call cup_env(zo,qeso,heo,heso,tn,qo,po,z1, &
-           psur,ierr,tcrit,-1,   &
-           itf,ktf, &
+      call cup_env(zo,qeso,heo,heso,tn,qo,po,z1,                   &
+           psur,ierr,tcrit,-1,                                     &
+           itf,ktf,                                                &
            its,ite, kts,kte)
 
 !
 !--- environmental values on cloud levels
 !
-      call cup_env_clev(t,qes,q,he,hes,z,po,qes_cup,q_cup,he_cup, &
-           hes_cup,z_cup,p_cup,gamma_cup,t_cup,psur, &
-           ierr,z1,          &
-           itf,ktf, &
+      call cup_env_clev(t,qes,q,he,hes,z,po,qes_cup,q_cup,he_cup,  &
+           hes_cup,z_cup,p_cup,gamma_cup,t_cup,psur,               &
+           ierr,z1,                                                &
+           itf,ktf,                                                &
            its,ite, kts,kte)
       call cup_env_clev(tn,qeso,qo,heo,heso,zo,po,qeso_cup,qo_cup, &
            heo_cup,heso_cup,zo_cup,po_cup,gammao_cup,tn_cup,psur,  &
-           ierr,z1,          &
-           itf,ktf, &
+           ierr,z1,                                                &
+           itf,ktf,                                                &
            its,ite, kts,kte)
       do i=its,itf
         if(ierr(i).eq.0)then
@@ -620,17 +618,17 @@ contains
       jprnt=0
       iloop=1
       if(imid.eq.1)iloop=5
-      call cup_kbcon(ierrc,cap_max_increment,iloop,k22,kbcon,heo_cup,heso_cup, &
-           hkbo,ierr,kbmax,po_cup,cap_max, &
-           ztexec,zqexec,       &
-           jprnt,itf,ktf, &
-           its,ite, kts,kte, &
+      call cup_kbcon(ierrc,cap_max_increment,iloop,k22,kbcon,heo_cup,heso_cup,  &
+           hkbo,ierr,kbmax,po_cup,cap_max,                                      &
+           ztexec,zqexec,                                                       &
+           jprnt,itf,ktf,                                                       &
+           its,ite, kts,kte,                                                    &
            z_cup,entr_rate,heo,imid)
 !
 !--- increase detrainment in stable layers
 !
-      CALL cup_minimi(HEso_cup,Kbcon,kstabm,kstabi,ierr,  &
-           itf,ktf, &
+      CALL cup_minimi(HEso_cup,Kbcon,kstabm,kstabi,ierr,                        &
+           itf,ktf,                                                             &
            its,ite, kts,kte)
       DO i=its,itf
          IF(ierr(I) == 0)THEN
@@ -662,7 +660,7 @@ contains
 !--- get inversion layers for mid level cloud tops
 !
       if(imid.eq.1)then
-      call get_inversion_layers(ierr,p_cup,t_cup,z_cup,q_cup,qes_cup,k_inv_layers,       &
+      call get_inversion_layers(ierr,p_cup,t_cup,z_cup,q_cup,qes_cup,k_inv_layers, &
                                kbcon,kstabi,dtempdz,itf,ktf,its,ite, kts,kte)
       endif
       DO i=its,itf
@@ -681,12 +679,18 @@ contains
                entr_rate_2d(i,k)=entr_rate(i) *(1.3-frh)
             enddo
             if(imid.eq.1)then
-               if(k_inv_layers(i,2) > 0 )then
-                 ktop(i)=k_inv_layers(i,2)
+                if(k_inv_layers(i,2).gt.0 .and.   &
+                  (po_cup(i,k22(i))-po_cup(i,k_inv_layers(i,2))).lt.500.)then
+
+                 ktop(i)=min(kstabi(i),k_inv_layers(i,2))
                  ktopdby(i)=ktop(i)
                else
-                  ktop(i)=kstabi(i)+1
-                  ktopdby(i)=kstabi(i)+1
+                 do k=kbcon(i)+1,ktf
+                  if((po_cup(i,k22(i))-po_cup(i,k)).gt.500.)then
+                    ktop(i)=k
+                    exit
+                  endif
+                 enddo
                endif ! k_inv_lay
             endif
 
@@ -727,14 +731,14 @@ contains
            zu (i,k)=0.
            xzu(i,k)=0.
          enddo
-	endif
+        endif
       enddo
 !
 ! calculate mass entrainment and detrainment
 !
-      CALL get_lateral_massflux(itf,ktf, its,ite, kts,kte &
-                                ,ierr,ktop,zo_cup,zuo,cd,entr_rate_2d        &
-                                ,up_massentro, up_massdetro ,up_massentr, up_massdetr &
+      CALL get_lateral_massflux(itf,ktf, its,ite, kts,kte                                &
+                                ,ierr,ktop,zo_cup,zuo,cd,entr_rate_2d                    &
+                                ,up_massentro, up_massdetro ,up_massentr, up_massdetr    &
                                 ,'deep',kbcon,k22,up_massentru,up_massdetru,lambau)
 
 
@@ -765,41 +769,62 @@ contains
          k=start_level(i)
          hc (i,k)=hkb(i)
          hco(i,k)=hkbo(i)
-       ENDIF
+       ENDIF 
       enddo
 
       DO i=its,itf
 
-       if(ierr(i) /= 0) cycle
+       ktopkeep(i)=0
+       dbyt(i,:)=0.
+       if(ierr(i) /= 0) cycle                 
+       ktopkeep(i)=ktop(i)
        DO k=start_level(i) +1,ktop(i)  !mass cons option
-
-	  denom=zuo(i,k-1)-.5*up_massdetro(i,k-1)+up_massentro(i,k-1)
+         
+          denom=zuo(i,k-1)-.5*up_massdetro(i,k-1)+up_massentro(i,k-1)
           if(denom.lt.1.e-8)then
            ierr(i)=51
            exit
           endif
 
-          hc(i,k)=(hc(i,k-1)*zu(i,k-1)-.5*up_massdetr(i,k-1)*hc(i,k-1)+ &
-                                          up_massentr(i,k-1)*he(i,k-1))   /            &
+          hc(i,k)=(hc(i,k-1)*zu(i,k-1)-.5*up_massdetr(i,k-1)*hc(i,k-1)+                 &
+                                          up_massentr(i,k-1)*he(i,k-1))   /             &
                             (zu(i,k-1)-.5*up_massdetr(i,k-1)+up_massentr(i,k-1))
-          uc(i,k)=(uc(i,k-1)*zu(i,k-1)-.5*up_massdetru(i,k-1)*uc(i,k-1)+ &
-                                          up_massentru(i,k-1)*us(i,k-1) &
-                            -pgcon*.5*(zu(i,k)+zu(i,k-1))*(u_cup(i,k)-u_cup(i,k-1))) /     &
+          uc(i,k)=(uc(i,k-1)*zu(i,k-1)-.5*up_massdetru(i,k-1)*uc(i,k-1)+                &
+                                          up_massentru(i,k-1)*us(i,k-1)                 &
+                            -pgcon*.5*(zu(i,k)+zu(i,k-1))*(u_cup(i,k)-u_cup(i,k-1))) /  &
                            (zu(i,k-1)-.5*up_massdetru(i,k-1)+up_massentru(i,k-1))
           vc(i,k)=(vc(i,k-1)*zu(i,k-1)-.5*up_massdetru(i,k-1)*vc(i,k-1)+                &
-                                          up_massentru(i,k-1)*vs(i,k-1)      &
-                         -pgcon*.5*(zu(i,k)+zu(i,k-1))*(v_cup(i,k)-v_cup(i,k-1))) /    &
+                                          up_massentru(i,k-1)*vs(i,k-1)                 &
+                         -pgcon*.5*(zu(i,k)+zu(i,k-1))*(v_cup(i,k)-v_cup(i,k-1))) /     &
                          (zu(i,k-1)-.5*up_massdetru(i,k-1)+up_massentru(i,k-1))
           dby(i,k)=hc(i,k)-hes_cup(i,k)
-          hco(i,k)=(hco(i,k-1)*zuo(i,k-1)-.5*up_massdetro(i,k-1)*hco(i,k-1)+ &
-                                             up_massentro(i,k-1)*heo(i,k-1))   /            &
+          hco(i,k)=(hco(i,k-1)*zuo(i,k-1)-.5*up_massdetro(i,k-1)*hco(i,k-1)+            &
+                                             up_massentro(i,k-1)*heo(i,k-1))   /        &
                          (zuo(i,k-1)-.5*up_massdetro(i,k-1)+up_massentro(i,k-1))
           dbyo(i,k)=hco(i,k)-heso_cup(i,k)
+          DZ=Zo_cup(i,K+1)-Zo_cup(i,K)
+          dbyt(i,k)=dbyt(i,k-1)+dbyo(i,k)*dz
        ENDDO
+! for now no overshooting (only very little)
+       kk=maxloc(dbyt(i,:),1)
+       ki=maxloc(zuo(i,:),1)
+!       if(ipr .eq.1)write(16,*)'cupgf2',kk,ki
+!       if(kk.lt.ki+3)then
+!         ierr(i)=423
+!       endif
+!
+        do k=ktop(i)-1,kbcon(i),-1
+           if(dbyo(i,k).gt.0.)then
+              ktopkeep(i)=k+1
+              exit
+           endif
+        enddo
+        ktop(I)=ktopkeep(i)
+        if(ierr(i).eq.0)ktop(I)=ktopkeep(i)
       ENDDO
 41    continue
       DO i=its,itf
-       if(ierr(i) /= 0) cycle
+       if(ierr(i) /= 0) cycle                 
        do k=ktop(i)+1,ktf
            HC(i,K)=hes_cup(i,k)
            UC(i,K)=u_cup(i,k)
@@ -879,7 +904,7 @@ contains
              endif
            enddo
          enddo
-         jmin(i) = jmini
+         jmin(i) = jmini 
          if ( jmini .le. 5 ) then
            ierr(i)=4
            ierrc(i) = "could not find jmini4"
@@ -931,7 +956,7 @@ contains
         cdd(i,jmin(i))=0.
         dd_massdetro(i,:)=0.
         dd_massentro(i,:)=0.
-           call get_zu_zd_pdf_fim(rand_vmas(i),0.,ipr,xland1(i),zuh2,"DOWN",ierr(i),kdet(i),jmin(i),zdo(i,:),kts,kte,ktf,beta,kpbl(i),csum(i),pmin_lev(i))
+        call get_zu_zd_pdf_fim(0,po_cup(i,:),rand_vmas(i),0.,ipr,xland1(i),zuh2,"DOWN",ierr(i),kdet(i),jmin(i),zdo(i,:),kts,kte,ktf,beta,kpbl(i),csum(i),pmin_lev(i))
         if(zdo(i,jmin(i)) .lt.1.e-8)then
           zdo(i,jmin(i))=0.
           jmin(i)=jmin(i)-1
@@ -940,7 +965,7 @@ contains
              cycle
           endif
         endif
-
+        
         do ki=jmin(i)  ,maxloc(zdo(i,:),1),-1
           !=> from jmin to maximum value zd -> change entrainment
           dzo=zo_cup(i,ki+1)-zo_cup(i,ki)
@@ -977,6 +1002,7 @@ contains
            c1d(i,k)=max(0.,c1d(i,k))
            c1d(i,k)=c1
          enddo
+         if(imid.eq.1)c1d(i,:)=0.
 !        do k=1,jmin(i)
 !         c1d(i,k)=0.
 !        enddo
@@ -996,19 +1022,19 @@ contains
             do ki=jmin(i)  ,1,-1
              dzo=zo_cup(i,ki+1)-zo_cup(i,ki)
              h_entr=.5*(heo(i,ki)+.5*(hco(i,ki)+hco(i,ki+1)))
-             ucd(i,ki)=(ucd(i,ki+1)*zdo(i,ki+1)                       &
-                         -.5*dd_massdetro(i,ki)*ucd(i,ki+1)+ &
-                        dd_massentro(i,ki)*us(i,ki)          &
-                        -pgcon*zdo(i,ki+1)*(us(i,ki+1)-us(i,ki)))   /     &
+             ucd(i,ki)=(ucd(i,ki+1)*zdo(i,ki+1)                                   &
+                         -.5*dd_massdetro(i,ki)*ucd(i,ki+1)+                      &
+                        dd_massentro(i,ki)*us(i,ki)                               &
+                        -pgcon*zdo(i,ki+1)*(us(i,ki+1)-us(i,ki)))   /             &
                         (zdo(i,ki+1)-.5*dd_massdetro(i,ki)+dd_massentro(i,ki))
-             vcd(i,ki)=(vcd(i,ki+1)*zdo(i,ki+1)                       &
-                         -.5*dd_massdetro(i,ki)*vcd(i,ki+1)+ &
-                        dd_massentro(i,ki)*vs(i,ki)            &
-                        -pgcon*zdo(i,ki+1)*(vs(i,ki+1)-vs(i,ki)))   /  &
+             vcd(i,ki)=(vcd(i,ki+1)*zdo(i,ki+1)                                   &
+                         -.5*dd_massdetro(i,ki)*vcd(i,ki+1)+                      &
+                        dd_massentro(i,ki)*vs(i,ki)                               &
+                        -pgcon*zdo(i,ki+1)*(vs(i,ki+1)-vs(i,ki)))   /             &
                         (zdo(i,ki+1)-.5*dd_massdetro(i,ki)+dd_massentro(i,ki))
-             hcdo(i,ki)=(hcdo(i,ki+1)*zdo(i,ki+1)                       &
-                         -.5*dd_massdetro(i,ki)*hcdo(i,ki+1)+ &
-                        dd_massentro(i,ki)*h_entr)   /            &
+             hcdo(i,ki)=(hcdo(i,ki+1)*zdo(i,ki+1)                                 &
+                         -.5*dd_massdetro(i,ki)*hcdo(i,ki+1)+                     &
+                        dd_massentro(i,ki)*h_entr)   /                            &
                         (zdo(i,ki+1)-.5*dd_massdetro(i,ki)+dd_massentro(i,ki))
              dbydo(i,ki)=hcdo(i,ki)-heso_cup(i,ki)
              bud(i)=bud(i)+dbydo(i,ki)*dzo
@@ -1023,27 +1049,27 @@ contains
 !
 !--- calculate moisture properties of downdraft
 !
-      call cup_dd_moisture(ierrc,zdo,hcdo,heso_cup,qcdo,qeso_cup, &
-           pwdo,qo_cup,zo_cup,dd_massentro,dd_massdetro,jmin,ierr,gammao_cup, &
-           pwevo,bu,qrcdo,qo,heo,1, &
-           itf,ktf, &
+      call cup_dd_moisture(ierrc,zdo,hcdo,heso_cup,qcdo,qeso_cup,                &
+           pwdo,qo_cup,zo_cup,dd_massentro,dd_massdetro,jmin,ierr,gammao_cup,    &
+           pwevo,bu,qrcdo,qo,heo,1,                                              &
+           itf,ktf,                                                              &
            its,ite, kts,kte)
 !
 !--- calculate moisture properties of updraft
 !
       if(imid.eq.1)then
-        call cup_up_moisture('mid',ierr,zo_cup,qco,qrco,pwo,pwavo, &
-             p_cup,kbcon,ktop,dbyo,clw_all,xland1, &
-             qo,GAMMAo_cup,zuo,qeso_cup,k22,qo_cup,        &
-             ZQEXEC,ccn,rho,c1d,tn_cup,up_massentr,up_massdetr,psum,psumh,&
-             1,itf,ktf, &
+        call cup_up_moisture('mid',ierr,zo_cup,qco,qrco,pwo,pwavo,               &
+             p_cup,kbcon,ktop,dbyo,clw_all,xland1,                               &
+             qo,GAMMAo_cup,zuo,qeso_cup,k22,qo_cup,                              &
+             ZQEXEC,ccn,rho,c1d,tn_cup,up_massentr,up_massdetr,psum,psumh,       &
+             1,itf,ktf,                                                          &
              its,ite, kts,kte)
       else
-         call cup_up_moisture('deep',ierr,zo_cup,qco,qrco,pwo,pwavo, &
-             p_cup,kbcon,ktop,dbyo,clw_all,xland1, &
-             qo,GAMMAo_cup,zuo,qeso_cup,k22,qo_cup,        &
-             ZQEXEC,ccn,rho,c1d,tn_cup,up_massentr,up_massdetr,psum,psumh,&
-             1,itf,ktf, &
+         call cup_up_moisture('deep',ierr,zo_cup,qco,qrco,pwo,pwavo,             &
+             p_cup,kbcon,ktop,dbyo,clw_all,xland1,                               &
+             qo,GAMMAo_cup,zuo,qeso_cup,k22,qo_cup,                              &
+             ZQEXEC,ccn,rho,c1d,tn_cup,up_massentr,up_massdetr,psum,psumh,       &
+             1,itf,ktf,                                                          &
              its,ite, kts,kte)
       endif
       do i=its,itf
@@ -1058,13 +1084,13 @@ contains
 !
 !--- calculate workfunctions for updrafts
 !
-      call cup_up_aa0(aa0,z,zu,dby,GAMMA_CUP,t_cup, &
-           kbcon,ktop,ierr,           &
-           itf,ktf, &
+      call cup_up_aa0(aa0,z,zu,dby,GAMMA_CUP,t_cup,                              &
+           kbcon,ktop,ierr,                                                      &
+           itf,ktf,                                                              &
            its,ite, kts,kte)
-      call cup_up_aa0(aa1,zo,zuo,dbyo,GAMMAo_CUP,tn_cup, &
-           kbcon,ktop,ierr,           &
-           itf,ktf, &
+      call cup_up_aa0(aa1,zo,zuo,dbyo,GAMMAo_CUP,tn_cup,                         &
+           kbcon,ktop,ierr,                                                      &
+           itf,ktf,                                                              &
            its,ite, kts,kte)
       do i=its,itf
          if(ierr(i).eq.0)then
@@ -1075,15 +1101,15 @@ contains
          endif
       enddo
 !
-!--- diurnal cycle closure
+!--- diurnal cycle closure 
 !
       !--- AA1 from boundary layer (bl) processes only
       aa1_bl      (:) = 0.0
       xf_dicycle   (:) = 0.0
       tau_ecmwf    (:) = 0.
       !- way to calculate the fraction of cape consumed by shallow convection
-      iversion=1 ! ecmwf
-      !iversion=0 ! orig
+      iversion=1 ! ecmwf  
+      !iversion=0 ! orig    
       !
       ! Betchold et al 2008 time-scale of cape removal
 !
@@ -1092,24 +1118,24 @@ contains
 !
       DO i=its,itf
             if(ierr(i).eq.0)then
-                !- mean vertical velocity
+                !- mean vertical velocity 
                 wmean(i) = 7.0 ! m/s ! in the future change for Wmean == integral( W dz) / cloud_depth
                 if(imid.eq.1)wmean(i) = 3.0
                 !- time-scale cape removal from  Betchold et al. 2008
-                tau_ecmwf(i)=( zo_cup(i,ktopdby(i))- zo_cup(i,kbcon(i)) ) / wmean(i)
-                tau_ecmwf(i)= tau_ecmwf(i) * (1.0061 + 1.23E-2 * (dx(i)/1000.))! dx(i) must be in meters
+                tau_ecmwf(i)=( zo_cup(i,ktopdby(i))- zo_cup(i,kbcon(i)) ) / wmean(i) 
+                tau_ecmwf(i)= tau_ecmwf(i) * (1.0061 + 1.23E-2 * (dx(i)/1000.))! dx(i) must be in meters 
             endif
       enddo
       tau_bl(:)     = 0.
       !
       IF(dicycle == 1) then
         DO i=its,itf
-
+            
             if(ierr(i).eq.0)then
                 if(xland1(i) ==  0 ) then
                   !- over water
                   umean= 2.0+sqrt(2.0*(US(i,1)**2+VS(i,1)**2+US(i,kbcon(i))**2+VS(i,kbcon(i))**2))
-                  tau_bl(i) = (zo_cup(i,kbcon(i))- z1(i)) /umean
+                  tau_bl(i) = (zo_cup(i,kbcon(i))- z1(i)) /umean        
                 else
                   !- over land
                   tau_bl(i) =( zo_cup(i,ktopdby(i))- zo_cup(i,kbcon(i)) ) / wmean(i)
@@ -1118,14 +1144,14 @@ contains
             endif
         ENDDO
 
-        if(iversion == 1) then
+        if(iversion == 1) then 
         !-- version ecmwf
         t_star=4.  !original =1
 
            !-- calculate pcape from BL forcing only
-            call cup_up_aa1bl(aa1_bl,t,tn,q,qo,dtime, &
-                              zo_cup,zuo,dbyo_bl,GAMMAo_CUP_bl,tn_cup_bl, &
-                              kbcon,ktop,ierr,               &
+            call cup_up_aa1bl(aa1_bl,t,tn,q,qo,dtime,                            &
+                              zo_cup,zuo,dbyo_bl,GAMMAo_CUP_bl,tn_cup_bl,        &
+                              kbcon,ktop,ierr,                                   &
                               itf,ktf,its,ite, kts,kte)
 
             DO i=its,itf
@@ -1133,19 +1159,19 @@ contains
             if(ierr(i).eq.0)then
 
                !- only for convection rooting in the PBL
-               if(zo_cup(i,kbcon(i))-z1(i) > zo(i,kpbl(i)-1)) then
+               if(zo_cup(i,kbcon(i))-z1(i) > zo(i,kpbl(i)-1)) then 
                   aa1_bl(i) = 0.0
                else
                !- multiply aa1_bl the " time-scale" - tau_bl
                   aa1_bl(i) = max(0.,aa1_bl(i)/t_star* tau_bl(i))
-               endif
+               endif 
             endif
             ENDDO
-
+            
         else
-
+        
           !- version for real cloud-work function
-
+          
           !-get the profiles modified only by bl tendencies
           DO i=its,itf
            tn_bl(i,:)=0.;qo_bl(i,:)=0.
@@ -1156,20 +1182,20 @@ contains
                  !above kbcon -> keep environment profiles
             tn_bl(i,kbcon(i)+1:ktf) = t(i,kbcon(i)+1:ktf)
             qo_bl(i,kbcon(i)+1:ktf) = q(i,kbcon(i)+1:ktf)
-           endif
+           endif 
           ENDDO
           !--- calculate moist static energy, heights, qes, ... only by bl tendencies
-          call cup_env(zo,qeso_bl,heo_bl,heso_bl,tn_bl,qo_bl,po,z1, &
-                     psur,ierr,tcrit,-1,   &
+          call cup_env(zo,qeso_bl,heo_bl,heso_bl,tn_bl,qo_bl,po,z1,                              &
+                     psur,ierr,tcrit,-1,                                                         &
                      itf,ktf, its,ite, kts,kte)
           !--- environmental values on cloud levels only by bl tendencies
-          call cup_env_clev(tn_bl,qeso_bl,qo_bl,heo_bl,heso_bl,zo,po,qeso_cup_bl,qo_cup_bl, &
-                              heo_cup_bl,heso_cup_bl,zo_cup,po_cup,gammao_cup_bl,tn_cup_bl,psur,  &
-                              ierr,z1,               &
+          call cup_env_clev(tn_bl,qeso_bl,qo_bl,heo_bl,heso_bl,zo,po,qeso_cup_bl,qo_cup_bl,      &
+                              heo_cup_bl,heso_cup_bl,zo_cup,po_cup,gammao_cup_bl,tn_cup_bl,psur, &
+                              ierr,z1,                                                           &
                               itf,ktf,its,ite, kts,kte)
           DO i=its,itf
             IF(ierr(I).eq.0)THEN
-               hkbo_bl(i)=heo_cup_bl(i,k22(i))
+               hkbo_bl(i)=heo_cup_bl(i,k22(i)) 
             endif ! ierr
           ENDDO
           DO k=kts,ktf
@@ -1188,13 +1214,13 @@ contains
              DBYo_bl(i,k)=Hkbo_bl(i) - HESo_cup_bl(i,k)
             ENDIF
           ENDDO
-!
-!
+!          
+!          
           DO i=its,itf
             if(ierr(i).eq.0)then
                do k=kbcon(i)+1,ktop(i)
                     hco_bl(i,k)=(hco_bl(i,k-1)*zuo(i,k-1)-.5*up_massdetro(i,k-1)*hco_bl(i,k-1)+ &
-                               up_massentro(i,k-1)*heo_bl(i,k-1))   /               &
+                               up_massentro(i,k-1)*heo_bl(i,k-1))   /                           &
                                (zuo(i,k-1)-.5*up_massdetro(i,k-1)+up_massentro(i,k-1))
                     dbyo_bl(i,k)=hco_bl(i,k)-heso_cup_bl(i,k)
                enddo
@@ -1204,14 +1230,14 @@ contains
                enddo
             endif
           ENDDO
-
+        
           !--- calculate workfunctions for updrafts
-          call cup_up_aa0(aa1_bl,zo,zuo,dbyo_bl,GAMMAo_CUP_bl,tn_cup_bl, &
-                        kbcon,ktop,ierr,           &
+          call cup_up_aa0(aa1_bl,zo,zuo,dbyo_bl,GAMMAo_CUP_bl,tn_cup_bl,        &
+                        kbcon,ktop,ierr,                                        &
                         itf,ktf,its,ite, kts,kte)
 
           DO i=its,itf
-
+            
             if(ierr(i).eq.0)then
                 !- get the increment on AA0 due the BL processes
                 aa1_bl(i) = aa1_bl(i) - aa0(i)
@@ -1221,8 +1247,8 @@ contains
                 !else
                 !   !- multiply aa1_bl the "normalized time-scale" - tau_bl/ model_timestep
                    aa1_bl(i) = aa1_bl(i)* tau_bl(i)/ dtime
-                !endif
-                print*,'aa0,aa1bl=',aa0(i),aa1_bl(i),aa0(i)-aa1_bl(i),tau_bl(i)!,dtime,xland(i)
+                !endif 
+                print*,'aa0,aa1bl=',aa0(i),aa1_bl(i),aa0(i)-aa1_bl(i),tau_bl(i)!,dtime,xland(i)     
             endif
            ENDDO
         ENDIF
@@ -1234,9 +1260,9 @@ contains
 !
 !--- DETERMINE DOWNDRAFT STRENGTH IN TERMS OF WINDSHEAR
 !
-      call cup_dd_edt(ierr,us,vs,zo,ktop,kbcon,edt,po,pwavo, &
-           pwo,ccn,pwevo,edtmax,edtmin,edtc,psum,psumh, &
-           rho,aeroevap,itf,ktf, &
+      call cup_dd_edt(ierr,us,vs,zo,ktop,kbcon,edt,po,pwavo,  &
+           pwo,ccn,pwevo,edtmax,edtmin,edtc,psum,psumh,       &
+           rho,aeroevap,itf,ktf,                              &
            its,ite, kts,kte)
         do i=its,itf
          if(ierr(i).eq.0)then
@@ -1350,19 +1376,19 @@ contains
              pgc=pgcon
             if(k.ge.ktop(i))pgc=0.
 
-             dellu(i,k) =-(zuo(i,k+1)*(uc (i,k+1)-u_cup(i,k+1) ) - &
-                            zuo(i,k  )*(uc (i,k  )-u_cup(i,k  ) ) )*g/dp &
-                          +(zdo(i,k+1)*(ucd(i,k+1)-u_cup(i,k+1) ) - &
-                            zdo(i,k  )*(ucd(i,k  )-u_cup(i,k  ) ) )*g/dp*edto(i)*pgcd &
-                     +(pgc*.5*(zuo(i,k)+zuo(i,k+1))*(u_cup(i,k+1)-u_cup(i,k)) &
+             dellu(i,k) =-(zuo(i,k+1)*(uc (i,k+1)-u_cup(i,k+1) ) -                               &
+                            zuo(i,k  )*(uc (i,k  )-u_cup(i,k  ) ) )*g/dp                         &
+                          +(zdo(i,k+1)*(ucd(i,k+1)-u_cup(i,k+1) ) -                              &
+                            zdo(i,k  )*(ucd(i,k  )-u_cup(i,k  ) ) )*g/dp*edto(i)*pgcd            &
+                     +(pgc*.5*(zuo(i,k)+zuo(i,k+1))*(u_cup(i,k+1)-u_cup(i,k))                    &
                      + pgcd*pgc*.5*edto(i)*(zdo(i,k)+zdo(i,k+1))*(u_cup(i,k+1)-u_cup(i,k)))*g/dp
-             dellv(i,k) =-(zuo(i,k+1)*(vc (i,k+1)-v_cup(i,k+1) ) - &
-                            zuo(i,k  )*(vc (i,k  )-v_cup(i,k  ) ) )*g/dp &
-                         +(zdo(i,k+1)*(vcd(i,k+1)-v_cup(i,k+1) ) - &
-                            zdo(i,k  )*(vcd(i,k  )-v_cup(i,k  ) ) )*g/dp*edto(i)*pgcd &
-                     +(pgc*.5*(zuo(i,k)+zuo(i,k+1))*(v_cup(i,k+1)-v_cup(i,k)) &
+             dellv(i,k) =-(zuo(i,k+1)*(vc (i,k+1)-v_cup(i,k+1) ) -                               &
+                            zuo(i,k  )*(vc (i,k  )-v_cup(i,k  ) ) )*g/dp                         &
+                         +(zdo(i,k+1)*(vcd(i,k+1)-v_cup(i,k+1) ) -                               &
+                            zdo(i,k  )*(vcd(i,k  )-v_cup(i,k  ) ) )*g/dp*edto(i)*pgcd            &
+                     +(pgc*.5*(zuo(i,k)+zuo(i,k+1))*(v_cup(i,k+1)-v_cup(i,k))                    &
                      + pgcd*pgc*.5*edto(i)*(zdo(i,k)+zdo(i,k+1))*(v_cup(i,k+1)-v_cup(i,k)))*g/dp
-
+ 
        enddo   ! k
 
       endif
@@ -1376,22 +1402,22 @@ contains
 
          dp=100.*(po_cup(i,1)-po_cup(i,2))
 
-         dellah(i,1)=(edto(i)*zdo(i,2)*hcdo(i,2)   &
+         dellah(i,1)=(edto(i)*zdo(i,2)*hcdo(i,2)          &
                      -edto(i)*zdo(i,2)*heo_cup(i,2))*g/dp
 
-         dellaq (i,1)=(edto(i)*zdo(i,2)*qcdo(i,2)   &
+         dellaq (i,1)=(edto(i)*zdo(i,2)*qcdo(i,2)         &
                       -edto(i)*zdo(i,2)*qo_cup(i,2))*g/dp
-
+        
          G_rain=  0.5*(pwo (i,1)+pwo (i,2))*g/dp
          E_dn  = -0.5*(pwdo(i,1)+pwdo(i,2))*g/dp*edto(i)  ! pwdo < 0 and E_dn must > 0
          dellaq(i,1) = dellaq(i,1)+ E_dn-G_rain
-
+         
          !--- conservation check
          !- water mass balance
-         !trash = trash  + (dellaq(i,1)+dellaqc(i,1)+G_rain-E_dn)*dp/g
+         !trash = trash  + (dellaq(i,1)+dellaqc(i,1)+G_rain-E_dn)*dp/g          
          !- H  budget
          !trash2 = trash2+ (dellah(i,1))*dp/g
-
+         
 
          do k=kts+1,ktop(i)
             dp=100.*(po_cup(i,k)-po_cup(i,k+1))
@@ -1401,16 +1427,16 @@ contains
                            zuo(i,k  )*(hco (i,k  )-heo_cup(i,k  ) ) )*g/dp            &
                          +(zdo(i,k+1)*(hcdo(i,k+1)-heo_cup(i,k+1) ) -                 &
                            zdo(i,k  )*(hcdo(i,k  )-heo_cup(i,k  ) ) )*g/dp*edto(i)
+                        
 
-
-            !- check H conservation
+            !- check H conservation 
             ! trash2 = trash2+ (dellah(i,k))*dp/g
-
-
+        
+        
             !-- take out cloud liquid water for detrainment
             detup=up_massdetro(i,k)
             dz=zo_cup(i,k+1)-zo_cup(i,k)
-            if(k.lt.ktop(i)) dellaqc(i,k) = zuo(i,k)*c1d(i,k)*qrco(i,k)*dz/dp*g
+            if(k.lt.ktop(i)) dellaqc(i,k) = zuo(i,k)*c1d(i,k)*qrco(i,k)*dz/dp*g 
 !             dellaqc(i,k)=  detup*0.5*(qrco(i,k+1)+qrco(i,k)) *g/dp
             if(k.eq.ktop(i))dellaqc(i,k)= detup*0.5*(qrco(i,k+1)+qrco(i,k)) *g/dp
             !---
@@ -1418,12 +1444,12 @@ contains
             E_dn  = -0.5*(pwdo(i,k)+pwdo(i,k+1))*g/dp*edto(i) ! pwdo < 0 and E_dn must > 0
             !-- condensation source term = detrained + flux divergence of
             !-- cloud liquid water (qrco) + converted to rain
-
-            C_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -       &
+        
+            C_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -                           &
                                 zuo(i,k  )* qrco(i,k  )  )*g/dp + G_rain
 !            C_up = dellaqc(i,k)+ G_rain
             !-- water vapor budget
-            !-- = flux divergence z*(Q_c - Q_env)_up_and_down &
+            !-- = flux divergence z*(Q_c - Q_env)_up_and_down                        &
             !--   - condensation term + evaporation
             dellaq(i,k) =-(zuo(i,k+1)*(qco (i,k+1)-qo_cup(i,k+1) ) -                 &
                            zuo(i,k  )*(qco (i,k  )-qo_cup(i,k  ) ) )*g/dp            &
@@ -1469,17 +1495,17 @@ contains
 !
 !--- calculate moist static energy, heights, qes
 !
-      call cup_env(xz,xqes,xhe,xhes,xt,xq,po,z1, &
-           psur,ierr,tcrit,-1,   &
-           itf,ktf, &
+      call cup_env(xz,xqes,xhe,xhes,xt,xq,po,z1,                   &
+           psur,ierr,tcrit,-1,                                     &
+           itf,ktf,                                                &
            its,ite, kts,kte)
 !
 !--- environmental values on cloud levels
 !
       call cup_env_clev(xt,xqes,xq,xhe,xhes,xz,po,xqes_cup,xq_cup, &
            xhe_cup,xhes_cup,xz_cup,po_cup,gamma_cup,xt_cup,psur,   &
-           ierr,z1,          &
-           itf,ktf, &
+           ierr,z1,                                                &
+           itf,ktf,                                                &
            its,ite, kts,kte)
 !
 !
@@ -1525,10 +1551,10 @@ contains
 !--- workfunctions for updraft
 !
       call cup_up_aa0(xaa0,xz,xzu,xdby,GAMMA_CUP,xt_cup, &
-           kbcon,ktop,ierr,           &
-           itf,ktf, &
+           kbcon,ktop,ierr,                              &
+           itf,ktf,                                      &
            its,ite, kts,kte)
-      do i=its,itf
+      do i=its,itf 
          if(ierr(i).eq.0)then
            xaa0_ens(i,1)=xaa0(i)
            do k=kts,ktop(i)
@@ -1536,7 +1562,7 @@ contains
                  if(nens3.eq.7)then
 !--- b=0
                  pr_ens(i,nens3)=pr_ens(i,nens3)  &
-                                    +pwo(i,k)+edto(i)*pwdo(i,k)
+                                    +pwo(i,k)+edto(i)*pwdo(i,k) 
 !--- b=beta
                  else if(nens3.eq.8)then
                  pr_ens(i,nens3)=pr_ens(i,nens3)+ &
@@ -1570,7 +1596,7 @@ contains
 !--- LARGE SCALE FORCING
 !
 !
-!------- CHECK wether aa0 should have been zero, assuming this
+!------- CHECK wether aa0 should have been zero, assuming this 
 !        ensemble is chosen
 !
 !
@@ -1579,22 +1605,22 @@ contains
          ierr3(i)=ierr(i)
          k22x(i)=k22(i)
       enddo
-        CALL cup_MAXIMI(HEO_CUP,2,KBMAX,K22x,ierr, &
-             itf,ktf, &
+        CALL cup_MAXIMI(HEO_CUP,2,KBMAX,K22x,ierr,                        &
+             itf,ktf,                                                     &
              its,ite, kts,kte)
         iloop=2
         call cup_kbcon(ierrc,cap_max_increment,iloop,k22x,kbconx,heo_cup, &
-             heso_cup,hkbo,ierr2,kbmax,po_cup,cap_max, &
-             ztexec,zqexec,       &
-             0,itf,ktf, &
-             its,ite, kts,kte, &
+             heso_cup,hkbo,ierr2,kbmax,po_cup,cap_max,                    &
+             ztexec,zqexec,                                               &
+             0,itf,ktf,                                                   &
+             its,ite, kts,kte,                                            &
              z_cup,entr_rate,heo,imid)
         iloop=3
         call cup_kbcon(ierrc,cap_max_increment,iloop,k22x,kbconx,heo_cup, &
-             heso_cup,hkbo,ierr3,kbmax,po_cup,cap_max, &
-             ztexec,zqexec,       &
-             0,itf,ktf, &
-             its,ite, kts,kte, &
+             heso_cup,hkbo,ierr3,kbmax,po_cup,cap_max,                    &
+             ztexec,zqexec,                                               &
+             0,itf,ktf,                                                   &
+             its,ite, kts,kte,                                            &
              z_cup,entr_rate,heo,imid)
 !
 !--- calculate cloud base mass flux
@@ -1602,19 +1628,19 @@ contains
 
       DO I = its,itf
         mconv(i) = 0
-        if(ierr(i) /= 0) cycle
-      DO K=1,ktop(i)
-        dq=(qo_cup(i,k+1)-qo_cup(i,k))
-        mconv(i)=mconv(i)+omeg(i,k)*dq/g
+        if(ierr(i)/=0)cycle
+        DO K=1,ktop(i)
+          dq=(qo_cup(i,k+1)-qo_cup(i,k))
+          mconv(i)=mconv(i)+omeg(i,k)*dq/g
+        ENDDO
       ENDDO
-     ENDDO
-      call cup_forcing_ens_3d(closure_n,xland1,aa0,aa1,xaa0_ens,mbdt,dtime,   &
-           ierr,ierr2,ierr3,xf_ens,axx,forcing,                 &
-           maxens3,mconv,rand_clos,            &
-           po_cup,ktop,omeg,zdo,k22,zuo,pr_ens,edto,kbcon,    &
-           ichoice,     &
-           imid,ipr,itf,ktf, &
-           its,ite, kts,kte, &
+      call cup_forcing_ens_3d(closure_n,xland1,aa0,aa1,xaa0_ens,mbdt,dtime, &
+           ierr,ierr2,ierr3,xf_ens,axx,forcing,                             &
+           maxens3,mconv,rand_clos,                                         &
+           po_cup,ktop,omeg,zdo,k22,zuo,pr_ens,edto,kbcon,                  &
+           ichoice,                                                         &
+           imid,ipr,itf,ktf,                                                &
+           its,ite, kts,kte,                                                &
            dicycle,tau_ecmwf,aa1_bl,xf_dicycle)
 !
       do k=kts,ktf
@@ -1623,8 +1649,8 @@ contains
            dellat_ens (i,k,1)=dellat(i,k)
            dellaq_ens (i,k,1)=dellaq(i,k)
            dellaqc_ens(i,k,1)=dellaqc(i,k)
-           pwo_ens    (i,k,1)=pwo(i,k)+edto(i)*pwdo(i,k)
-        else
+           pwo_ens    (i,k,1)=pwo(i,k) !+edto(i)*pwdo(i,k)
+        else 
            dellat_ens (i,k,1)=0.
            dellaq_ens (i,k,1)=0.
            dellaqc_ens(i,k,1)=0.
@@ -1638,7 +1664,7 @@ contains
 !
        if(imid.eq.1 .and. ichoice .le.2)then
          do i=its,itf
-          !-boundary layer QE
+          !-boundary layer QE 
           xff_mid(i,1)=0.
           xff_mid(i,2)=0.
           if(ierr(i).eq.0)then
@@ -1657,13 +1683,13 @@ contains
          enddo
        endif
        call cup_output_ens_3d(xff_mid,xf_ens,ierr,dellat_ens,dellaq_ens, &
-            dellaqc_ens,outt,     &
-            outq,outqc,zuo,pre,pwo_ens,xmb,ktop,      &
-            'deep',ierr2,ierr3,         &
-            pr_ens,maxens3,                    &
-            sig,closure_n,xland1,xmbm_in,xmbs_in,   &
-            ichoice,imid,ipr,itf,ktf,                        &
-            its,ite, kts,kte, &
+            dellaqc_ens,outt,                                            &
+            outq,outqc,zuo,pre,pwo_ens,xmb,ktop,                         &
+            edto,pwdo,'deep',ierr2,ierr3,                                          &
+            po_cup,pr_ens,maxens3,                                              &
+            sig,closure_n,xland1,xmbm_in,xmbs_in,                        &
+            ichoice,imid,ipr,itf,ktf,                                    &
+            its,ite, kts,kte,                                            &
             dicycle,xf_dicycle )
       k=1
       do i=its,itf
@@ -1752,7 +1778,7 @@ contains
                 dp=-.5*(po(i,k+1)-po(i,k-1))*100.
 !total KE dissiptaion estimate
                 dts= dts +(outu(i,k)*us(i,k)+outv(i,k)*vs(i,k))*dp/g
-! fpi needed for calcualtion of conversion to pot. energyintegrated
+! fpi needed for calcualtion of conversion to pot. energyintegrated 
                 fpi = fpi  +sqrt(outu(i,k)*outu(i,k) + outv(i,k)*outv(i,k))*dp
              enddo
              if(fpi.gt.0.)then
@@ -1773,36 +1799,36 @@ contains
 
 
    SUBROUTINE cup_dd_edt(ierr,us,vs,z,ktop,kbcon,edt,p,pwav, &
-              pw,ccn,pwev,edtmax,edtmin,edtc,psum2,psumh, &
-              rho,aeroevap,itf,ktf,          &
+              pw,ccn,pwev,edtmax,edtmin,edtc,psum2,psumh,    &
+              rho,aeroevap,itf,ktf,                          &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-        aeroevap,itf,ktf,           &
+     integer                                                 &
+        ,intent (in   )                   ::                 &
+        aeroevap,itf,ktf,                                    &
         its,ite, kts,kte
   !
   ! ierr error value, maybe modified in this routine
   !
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                    &
+        ,intent (in   )                   ::                 &
         rho,us,vs,z,p,pw
-     real,    dimension (its:ite,1)                            &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite,1)                          &
+        ,intent (out  )                   ::                 &
         edtc
-     real,    dimension (its:ite)                                      &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite)                            &
+        ,intent (out  )                   ::                 &
         edt
-     real,    dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite)                            &
+        ,intent (in   )                   ::                 &
         pwav,pwev,ccn,psum2,psumh,edtmax,edtmin
-     integer, dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     integer, dimension (its:ite)                            &
+        ,intent (in   )                   ::                 &
         ktop,kbcon
-     integer, dimension (its:ite)                                      &
-        ,intent (inout)                   ::                           &
+     integer, dimension (its:ite)                            &
+        ,intent (inout)                   ::                 &
         ierr
 !
 !  local variables in this routine
@@ -1810,7 +1836,7 @@ contains
 
      integer i,k,kk
      real    einc,pef,pefb,prezk,zkbc
-     real,    dimension (its:ite)         ::                           &
+     real,    dimension (its:ite)         ::                 &
       vshear,sdp,vws
      real :: prop_c,pefc,aeroadd,alpha3,beta3
      prop_c=8. !10.386
@@ -1836,9 +1862,9 @@ contains
          do 62 i=its,itf
           IF(ierr(i).ne.0)GO TO 62
           if (kk .le. min0(ktop(i),ktf) .and. kk .ge. kbcon(i)) then
-             vws(i) = vws(i)+ &
-              (abs((us(i,kk+1)-us(i,kk))/(z(i,kk+1)-z(i,kk))) &
-          +   abs((vs(i,kk+1)-vs(i,kk))/(z(i,kk+1)-z(i,kk)))) * &
+             vws(i) = vws(i)+                                        &
+              (abs((us(i,kk+1)-us(i,kk))/(z(i,kk+1)-z(i,kk)))        &
+          +   abs((vs(i,kk+1)-vs(i,kk))/(z(i,kk+1)-z(i,kk)))) *      &
               (p(i,kk) - p(i,kk+1))
             sdp(i) = sdp(i) + p(i,kk) - p(i,kk+1)
           endif
@@ -1847,7 +1873,7 @@ contains
        end do
       do i=its,itf
          IF(ierr(i).eq.0)then
-            pef=(1.591-.639*VSHEAR(I)+.0953*(VSHEAR(I)**2) &
+            pef=(1.591-.639*VSHEAR(I)+.0953*(VSHEAR(I)**2)            &
                -.00496*(VSHEAR(I)**3))
             if(pef.gt.0.9)pef=0.9
             if(pef.lt.0.1)pef=0.1
@@ -1897,20 +1923,20 @@ contains
    END SUBROUTINE cup_dd_edt
 
 
-   SUBROUTINE cup_dd_moisture(ierrc,zd,hcd,hes_cup,qcd,qes_cup,    &
-              pwd,q_cup,z_cup,dd_massentr,dd_massdetr,jmin,ierr,            &
-              gamma_cup,pwev,bu,qrcd,                        &
-              q,he,iloop,           &
-              itf,ktf,                     &
+   SUBROUTINE cup_dd_moisture(ierrc,zd,hcd,hes_cup,qcd,qes_cup,  &
+              pwd,q_cup,z_cup,dd_massentr,dd_massdetr,jmin,ierr, &
+              gamma_cup,pwev,bu,qrcd,                            &
+              q,he,iloop,                                        &
+              itf,ktf,                                           &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-                                  itf,ktf,           &
+     integer                                                     &
+        ,intent (in   )                   ::                     &
+                                  itf,ktf,                       &
                                   its,ite, kts,kte
-  ! cdd= detrainment function
+  ! cdd= detrainment function 
   ! q = environmental q on model levels
   ! q_cup = environmental q on model cloud levels
   ! qes_cup = saturation q on model cloud levels
@@ -1924,35 +1950,35 @@ contains
   ! qrch = saturation q in cloud
   ! pwd = evaporate at that level
   ! pwev = total normalized integrated evaoprate (I2)
-  ! entr= entrainment rate
+  ! entr= entrainment rate 
   !
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
-        zd,hes_cup,hcd,qes_cup,q_cup,z_cup,                      &
-        dd_massentr,dd_massdetr,gamma_cup,q,he
-     integer                                                           &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)               &
+        ,intent (in   )                   ::            &
+        zd,hes_cup,hcd,qes_cup,q_cup,z_cup,             &
+        dd_massentr,dd_massdetr,gamma_cup,q,he 
+     integer                                            &
+        ,intent (in   )                   ::            &
         iloop
-     integer, dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     integer, dimension (its:ite)                       &
+        ,intent (in   )                   ::            &
         jmin
-     integer, dimension (its:ite)                                      &
-        ,intent (inout)                   ::                           &
+     integer, dimension (its:ite)                       &
+        ,intent (inout)                   ::            &
         ierr
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite,kts:kte)&
+        ,intent (out  )                   ::            &
         qcd,qrcd,pwd
-     real,    dimension (its:ite)                                      &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite)&
+        ,intent (out  )                   ::            &
         pwev,bu
      character*50 :: ierrc(its:ite)
 !
 !  local variables in this routine
 !
 
-     integer                              ::                           &
+     integer                              ::            &
         i,k,ki
-     real                                 ::                           &
+     real                                 ::            &
         denom,dh,dz,dqeva
 
       do i=its,itf
@@ -2000,9 +2026,9 @@ contains
             ierr(i)=51
             exit
          endif
-         qcd(i,ki)=(qcd(i,ki+1)*zd(i,ki+1)                          &
-                  -.5*dd_massdetr(i,ki)*qcd(i,ki+1)+ &
-                  dd_massentr(i,ki)*q(i,ki))   /            &
+         qcd(i,ki)=(qcd(i,ki+1)*zd(i,ki+1)                    &
+                  -.5*dd_massdetr(i,ki)*qcd(i,ki+1)+          &
+                  dd_massentr(i,ki)*q(i,ki))   /              &
                   (zd(i,ki+1)-.5*dd_massdetr(i,ki)+dd_massentr(i,ki))
 !
 !--- to be negatively buoyant, hcd should be smaller than hes!
@@ -2011,7 +2037,7 @@ contains
 !
          DH=HCD(I,ki)-HES_cup(I,Ki)
          bu(i)=bu(i)+dz*dh
-         QRCD(I,Ki)=qes_cup(i,ki)+(1./XLV)*(GAMMA_cup(i,ki) &
+         QRCD(I,Ki)=qes_cup(i,ki)+(1./XLV)*(GAMMA_cup(i,ki)   &
                   /(1.+GAMMA_cup(i,ki)))*DH
          dqeva=qcd(i,ki)-qrcd(i,ki)
          if(dqeva.gt.0.)then
@@ -2042,16 +2068,16 @@ contains
 
    END SUBROUTINE cup_dd_moisture
 
-   SUBROUTINE cup_env(z,qes,he,hes,t,q,p,z1,                 &
-              psur,ierr,tcrit,itest,                   &
-              itf,ktf,                     &
+   SUBROUTINE cup_env(z,qes,he,hes,t,q,p,z1,                &
+              psur,ierr,tcrit,itest,                        &
+              itf,ktf,                                      &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-        itf,ktf,           &
+     integer                                                &
+        ,intent (in   )                   ::                &
+        itf,ktf,                                            &
         its,ite, kts,kte
   !
   ! ierr error value, maybe modified in this routine
@@ -2065,31 +2091,31 @@ contains
   ! hes         = environmental saturation moist static energy
   ! psur        = surface pressure
   ! z1          = terrain elevation
+  ! 
   !
-  !
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                &
+        ,intent (in   )                   ::             &
         p,t,q
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                &
+        ,intent (out  )                   ::             &
         he,hes,qes
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (inout)                   ::                           &
+     real,    dimension (its:ite,kts:kte)                &
+        ,intent (inout)                   ::             &
         z
-     real,    dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite)                        &
+        ,intent (in   )                   ::             &
         psur,z1
-     integer, dimension (its:ite)                                      &
-        ,intent (inout)                   ::                           &
+     integer, dimension (its:ite)                        &
+        ,intent (inout)                   ::             &
         ierr
-     integer                                                           &
-        ,intent (in   )                   ::                           &
+     integer                                             &
+        ,intent (in   )                   ::             &
         itest
 !
 !  local variables in this routine
 !
 
-     integer                              ::                           &
+     integer                              ::             &
        i,k
 !     real, dimension (1:2) :: AE,BE,HT
       real, dimension (its:ite,kts:kte) :: tv
@@ -2173,17 +2199,17 @@ contains
    END SUBROUTINE cup_env
 
 
-   SUBROUTINE cup_env_clev(t,qes,q,he,hes,z,p,qes_cup,q_cup,   &
-              he_cup,hes_cup,z_cup,p_cup,gamma_cup,t_cup,psur, &
-              ierr,z1,                                &
-              itf,ktf,                       &
+   SUBROUTINE cup_env_clev(t,qes,q,he,hes,z,p,qes_cup,q_cup,        &
+              he_cup,hes_cup,z_cup,p_cup,gamma_cup,t_cup,psur,      &
+              ierr,z1,                                              &
+              itf,ktf,                                              &
               its,ite, kts,kte                       )
 
    IMPLICIT NONE
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-        itf,ktf,           &
+     integer                                                        &
+        ,intent (in   )                   ::                        &
+        itf,ktf,                                                    &
         its,ite, kts,kte
   !
   ! ierr error value, maybe modified in this routine
@@ -2204,25 +2230,25 @@ contains
   ! gamma_cup   = gamma on cloud levels
   ! psur        = surface pressure
   ! z1          = terrain elevation
+  ! 
   !
-  !
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                        &
+        ,intent (in   )                   ::                     &
         qes,q,he,hes,z,p,t
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                        &
+        ,intent (out  )                   ::                     &
         qes_cup,q_cup,he_cup,hes_cup,z_cup,p_cup,gamma_cup,t_cup
-     real,    dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite)                                &
+        ,intent (in   )                   ::                     &
         psur,z1
-     integer, dimension (its:ite)                                      &
-        ,intent (inout)                   ::                           &
+     integer, dimension (its:ite)                                &
+        ,intent (inout)                   ::                     &
         ierr
 !
 !  local variables in this routine
 !
 
-     integer                              ::                           &
+     integer                              ::                     &
        i,k
 
 
@@ -2275,20 +2301,20 @@ contains
    END SUBROUTINE cup_env_clev
 
    SUBROUTINE cup_forcing_ens_3d(closure_n,xland,aa0,aa1,xaa0,mbdt,dtime,ierr,ierr2,ierr3,&
-              xf_ens,axx,forcing,maxens3,mconv,rand_clos,    &
-              p_cup,ktop,omeg,zd,k22,zu,pr_ens,edt,kbcon,      &
-              ichoice,            &
-              imid,ipr,itf,ktf,               &
-              its,ite, kts,kte, &
+              xf_ens,axx,forcing,maxens3,mconv,rand_clos,             &
+              p_cup,ktop,omeg,zd,k22,zu,pr_ens,edt,kbcon,             &
+              ichoice,                                                &
+              imid,ipr,itf,ktf,                                       &
+              its,ite, kts,kte,                                       &
               dicycle,tau_ecmwf,aa1_bl,xf_dicycle  )
 
    IMPLICIT NONE
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-        imid,ipr,itf,ktf,           &
+     integer                                                          &
+        ,intent (in   )                   ::                          &
+        imid,ipr,itf,ktf,                                             &
         its,ite, kts,kte
-     integer, intent (in   )              ::                           &
+     integer, intent (in   )              ::                          &
         maxens3
   !
   ! ierr error value, maybe modified in this routine
@@ -2315,7 +2341,7 @@ contains
         ,intent (inout)                   ::                           &
         pr_ens
      real,    dimension (its:ite,1:maxens3)                            &
-        ,intent (inout  )                   ::                         &
+        ,intent (inout  )                 ::                           &
         xf_ens
      real,    dimension (its:ite,kts:kte)                              &
         ,intent (in   )                   ::                           &
@@ -2328,7 +2354,7 @@ contains
         xaa0
      real,    dimension (its:ite,4)                                    &
         ,intent (in   )                   ::                           &
-       rand_clos
+       rand_clos 
      real,    dimension (its:ite)                                      &
         ,intent (in   )                   ::                           &
         aa1,edt
@@ -2338,17 +2364,17 @@ contains
      real,    dimension (its:ite)                                      &
         ,intent (inout)                   ::                           &
         aa0,closure_n
-     real                                         &
+     real                                                              &
         ,intent (in   )                   ::                           &
         mbdt
      real                                                              &
         ,intent (in   )                   ::                           &
         dtime
      integer, dimension (its:ite)                                      &
-        ,intent (inout   )                   ::                           &
+        ,intent (inout   )                ::                           &
         k22,kbcon,ktop
      integer, dimension (its:ite)                                      &
-        ,intent (in      )                   ::                           &
+        ,intent (in      )                ::                           &
         xland
      integer, dimension (its:ite)                                      &
         ,intent (inout)                   ::                           &
@@ -2368,12 +2394,12 @@ contains
 
      real,    dimension (1:maxens3)       ::                           &
        xff_ens3
-     real,    dimension (1)        ::                           &
+     real,    dimension (1)               ::                           &
        xk
      integer                              ::                           &
        kk,i,k,n,ne
 !     integer, parameter :: mkxcrt=15
-!     real,    dimension(1:mkxcrt)         ::                           &
+!     real,    dimension(1:mkxcrt)        ::                           &
 !       pcrit,acrit,acritt
      integer, dimension (its:ite)         :: kloc
      real                                 ::                           &
@@ -2395,8 +2421,8 @@ contains
            kloc(i)=maxloc(zu(i,:),1)
            ens_adj(i)=1.
 !ss --- comment out adjustment over ocean
-           if(ierr2(i).gt.0.and.ierr3(i).eq.0)ens_adj(i)=0. ! 2./3.
-           if(ierr2(i).gt.0.and.ierr3(i).gt.0)ens_adj(i)=0.
+!ss           if(ierr2(i).gt.0.and.ierr3(i).eq.0)ens_adj(i)=0.666 ! 2./3.
+!ss           if(ierr2(i).gt.0.and.ierr3(i).gt.0)ens_adj(i)=0.333
 !
              a_ave=0.
              a_ave=axx(i)
@@ -2410,10 +2436,10 @@ contains
              xff_ens3(3)=max(0.,(AA1(I)-AA0(I))/dtime)
              xff_ens3(16)=max(0.,(AA1(I)-AA0(I))/dtime)
              forcing(i,1)=xff_ens3(2)
-!
+!   
 !--- omeg is in bar/s, mconv done with omeg in Pa/s
 !     more like Brown (1979), or Frank-Cohen (199?)
-!
+!  
 ! average aaround kbcon
 !
              xomg=0.
@@ -2428,7 +2454,7 @@ contains
                      endif
              enddo
              if(kk.gt.0)xff_ens3(4)=xomg/float(kk)
-
+            
 !
 ! max below kbcon
 !             xff_ens3(6)=-omeg(i,k22(i))/9.81
@@ -2475,11 +2501,9 @@ contains
                      xff_ens3(12)=0.
                      xff_ens3(13)= 0.
                      xff_ens3(16)= 0.
-                     xff_dicycle = 0.
+                     closure_n(i)=12.
+!                     xff_dicycle = 0.
                 endif  !xff0
-                  if(xff0.lt.0 .and. xland(i).lt.0.1)then
-                     xff_ens3(:)=0.
-                  endif
              endif ! ichoice
 
              XK(1)=(XAA0(I,1)-AA1(I))/MBDT
@@ -2489,7 +2513,7 @@ contains
              forcing(i,7)=xk(1)
              if(xk(1).le.0.and.xk(1).gt.-.01*mbdt) &
                            xk(1)=-.01*mbdt
-             if(xk(1).gt.0.and.xk(1).lt.1.e-2) &
+             if(xk(1).gt.0.and.xk(1).lt.1.e-2)     &
                            xk(1)=1.e-2
              !   enddo
 !
@@ -2503,9 +2527,9 @@ contains
                       xff_ens3(1) =ens_adj(i)*xff_ens3(1)
                       xff_ens3(2) =ens_adj(i)*xff_ens3(2)
                       xff_ens3(3) =ens_adj(i)*xff_ens3(3)
-!                      xff_ens3(4) =ens_adj(i)*xff_ens3(4)
-!                      xff_ens3(5) =ens_adj(i)*xff_ens3(5)
-!                      xff_ens3(6) =ens_adj(i)*xff_ens3(6)
+                      xff_ens3(4) =ens_adj(i)*xff_ens3(4)
+                      xff_ens3(5) =ens_adj(i)*xff_ens3(5)
+                      xff_ens3(6) =ens_adj(i)*xff_ens3(6)
                       xff_ens3(7) =ens_adj(i)*xff_ens3(7)
                       xff_ens3(8) =ens_adj(i)*xff_ens3(8)
                       xff_ens3(9) =ens_adj(i)*xff_ens3(9)
@@ -2513,7 +2537,7 @@ contains
                       xff_ens3(11) =ens_adj(i)*xff_ens3(11)
                       xff_ens3(12) =ens_adj(i)*xff_ens3(12)
                       xff_ens3(13) =ens_adj(i)*xff_ens3(13)
-!                      xff_ens3(14) =ens_adj(i)*xff_ens3(14)
+                      xff_ens3(14) =ens_adj(i)*xff_ens3(14)
                       xff_ens3(15) =ens_adj(i)*xff_ens3(15)
                       xff_ens3(16) =ens_adj(i)*xff_ens3(16)
                       !srf
@@ -2597,7 +2621,7 @@ contains
               endif
 !srf-end
               if(ichoice.ge.1)then
-                 closure_n(i)=0.
+!                 closure_n(i)=0.
                  xf_ens(i,1)=xf_ens(i,ichoice)
                  xf_ens(i,2)=xf_ens(i,ichoice)
                  xf_ens(i,3)=xf_ens(i,ichoice)
@@ -2626,10 +2650,10 @@ contains
    END SUBROUTINE cup_forcing_ens_3d
 
    SUBROUTINE cup_kbcon(ierrc,cap_inc,iloop_in,k22,kbcon,he_cup,hes_cup, &
-              hkb,ierr,kbmax,p_cup,cap_max,                         &
-              ztexec,zqexec,       &
-              jprnt,itf,ktf,                        &
-              its,ite, kts,kte, &
+              hkb,ierr,kbmax,p_cup,cap_max,                              &
+              ztexec,zqexec,                                             &
+              jprnt,itf,ktf,                                             &
+              its,ite, kts,kte,                                          &
               z_cup,entr_rate,heo,imid                        )
 
    IMPLICIT NONE
@@ -2639,11 +2663,11 @@ contains
 
      integer                                                           &
         ,intent (in   )                   ::                           &
-        jprnt,itf,ktf,imid,           &
+        jprnt,itf,ktf,imid,                                            &
         its,ite, kts,kte
-  !
-  !
-  !
+  ! 
+  ! 
+  ! 
   ! ierr error value, maybe modified in this routine
   !
      real,    dimension (its:ite,kts:kte)                              &
@@ -2653,7 +2677,7 @@ contains
         ,intent (in   )                   ::                           &
         entr_rate,ztexec,zqexec,cap_inc,cap_max
      real,    dimension (its:ite)                                      &
-        ,intent (inout   )                   ::                           &
+        ,intent (inout   )                   ::                        &
         hkb !,cap_max
      integer, dimension (its:ite)                                      &
         ,intent (in   )                   ::                           &
@@ -2765,7 +2789,7 @@ contains
 
 
    SUBROUTINE cup_MAXIMI(ARRAY,KS,KE,MAXX,ierr,              &
-              itf,ktf,                     &
+              itf,ktf,                                       &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
@@ -2777,7 +2801,7 @@ contains
 
      integer                                                           &
         ,intent (in   )                   ::                           &
-         itf,ktf,                                    &
+         itf,ktf,                                                      &
          its,ite, kts,kte
   ! array input array
   ! x output array with return values
@@ -2821,7 +2845,7 @@ contains
 
 
    SUBROUTINE cup_minimi(ARRAY,KS,KEND,KT,ierr,              &
-              itf,ktf,                     &
+              itf,ktf,                                       &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
@@ -2831,26 +2855,26 @@ contains
 
    ! only local wrf dimensions are need as of now in this routine
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-         itf,ktf,                                    &
+     integer                                                 &
+        ,intent (in   )                   ::                 &
+         itf,ktf,                                            &
          its,ite, kts,kte
   ! array input array
   ! x output array with return values
   ! kt output array of levels
   ! ks,kend  check-range
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                    &
+        ,intent (in   )                   ::                 &
          array
-     integer, dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     integer, dimension (its:ite)                            &
+        ,intent (in   )                   ::                 &
          ierr,ks,kend
-     integer, dimension (its:ite)                                      &
-        ,intent (out  )                   ::                           &
+     integer, dimension (its:ite)                            &
+        ,intent (out  )                   ::                 &
          kt
-     real,    dimension (its:ite)         ::                           &
+     real,    dimension (its:ite)         ::                 &
          x
-     integer                              ::                           &
+     integer                              ::                 &
          i,k,kstop
 
        DO 200 i=its,itf
@@ -2873,7 +2897,7 @@ contains
 
    SUBROUTINE cup_up_aa0(aa0,z,zu,dby,GAMMA_CUP,t_cup,       &
               kbcon,ktop,ierr,                               &
-              itf,ktf,                     &
+              itf,ktf,                                       &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
@@ -2883,42 +2907,42 @@ contains
 
    ! only local wrf dimensions are need as of now in this routine
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-        itf,ktf,                                     &
+     integer                                                 &
+        ,intent (in   )                   ::                 &
+        itf,ktf,                                             &
         its,ite, kts,kte
   ! aa0 cloud work function
   ! gamma_cup = gamma on model cloud levels
   ! t_cup = temperature (Kelvin) on model cloud levels
   ! dby = buoancy term
   ! zu= normalized updraft mass flux
-  ! z = heights of model levels
+  ! z = heights of model levels 
   ! ierr error value, maybe modified in this routine
   !
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                     &
+        ,intent (in   )                   ::                  &
         z,zu,gamma_cup,t_cup,dby
-     integer, dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+     integer, dimension (its:ite)                             &
+        ,intent (in   )                   ::                  &
         kbcon,ktop
 !
 ! input and output
 !
 
 
-     integer, dimension (its:ite)                                      &
-        ,intent (inout)                   ::                           &
+     integer, dimension (its:ite)                             &
+        ,intent (inout)                   ::                  &
         ierr
-     real,    dimension (its:ite)                                      &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite)                             &
+        ,intent (out  )                   ::                  &
         aa0
 !
 !  local variables in this routine
 !
 
-     integer                              ::                           &
+     integer                              ::                  &
         i,k
-     real                                 ::                           &
+     real                                 ::                  &
         dz,da
 !
         do i=its,itf
@@ -2941,7 +2965,7 @@ contains
    END SUBROUTINE cup_up_aa0
 
 !====================================================================
-   SUBROUTINE neg_check(name,j,dt,q,outq,outt,outu,outv,   &
+   SUBROUTINE neg_check(name,j,dt,q,outq,outt,outu,outv,                      &
                                     outqc,pret,its,ite,kts,kte,itf,ktf)
 
    INTEGER,      INTENT(IN   ) ::            j,its,ite,kts,kte,itf,ktf
@@ -2955,7 +2979,7 @@ contains
      real, dimension (its:ite  )                            ,                 &
       intent(inout   ) ::                                                     &
        pret
-      character *(*), intent (in)         ::                           &
+      character *(*), intent (in)         ::                                  &
        name
      real                                                                     &
         ,intent (in  )                   ::                                   &
@@ -2983,7 +3007,7 @@ contains
          if(qmem.gt.thresh)then
            qmem2=thresh/qmem
            qmemf=min(qmemf,qmem2)
-           icheck=1
+      icheck=1
 !
 !
 !          print *,'1',' adjusted massflux by factor ',i,j,k,qmem,qmem2,qmemf,dt
@@ -3003,11 +3027,11 @@ contains
          outv(i,k)=outv(i,k)*qmemf
          outqc(i,k)=outqc(i,k)*qmemf
       enddo
-      pret(i)=pret(i)*qmemf
+      pret(i)=pret(i)*qmemf 
       enddo
-     return
+      return
 !
-! check whether routine produces negative q's. This can happen, since
+! check whether routine produces negative q's. This can happen, since 
 ! tendencies are calculated based on forced q's. This should have no
 ! influence on conservation properties, it scales linear through all
 ! tendencies
@@ -3039,20 +3063,20 @@ contains
          outv(i,k)=outv(i,k)*qmemf
          outqc(i,k)=outqc(i,k)*qmemf
       enddo
-      pret(i)=pret(i)*qmemf
+      pret(i)=pret(i)*qmemf 
       enddo
 
    END SUBROUTINE neg_check
 
 
    SUBROUTINE cup_output_ens_3d(xff_mid,xf_ens,ierr,dellat,dellaq,dellaqc,  &
-              outtem,outq,outqc,     &
-              zu,pre,pw,xmb,ktop,                 &
-              name,ierr2,ierr3,pr_ens,             &
-              maxens3,                            &
-              sig,closure_n,xland1,xmbm_in,xmbs_in,    &
-              ichoice,imid,ipr,itf,ktf, &
-              its,ite, kts,kte, &
+              outtem,outq,outqc,                                            &
+              zu,pre,pw,xmb,ktop,                                           &
+              edt,pwd,name,ierr2,ierr3,p_cup,pr_ens,                        &
+              maxens3,                                                      &
+              sig,closure_n,xland1,xmbm_in,xmbs_in,                         &
+              ichoice,imid,ipr,itf,ktf,                                     &
+              its,ite, kts,kte,                                             &
               dicycle,xf_dicycle )
 
    IMPLICIT NONE
@@ -3063,7 +3087,7 @@ contains
 
      integer                                                           &
         ,intent (in   )                   ::                           &
-        ichoice,imid,ipr,itf,ktf,     &
+        ichoice,imid,ipr,itf,ktf,                                      &
         its,ite, kts,kte
      integer, intent (in   )              ::                           &
         maxens3
@@ -3081,28 +3105,28 @@ contains
   ! pw = pw -epsilon*pd (ensemble dependent)
   ! ierr error value, maybe modified in this routine
   !
-     real,    dimension (its:ite,1:maxens3)                     &
+     real,    dimension (its:ite,1:maxens3)                            &
         ,intent (inout)                   ::                           &
        xf_ens,pr_ens
      real,    dimension (its:ite,kts:kte)                              &
-        ,intent (inout  )                   ::                           &
+        ,intent (inout  )                 ::                           &
         outtem,outq,outqc
      real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in  )                   ::                           &
-        zu
-     real,   dimension (its:ite)                                      &
+        ,intent (in  )                    ::                           &
+        zu,pwd,p_cup
+     real,   dimension (its:ite)                                       &
          ,intent (in  )                   ::                           &
-        sig,xmbm_in,xmbs_in
-     real,   dimension (its:ite,2)                                      &
+        sig,xmbm_in,xmbs_in,edt
+     real,   dimension (its:ite,2)                                     &
          ,intent (in  )                   ::                           &
         xff_mid
      real,    dimension (its:ite)                                      &
-        ,intent (inout  )                   ::                           &
+        ,intent (inout  )                 ::                           &
         pre,xmb
      real,    dimension (its:ite)                                      &
-        ,intent (inout  )                   ::                           &
+        ,intent (inout  )                 ::                           &
         closure_n
-     real,    dimension (its:ite,kts:kte,1)                     &
+     real,    dimension (its:ite,kts:kte,1)                            &
         ,intent (in   )                   ::                           &
        dellat,dellaqc,dellaq,pw
      integer, dimension (its:ite)                                      &
@@ -3120,11 +3144,11 @@ contains
      integer                              ::                           &
         i,k,n
      real                                 ::                           &
-        dtt,dtq,dtqc,dtpw
-     real,    dimension (its:ite)::                           &
-       xmb_ave
+        clos_wei,dtt,dp,dtq,dtqc,dtpw,dtpwd
+     real,    dimension (its:ite)         ::                           &
+       xmb_ave,pwtot
 !
-      character *(*), intent (in)        ::                           &
+      character *(*), intent (in)         ::                           &
        name
 
 !
@@ -3151,7 +3175,7 @@ contains
 !
 !--- calculate ensemble average mass fluxes
 !
-
+       
 !
 !-- now do feedback
 !
@@ -3174,12 +3198,12 @@ contains
             xmb_ave(i)=min(xmb_ave(i),xmb_ave(i) - xf_dicycle(i))
             xmb_ave(i)=max(0.,xmb_ave(i))
          endif
-         xmb_ave(i)=min(xmb_ave(i),100.)
-         xmb(i)=sig(i)*xmb_ave(i)
 ! --- Now use proper count of how many closures were actually
 !       used in cup_forcing_ens (including screening of some
 !       closures over water) to properly normalize xmb
-!           clos_wei=16./max(1.,closure_n(i))
+           clos_wei=16./max(1.,closure_n(i))
+         xmb_ave(i)=min(xmb_ave(i),100.)
+         xmb(i)=sig(i)*xmb_ave(i)
 
            if(xmb(i) < 1.e-16)then
               ierr(i)=19
@@ -3222,18 +3246,36 @@ contains
       endif        ! imid=1
 
       do i=its,itf
+        pwtot(i)=0.
         IF(ierr(i).eq.0)then
             DO k=kts,ktop(i)
+              pwtot(i)=pwtot(i)+pw(i,k,1)
+            enddo
+            DO k=kts,ktop(i)
+            dp=100.*(p_cup(i,k)-p_cup(i,k+1))/g
             dtt =dellat  (i,k,1)
             dtq =dellaq  (i,k,1)
-            dtqc=dellaqc (i,k,1)
-            dtpw=pw      (i,k,1)
+! necessary to drive downdraft
+            dtpwd=-pwd(i,k)*edt(i)
+! take from dellaqc first
+            dtqc=dellaqc (i,k,1)*dp - dtpwd
+! if this is negative, it needs to come from rain
+           if(dtqc < 0.)then
+             dtpwd=dtpwd-dellaqc(i,k,1)*dp
+             dtqc=0.
+! if this is positive, can come from clw detrainment
+           else
+             dtpwd=0.
+             dtqc=dtqc/dp
+           endif
            OUTTEM(I,K)= XMB(I)* dtt
            OUTQ  (I,K)= XMB(I)* dtq
            OUTQC (I,K)= XMB(I)* dtqc
-           PRE(I)=PRE(I)+XMB(I)*dtpw
            xf_ens(i,:)=sig(i)*xf_ens(i,:)
+! what is evaporated
+           PRE(I)=PRE(I)-XMB(I)*dtpwd
           enddo
+          PRE(I)=-PRE(I)+XMB(I)*pwtot(i)
         endif
       enddo
 
@@ -3241,11 +3283,11 @@ contains
    END SUBROUTINE cup_output_ens_3d
 !-------------------------------------------------------
    SUBROUTINE cup_up_moisture(name,ierr,z_cup,qc,qrc,pw,pwav,     &
-              p_cup,kbcon,ktop,dby,clw_all,xland1,&
-              q,GAMMA_cup,zu,qes_cup,k22,qe_cup,         &
-              ZQEXEC,ccn,rho,c1d,t, &
+              p_cup,kbcon,ktop,dby,clw_all,xland1,                &
+              q,GAMMA_cup,zu,qes_cup,k22,qe_cup,                  &
+              ZQEXEC,ccn,rho,c1d,t,                               &
               up_massentr,up_massdetr,psum,psumh,                 &
-              itest,itf,ktf,                &
+              itest,itf,ktf,                                      &
               its,ite, kts,kte                     )
 
    IMPLICIT NONE
@@ -3257,29 +3299,29 @@ contains
 
    ! only local wrf dimensions are need as of now in this routine
 
-     integer                                                           &
-        ,intent (in   )                   ::                           &
-                                  itest,itf,ktf,           &
+     integer                                                      &
+        ,intent (in   )                   ::                      &
+                                  itest,itf,ktf,                  &
                                   its,ite, kts,kte
-  ! cd= detrainment function
+  ! cd= detrainment function 
   ! q = environmental q on model levels
   ! qe_cup = environmental q on model cloud levels
   ! qes_cup = saturation q on model cloud levels
   ! dby = buoancy term
-  ! cd= detrainment function
+  ! cd= detrainment function 
   ! zu = normalized updraft mass flux
   ! gamma_cup = gamma on model cloud levels
   !
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (in   )                   ::                           &
-        p_cup,rho,q,zu,gamma_cup,qe_cup,                         &
+     real,    dimension (its:ite,kts:kte)                         &
+        ,intent (in   )                   ::                      &
+        p_cup,rho,q,zu,gamma_cup,qe_cup,                          &
         up_massentr,up_massdetr,dby,qes_cup,z_cup
-     real,    dimension (its:ite)                              &
-        ,intent (in   )                   ::                           &
+     real,    dimension (its:ite)                                 &
+        ,intent (in   )                   ::                      &
         zqexec
-  ! entr= entrainment rate
-     integer, dimension (its:ite)                                      &
-        ,intent (in   )                   ::                           &
+  ! entr= entrainment rate 
+     integer, dimension (its:ite)                                 &
+        ,intent (in   )                   ::                      &
         kbcon,ktop,k22,xland1
 !
 ! input and output
@@ -3287,10 +3329,10 @@ contains
 
    ! ierr error value, maybe modified in this routine
 
-     integer, dimension (its:ite)                                      &
-        ,intent (inout)                   ::                           &
+     integer, dimension (its:ite)                                  &
+        ,intent (inout)                   ::                       &
         ierr
-      character *(*), intent (in)        ::                           &
+      character *(*), intent (in)         ::                       &
        name
    ! qc = cloud q (including liquid water) after entrainment
    ! qrch = saturation q in cloud
@@ -3299,37 +3341,37 @@ contains
    ! pwav = totan normalized integrated condensate (I1)
    ! c0 = conversion rate (cloud to rain)
 
-     real,    dimension (its:ite,kts:kte)                              &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite,kts:kte)                          &
+        ,intent (out  )                   ::                       &
         qc,qrc,pw,clw_all
-     real,    dimension (its:ite,kts:kte) ::                           &
+     real,    dimension (its:ite,kts:kte) ::                       &
         qch,qrcb,pwh,clw_allh,c1d,t
-     real,    dimension (its:ite)         ::                           &
+     real,    dimension (its:ite)         ::                       &
         pwavh
-     real,    dimension (its:ite)                                      &
-        ,intent (out  )                   ::                           &
+     real,    dimension (its:ite)                                  &
+        ,intent (out  )                   ::                       &
         pwav,psum,psumh
-     real,    dimension (its:ite)                                      &
-        ,intent (in  )                   ::                           &
+     real,    dimension (its:ite)                                  &
+        ,intent (in  )                    ::                       &
         ccn
 !
 !  local variables in this routine
 !
 
-     integer                              ::                           &
+     integer                              ::                       &
         iprop,iall,i,k
      integer :: start_level(its:ite)
-     real                                 ::                           &
-        prop_ave,qrcb_h,bdsp,dp,rhoc,qrch,qaver, &
+     real                                 ::                       &
+        prop_ave,qrcb_h,bdsp,dp,rhoc,qrch,qaver,                   &
         c0,dz,berryc0,q1,berryc
-     real                                 ::                           &
+     real                                 ::                       &
         denom
-     real,    dimension (kts:kte)         ::                           &
+     real,    dimension (kts:kte)         ::                       &
         prop_b
 !
         prop_b(kts:kte)=0
         iall=0
-        c0=.004
+        c0=.002
         bdsp=BDISPM
 !
 !--- no precip for small clouds
@@ -3360,9 +3402,9 @@ contains
       if(ierr(i).eq.0)then
          start_level=k22(i)
          call get_cloud_bc(kte,qe_cup (i,1:kte),qaver,k22(i))
-         qaver = qaver
+         qaver = qaver 
          k=start_level(i)
-         qc (i,k)= qaver
+         qc (i,k)= qaver 
          qch (i,k)= qaver
          do k=1,start_level(i)-1
            qc (i,k)= qe_cup(i,k)
@@ -3375,7 +3417,7 @@ contains
       enddo
 
        DO 100 i=its,itf
-        c0=.004
+        c0=.002
          IF(ierr(i).eq.0)then
 
 ! below LFC, but maybe above LCL
@@ -3383,10 +3425,10 @@ contains
 !            if(name == "deep" )then
             DO k=k22(i)+1,kbcon(i)
               qc(i,k)=   (qc(i,k-1)*zu(i,k-1)-.5*up_massdetr(i,k-1)* qc(i,k-1)+ &
-                         up_massentr(i,k-1)*q(i,k-1))   /            &
+                         up_massentr(i,k-1)*q(i,k-1))   /                       &
                          (zu(i,k-1)-.5*up_massdetr(i,k-1)+up_massentr(i,k-1))
 !              QRCH=QES_cup(I,K)
-               QRCH=QES_cup(I,K)+(1./XLV)*(GAMMA_cup(i,k) &
+               QRCH=QES_cup(I,K)+(1./XLV)*(GAMMA_cup(i,k)                       &
                  /(1.+GAMMA_cup(i,k)))*DBY(I,K)
               if(k.lt.kbcon(i))qrch=qc(i,k)
               if(qc(i,k).gt.qrch)then
@@ -3402,7 +3444,7 @@ contains
 !now do the rest
 !
             DO k=kbcon(i)+1,ktop(i)
-               c0=.004
+               c0=.002
                if(t(i,k).lt.270.)c0=.002
                denom=zu(i,k-1)-.5*up_massdetr(i,k-1)+up_massentr(i,k-1)
                if(denom.lt.1.e-8)then
@@ -3410,14 +3452,14 @@ contains
                 exit
                endif
 
-
+   
                rhoc=.5*(rho(i,k)+rho(i,k-1))
                DZ=Z_cup(i,K)-Z_cup(i,K-1)
                DP=p_cup(i,K)-p_cup(i,K-1)
 !
 !--- saturation  in cloud, this is what is allowed to be in it
 !
-               QRCH=QES_cup(I,K)+(1./XLV)*(GAMMA_cup(i,k) &
+               QRCH=QES_cup(I,K)+(1./XLV)*(GAMMA_cup(i,k)                       &
                  /(1.+GAMMA_cup(i,k)))*DBY(I,K)
 !
 !------    1. steady state plume equation, for what could
@@ -3425,10 +3467,10 @@ contains
 !
 !
                qc(i,k)=   (qc(i,k-1)*zu(i,k-1)-.5*up_massdetr(i,k-1)* qc(i,k-1)+ &
-                         up_massentr(i,k-1)*q(i,k-1))   /            &
+                         up_massentr(i,k-1)*q(i,k-1))   /                        &
                          (zu(i,k-1)-.5*up_massdetr(i,k-1)+up_massentr(i,k-1))
                qch(i,k)= (qch(i,k-1)*zu(i,k-1)-.5*up_massdetr(i,k-1)*qch(i,k-1)+ &
-                         up_massentr(i,k-1)*q(i,k-1))   /            &
+                         up_massentr(i,k-1)*q(i,k-1))   /                        &
                          (zu(i,k-1)-.5*up_massdetr(i,k-1)+up_massentr(i,k-1))
 
                if(qc(i,k).le.qrch)then
@@ -3447,7 +3489,7 @@ contains
                IF(autoconv.eq.2) then
 
 
-!
+! 
 ! normalized berry
 !
 ! first calculate for average conditions, used in cup_dd_edt!
@@ -3455,7 +3497,7 @@ contains
 ! would give the same results as c0 under these conditions
 !
                  q1=1.e3*rhoc*qrcb(i,k)  ! g/m^3 ! g[h2o]/cm^3
-                 berryc0=q1*q1/(60.0*(5.0 + 0.0366*CCNclean/ &
+                 berryc0=q1*q1/(60.0*(5.0 + 0.0366*CCNclean/                           &
                     ( q1 * BDSP)  ) ) !/(
                  qrcb_h=((QCH(I,K)-QRCH)*zu(i,k)-qrcb(i,k-1)*(.5*up_massdetr(i,k-1)))/ &
                    (zu(i,k)+.5*up_massdetr(i,k-1)+c0*dz*zu(i,k))
@@ -3476,7 +3518,7 @@ contains
 ! then the real berry
 !
                  q1=1.e3*rhoc*qrc(i,k)  ! g/m^3 ! g[h2o]/cm^3
-                 berryc0=q1*q1/(60.0*(5.0 + 0.0366*CCN(i)/ &
+                 berryc0=q1*q1/(60.0*(5.0 + 0.0366*CCN(i)/                                             &
                     ( q1 * BDSP)  ) ) !/(
                  berryc0=1.e-3*berryc0*dz*prop_b(k) ! 2.
                  berryc=qrc(i,k)
@@ -3532,7 +3574,7 @@ contains
 
  REAL FUNCTION satvap(temp2)
       implicit none
-      real :: temp2, temp, toot, toto, eilog, tsot,  &
+      real :: temp2, temp, toot, toto, eilog, tsot,            &
      &        ewlog, ewlog2, ewlog3, ewlog4
       temp = temp2-273.155
       if (temp.lt.-20.) then   !!!! ice saturation
@@ -3543,11 +3585,11 @@ contains
         satvap = 10 ** eilog
       else
         tsot = 373.16 / temp2
-        ewlog = -7.90298 * (tsot - 1) + 5.02808 * &
+        ewlog = -7.90298 * (tsot - 1) + 5.02808 *              &
      &             (log(tsot) / log(10.))
-        ewlog2 = ewlog - 1.3816e-07 * &
+        ewlog2 = ewlog - 1.3816e-07 *                          &
      &             (10 ** (11.344 * (1 - (1 / tsot))) - 1)
-        ewlog3 = ewlog2 + .0081328 * &
+        ewlog3 = ewlog2 + .0081328 *                           &
      &             (10 ** (-3.49149 * (tsot - 1)) - 1)
         ewlog4 = ewlog3 + (log(1013.246) / log(10.))
         satvap = 10 ** ewlog4
@@ -3594,10 +3636,10 @@ contains
      !-local vars
      real, dimension (its:ite,kts:kte) :: hcot
      real :: beta_u,dz,dbythresh,dzh2,zustart,zubeg,massent,massdetr
-     real :: dby(kts:kte),zux(kts:kte)
+     real :: dby(kts:kte),dbm(kts:kte),zux(kts:kte)
      real zuh2(40),zh2(40)
-     integer :: i,kk,kbegin,k,kfinalzu
-     integer, dimension (its:ite) :: start_level
+     integer :: kklev,i,kk,kbegin,k,kfinalzu
+     integer, dimension (its:ite) :: start_level 
      !
      zustart=.1
      dbythresh= 1. !.0.95 ! 0.85, 0.6
@@ -3609,6 +3651,7 @@ contains
       beta_u=max(.1,.2-float(csum(i))*.01)
       zuo(i,:)=0.
       dby(:)=0.
+      dbm(:)=0.
       kbcon(i)=max(kbcon(i),2)
       if(ierr(i).eq.0)then
        start_level(i)=k22(i)
@@ -3630,11 +3673,13 @@ contains
            dz=z_cup(i,k)-z_cup(i,k-1)
 
            hcot(i,k)=( (1.-0.5*entr_rate_2d(i,k-1)*dz)*hcot(i,k-1) &
-                      + entr_rate_2d(i,k-1)*dz*heo(i,k-1))/ &
+                      + entr_rate_2d(i,k-1)*dz*heo(i,k-1))/        &
                       (1.+0.5*entr_rate_2d(i,k-1)*dz)
            if(k >= kbcon(i)) dby(k)=dby(k-1)+(hcot(i,k)-heso_cup(i,k))*dz
+           if(k >= kbcon(i)) dbm(k)=hcot(i,k)-heso_cup(i,k)
         enddo
         ktopdby(i)=maxloc(dby(:),1)
+        kklev=maxloc(dbm(:),1)
         do k=maxloc(dby(:),1)+1,ktf-2
           if(dby(k).lt.dbythresh*maxval(dby))then
               kfinalzu=k  - 1
@@ -3654,9 +3699,11 @@ contains
               ierr(i)=41
               ktop(i)= 0
         else
-!           call get_zu_zd_pdf_fim(ipr,xland(i),zuh2,"UP",ierr(i),start_level(i), &
-           call get_zu_zd_pdf_fim(rand_vmas(i),zubeg,ipr,xland(i),zuh2,"UP",ierr(i),k22(i), &
-            kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kpbl(i),csum(i),pmin_lev(i))
+!           call get_zu_zd_pdf_fim(ipr,xland(i),zuh2,"UP",ierr(i),start_level(i),             &
+!           call get_zu_zd_pdf_fim(rand_vmas(i),zubeg,ipr,xland(i),zuh2,"UP",ierr(i),kbcon(i), &
+!            kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kpbl(i),csum(i),pmin_lev(i))
+           call get_zu_zd_pdf_fim(kklev,p_cup(i,:),rand_vmas(i),zubeg,ipr,xland(i),zuh2,"UP",ierr(i),k22(i), &
+            kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kstabi(i),csum(i),pmin_lev(i))
         endif
       endif ! end deep
       if ( name == 'mid' ) then
@@ -3666,7 +3713,7 @@ contains
        else
            kfinalzu=ktop(i)
            ktopdby(i)=ktop(i)+1
-          call get_zu_zd_pdf_fim(rand_vmas(i),zubeg,ipr,xland(i),zuh2,"MID",ierr(i),k22(i),kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+          call get_zu_zd_pdf_fim(kklev,p_cup(i,:),rand_vmas(i),zubeg,ipr,xland(i),zuh2,"MID",ierr(i),k22(i),kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
 !           kbegin=0
 !           dzh2=(z_cup(i,ktop(i))-z_cup(i,k22(i)))/40.
 !           zh2(1)=z_cup(i,k22(i))
@@ -3694,47 +3741,30 @@ contains
        else
            kfinalzu=ktop(i)
            ktopdby(i)=ktop(i)
-           call get_zu_zd_pdf_fim(rand_vmas(i),zubeg,ipr,xland(i),zuh2,"SH3",ierr(i),k22(i),kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
-           kbegin=0
-           dzh2=(z_cup(i,kfinalzu)-z_cup(i,k22(i)))/40.
-           zh2(1)=z_cup(i,k22(i))
-           if(zuh2(1).gt.0.1 .and. kbegin.eq.0)kbegin=1
-           do k=2,40
-             zh2(k)=zh2(k-1)+dzh2
-             if(zuh2(k).gt.0.1 .and. kbegin.eq.0)kbegin=k
-           enddo
-           zuo(i,k22(i))=zuh2(kbegin)
-           do k=k22(i)+1,kfinalzu
-              do kk=kbegin,39
-              if(z_cup(i,k).gt.zh2(kk) .and.  z_cup(i,k).le.zh2(kk+1)) then
-                  zuo(i,k)=zuh2(kk)
-                  exit
-               endif
-              enddo
-           enddo
+           call get_zu_zd_pdf_fim(kklev,p_cup(i,:),rand_vmas(i),zubeg,ipr,xland(i),zuh2,"SH2",ierr(i),k22(i), &
+             kfinalzu,zuo(i,kts:kte),kts,kte,ktf,beta_u,kpbl(i),csum(i),pmin_lev(i))
+
          endif
          endif ! shal
-!         do k=k22(i),kbcon(i)
-!           zuo(i,k)=zux(k)
-!         enddo
       ENDIF ! ierr
      ENDDO
 
   END SUBROUTINE rates_up_pdf
 !-------------------------------------------------------------------------
- SUBROUTINE get_zu_zd_pdf_fim(rand_vmas,zubeg,ipr,xland,zuh2,draft,ierr,kb,kt,zu,kts,kte,ktf,max_mass,kpbli,csum,pmin_lev)
+ SUBROUTINE get_zu_zd_pdf_fim(kklev,p,rand_vmas,zubeg,ipr,xland,zuh2,draft,ierr,kb,kt,zu,kts,kte,ktf,max_mass,kpbli,csum,pmin_lev)
 
  implicit none
- integer, intent(in) ::ipr,xland,kb,kt,kts,kte,ktf,kpbli,csum,pmin_lev
+ integer, intent(in) ::ipr,xland,kb,kklev,kt,kts,kte,ktf,kpbli,csum,pmin_lev
  real, intent(in) ::max_mass,zubeg
  real, intent(inout) :: zu(kts:kte)
+ real, intent(in) :: p(kts:kte)
  real  :: zuh(kts:kte),zuh2(1:40)
  integer, intent(inout) :: ierr
  character*(*), intent(in) ::draft
 
  !- local var
  integer :: kk,k,kb_adj,kpbli_adj
- real    :: krmax,beta, alpha,kratio,tunning,FZU,rand_vmas
+ real    :: krmax,beta, alpha,kratio,tunning,FZU,rand_vmas,lev_start
  !- kb cannot be at 1st level
 
  !-- fill zu with zeros
@@ -3742,37 +3772,17 @@ contains
  zuh=0.0
    kb_adj=max(kb,2)
  IF(draft == "UP") then
+   lev_start=min(.9,.7+csum*.013)
    kb_adj=max(kb,2)
-  !beta=4.  !=> must larger than 1
-            !=> higher makes the profile sharper
-            !=> around the maximum zu
-  !- 2nd approach for beta and alpha parameters
-  !- the tunning parameter must be between 0.5 (low  level max zu)
-  !-                                   and 1.5 (high level max zu)
-     tunning = 2.-min(1.,float(csum)*.03)
-     if(rand_vmas /= 0. ) tunning=1.5+.5*rand_vmas
-     beta    = max(1.5,2./tunning)
-!
-! make profile sharper when higher up or lower (compared to middle)
-!
-  alpha   = tunning*beta+abs(1.5-tunning)*5.
-  fzu=1.
-  do k=kb_adj,min(kte,kt+1)
-      kratio= float(k)/float(kt+1)
+   tunning=p(kklev) !p(kt)+(p(kpbli)-p(kt))*lev_start
+   tunning =min(0.9, (tunning-p(kb_adj))/(p(kt)-p(kb_adj))) !=.6
+   tunning =max(0.2, tunning)
+   beta    = 1.3 !2.5 ! max(2.5,2./tunning)
+   alpha= (tunning*(beta -2.)+1.)/(1.-tunning)
+   fzu = gamma(alpha + beta)/(gamma(alpha)*gamma(beta))
+  do k=kb_adj,min(kte,kt)
+      kratio= (p(k)-p(kb_adj))/(p(kt)-p(kb_adj)) !float(k)/float(kt+1)
       zu(k) = zubeg+FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
-   enddo
-! too low
-   do while (maxloc(zu(:),1) < pmin_lev)
-       tunning=tunning+.1
-       beta    = max(1.5,2./tunning)
-!       alpha   = tunning*beta
-       alpha   = tunning*beta+abs(1.5-tunning)*5.
-       if(tunning > 2.1) ierr=123
-       if(tunning > 2.1) exit
-       do k=kb_adj,min(kte,kt+1)
-           kratio= float(k)/float(kt+1)
-           zu(k) = zubeg+FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
-        enddo
    enddo
 
    if(maxval(zu(kts:min(ktf,kt+1))).gt.0.)  &
@@ -3783,19 +3793,36 @@ contains
          exit
        endif
      enddo
-!    if(zu(kt).gt.max_mass)fzu=max_mass/zu(kt) ! max(0.,zu(2)-max_mass)
-!     do k=2,kt+1
-!       zu(k)=fzu*zu(k)
-!     enddo
      kb_adj=max(2,kb_adj)
      do k=kts,kb_adj-1
        zu(k)=0.
+     enddo
+
+ ELSEIF(draft == "SH2") then
+   tunning =min(0.8, (p(kpbli)-p(kb_adj))/(p(kt)-p(kb_adj))) !=.6
+   tunning =max(0.2, tunning)
+   beta    = 2.5 !2.5 ! max(2.5,2./tunning)
+   alpha= (tunning*(beta -2.)+1.)/(1.-tunning)
+   fzu = gamma(alpha + beta)/(gamma(alpha)*gamma(beta))
+  do k=kb_adj,min(kte,kt)
+      kratio= (p(k)-p(kb_adj))/(p(kt)-p(kb_adj)) !float(k)/float(kt+1)
+      zu(k) = zubeg+FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
+   enddo
+   if(maxval(zu(kts:min(ktf,kt+1))).gt.0.)  &
+      zu(kts:min(ktf,kt+1))= zu(kts:min(ktf,kt+1))/maxval(zu(kts:min(ktf,kt+1)))
+     do k=maxloc(zu(:),1),1,-1
+       if(zu(k).lt.1.e-6)then
+         kb_adj=k+1
+         exit
+       endif
      enddo
 
  ELSEIF(draft == "SH3") then
   tunning = 0.6
   beta    =2.2/tunning
   alpha   = tunning*beta
+   beta    = 3.5 ! max(2.5,2./tunning)
+   alpha   = beta -2. ! +1 !max(1.1,tunning*beta-abs(1.5-tunning)*5.)
   fzu=1.
   do k=1,40
       kratio= float(k)/float(40)
@@ -3805,27 +3832,16 @@ contains
       zuh2(:)= zuh2(:)/ maxval(zuh2(1:40))
  ELSEIF(draft == "MID") then
    kb_adj=max(kb,2)
-     tunning = 1.2
-     beta    = 2.5 ! 2.0/tunning
-  alpha   = tunning*beta
-  fzu=1.
-  do k=kb_adj,min(kte,kt+1)
-      kratio= float(k)/float(kt+1)
+   tunning=p(kt)+(p(kb_adj)-p(kt))*.9 !*.33
+   tunning =min(0.9, (tunning-p(kb_adj))/(p(kt)-p(kb_adj))) !=.6
+   tunning =max(0.2, tunning)
+   beta    = 1.3 !2.5 ! max(2.5,2./tunning)
+   alpha= (tunning*(beta -2.)+1.)/(1.-tunning)
+   fzu = gamma(alpha + beta)/(gamma(alpha)*gamma(beta))
+  do k=kb_adj,min(kte,kt)
+      kratio= (p(k)-p(kb_adj))/(p(kt)-p(kb_adj)) !float(k)/float(kt+1)
       zu(k) = zubeg+FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
    enddo
-! too low
-   do while (maxloc(zu(:),1) < pmin_lev)
-       tunning=tunning+.05
-       if(tunning > 1.) ierr=123
-       if(tunning > 1.) exit
-       beta    = max(2.5,2./tunning)
-       alpha   = tunning*beta
-       do k=kb_adj,min(kte,kt+1)
-           kratio= float(k)/float(kt+1)
-           zu(k) = zubeg+FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
-        enddo
-   enddo
-
    if(maxval(zu(kts:min(ktf,kt+1))).gt.0.)  &
       zu(kts:min(ktf,kt+1))= zu(kts:min(ktf,kt+1))/maxval(zu(kts:min(ktf,kt+1)))
      do k=maxloc(zu(:),1),1,-1
@@ -3843,37 +3859,43 @@ contains
 
   ! tunning = 0.8
   ! beta    = 3.0/tunning
-  tunning = 0.8
-  beta    =2.0/tunning
-  alpha   = tunning*beta
-  fzu=1.
-  zuh(:)=0.
+!  tunning = 0.8
+!  beta    =2.0/tunning
+!  alpha   = tunning*beta
+!  fzu=1.
+!  zuh(:)=0.
+   tunning=p(kb)
+   tunning =min(0.9, (tunning-p(1))/(p(kt)-p(1))) !=.6
+   tunning =max(0.2, tunning)
+   beta    = 4. !2.5 ! max(2.5,2./tunning)
+   alpha= (tunning*(beta -2.)+1.)/(1.-tunning)
+   fzu = gamma(alpha + beta)/(gamma(alpha)*gamma(beta))
   zu(:)=0.
-  do k=kts,min(kt+1,ktf)
-      kratio= float(k)/float(kt+1)
-      zuh(k) = FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
+  do k=2,min(kt,ktf)
+      kratio= (p(k)-p(1))/(p(kt)-p(1))
+      zu(k) = FZU*kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
    enddo
-   if(maxloc(zuh(:),1).ge.kpbli)then
-      do k=maxloc(zuh(:),1),1,-1
-         kk=kpbli+k-maxloc(zuh(:),1)
-         if(kk.gt.1)zu(kk)=zuh(k)
-      enddo
-      do k=maxloc(zuh(:),1)+1,kt
-         kk=kpbli+k-maxloc(zuh(:),1)
-         if(kk.le.kt)zu(kk)=zuh(k)
-      enddo
-   else
-      do k=2,kt ! maxloc(zuh(:),1)
-        zu(k)=zuh(k-1)
-      enddo
-   endif
-   fzu=maxval(zu(kts:min(ktf,kt+1)))
+!   if(maxloc(zuh(:),1).ge.kpbli)then
+!      do k=maxloc(zuh(:),1),1,-1
+!         kk=kpbli+k-maxloc(zuh(:),1)
+!         if(kk.gt.1)zu(kk)=zuh(k)
+!      enddo
+!      do k=maxloc(zuh(:),1)+1,kt
+!         kk=kpbli+k-maxloc(zuh(:),1)
+!         if(kk.le.kt)zu(kk)=zuh(k)
+!      enddo
+!   else
+!      do k=2,kt ! maxloc(zuh(:),1)
+!        zu(k)=zuh(k-1)
+!      enddo
+!   endif
+    fzu=maxval(zu(kts:min(ktf,kt+1)))
    if(fzu.gt.0.)  &
       zu(kts:min(ktf,kt+1))= zu(kts:min(ktf,kt+1))/fzu
-    if(zu(2).gt.max_mass)fzu=max_mass/zu(2) ! max(0.,zu(2)-max_mass)
-     do k=2,kt+1
-       zu(k)=fzu*zu(k)
-     enddo
+!    if(zu(2).gt.max_mass)fzu=max_mass/zu(2) ! max(0.,zu(2)-max_mass)
+!     do k=2,kt+1
+!       zu(k)=fzu*zu(k)
+!     enddo
      zu(1)=0.
 
 
@@ -3887,7 +3909,7 @@ contains
   SUBROUTINE cup_up_aa1bl(aa0,t,tn,q,qo,dtime,  &
               z,zu,dby,gamma_cup,t_cup,         &
               kbcon,ktop,ierr,                  &
-              itf,ktf,                      &
+              itf,ktf,                          &
               its,ite, kts,kte         )
 
    IMPLICIT NONE
@@ -3899,14 +3921,14 @@ contains
 
      integer                                                           &
         ,intent (in   )                   ::                           &
-        itf,ktf,                                     &
+        itf,ktf,                                                       &
         its,ite, kts,kte
   ! aa0 cloud work function
   ! gamma_cup = gamma on model cloud levels
   ! t_cup = temperature (Kelvin) on model cloud levels
   ! dby = buoancy term
   ! zu= normalized updraft mass flux
-  ! z = heights of model levels
+  ! z = heights of model levels 
   ! ierr error value, maybe modified in this routine
   !
      real,    dimension (its:ite,kts:kte)                              &
@@ -3945,7 +3967,7 @@ contains
          IF(k.gt.KBCON(i))GO TO 100
 
          DZ=Z(I,K)-Z(I,K-1)
-         !print*,"dz=",i,k,z(i,k),Z(I,K-1),dz
+         !print*,"dz=",i,k,z(i,k),Z(I,K-1),dz         
          !da=zu(i,k)*DZ*(9.81/(1004.*( &
          !        (T_cup(I,K)))))*DBY(I,K-1)/ &
          !     (1.+GAMMA_CUP(I,K))
@@ -3956,24 +3978,24 @@ contains
 100     CONTINUE
 
  END SUBROUTINE cup_up_aa1bl
-!----------------------------------------------------------------------
- SUBROUTINE get_inversion_layers(ierr,p_cup,t_cup,z_cup,qo_cup,qeso_cup,k_inv_layers,&
+!---------------------------------------------------------------------- 
+ SUBROUTINE get_inversion_layers(ierr,p_cup,t_cup,z_cup,qo_cup,qeso_cup,k_inv_layers,&           
                      kstart,kend,dtempdz,itf,ktf,its,ite, kts,kte)
-
+                                    
         IMPLICIT NONE
         integer                      ,intent (in ) :: itf,ktf,its,ite,kts,kte
         integer, dimension (its:ite) ,intent (in ) :: ierr,kstart,kend
         integer, dimension (its:ite) :: kend_p3
-
-        real,    dimension (its:ite,kts:kte), intent (in ) :: p_cup,t_cup,z_cup,qo_cup,qeso_cup
-        real,    dimension (its:ite,kts:kte), intent (out) :: dtempdz
+                    
+        real,    dimension (its:ite,kts:kte), intent (in ) :: p_cup,t_cup,z_cup,qo_cup,qeso_cup                            
+        real,    dimension (its:ite,kts:kte), intent (out) :: dtempdz                    
         integer, dimension (its:ite,kts:kte), intent (out) :: k_inv_layers
         !-local vars
         real   :: dp,l_mid,l_shal,first_deriv(kts:kte),sec_deriv(kts:kte)
         integer:: ken,kadd,kj,i,k,ilev,kk,ix,k800,k550,mid,shal
         !
         !-initialize k_inv_layers as undef
-        l_mid=400.
+        l_mid=300.
         l_shal=100.
         k_inv_layers(:,:) = 1
          do i = its,itf
@@ -3981,32 +4003,32 @@ contains
            kend_p3(i)=kend(i)+3
            DO k = kts+1,kend_p3(i)+4
             !-  get the 1st der
-            first_deriv(k)= (t_cup(i,k+1)-t_cup(i,k-1))/(z_cup(i,k+1)-z_cup(i,k-1))
+            first_deriv(k)= (t_cup(i,k+1)-t_cup(i,k-1))/(z_cup(i,k+1)-z_cup(i,k-1))        
             dtempdz(i,k)=first_deriv(k)
                enddo
            DO k = kts+2,kend_p3(i)+3
             !  get the 2nd der
-            sec_deriv(k)= (first_deriv(k+1)-first_deriv(k-1))/(z_cup(i,k+1)-z_cup(i,k-1))
-            sec_deriv(k)= abs(sec_deriv(k))
+            sec_deriv(k)= (first_deriv(k+1)-first_deriv(k-1))/(z_cup(i,k+1)-z_cup(i,k-1))        
+            sec_deriv(k)= abs(sec_deriv(k))        
            enddo
-
+        
          ilev=max(kts+2,kstart(i)+1)
          ix=1
          k=ilev
          DO WHILE (ilev < kend_p3(i)) !(z_cup(i,ilev)<15000.)
            do kk=k,kend_p3(i)+2 !k,ktf-2
-
+             
              if(sec_deriv(kk) <        sec_deriv(kk+1) .and.  &
                 sec_deriv(kk) < sec_deriv(kk-1)        ) then
               k_inv_layers(i,ix)=kk
               ix=min(5,ix+1)
               ilev=kk+1
-              exit
+              exit   
              endif
               ilev=kk+1
                enddo
            k=ilev
-         ENDDO
+         ENDDO         
         !- 2nd criteria
          kadd=0
          ken=maxloc(k_inv_layers(i,:),1)
@@ -4025,13 +4047,13 @@ contains
          ENDDO
         endif
         ENDDO
-100 format(1x,16i3)
+100 format(1x,16i3)        
         !- find the locations of inversions around 800 and 550 hPa
         sec_deriv(:)=1.e9
         do i = its,itf
          if(ierr(i) /= 0) cycle
 
-         !- now find the closest layers of 800 and 550 hPa.
+         !- now find the closest layers of 800 and 550 hPa.         
          do k=1,maxloc(k_inv_layers(i,:),1) !kts,kte !kstart(i),kend(i) !kts,kte
            dp=p_cup(i,k_inv_layers(i,k))-p_cup(i,kstart(i))
            sec_deriv(k)=abs(dp)-l_shal
@@ -4052,13 +4074,13 @@ contains
          k_inv_layers(i,mid+1:kte)=-1
         ENDDO
 
-
+        
  END SUBROUTINE get_inversion_layers
 !-----------------------------------------------------------------------------------
  FUNCTION DERIV3(xx, xi, yi, ni, m)
     !============================================================================*/
-    ! Evaluate first- or second-order derivatives
-    ! using three-point Lagrange interpolation
+    ! Evaluate first- or second-order derivatives 
+    ! using three-point Lagrange interpolation 
     ! written by: Alex Godunov (October 2009)
     ! input ...
     ! xx    - the abscissa at which the interpolation is to be evaluated
@@ -4069,7 +4091,7 @@ contains
     ! output ...
     ! deriv3  - interpolated value
     !============================================================================*/
-
+    
     implicit none
     integer, parameter :: n=3
     integer ni, m,i, j, k, ix
@@ -4133,26 +4155,26 @@ contains
     end if
  END FUNCTION DERIV3
 !=============================================================================================
-  SUBROUTINE get_lateral_massflux(itf,ktf, its,ite, kts,kte       &
-                                  ,ierr,ktop,zo_cup,zuo,cd,entr_rate_2d        &
+  SUBROUTINE get_lateral_massflux(itf,ktf, its,ite, kts,kte                             &
+                                  ,ierr,ktop,zo_cup,zuo,cd,entr_rate_2d                 &
                                   ,up_massentro, up_massdetro ,up_massentr, up_massdetr &
                                   ,draft,kbcon,k22,up_massentru,up_massdetru,lambau)
 
      Implicit none
      character *(*), intent (in) :: draft
      integer, intent(in):: itf,ktf, its,ite, kts,kte
-     integer, intent(in)   , dimension(its:ite) 	:: ierr,ktop,kbcon,k22
+     integer, intent(in)   , dimension(its:ite)         :: ierr,ktop,kbcon,k22
      real,    intent(in),  OPTIONAL , dimension(its:ite):: lambau
      real,    intent(in)   , dimension(its:ite,kts:kte) :: zo_cup,zuo
-     real,    intent(inout), dimension(its:ite,kts:kte) :: cd,entr_rate_2d
-     real,    intent(  out), dimension(its:ite,kts:kte) :: up_massentro, up_massdetro&
+     real,    intent(inout), dimension(its:ite,kts:kte) :: cd,entr_rate_2d   
+     real,    intent(  out), dimension(its:ite,kts:kte) :: up_massentro, up_massdetro  &
                                                           ,up_massentr,  up_massdetr
-     real,    intent(  out), dimension(its:ite,kts:kte),  OPTIONAL :: &
+     real,    intent(  out), dimension(its:ite,kts:kte),  OPTIONAL ::                  &
                                                           up_massentru,up_massdetru
      !-- local vars
      Integer :: i,k, incr1,incr2
      REAL :: dz,trash,trash2
-
+     
      do k=kts,kte
       do i=its,ite
          up_massentro(i,k)=0.
@@ -4171,11 +4193,11 @@ contains
      endif
      DO i=its,itf
        if(ierr(i).eq.0)then
-
+         
           do k=max(2,k22(i)+1),maxloc(zuo(i,:),1)
            !=> below maximum value zu -> change entrainment
            dz=zo_cup(i,k)-zo_cup(i,k-1)
-
+        
            up_massdetro(i,k-1)=cd(i,k-1)*dz*zuo(i,k-1)
            up_massentro(i,k-1)=zuo(i,k)-zuo(i,k-1)+up_massdetro(i,k-1)
            if(up_massentro(i,k-1).lt.0.)then
@@ -4195,21 +4217,21 @@ contains
               up_massentro(i,k-1)=zuo(i,k)-zuo(i,k-1)
               if(zuo(i,k-1).gt.0.)entr_rate_2d(i,k-1)=(up_massentro(i,k-1))/(dz*zuo(i,k-1))
            endif
-
+        
            if(zuo(i,k-1).gt.0.)cd(i,k-1)=up_massdetro(i,k-1)/(dz*zuo(i,k-1))
          enddo
          up_massdetro(i,ktop(i))=zuo(i,ktop(i))
          up_massentro(i,ktop(i))=0.
-	 do k=ktop(i)+1,ktf
-	   cd(i,k)=0.
-	   entr_rate_2d(i,k)=0.
-	   up_massentro(i,k)=0.
-	   up_massdetro(i,k)=0.
+         do k=ktop(i)+1,ktf
+           cd(i,k)=0.
+           entr_rate_2d(i,k)=0.
+           up_massentro(i,k)=0.
+           up_massdetro(i,k)=0.
          enddo
          do k=2,ktf-1
            up_massentr (i,k-1)=up_massentro(i,k-1)
            up_massdetr (i,k-1)=up_massdetro(i,k-1)
-         enddo
+         enddo         
          if(present(up_massentru) .and. present(up_massdetru))then
           do k=2,ktf-1
            up_massentru(i,k-1)=up_massentro(i,k-1)+lambau(i)*up_massdetro(i,k-1)
@@ -4225,12 +4247,12 @@ contains
          do k=k22(i)+1,kbcon(i)
             trash=trash+entr_rate_2d(i,k)
          enddo
-
+  
        endif
     ENDDO
  END SUBROUTINE get_lateral_massflux
 !==============================================================================
-!----------------------------------------------------------------------
+!---------------------------------------------------------------------- 
   SUBROUTINE gfinit(RTHCUTEN,RQVCUTEN,RQCCUTEN,RQICUTEN,            &
                         RUCUTEN,RVCUTEN,                            &
                         restart,                                    &
@@ -4240,7 +4262,7 @@ contains
                         ids, ide, jds, jde, kds, kde,               &
                         ims, ime, jms, jme, kms, kme,               &
                         its, ite, jts, jte, kts, kte               )
-!--------------------------------------------------------------------
+!--------------------------------------------------------------------   
    IMPLICIT NONE
 !--------------------------------------------------------------------
    LOGICAL , INTENT(IN)           ::  restart,allowed_to_read
@@ -4250,17 +4272,17 @@ contains
    INTEGER , INTENT(IN)           ::  P_FIRST_SCALAR, P_QI, P_QC
 
    REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT) ::       &
-                                                          RTHCUTEN, &
-                                                          RQVCUTEN, &
-                                                          RQCCUTEN, &
+                                                          RTHCUTEN,          &
+                                                          RQVCUTEN,          &
+                                                          RQCCUTEN,          &
                                                           RQICUTEN
 
    REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT) ::       &
-                                                          RUCUTEN,  &
+                                                          RUCUTEN,           &
                                                           RVCUTEN
 
    REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT) ::       &
-                                                          RTHFTEN,  &
+                                                          RTHFTEN,           &
                                                           RQVFTEN
 
    INTEGER :: i, j, k, itf, jtf, ktf
@@ -4313,6 +4335,4 @@ contains
    ENDIF
 
    END SUBROUTINE gfinit
-
-!==============================================================================
 END MODULE module_cu_gf_deep

--- a/phys/module_cu_gf_sh.F
+++ b/phys/module_cu_gf_sh.F
@@ -40,7 +40,7 @@
 !    itf,ktf,its,ite, kts,kte are dimensions
 !    ztexec,zqexec    excess temperature and moisture for updraft
 MODULE module_cu_gf_sh
-    real, parameter:: c1_shal=0.002 ! .0005
+    real, parameter:: c1_shal=0.! .0005
     real, parameter:: g  =9.81
     real, parameter:: cp =1004.
     real, parameter:: xlv=2.5e6
@@ -164,7 +164,7 @@ contains
         xqes_cup,xq_cup,xhe_cup,xhes_cup,xz_cup,     &
         xt_cup,dby,hc,zu,   &
         dbyo,qco,pwo,hco,qrco,     &
-        xdby,xhc,xzu,            &
+        dbyt,xdby,xhc,xzu,            &
 
   ! cd  = detrainment function for updraft
   ! dellat = change of temperature per unit mass flux of cloud ensemble
@@ -188,7 +188,7 @@ contains
        kstabi,xland1,KBMAX,ktopx
 
      integer                              ::                           &
-       I,K
+       I,K,ki
      real                                 ::                           &
       dz,mbdt,zkbmax,      &
       cap_maxs,trash,trash2,frh
@@ -204,12 +204,14 @@ contains
      integer, dimension (its:ite,kts:kte) ::  k_inv_layers 
      integer, dimension (its:ite) ::  start_level
      start_level(:)=0
+     rand_vmas(:)=0.
      flux_tun=fluxtune
       do i=its,itf
         xland1(i)=int(xland(i)+.001) ! 1.
         ktopx(i)=0
         if(xland(i).gt.1.5 .or. xland(i).lt.0.5)then
             xland1(i)=0
+!            ierr(i)=100
         endif
         pre(i)=0.
         xmb_out(i)=0.
@@ -395,12 +397,14 @@ contains
 ! first estimate for shallow convection
 !
             ktop(i)=1
-            if(k_inv_layers(i,1).gt.0)then
-!               ktop(i)=min(k_inv_layers(i,1),k_inv_layers(i,2))
+!            if(k_inv_layers(i,1).gt.0)then
+!!               ktop(i)=min(k_inv_layers(i,1),k_inv_layers(i,2))
+            if(k_inv_layers(i,1).gt.0 .and.   &
+               (po_cup(i,kbcon(i))-po_cup(i,k_inv_layers(i,1))).lt.200.)then
                ktop(i)=k_inv_layers(i,1)
             else
                do k=kbcon(i)+1,ktf
-                  if((po_cup(i,kbcon(i))-po_cup(i,k)).gt.100.)then
+                  if((po_cup(i,kbcon(i))-po_cup(i,k)).gt.200.)then
                     ktop(i)=k
                     exit
                   endif
@@ -476,6 +480,7 @@ contains
 !
 !
       do 42 i=its,itf
+        dbyt(i,:)=0.
         IF(ierr(I) /= 0) cycle
          do k=start_level(i)+1,ktop(i)
           hc(i,k)=(hc(i,k-1)*zu(i,k-1)-.5*up_massdetr(i,k-1)*hc(i,k-1)+ &
@@ -485,8 +490,25 @@ contains
           hco(i,k)=(hco(i,k-1)*zuo(i,k-1)-.5*up_massdetro(i,k-1)*hco(i,k-1)+ &
                          up_massentro(i,k-1)*heo(i,k-1))   /            &
                          (zuo(i,k-1)-.5*up_massdetro(i,k-1)+up_massentro(i,k-1))
-          dbyo(i,k)=max(0.,hco(i,k)-heso_cup(i,k))
+          dbyo(i,k)=hco(i,k)-heso_cup(i,k)
+          DZ=Zo_cup(i,K+1)-Zo_cup(i,K)
+          dbyt(i,k)=dbyt(i,k-1)+dbyo(i,k)*dz
          enddo
+       ki=maxloc(dbyt(i,:),1)
+       if(ktop(i).gt.ki+1)then
+         ktop(i)=ki+1
+         zuo(i,ktop(i)+1:ktf)=0.
+         zu(i,ktop(i)+1:ktf)=0.
+         cd(i,ktop(i)+1:ktf)=0.
+         up_massdetro(i,ktop(i))=zuo(i,ktop(i))
+!         up_massentro(i,ktop(i))=0.
+         up_massentro(i,ktop(i):ktf)=0.
+         up_massdetro(i,ktop(i)+1:ktf)=0.
+         entr_rate_2d(i,ktop(i)+1:ktf)=0.
+
+!         ierr(i)=423
+       endif
+
          if(ktop(i).lt.kbcon(i)+1)then
             ierr(i)=5
             ierrc(i)='ktop is less than kbcon+1'
@@ -515,7 +537,7 @@ contains
                        up_massentr(i,k-1)*qo(i,k-1))   /            &
                        (zuo(i,k-1)-.5*up_massdetr(i,k-1)+up_massentr(i,k-1))
 
-          if(qco(i,k)>=trash .and. dbyo(i,k) > 0.) then
+          if(qco(i,k)>=trash ) then 
               DZ=Z_cup(i,K)-Z_cup(i,K-1)
               ! cloud liquid water
               qrco(i,k)= (qco(i,k)-trash)/(1.+(c0_shal+c1_shal)*dz)
@@ -535,6 +557,7 @@ contains
           dp=100.*(po_cup(i,k)-po_cup(i,k+1))
           cnvwt(i,k)=zuo(i,k)*cupclw(i,k)*g/dp
           trash2=trash2+entr_rate_2d(i,k)
+          qco(i,k)=qco(i,k)-qrco(i,k)
          enddo
          do k=k22(i)+1,max(kbcon(i),k22(i)+1)
           trash=trash+entr_rate_2d(i,k)
@@ -649,9 +672,9 @@ contains
 
             !-- condensation source term = detrained + flux divergence of 
             !-- cloud liquid water (qrco)
-!           C_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -       &
-!                                 zuo(i,k  )* qrco(i,k  )  )*g/dp
-            C_up = dellaqc(i,k)
+            C_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -       &
+                                  zuo(i,k  )* qrco(i,k  )  )*g/dp
+!            C_up = dellaqc(i,k)
             !-- water vapor budget (flux divergence of Q_up-Q_env - condensation
             !term)
             dellaq(i,k) =-(zuo(i,k+1)*(qco(i,k+1)-qo_cup(i,k+1) ) -      &


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: GF cumulus

SOURCE: Georg Grell, Joseph B Olson (NOAA)

DESCRIPTION OF CHANGES: 
This is a further clean-up of the GF parameterization for the release.

Changes include minor bug fixes as well as some more major changes that resulted from tuning experiments. Those changes caused area coverage of non resolved precipitation to decrease but magnitudes to increase. Bias and equitable threat-scores over CONUS were improved significantly in a retro test of the Rapid Refresh modeling domain.

We added gamma functions for the calculation of the mass flux PDF’s. These may replaced in the future with lookup table approximations.

LIST OF MODIFIED FILES :
modified:   phys/module_cu_gf_deep.F
modified:   phys/module_cu_gf_sh.F

TESTS CONDUCTED: 
1. Regression 3.06 OK
-> except tests with GF and WDM6 have MPI bit-for-bit diffs with the PGI compiler
Resolution: GF and WDM6 tests are maintained, but the combination will be removed in the next WTF version. The GF developers will look at the issue. Not considered critical.