### PR TITLE
Fix for undefined time index when analysis time is at the end of time windows for DA 4D-Ensemble-Var

### DIFF
--- a/var/da/da_tools/da_get_time_slots.inc
+++ b/var/da/da_tools/da_get_time_slots.inc
@@ -56,6 +56,8 @@ subroutine da_get_time_slots(nt,tmin,tana,tmax,time_slots,itime_ana)
    ! (time_slots(i)-time_slots(i-1))/2 corresponds to fg index i
    if ( nt == 1 .or.  abs(time_ana-time_slots(0)) < 0.1 ) then
       itime_ana = 1
+   else if ( abs(time_ana-time_slots(nt)) < 0.1 ) then
+      itime_ana = nt
    else
       do it = 2, nt-1
          time_tmp = time_slots(0) + (it-1) * dt


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4D-En-Var, use_4denvar

SOURCE: internal (error pointed out by Hongli Wang of Panasonic Weather Solutions)

DESCRIPTION OF CHANGES:
In the recently modified code (b449e86 commit) for finding the time index of the analysis time,
the case that the analysis time is at the end of time windows is not handled.

LIST OF MODIFIED FILES:
M       var/da/da_tools/da_get_time_slots.inc

TESTS CONDUCTED:
1. The problem revealed by a toy case with num_fgat_time=2.