### PR TITLE
Adaptive time step for small grid distance

### DIFF
--- a/dyn_em/adapt_timestep_em.F
+++ b/dyn_em/adapt_timestep_em.F
@@ -123,7 +123,12 @@ RECURSIVE SUBROUTINE adapt_timestep(grid, config_flags)
   !
   ! Else, calculate the time step based on cfl.
   !
-  if ( ( domain_get_advanceCount ( grid ) .EQ. 1 ) .AND. ( .NOT. config_flags%restart ) ) then
+  !BPR BEGIN
+  !At the initial time advanceCount == 0, but the following line instead looked
+  !for advanceCount == 1
+  !if ( ( domain_get_advanceCount ( grid ) .EQ. 1 ) .AND. ( .NOT. config_flags%restart ) ) then
+  if ( ( domain_get_advanceCount ( grid ) .EQ. 0 ) .AND. ( .NOT. config_flags%restart ) ) then
+  !BPR END
      if ( grid%starting_time_step_den .EQ. 0 ) then
         CALL WRFU_TimeIntervalSet(dtInterval, Sn=grid%starting_time_step, Sd=1)
      else
@@ -471,6 +476,15 @@ SUBROUTINE calc_dt(dtInterval, max_cfl, max_increase_factor, precision, &
         !
         
         factor = ( target_cfl - 0.5 * (max_cfl - target_cfl) ) / max_cfl
+
+        ! BPR BEGIN
+        ! Factor can be negative in some cases so prevent factor from being
+        ! lower than 0.1
+        ! Otherwise model crashes can occur in normalize_basetime noting that
+        ! denominator of seconds cannot be negative
+        factor = MAX(0.1,factor)
+        ! BPR END
+
         num = INT(factor * precision + 0.5)
         den = precision
 

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -900,6 +900,23 @@
         ( ( grid%dfi_opt .EQ. DFI_NODFI ) .OR. ( grid%dfi_stage .EQ. DFI_FST ) ) ) THEN
 
 !  Calculate any variables that were not set
+!BPR BEGIN
+!     This subroutine is called more than once at the first time step for a
+!     given domain.  The following if statement is to prevent the code in
+!     the if statement from executing more than once per domain at the
+!     beginning of the model run (since last_step_update=-1 the first time
+!     this is reached and should be =0 after this).
+!     Without this if statement, when this code was executed for the second
+!     time it can result in grid%dt being set incorrectly.
+!     -This is because grid%dt will be set equal to grid%starting_time_step
+!      which ignores a possible denominator in the starting time step.
+!     -The first time this code is reached is also does this, but then the
+!      call to adapt_timestep correct this
+!     -Subsequent times this code is reached adapt_timestep will not correct
+!      this because it will recognize that it has already been executed for
+!      this timestep and exit out before doing the calculation.
+
+      if (grid%last_step_updated .NE. grid%itimestep) then
 
       if (grid%starting_time_step == -1) then
          grid%starting_time_step = NINT(4 * MIN(grid%dx,grid%dy) / 1000)
@@ -937,6 +954,8 @@
       CALL wrf_dm_maxval(grid%max_msftx, idex, jdex)
       CALL wrf_dm_maxval(grid%max_msfty, idex, jdex)
 #endif
+      end if
+!BPR END
 
 !     This first call just initializes variables.
 !     If a restart, get initialized variables from restart file

--- a/frame/module_domain.F
+++ b/frame/module_domain.F
@@ -768,11 +768,13 @@ CONTAINS
       new_grid%max_tiles   = 0
       new_grid%num_tiles_spec   = 0
       new_grid%nframes   = 0         ! initialize the number of frames per file (array assignment)
-#if (EM_CORE == 1)
-      new_grid%stepping_to_time = .FALSE.
-      new_grid%adaptation_domain = 1
-      new_grid%last_step_updated = -1
-#endif
+!BPR BEGIN
+!#if (EM_CORE == 1)
+!      new_grid%stepping_to_time = .FALSE.
+!      new_grid%adaptation_domain = 1
+!      new_grid%last_step_updated = -1
+!#endif
+!BPR BEGIN
 
 !      IF (active) THEN
         ! only allocate state if this set of tasks actually computes that domain, jm 20140822
@@ -790,6 +792,16 @@ CONTAINS
 !        WRITE (wrf_err_message,*)"Not allocating storage for domain ",domain_id," on this set of tasks"
 !        CALL wrf_message(TRIM(wrf_err_message))
 !      ENDIF
+
+!BPR BEGIN
+#if (EM_CORE == 1)
+!Set these here, after alloc_space_field, which initializes at least last_step_updated to zero
+      new_grid%stepping_to_time = .FALSE.
+      new_grid%adaptation_domain = 1
+      new_grid%last_step_updated = -1
+#endif
+!BPR END
+
 #if MOVE_NESTS
 !set these here, after alloc_space_field, which initializes vc_i, vc_j to zero
       new_grid%xi = -1.0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: adaptive time step

SOURCE: Bryan Reen (US Army)

DESCRIPTION OF CHANGES:
(1) In dyn_em/adapt_timestep_em.F
-When reducing the time step it calculates "factor" to determine what to
multiply the old timestep by to get the new timestep.  However, the way this
is calculated sometimes results in a negative multiplier. Now, the factor is
limited to being at least 0.1.
-When determining whether we are currently at the first time step (and thus
should use time step lengths specified for the first time step) it
previously incorrectly checked for advanceCount==1 instead of
advanceCount==0. Now it checks for advanceCount==0.

(2) in dyn_em/start_em.F
-Previously, denominators in starting time steps were effectively ignored.
This could result in a much larger timestep than desired at the first time
step which could result in model crashes due to CFL criteria. Now,
denominators specified for starting time steps are used. 

(3) in frame/module_domain.F
-Previously, some initializations of new_grid were overwritten immediately
after having been made.  For example, previously new_grid%last_step_updated
would be set to -1, but then immediately set to 0 by alloc_space_field. Then
adapt_timestep would see at time step 0 that last_step_updated=0 and so
assume that it had already calculated a timestep for the current time step
when it actually had not. Therefore, now some initializations of new_grid
have been moved down slightly to prevent them from being overwritten.

(4) external/esmf_time_f90/Meat.F90
 -Add call to the subroutine simplify to simplify fractions relating to time
steps whenever they are normalized. 
 
LIST OF MODIFIED FILES: 
M       dyn_em/adapt_timestep_em.F
M       dyn_em/start_em.F
M       external/esmf_time_f90/Meat.F90
M       frame/module_domain.F

TESTS CONDUCTED:
1. Regression 3.06
2. A user test case with 3-nesting domain and adaptive time step 

@davegill Please review these changes to see if they are correct