### PR TITLE
P3 changes added to fast RRTMG versions too

### DIFF
--- a/phys/module_ra_rrtmg_lwf.F
+++ b/phys/module_ra_rrtmg_lwf.F
@@ -15874,6 +15874,20 @@ integer,external :: omp_get_thread_num
                   resnow1D(icol,K) = 10.0
                ENDDO
             ENDIF
+
+! special case for P3 microphysics
+! put ice into snow category for optics, then set ice to zero
+            IF (has_reqs .eq. 0 .and. has_reqi .ne. 0 .and. has_reqc .ne. 0) THEN
+               inflglw  = 5
+               iceflglw = 5
+               DO K=kts,kte
+                  resnow1D(ncol,K) = MAX(10., re_ice(I,K,J)*1.E6)
+                  QS1D(K)=QI3D(I,K,J)
+                  QI1D(K)=0.
+                  reice1D(ncol,K)=10.
+               END DO
+            END IF
+
          ENDIF
 
 ! Layer indexing goes bottom to top here for all fields.

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11880,6 +11880,21 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
                   resnow1D(icol,K) = 10.
                ENDDO
             ENDIF
+
+! special case for P3 microphysics
+! put ice into snow category for optics, then set ice to zero
+            IF ( has_reqs .eq. 0 .and. has_reqi .ne. 0 .and. has_reqc .ne. 0) THEN
+               inflgsw  = 5
+               iceflgsw = 5
+               DO K=kts,kte
+                  resnow1D(ncol,K) = MAX(10., re_ice(I,K,J)*1.E6)
+                  QS1D(K)=QI3D(I,K,J)
+                  QI1D(K)=0.
+                  reice1D(ncol,K)=10.
+               END DO
+
+            END IF
+
          ENDIF
 
 ! Set cosine of solar zenith angle


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: P3 microphysics, RRTMG fast options

SOURCE: internal

DESCRIPTION OF CHANGES: 
Extend previous RRTMG changes related to P3 to the RRTMG "fast" options
that were inadvertently not committed before.

LIST OF MODIFIED FILES: 
M       phys/module_ra_rrtmg_lwf.F
M       phys/module_ra_rrtmg_swf.F

TESTS CONDUCTED: 
WTF v3.06 regtest with namelist using this combination
