### PR TITLE
Changed 'PROJ_CASSINI' to 'polar' 

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2590,15 +2590,15 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    max_horiz_cfl = 0.
    total = 0
 
-   IF(config_flags%map_proj == PROJ_CASSINI ) then
+   IF(config_flags%polar ) then
      msfxffl = 1.0/COS(config_flags%fft_filter_lat*degrad) 
    END IF
 
    IF ( config_flags%w_damping == 1 ) THEN
 #ifdef OPTIMIZE_CFL_TEST
 ! 20121025, L. Meadows vector optimization does not include special case for Cassini
-     IF(config_flags%map_proj == PROJ_CASSINI ) then
-       CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support PROJ_CASSINI')
+     IF(config_flags%polar ) then
+       CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
      END IF
 #endif
 
@@ -2615,7 +2615,7 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
            max_vert_cfl = vert_cfl
         ENDIF
 #  else
-        IF(config_flags%map_proj == PROJ_CASSINI ) then
+        IF(config_flags%polar ) then
            msfuxt = MIN(msfux(i,j), msfxffl)
         ELSE
            msfuxt = msfux(i,j)
@@ -2673,7 +2673,7 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
         ENDIF
 #  else
 ! L. Meadows MIC optimization, 20121025
-        IF(config_flags%map_proj == PROJ_CASSINI ) then
+        IF(config_flags%polar ) then
            msfuxt = MIN(msfux(i,j), msfxffl)
         ELSE
            msfuxt = msfux(i,j)

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -266,7 +266,7 @@ integer::oops1,oops2
       !  Send out a quick message about the time steps based on the map scale factors.
 
       IF ( ( internal_time_loop .EQ. 1 ) .AND. ( grid%id .EQ. 1 ) .AND. &
-           ( .NOT. config_flags%map_proj .EQ. PROJ_CASSINI ) ) THEN
+           ( .NOT. config_flags%polar ) ) THEN
          max_mf = grid%msft(its,jts)
          DO j=jts,MIN(jde-1,jte)
             DO i=its,MIN(ide-1,ite)
@@ -329,7 +329,7 @@ integer::oops1,oops2
                  ( config_flags%grid_fdda .NE. 0 ) .OR. &
                  ( config_flags%sst_update .EQ. 1 ) .OR. &
                  ( config_flags%all_ic_times ) .OR. &
-                 ( config_flags%map_proj .EQ. PROJ_CASSINI )
+                 ( config_flags%polar )
 
       !  There are a few checks that we need to do when the input data comes in with the middle
       !  excluded by WPS.
@@ -352,7 +352,7 @@ integer::oops1,oops2
             CALL wrf_message ( a_message ) 
             WRITE ( a_message,* ) ' ( config_flags%smooth_cg_topo )             ', ( config_flags%smooth_cg_topo )
             CALL wrf_message ( a_message ) 
-            WRITE ( a_message,* ) ' ( config_flags%map_proj .EQ. PROJ_CASSINI ) ', ( config_flags%map_proj .EQ. PROJ_CASSINI )
+            WRITE ( a_message,* ) ' ( config_flags%polar )                      ', ( config_flags%polar )
             CALL wrf_message ( a_message ) 
 
             WRITE ( a_message,* ) 'Problems, we cannot have excluded middle data from WPS'
@@ -465,14 +465,14 @@ integer::oops1,oops2
                grid%msfvx_inv(i,jte) = 0.
             END DO
          END IF
-      ELSE IF ( ( config_flags%map_proj .EQ. PROJ_CASSINI ) .AND. ( flag_mf_xy .EQ. 1 ) ) THEN
+      ELSE IF ( ( config_flags%polar ) .AND. ( flag_mf_xy .EQ. 1 ) ) THEN
          DO j=jts,jte
             DO i=its,min(ide-1,ite)
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE 
                grid%msfvx_inv(i,j) = 1./grid%msfvx(i,j)
             END DO
          END DO
-      ELSE IF ( ( .NOT. config_flags%map_proj .EQ. PROJ_CASSINI ) .AND. ( flag_mf_xy .NE. 1 ) ) THEN
+      ELSE IF ( ( .NOT. config_flags%polar ) .AND. ( flag_mf_xy .NE. 1 ) ) THEN
          DO j=jts,jte
             DO i=its,ite
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE 
@@ -490,7 +490,7 @@ integer::oops1,oops2
                grid%msfvx_inv(i,j) = 1./grid%msfvx(i,j)
             END DO
          END DO
-      ELSE IF ( ( .NOT. config_flags%map_proj .EQ. PROJ_CASSINI ) .AND. ( flag_mf_xy .EQ. 1 ) ) THEN
+      ELSE IF ( ( .NOT. config_flags%polar ) .AND. ( flag_mf_xy .EQ. 1 ) ) THEN
          IF ( grid%msfvx(its,jts) .EQ. 0 ) THEN
             CALL wrf_error_fatal ( 'Maybe you do not have the new map factors, try re-running geogrid' )
          END IF
@@ -500,7 +500,7 @@ integer::oops1,oops2
                grid%msfvx_inv(i,j) = 1./grid%msfvx(i,j)
             END DO
          END DO
-      ELSE IF ( ( config_flags%map_proj .EQ. PROJ_CASSINI ) .AND. ( flag_mf_xy .NE. 1 ) ) THEN
+      ELSE IF ( ( config_flags%polar ) .AND. ( flag_mf_xy .NE. 1 ) ) THEN
          CALL wrf_error_fatal ( 'Neither SI data nor older metgrid data can initialize a global domain' )
       ENDIF
 
@@ -654,7 +654,7 @@ integer::oops1,oops2
             
          END IF
 
-         !  Filter the input topography if this is a polar projection.
+         !  Filter the input topography if this is a global domain.
 
          IF ( ( config_flags%polar ) .AND. ( grid%fft_filter_lat .GT. 90 ) ) THEN
             CALL wrf_error_fatal ( 'If the polar boundary condition is used, then fft_filter_lat must be set in namelist.input' )

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -252,7 +252,7 @@
       ! Print out the maximum map scale factor on the coarse domain 
 
       IF ( ( first_trip_for_this_domain ) .AND. ( grid%id .EQ. 1 ) .AND. &
-           ( .NOT. config_flags%map_proj .EQ. PROJ_CASSINI ) ) THEN
+           ( .NOT. config_flags%polar ) ) THEN
          max_mf = grid%msft(its,jts)
          DO j=jts,MIN(jde-1,jte)
             DO i=its,MIN(ide-1,ite)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: PROJ_CASSINI, polar, global, lat-lon, module_big_step_utilities_em.F, module_initialize_real.F, start_em.F

SOURCE: internal

DESCRIPTION OF CHANGES: There were several locations within these 3 files where the if-tests used 'PROJ_CASSINI' when should have been specifically referring to a global lat-lon projection.  These have been corrected to state 'polar' now.  There was also one text change to the wording of a comment to clear up confusion about this.  This was causing problems for a user who was running a non-global lat-lon run.

From David Gill: "This PR fixes a problem with assuming that all domains which use the
Cassini projection are in fact global domains. This is an incorrect
assumption. There are now regional lat/lon domains (which use the Cassini
projection). The code was trying to use various IF tests to do special
processing for global domains (topography filtering, setting adaptive time
steps based on the FFT filter latitude, etc). It is no longer sufficient to
test on a Cassini projection being used when a global domain is the actual
target of the IF test. What is required is to test if the lateral boundary
flag "polar" is set to true. I agree that "polar" was unfortunately a poor
choice of flag names in the lateral boundary namelist record. In this
instance however, the "polar" flag refers to how the finite differencing is
handled at the pole for a global domain (zero area at the pole, no
advection through that cell face), and has nothing at all to do with a
Polar Stereographic projection."

LIST OF MODIFIED FILES: list of changed files 
M     dyn_em/module_big_step_utilities_em.F
M     dyn_em/module_initialize_real.F
M     dyn_em/start_em.F

TESTS CONDUCTED: Passed modified code to user who verified that these corrections fixed his problem.  Tested this myself.  Reg-tests pass.
