### PR TITLE
Limit ZNT as in ISFTCFLX option in MM5 surface layer schemes

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -824,6 +824,8 @@ CONTAINS
 !         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
 ! Since V3.7 (ref: EC Physics document for Cy36r1)
           ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+! V3.9: Add limit as in isftcflx = 1,2
+          ZNT(I)=MIN(ZNT(I),2.85e-3)
 ! COARE 3.5 (Edson et al. 2013)
 !         CZC = 0.0017*WSPD(I)-0.005
 !         CZC = min(CZC,0.028)

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -925,6 +925,8 @@ CONTAINS
 !         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
 ! Since V3.7 (ref: EC Physics document for Cy36r1)
           ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+! V3.9: Add limit as in isftcflx = 1,2
+          ZNT(I)=MIN(ZNT(I),2.85e-3)
 ! COARE 3.5 (Edson et al. 2013)
 !         CZC = 0.0017*WSPD(I)-0.005
 !         CZC = min(CZC,0.028)


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: surface layer physics, ZNT

SOURCE: internal

DESCRIPTION OF CHANGES: 
This change modifies Charnock's formula so that ZNT is limited at high wind to a value of about 2.4e-3.

LIST OF MODIFIED FILES:
phys/module_sf_sfclay.F
phys/module_sf_sfclayrev.F

TESTS CONDUCTED:
Reg tested pending. Tested in two hurricane season in MPAS.
