### PR TITLE
Add metadata for hybrid vertical coordinate

### DIFF
--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -197,6 +197,9 @@
 #if ( HYBRID_COORD==1 )
     CALL nl_get_hybrid_opt ( 1       , hybrid_opt )
     CALL nl_get_etac       ( 1       , etac )
+    IF ( hybrid_opt .EQ. 0 ) THEN
+       etac = 0.
+    END IF
 #endif
 
     IF ( grid_fdda == 1 ) THEN


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: hybrid, HVC, metadata

### SOURCE: internal

### DESCRIPTION OF CHANGES:
Add hybrid_opt and etac to the list of metadata in the WRF model files. Special cases:
- If this code was built without the hybrid option, set hybrid_opt=-1, etac=0.
- If this code was built with hybrid:
    - If hybrid_opt = 0, set etac = 0.


### LIST OF MODIFIED FILES:
M       share/output_wrf.F

### TESTS CONDUCTED:
When running with hybrid_opt activated:
```
$ grep hybrid_opt namelist.input
 hybrid_opt = 2
$ ncdump -h wrfinput_d01 | tail -3 | head -2
		:HYBRID_OPT = 2 ;
		:ETAC = 0.2f ;
```
When running with the hybrid_opt turned off:
```
[gill@yslogin2 em_real]$ grep hybrid_opt namelist.input
 hybrid_opt = 0
[gill@yslogin2 em_real]$ ncdump -h wrfinput_d01 | tail -3 | head -2
		:HYBRID_OPT = 0 ;
		:ETAC = 0.0f ;
```