### PR TITLE
Fix fatal error for GPSREF ASCII observations above 30km elevation

### DIFF
--- a/var/da/da_obs_io/da_read_obs_ascii.inc
+++ b/var/da/da_obs_io/da_read_obs_ascii.inc
@@ -1156,17 +1156,6 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
                    nlocal(gpsref) = nlocal(gpsref) + 1
                    ilocal(gpsref) = ilocal(gpsref) + 1
                 end if
-!
-! discarded the GPSRO data above 30-km (refer to GSI, Lidia Cucurull, Nov. 2009).
-! YRG, 02/01/2010.
-            do i = 1, nlevels
-               if ( platform%each(i)%height> 30000.0 ) then
-                  nlevels = i-1
-                  exit
-               endif
-            enddo
-            levs = nlevels
-!
             if( nlocal(gpsref) == ilocal(gpsref)) then
                allocate (iv%gpsref(ilocal(gpsref))%h (1:iv%info(gpsref)%max_lev))
                allocate (iv%gpsref(ilocal(gpsref))%ref(1:iv%info(gpsref)%max_lev))


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, GPSREF, ASCII observations, 

SOURCE: internal

DESCRIPTION OF CHANGES: In running some realtime verification experiments, I ran into an error related to GPSREF observations in ASCII format. In the verification process, these observations are read in from an NCEP BUFR file (gpsro.bufr), run through basic quality control, and then output in WRFDA ASCII format (ob.ascii) as a large number of single-level observations. WRFDA is then run again, reading the GPSREF observations from ob.ascii instead, and this is where the error was occurring.

The error was due to an old check (from February 2010: d671fbd) which was meant to reject GPSREF observations above 30km, which had been found to be of poor quality. Instead of fully rejecting the observation in var/da/da_obs_io/da_read_obs_ascii.inc, it just decreased the number of vertical levels by 1 if the observation level being read was over 30 km. Normally, if there are remaining observations below 30km, this does not present a problem. However, in the case where there is only one observation (which is the case for these verification experiments), the number of vertical levels for these observations ends up as zero. Since the quality control flag does not get set to a "bad" value, the observation is not properly rejected, but ends up a bad state of quasi-rejection: later on in that same subroutine, a whole bunch of information about the observation does not get properly populated into the iv%info structure. This is a problem, because when the code runs along to var/da/da_gpsref/da_get_innov_vector_gpsref.inc, it tries to read undefined variables (specifically, for the calculations of model height), and fails in a very bad way.

The solution is actually very easy: remove the offending code. We can do this because this check was actually superseded by a later change in July 2011 (4103d221) which rejects GPSREF values above and below namelist-specified elevations, which achieves the same thing but as a better implementation, properly setting QC flags for data outside of these specified elevations, and preventing this zero-level observation condition.

LIST OF MODIFIED FILES: 
M       var/da/da_obs_io/da_read_obs_ascii.inc

TESTS CONDUCTED: WRFDA regression test (GNU 4.8.2) passes as expected. The failures that I was seeing in the WRFDA verification experiments no longer occur.
