### PR TITLE
Fix dimension sizes for mass_weight routine (for HVC)

### DIFF
--- a/dyn_em/module_bc_em.F
+++ b/dyn_em/module_bc_em.F
@@ -284,16 +284,9 @@ CONTAINS
            CALL mass_weight ( ph , mut , rfield , c1f, c2f, &
                               ids,ide, jds,jde, kds,kde,    &        ! domain dims
                               ims,ime, jms,jme, kms,kme,    &        ! memory dims
-                              its-1,ite+1 , jts-1:jte+1 ,   &        ! rfield dims
-                              kts:kte,                      &        ! rfield
+                              its-1,ite+1 , jts-1,jte+1 ,   &        ! rfield dims
+                              kts,kte,                      &        ! rfield
                               i_start,i_end, j_start,j_end, kts,kte)  ! tile dims
-!do j = j_start,j_end
-!do k = kts,kte
-!do i = i_start,i_end
-!rfield(i,k,j) = ph(i,k,j)*(c1f(k)*MUT(i,j)+c2f(k))
-!end do
-!end do
-!end do
 
            CALL relax_bdytend_tile ( rfield, ph_tendf,             &
                                ph_bxs,ph_bxe,ph_bys,ph_bye, ph_btxs,ph_btxe,ph_btys,ph_btye,       &
@@ -309,16 +302,9 @@ CONTAINS
            CALL mass_weight ( t,   mut , rfield , c1h, c2h, &
                               ids,ide, jds,jde, kds,kde,    &         ! domain dims
                               ims,ime, jms,jme, kms,kme,    &         ! memory dims
-                              its-1,ite+1 , jts-1:jte+1 ,   &        ! rfield dims
-                              kts:kte,                      &        ! rfield
+                              its-1,ite+1 , jts-1,jte+1 ,   &        ! rfield dims
+                              kts,kte,                      &        ! rfield
                               i_start,i_end, j_start,j_end, kts,kte-1) ! tile dims
-!do j = j_start,j_end
-!do k = kts,kte-1
-!do i = i_start,i_end
-!rfield(i,k,j) = t(i,k,j)*(c1h(k)*MUT(i,j)+c2h(k))
-!end do
-!end do
-!end do
 
            CALL relax_bdytend_tile ( rfield, t_tendf,              &
                                t_bxs,t_bxe,t_bys,t_bye, t_btxs,t_btxe,t_btys,t_btye,       &
@@ -351,16 +337,9 @@ CONTAINS
            CALL mass_weight ( w , mut , rfield , c1f, c2f, &
                               ids,ide, jds,jde, kds,kde,   &        ! domain dims
                               ims,ime, jms,jme, kms,kme,   &        ! memory dims
-                              its-1,ite+1 , jts-1:jte+1 ,  &        ! rfield dims
-                              kts:kte,                     &        ! rfield
+                              its-1,ite+1 , jts-1,jte+1 ,  &        ! rfield dims
+                              kts,kte,                     &        ! rfield
                               i_start,i_end, j_start,j_end, kts,kte) ! tile dims
-!do j = j_start,j_end
-!do k = kts,kte
-!do i = i_start,i_end
-!rfield(i,k,j) = w(i,k,j)*(c1f(k)*MUT(i,j)+c2f(k))
-!end do
-!end do
-!end do
 
            CALL relax_bdytend_tile ( rfield, rw_tendf,             &
                                w_bxs,w_bxe,w_bys,w_bye, w_btxs,w_btxe,w_btys,w_btye,       &
@@ -424,6 +403,7 @@ CONTAINS
            CALL mass_weight ( scalar , mu , rscalar, c1h, c2h, &
                               ids,ide, jds,jde, kds,kde,   &          ! domain dims
                               ims,ime, jms,jme, kms,kme,   &          ! memory dims
+                              ims,ime, jms,jme, kms,kme,   &          ! rfield dims
                               i_start,i_end, j_start,j_end, kts,kte-1) ! tile dims
 
            CALL relax_bdytend (rscalar, scalar_tend,             &
@@ -1753,6 +1733,7 @@ CONTAINS
 
       INTEGER , INTENT(IN   ) :: ids,ide, jds,jde, kds,kde, &
                                  ims,ime, jms,jme, kms,kme, &
+                                 irs,ire, jrs,jre, krs,kre, &
                                  its,ite, jts,jte, kts,kte 
       REAL , DIMENSION(ims:ime, kms:kme, jms:jme) , INTENT(IN   ) :: field
       REAL , DIMENSION(ims:ime,          jms:jme) , INTENT(IN   ) :: mut


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: dimension mass_weight HVC

### SOURCE: Problem found by Jamie Bresch

### DESCRIPTION OF CHANGES:
The dimension sizes for the local variable "rfield" are unusual, and need to be passed into the mass_weight routine specifically. THIS explains why this mass_weight routine never, ever worked (and why I had to put in that commented out DO LOOP).

### LIST OF MODIFIED FILES:
M	dyn_em/module_bc_em.F

### TESTS CONDUCTED:
1. Test that the results are bit-for-bit: using DO loop vs subroutine call (24-h forecast at 180 s dt).
- [x] checked means completed
2. Reggie 3.06
- [x] checked means completed