### PR TITLE
Fix HVC when scaling 2d MU by map factor - GSD Jan 17 "V noise at model lid"

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -731,14 +731,12 @@ SUBROUTINE calc_ww_cp ( u, v, mup, mub, c1h, c2h, ww,    &
 
       DO j=jts,jtf
       DO i=its,min(ite+1,ide)
-        ! u is always coupled with my
         MUU(i,j) = 0.5*(MUP(i,j)+MUB(i,j)+MUP(i-1,j)+MUB(i-1,j))
       ENDDO
       ENDDO
 
       DO j=jts,min(jte+1,jde)
       DO i=its,itf
-       ! v is always coupled with mx
         MUV(i,j) = 0.5*(MUP(i,j)+MUB(i,j)+MUP(i,j-1)+MUB(i,j-1))
       ENDDO
       ENDDO


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: HVC MU map factor

### SOURCE: internal

### DESCRIPTION OF CHANGES:
Wanted:
```
LHS = u(i,k,j) /mf(i,j) * muu(i,j)
```

Because U was coupled with the map factor, the code was broken up with a preceeding loop to handle the 2d division muu/mf (to save computations). Then we can say
```
LHS = u(i,k,j) * muu(i,j)
```

But muu(i,j) is automatically expanded into something like
```
(c1(k)*muu(i,j)+c2(k))
```

The resulting code was algebraically identical to:
```
LHS = u(i,k,j) * (c1(k)*muu(i,j)/mf(i,j) + c2(k))
```
instead of the correct
```
LHS = u(i,k,j) * (c1(k)*muu(i,j)+c2(k))/mf(i,j)
```

### LIST OF MODIFIED FILES: 
M	dyn_em/module_big_step_utilities_em.F

### TESTS CONDUCTED:
- [x] Works for problem case from GSD
- [x] Reggie 3.06