### PR TITLE
Mynn stochastic

### DIFF
--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -819,16 +819,15 @@ CONTAINS
            wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
            tau_cloud = tau_cloud*(1.-wt) + 50.*wt
 
-           elb_cloud = MIN(tau_cloud*SQRT(MIN(qtke(k),20.)), zwk)
-           elb = elb_cloud
-           elf = elb_cloud
+           elb = MIN(tau_cloud*SQRT(MIN(qtke(k),20.)), zwk)
+           elf = elb
            elb_mf = elb
            IF (zwk > zi .AND. elf > 500.) THEN
              ! COMPUTE BouLac mixing length for dry conditions in free atmosphere
              CALL boulac_length0(k,kts,kte,zw,dz,qtke,thetaw,elBLmin0,elBLavg0)
-             elf = alp5*elBLavg0*(1.-cldfra_bl1D(k)) + elb_cloud*cldfra_bl1D(k)
+             elf = alp5*elBLavg0*(1.-cldfra_bl1D(k)) + elf*cldfra_bl1D(k)
            END IF
-           elf = elf*(1.-cldfra_bl1D(k)) + elb_cloud*cldfra_bl1D(k)
+           elf = elf*(1.-cldfra_bl1D(k)) + elb*cldfra_bl1D(k)
 
          END IF
        END IF


### PR DESCRIPTION
Bug fix, code clean-up and small tweaks.

TYPE: bug fix & enhancement, only impacts the non-default options

KEYWORDS: subgrid buoyancy flux, mixing length

SOURCE: Joseph Olson (NOAA-ESRL/GSD)

DESCRIPTION OF CHANGES:
            bug fixes: (1) was not updating temperature properly in loop, so it was always using the temperature at the layer below - small impact only impacting the subgrid buoyancy fluxes. (2) a multiplier for the cloud fraction was being added before the buoyancy flux terms were calculated, causing too much TKE in clouds, ultimately mixing them away too easily and reducing the cloud cover. This bug fix helps to retain the stratus clouds. Other comments and code in this subroutine have been cleaned up. In a related change to the mass-flux clouds, a limit was added to the buoyancy flux calculation, which also helps to retain resolved-scale stratus, especially over the ocean.

Modification to the experimental mixing length for (bl_mynn_mixlength = 2, non-default). This option has a high-bias in 10m wind speeds relative to the default option (=1). By altering the blending and the integration height of the turbulent length scale, this option now has a slightly reduced mixing length near the surface in stable conditions, resulting in a smaller downward momentum flux, and improved 10m winds (still slightly larger than the default option but the difference was cut in half).

LIST OF MODIFIED FILES:
M       phys/module_bl_mynn.F

TESTS CONDUCTED: Ran WTF tests (/glade/scratch/jbolson/regtests/WTF-3.06/Runs). There were fails, but in each of those tests, the MYNN was not run (i.e. bl_pbl_physics =0 or 8). Not sure what that means...