### PR TITLE
 bug fix for periodic boundaries using TKE

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2952,8 +2952,8 @@ halo      HALO_EM_B2 dyn_em 4:ru_tend,rv_tend
 halo      HALO_EM_C dyn_em    4:u_2,v_2
 halo      HALO_EM_C2 dyn_em    4:ph_2,al,p,mu_2,muts,mudf
 halo      HALO_EM_D dyn_em    24:ru_m,rv_m,ww_m,mut,muts
-halo      HALO_EM_D2_3 dyn_em 24:u_2,v_2,w_2,t_2,ph_2;24:moist,chem,tracer,scalar;4:mu_2,al
-halo      HALO_EM_D2_5 dyn_em 48:u_2,v_2,w_2,t_2,ph_2;24:moist,chem,tracer,scalar;4:mu_2,al
+halo      HALO_EM_D2_3 dyn_em 24:u_2,v_2,w_2,t_2,ph_2;24:moist,chem,tracer,scalar,tke_2;4:mu_2,al
+halo      HALO_EM_D2_5 dyn_em 48:u_2,v_2,w_2,t_2,ph_2;24:moist,chem,tracer,scalar,tke_2;4:mu_2,al
 halo      HALO_EM_D3_3 dyn_em 24:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,moist,chem,tracer,scalar;4:mu_1,mu_2
 halo      HALO_EM_D3_5 dyn_em 48:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,moist,chem,tracer,scalar;4:mu_1,mu_2
 halo      HALO_EM_E_3 dyn_em 24:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,;4:mu_1,mu_2

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -41,7 +41,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
                  ,period_bdy_em_d_sub,period_bdy_em_e_sub,period_bdy_em_moist2_sub         &
                  ,period_bdy_em_moist_old_sub,period_bdy_em_moist_sub                      &
                  ,period_bdy_em_scalar2_sub,period_bdy_em_scalar_old_sub                   &
-                 ,period_bdy_em_scalar_sub,period_bdy_em_tke_old_sub                       &
+                 ,period_bdy_em_scalar_sub,period_bdy_em_tke_old_sub, period_bdy_em_tke_sub  &
                  ,period_bdy_em_tracer2_sub,period_bdy_em_tracer_old_sub                   &
                  ,period_bdy_em_tracer_sub,period_em_da_sub,period_em_hydro_uv_sub         &
                  ,halo_em_f_sub,halo_em_init_4_sub,halo_em_thetam_sub,period_em_thetam_sub
@@ -3235,6 +3235,7 @@ BENCH_END(calc_p_rho_tim)
 #  include "PERIOD_BDY_EM_CHEM2.inc"
 #  include "PERIOD_BDY_EM_TRACER2.inc"
 #  include "PERIOD_BDY_EM_SCALAR2.inc"
+#  include "PERIOD_BDY_EM_TKE.inc"
 #endif
 
 BENCH_START(bc_end_tim)


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: LES, ideal, TKE, periodic boundary, registry, communication

### SOURCE: internal

### DESCRIPTION OF CHANGES: 
This problem has been in the source code forever.  Two changes are required to get bit-for-bit correct results when running periodic lateral boundary conditions with the TKE option enabled:

1. There was a missing HALO communication exchange for the TKE_2 field (all of the other scalar fields were already communicated: moist, chem, scalar, tracer). The TKE_2 field was added to the HALO list in the Registry for HALO_EM_D2_3 (and _5).  This HALO communication allows the neighboring grid cells to update each other regarding the recently changed TKE_2 field.

2. After this HALO communication, THEN a PERIOD communication for TKE_2 is inserted into solve_em.F, so that the boundaries may swap there "normal" (i.e. straight line) fields.

These "straight line" communications were actually the trouble. Here the "x" character represents old data that needs to be updated in the halo region for a four-processor periodic case, the "A B C D E" and "0 1 2 3 4" (etc) represent valid data, and the "|" and " - - " represent the halo boundary.

```
          Proc 2                       Proc 3
          Left                          Right 
          Side                           Side

    x x | A B C D E                 V W X Y Z | x x
    - - - - - - - -                 - - - - - - - -
    x x | x x x x x                 x x x x x | x x


    x x | x x x x x                 x x x x x | x x
    - - - - - - - -                 - - - - - - - -
    x x | 0 1 2 3 4                 5 6 7 8 9 | x x

          Proc 0                       Proc 1
          Left                          Right 
          Side                           Side
```



After the HALO communication, the nearest neighbors exchange data (showing north south example).

```
          Proc 2                       Proc 3
          Left                          Right 
          Side                           Side

    x x | A B C D E                 V W X Y Z | x x
    - - - - - - - -                 - - - - - - - -
    x x | 0 1 2 3 4                 5 6 7 8 9 | x x



    x x | A B C D E                 V W X Y Z | x x
    - - - - - - - -                 - - - - - - - -
    x x | 0 1 2 3 4                 5 6 7 8 9 | x x

          Proc 0                       Proc 1
          Left                          Right 
          Side                           Side
```

After the PERIOD communication, the boundary neighbors exchange data (showing east west example)

```
          Proc 2                       Proc 3
          Left                          Right 
          Side                           Side

    Y Z | A B C D E                 V W X Y Z | A B
    - - - - - - - -                 - - - - - - - -
    8 9 | 0 1 2 3 4                 5 6 7 8 9 | 0 1



    Y Z | A B C D E                 V W X Y Z | A B
    - - - - - - - -                 - - - - - - - -
    8 9 | 0 1 2 3 4                 5 6 7 8 9 | 0 1

          Proc 0                       Proc 1
          Left                          Right 
          Side                           Side
```

Without the initial HALO communication for the TKE_2 field, the memory locations in the halo region that were exchanged during the existing PERIOD communications were getting junk from each other.

### LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/solve_em.F

### TESTS CONDUCTED: 
1. regression v3.06 
- [x] complete
2. A separate test using the ideal LES case with periodic LBCs and TKE.  After these communication mods, the results are bit for bit with different numbers of processors (even after 3500+ time steps).  Without these mods, the bit for bit differences along the lateral boundaries show up after 5-10 time steps.       
- [x] complete