### PR TITLE
Avoid divide-by-zero condition for model_qs_ice for use_radar_rqv option

### DIFF
--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -198,11 +198,7 @@ END IF
    if ( use_radar_rqv ) then
       do n=iv%info(radar)%n1,iv%info(radar)%n2
          do k=1,iv%info(radar)%levels(n)
-            if(model_tc(k,n).gt.-273.15) then
-               model_qs_ice(k,n) = model_qs(k,n)*exp((2.837E6 - 2.501E6)/461.5*(1./273.15 - 1./(model_tc(k,n)+273.15)))
-            else
-               model_qs_ice(k,n) = model_qs(k,n)
-            end if
+            model_qs_ice(k,n) = model_qs(k,n)*exp((2.837E6 - 2.501E6)/461.5*(1./273.15 - 1./(model_tc(k,n)+273.15)))
          end do
       end do
    end if


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, radar, divide-by-zero, debug

SOURCE: Ki-Hong Min (Kyungpook National University)

DESCRIPTION OF CHANGES: Running WRFDA tests with debug compile flags led to the discovery of division-by-zero conditions in new radar code related to option use_radar_rqv. Because radar observations have varying numbers of levels, each radar observation object is allocated with the maximum number of levels, and the observation levels that are not used are filled with garbage data. The way the code was written, the variable "model_tc" was initialized to zero, which eventually led to division by zero in the equation for calculating model_qs_ice. Even though these values are never used, the GNU compiler still fails with debug flags, and it is still possible that others could fail even for normal compiled code.

The fix is to correctly loop only over levels that contain observations. Now the division by zero condition should never occur.

LIST OF MODIFIED FILES: 
M       var/da/da_radar/da_get_innov_vector_radar.inc

TESTS CONDUCTED: WRFDA Regtest now successful for the failing test for debug compiles.