### PR TITLE
Print correct file name for FY3 assimilation when observation file can not be opened

### DIFF
--- a/var/da/da_radiance/da_read_obs_fy3.inc
+++ b/var/da/da_radiance/da_read_obs_fy3.inc
@@ -219,7 +219,7 @@ bufrfile:  do ibufr=1,numbufr
       iostat = iost, status = 'old')
    if (iost /= 0) then
       call da_warning(__FILE__,__LINE__, &
-         (/"Cannot open file "//infile/))
+         (/"Cannot open file "//filename/))
       if (trace_use) call da_trace_exit("da_read_obs_fy3")
       return
    end if


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: WRFDA, FY3, error message

SOURCE: internal

DESCRIPTION OF CHANGES: In communication with a user I discovered that the error messages for FY3 assimilation when the observation file can not be read (usually because it does not exist) does not actually list the filename that was being read. If the file "mwhsa.dat" does not exist, this is the warning message generated:

    Cannot open file mwhsa

This could cause confusion for users. The fix is to properly use the "filename" variable, rather than "infile". The resulting warning message after the fix is correct:

    Cannot open file mwhsa.dat

LIST OF MODIFIED FILES:
M       var/da/da_radiance/da_read_obs_fy3.inc

TESTS CONDUCTED: WRFDA regression test passed as expected. Ran a case with FY3 assimilation options turned on (but no observation file), confirmed that the warning message is now correct.
