### PR TITLE
Fill HVC 1d arrays for older WRF input (TF)

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -529,9 +529,9 @@
          grid%c3h(k) = grid%znu(k)
          grid%c4h(k) = 0.
 #elif ( HYBRID_COORD==1 )
-         IF ( c1f(1) .NE. 1. ) THEN
+         IF ( grid%c1f(1) .NE. 1. ) THEN
             CALL wrf_debug ( 0 , '---- WARNING : Maybe old non-HVC input, setting default 1d array values for TF' )
-            IF ( grid%hybrid_opt .NE 0 ) THEN
+            IF ( grid%hybrid_opt .NE. 0 ) THEN
                CALL wrf_error_fatal ( '---- Error : Cannot use old input and try to use hybrid vertical coordinate option' )
             END IF
             grid%c1f(k) = 1.


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: HVC input TF 1d

### SOURCE: Problem found by Jamie Bresch

### DESCRIPTION OF CHANGES:
1. For non-hybrid build, properly initialize all HVC 1d arrays to defaults for TF results.
2. For hybrid build, if the input values of the 1d arrays is incorrect (as when using older input data), set values to TF defaults. Print warning message.
3. If input is old data, and user has hybrid_opt .ne. 0, then issue fatal error

### LIST OF MODIFIED FILES:
M       dyn_em/start_em.F

### TESTS CONDUCTED:
1. Test that these messages actually happen
```
>grep hybrid_opt namelist.input 
 hybrid_opt = 2

>wrf.exe
 Ntasks in X            1 , ntasks in Y            1
--- WARNING: traj_opt is zero, but num_traj is not zero; setting num_traj to zero.
blah blah blah
--- ERROR: The code was not built with hybrid vertical coordinate enabled
---        Either set hybrid_opt=0 in the namelist.input file, or
---        re-compile with the hybrid vertical coordinate enabled
---        For example: clean -a ; configure -hyb ; compile em_real
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1507
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```

- [x] checked means completed
2. reggie 3.06
- [x] checked means completed