### PR TITLE
Added 'KNL' to the system description for Linux/Intel builds

### DIFF
--- a/arch/configure_new.defaults
+++ b/arch/configure_new.defaults
@@ -1781,7 +1781,7 @@ RLFLAGS		=
 CC_TOOLS        =      $(SCC) 
 
 ###########################################################
-#ARCH    Linux x86_64 ppc64le i486 i586 i686 #serial smpar dmpar dm+sm
+#ARCH    Linux KNL x86_64 ppc64le i486 i586 i686 #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       INTEL ($SFC/$SCC): KNL MIC
 DMPARALLEL      =       # 1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: KNL, Linux, Intel, configure_new.defaults

SOURCE: John Cazes, HPC Applications

DESCRIPTION OF CHANGES: When configuring for a KNL system, when one of the KNL options is chosen, the configure scripts create a configure file for Haswell/Broadwell with the "-xCORE-AVX2" optimization flag instead of the "-xMIC-AVX512" flag.   The problem is that the ARCH entry in the file arch/configure_new.defaults for HSW/BDW (#ARCH    Linux x86_64 ppc64le i486 i586 i686 #serial smpar dmpar dm+sm) is the same as the ARCH entry for KNL.  Simply adding 'KNL' to the ARCH entry (#ARCH    Linux KNL x86_64 ppc64le i486 i586 i686 #serial smpar dmpar dm+sm) corrects this.  With this ARCH entry, the perl script chooses the correct entry for KNL options from the configure_new.defaults file.

LIST OF MODIFIED FILES: 
M       arch/configure_new.defaults

TESTS CONDUCTED: Tested whether this builds okay with Intel 15.0.1 on Yellowstone.  Regression tests passed (with the exception of 2 chem_kpp forecasts with PGI - I assume this is standard for the time being?).  User also conducted test to verify this corrects the problem on a KNL system.