### PR TITLE
HWRF bug fixes

### DIFF
--- a/Registry/registry.tracker
+++ b/Registry/registry.tracker
@@ -102,7 +102,7 @@ package   vt_track_nest vortex_tracker==2            -             state:pdyn_pa
 package   vt_centroid   vortex_tracker==3            -             state:pdyn_parent,pdyn_smooth
 package   vt_rev_centr  vortex_tracker==4            -             state:weightout,mslp_noisy,pdyn_parent,pdyn_smooth,distsq
 package   vt_pdyn       vortex_tracker==5            -             state:pdyn_parent,pdyn_smooth,distsq
-package   vt_ncep_2013  vortex_tracker==6            -             state:pdyn_parent,pdyn_smooth,p850rv,p700rv,p850wind,p700wind,p850z,p700z,m10wind,m10rv,sp850rv,sp700rv,sp850wind,sp700wind,sp850z,sp700z,sm10wind,sm10rv,smslp,tracker_fixes,distsq,tracker_distsq,nest_imid,nest_jmid
+package   vt_ncep_2013  vortex_tracker==6            -             state:pdyn_parent,pdyn_smooth,p850rv,p700rv,p850wind,p700wind,p850z,p700z,m10wind,m10rv,sp850rv,sp700rv,sp850wind,sp700wind,sp850z,sp700z,sm10wind,sm10rv,smslp,tracker_fixes,distsq,tracker_distsq
 package   vt_ncep_2014  vortex_tracker==7            -             state:pdyn_parent,pdyn_smooth,p850rv,p700rv,p850wind,p700wind,p850z,p700z,m10wind,m10rv,sp850rv,sp700rv,sp850z,sp700z,sm10rv,smslp,tracker_fixes,distsq,p500u,p500v,p700u,p700v,p850u,p850v,tracker_distsq
 #---------------------------------------------------------------
 # Vortex Tracker Variables

--- a/dyn_nmm/solve_nmm.F
+++ b/dyn_nmm/solve_nmm.F
@@ -1799,6 +1799,7 @@
      &   (CONFIG_FLAGS%CU_PHYSICS.eq.KFETASCHEME .or.                     &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.OSASSCHEME .or.                       &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.NSASSCHEME .or.                       &
+     &   CONFIG_FLAGS%CU_PHYSICS.eq.SCALESASSCHEME .or.                   &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.SASSCHEME))THEN                       ! 
 !
 #ifdef NMM_FIND_LOAD_IMBALANCE
@@ -1912,6 +1913,7 @@
         IF(MOD(grid%ntsd, GRID%NCNVC).eq.0.and.                 &
      &    (CONFIG_FLAGS%CU_PHYSICS.eq.OSASSCHEME.or.            &
      &     CONFIG_FLAGS%CU_PHYSICS.eq.NSASSCHEME.or.            &
+     &     CONFIG_FLAGS%CU_PHYSICS.eq.SCALESASSCHEME.or.        &
      &     CONFIG_FLAGS%CU_PHYSICS.eq.SASSCHEME))THEN 
 !emc_2010_bugfix_h50
 !
@@ -3511,8 +3513,8 @@
         POINTS=I_BY_J
         DO K=KTE,KTS,-1
           F_MEAN=SUMF_0(K)/POINTS
-          ST_DEV=SQRT((POINTS*SUMF2_0(K)-SUMF_0(K)*SUMF_0(K))/         &
-     &                (POINTS*(POINTS-1)))
+          ST_DEV=SQRT((AMAX1(0.0,POINTS*SUMF2_0(K)-SUMF_0(K)*SUMF_0(K))/ &
+     &                (POINTS*(POINTS-1))))
           RMS=SQRT(SUMF2_0(K)/POINTS)
           KFLIP=KTE-K+1
           WRITE(message,101)KFLIP,FMAX_0(K),FMIN_0(K)

--- a/phys/module_cu_scalesas.F
+++ b/phys/module_cu_scalesas.F
@@ -385,6 +385,7 @@ CONTAINS
         SLIMSK(i)=ABS(XLAND(i,j)-2.)
 
         garea(I)=DX2D(i,j)*DY*2.0         !wang,  grid box area in m^2
+        KCNV(I)=0                         !wang, initialize KCNV
       ENDDO
 
 #if (NMM_CORE == 1)
@@ -3257,7 +3258,7 @@ CONTAINS
             ucko(i,k) = 0.
             vcko(i,k) = 0.
             dbyo(i,k) = 0.
-!           pwo(i,k)  = 0.
+            pwo(i,k)  = 0.
             dellal(i,k) = 0.
             to(i,k)   = t1(i,k)
             qo(i,k)   = q1(i,k)
@@ -4270,7 +4271,7 @@ CONTAINS
         deltbar(i) = 0.
         delubar(i) = 0.
         delvbar(i) = 0.
-!       qcond(i) = 0.
+        qcond(i) = 0.
       enddo
       do k = 1, km
         do i = 1, im

--- a/phys/module_sf_exchcoef.F
+++ b/phys/module_sf_exchcoef.F
@@ -238,6 +238,7 @@ CONTAINS
         z10=10.0
             windmks=w10m
             if (windmks > 85.0) windmks=85.0
+            if (windmks < 1.0) windmks=1.0
             if ( icoef_sf .EQ. 1) then
               call  znot_m_v1(windmks,zm1)
               call  znot_t_v1(windmks,zt1)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: HWRF bug fixes

SOURCE: Internal and NCEP/EMC

DESCRIPTION OF CHANGES: 

Several minor bug fixes found during -D compiler checks, and ensuring
bit-for-bit identical results with the new scale-aware-SAS cumulus scheme
(varying # of processors).  The bug fixes are: uninitialized variables, halo
exchanges, divide-by-zero, array bounds.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

M       Registry/registry.tracker
M       dyn_nmm/solve_nmm.F
M       phys/module_cu_scalesas.F
M       phys/module_sf_exchcoef.F

TESTS CONDUCTED: 

WTF 3.06 with and without -D flags; multiple HWRF simulations.

