### PR TITLE
Chem_bug_fixes

### DIFF
--- a/chem/aerosol_driver.F
+++ b/chem/aerosol_driver.F
@@ -492,7 +492,7 @@
             ims,ime, jms,jme, kms,kme,                                 &
             its,ite, jts,jte, kts,kte                                  )
 
-   CASE (RACM_SOA_VBS_KPP)
+   CASE (RACM_SOA_VBS_KPP,RACM_SOA_VBS_AQCHEM_KPP)
        CALL wrf_debug(15,'sum_pm_driver: calling sum_pm_soa_vbs')
        CALL sum_pm_soa_vbs (                                           &
             alt, chem, h2oaj, h2oai,                                   &

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -143,12 +143,12 @@
 #ifdef CHEM_DBG_I
     call print_chem_species_index( config_flags%chem_opt )
 #endif
-   program_name = "*             PROGRAM:WRF/CHEM " // TRIM(release_version) // " MODEL"
+   program_name = "*             PROGRAM:WRF-Chem " // TRIM(release_version) // " MODEL"
 
 call wrf_message("*********************************************************************")
 call wrf_message(program_name)
 call wrf_message("*                                                                   *")
-call wrf_message("*    PLEASE REPORT ANY BUGS TO WRF/CHEM HELP at                     *")
+call wrf_message("*    PLEASE REPORT ANY BUGS TO WRF-Chem HELP at                     *")
 call wrf_message("*                                                                   *")
 call wrf_message("*              wrfchemhelp.gsd@noaa.gov                             *")
 call wrf_message("*                                                                   *")
@@ -1746,7 +1746,7 @@ ENDIF ghg_block
         endif
         chem(its:ite,kts:min(kte,kde-1),jts:jte,:)=max(chem(its:ite,kts:min(kte,kde-1),jts:jte,:),epsilc)
 !
-    CASE (RACM_SOA_VBS_AQCHEM_KPP,CB05_SORG_VBS_AQ_KPP)
+    CASE (CB05_SORG_VBS_AQ_KPP)
        CALL wrf_debug(15,'call MADE/SOA_VBS aerosols initialization')
 
        call aerosols_sorgam_vbs_init(chem,convfac,z_at_w,                &
@@ -1773,7 +1773,7 @@ ENDIF ghg_block
         endif
         chem(its:ite,kts:min(kte,kde-1),jts:jte,:)=max(chem(its:ite,kts:min(kte,kde-1),jts:jte,:),epsilc)
 
-    CASE (RACM_SOA_VBS_KPP)
+    CASE (RACM_SOA_VBS_KPP,RACM_SOA_VBS_AQCHEM_KPP)
        CALL wrf_debug(15,'call MADE/SOA_VBS aerosols initialization')
 
        call aerosols_soa_vbs_init(chem,convfac,z_at_w,                &
@@ -3342,7 +3342,7 @@ subroutine print_chem_species_index( chem_opt )
      print*,p_ac0,"ac0"
      print*,p_corn,"corn"
 !!! TUCCELLA
-case (RACM_SOA_VBS_AQCHEM_KPP)
+ case (RACM_SOA_VBS_AQCHEM_KPP)
      print*,p_so4aj,"so4aj"
      print*,p_so4ai,"so4ai"
      print*,p_nh4aj,"nh4aj"

--- a/chem/cloudchem_driver.F
+++ b/chem/cloudchem_driver.F
@@ -249,7 +249,7 @@
 
 
    CASE ( RADM2SORG_AQCHEM, RACMSORG_AQCHEM_KPP, RACM_ESRLSORG_AQCHEM_KPP, &
-          CB05_SORG_AQ_KPP )
+          CB05_SORG_AQ_KPP,RACM_SOA_VBS_AQCHEM_KPP )
 
        call wrf_debug(15, &
        'cloudchem_driver calling sorgam_aqchem_driver')

--- a/chem/module_bioemi_megan2.F
+++ b/chem/module_bioemi_megan2.F
@@ -1137,7 +1137,7 @@ is_mozm_species : &
 
              END DO
 
-          CASE (RACM_SOA_VBS_AQCHEM_KPP,CB05_SORG_AQ_KPP)
+          CASE (CB05_SORG_AQ_KPP)
 
              DO icount = 1, n_megan2cb05
                 IF ( p_of_cb05 (icount) .NE. non_react ) THEN
@@ -1400,7 +1400,7 @@ is_mozm_species : &
              END DO
 
 
-          CASE (RACM_SOA_VBS_KPP)
+          CASE (RACM_SOA_VBS_KPP,RACM_SOA_VBS_AQCHEM_KPP)
 
           DO icount = 1, n_megan2racmSOA
 


### PR DESCRIPTION
TYPE: bug fixes

KEYWORDS: chemistry fix

SOURCE: internal, D. Lowe (UK), P.Tuccella (Italy)

DESCRIPTION OF CHANGES: Few chemistry modules are changed to have correct CALL statements for the chem_opt=109

LIST OF MODIFIED FILES:
       modified:   chem/aerosol_driver.F
       modified:   chem/chemics_init.F
       modified:   chem/cloudchem_driver.F
       modified:   chem/module_bioemi_megan2.F

TESTS CONDUCTED: It passed the WTF reg. test