### PR TITLE
Fix k index in hill2d init

### DIFF
--- a/dyn_em/module_initialize_hill2d_x.F
+++ b/dyn_em/module_initialize_hill2d_x.F
@@ -539,8 +539,8 @@ CONTAINS
                    (grid%mub(i,j)+grid%mu_1(i,j))*grid%al(i,kk-1,j)+ &
                     grid%mu_1(i,j)*grid%alb(i,kk-1,j)  )
                                                    
-      grid%ph_2(i,k,j) = grid%ph_1(i,k,j) 
-      grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
+      grid%ph_2(i,kk,j) = grid%ph_1(i,kk,j) 
+      grid%ph0(i,kk,j) = grid%ph_1(i,kk,j) + grid%phb(i,kk,j)
     ENDDO
 
     if((i==2) .and. (j==2)) then


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: HVC hill2d k index

### SOURCE: Problem found by Katie Lundquist (LLNL)

### DESCRIPTION OF CHANGES:
Automatic vertical index is assumed to be "k".  The DO loop structure assumed that the correct location would be "k-1" for the half level variable. The indexing is modified twice so that "kk" is the loop index and "k=kk-1" is defined. This is already used in the routine, this location was just accidentally missed.

### LIST OF MODIFIED FILES:
M       dyn_em/module_initialize_hill2d_x.F

### TESTS CONDUCTED:
1. x-sections of the hill2d case
- [x] checked means completed

2. regression test 3.06
- [x] checked means completed