### PR TITLE
Enable initialization of ARW using QV (mixing ratio)

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1063,6 +1063,28 @@ integer::oops1,oops2
                END DO
             END DO
 
+         ELSE IF ( flag_qv .EQ. 1 ) THEN
+            IF ( grid%p_gc(i_valid,num_metgrid_levels,j_valid) .LT. grid%p_gc(i_valid,2,j_valid) ) THEN
+               k = 2
+            ELSE
+               k = num_metgrid_levels
+            END IF
+
+            DO j = jts, MIN(jte,jde-1)
+               DO k = 1 , num_metgrid_levels
+                  DO i = its, MIN(ite,ide-1)
+                     IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE 
+                     sat_vap_pres_mb = 0.6112*10.*EXP(17.67*(grid%t_gc(i,k,j)-273.15)/(grid%t_gc(i,k,j)-29.65))
+                     vap_pres_mb = grid%qv_gc(i,k,j) * grid%p_gc(i,k,j)/100. / (grid%qv_gc(i,k,j) + 0.622 )
+                     IF ( sat_vap_pres_mb .GT. 0 ) THEN
+                        grid%rh_gc(i,k,j) = ( vap_pres_mb / sat_vap_pres_mb ) * 100.
+                     ELSE
+                        grid%rh_gc(i,k,j) = 0.
+                     END IF
+                  END DO
+               END DO
+            END DO
+
          END IF
 
          !  Some data sets do not provide a 3d geopotential height field.  


### PR DESCRIPTION
**TYPE:** enhancement

**KEYWORDS:** initialization mixing ratio qv

**SOURCE:** internal

**PURPOSE:**
Enable initialization of the QVAPOR field in ARW from a first-guess QV (mixing ratio) field

**DESCRIPTION OF CHANGES:**
This PR adds a block of code to the `init_domain_rk( )` routine to handle the case when the `FLAG_QV` variable is set to 1, thereby allowing the initialization of the RH field from the first-guess QV (mixing ratio) field. The RH field is then interpolated and subsequently used to initialize the model QVAPOR field as usual. The changes for using QV are largely copy-and-paste from the code to use SPECHUMD.

**LIST OF MODIFIED FILES:**
* dyn_em/module_initialize_real.F

**TESTS CONDUCTED:**
1. All WTF regression tests *pending*.
2. Initialization of a WRF simulation using MPAS output data, which provides only mixing ratio as the moisture field, produces plausible initial and boundary values for the QVAPOR field.