### PR TITLE
bug fix for surface exchange coefficients

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -1271,14 +1271,14 @@ CONTAINS
 !
 !
 !      Limits to avoid dividing by small number
-            if (CHS(I,J) < 1.0E-02) then
-               CHS(I,J)  = 1.0E-02
+            if (CHS(I,J) < 1.0E-04) then
+               CHS(I,J)  = 1.0E-04
             endif
-            if (CHS2(I,J) < 1.0E-02) then
-               CHS2(I,J)  = 1.0E-02
+            if (CHS2(I,J) < 1.0E-04) then
+               CHS2(I,J)  = 1.0E-04
             endif
-            if (CQS2(I,J) < 1.0E-02) then
-               CQS2(I,J)  = 1.0E-02
+            if (CQS2(I,J) < 1.0E-04) then
+               CQS2(I,J)  = 1.0E-04
             endif
 !
             CHS_URB  = CHS(I,J)
@@ -3566,14 +3566,14 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   XXXC_URB = XXXC_URB2D(I,J)
       !
       !      Limits to avoid dividing by small number
-                  if (CHS(I,J) < 1.0E-02) then
-                     CHS(I,J)  = 1.0E-02
+                  if (CHS(I,J) < 1.0E-04) then
+                     CHS(I,J)  = 1.0E-04
                   endif
-                  if (CHS2(I,J) < 1.0E-02) then
-                     CHS2(I,J)  = 1.0E-02
+                  if (CHS2(I,J) < 1.0E-04) then
+                     CHS2(I,J)  = 1.0E-04
                   endif
-                  if (CQS2(I,J) < 1.0E-02) then
-                     CQS2(I,J)  = 1.0E-02
+                  if (CQS2(I,J) < 1.0E-04) then
+                     CQS2(I,J)  = 1.0E-04
                   endif
       !
                   CHS_URB  = CHS(I,J)
@@ -4409,14 +4409,14 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   XXXC_URB = XXXC_URB2D(I,J)
       !
       !      Limits to avoid dividing by small number
-                  if (CHS(I,J) < 1.0E-02) then
-                     CHS(I,J)  = 1.0E-02
+                  if (CHS(I,J) < 1.0E-04) then
+                     CHS(I,J)  = 1.0E-04
                   endif
-                  if (CHS2(I,J) < 1.0E-02) then
-                     CHS2(I,J)  = 1.0E-02
+                  if (CHS2(I,J) < 1.0E-04) then
+                     CHS2(I,J)  = 1.0E-04
                   endif
-                  if (CQS2(I,J) < 1.0E-02) then
-                     CQS2(I,J)  = 1.0E-02
+                  if (CQS2(I,J) < 1.0E-04) then
+                     CQS2(I,J)  = 1.0E-04
                   endif
       !
                   CHS_URB  = CHS(I,J)

--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -2405,14 +2405,14 @@ ILOOP : DO I = its, ite
     XXXC_URB = XXXC_URB2D(I,J)
 
 ! Limits to avoid dividing by small number
-    IF (CHS(I,J) < 1.0E-02) THEN
-      CHS(I,J)  = 1.0E-02
+    IF (CHS(I,J) < 1.0E-04) THEN
+      CHS(I,J)  = 1.0E-04
     ENDIF
-    IF (CHS2(I,J) < 1.0E-02) THEN
-      CHS2(I,J)  = 1.0E-02
+    IF (CHS2(I,J) < 1.0E-04) THEN
+      CHS2(I,J)  = 1.0E-04
     ENDIF
-    IF (CQS2(I,J) < 1.0E-02) THEN
-      CQS2(I,J)  = 1.0E-02
+    IF (CQS2(I,J) < 1.0E-04) THEN
+      CQS2(I,J)  = 1.0E-04
     ENDIF
 
     CHS_URB  = CHS(I,J)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah LSM, Urban

SOURCE: internal, pointed out by David Avisar (Israel)

DESCRIPTION OF CHANGES: 

The critical value of 2m surface exchange coefficient for heat and moisture is set to 1.0E-04 in Noah LSM, which is different to the value of 1.0E-02 in NoahMP. To keep the model consistent, we set the value to 1.0E-04 in both Noah and NoahMP. 

This affects only URBAN points when using UCM.

LIST OF MODIFIED FILES: 
M       phys/module_sf_noahdrv.F
M       phys/module_sf_noahmpdrv.F

TESTS CONDUCTED: regression test is being run