### PR TITLE
SST_UPDATE requires auxinput4 interval and io_form

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -679,9 +679,9 @@
       IF ( model_config_rec%sst_update .EQ. 1 ) THEN
          IF ( model_config_rec%io_form_auxinput4 ) .EQ. 0 ) THEN
             wrf_err_message = '--- ERROR: If sst_update /= 0, io_form_auxinput4 must be /= 0'
-            CALL wrf_message ( wrf_err_message )
+            CALL wrf_debug ( 0, TRIM(wrf_err_message) )
             wrf_err_message = '--- Set io_form_auxinput4 in the time_control namelist (probably to 2).'
-            CALL wrf_message ( TRIM( wrf_err_message ) )
+            CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
             count_fatal_error = count_fatal_error + 1
          END IF
 
@@ -692,9 +692,9 @@
               ( model_config_rec%auxinput4_interval_m(1) .EQ. 0 ) .AND. & 
               ( model_config_rec%auxinput4_interval_s(1) .EQ. 0 ) ) THEN
             wrf_err_message = '--- ERROR: If sst_update /= 0, one of the auxinput4_interval settings must be /= 0'
-            CALL wrf_message ( wrf_err_message )
+            CALL wrf_debug ( 0, TRIM(wrf_err_message) )
             wrf_err_message = '--- Set auxinput4_interval_s to the same value as interval_seconds (usually a pretty good guess).'
-            CALL wrf_message ( TRIM( wrf_err_message ) )
+            CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
             count_fatal_error = count_fatal_error + 1
          END IF
       END IF


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: sst_update, auxinput4

### SOURCE: internal

### DESCRIPTION OF CHANGES:
When sst_update .NE. 0, THEN we need to make sure that two things are set:
1. auxinput4_interval: usually same as the lateral BC time, but definitely NOT zero
2. io_form_auxinput4: usually 2, but again, not allowed to be zero

When the WRF model is run with sst_update activated, AND with the other two options not defined in the namelist (so default values from the Registry), then the model runs to completion, without informing the user that the SST was not updated. This is sneaky dangerous behavior.

### LIST OF MODIFIED FILES:
M       share/module_check_a_mundo.F

### TESTS CONDUCTED: 
- [x] Catches problem with partial sst_update info
real with sst_update=1, and aux4 interval and io_form not set:
```
 Ntasks in X            1 , ntasks in Y            1
--- WARNING: traj_opt is zero, but num_traj is not zero; setting num_traj to zero.
--- ERROR: If sst_update /= 0, io_form_auxinput4 must be /= 0
  --- Set io_form_auxinput4 in the time_control namelist (probably to 2).
  --- ERROR: If sst_update /= 0, io_form_auxinput4 must be /= 0
  --- Set io_form_auxinput4 in the time_control namelist (probably to 2).
  --- ERROR: If sst_update /= 0, one of the auxinput4_interval settings must be /= 0
  --- Set auxinput4_interval_s to the same value as interval_seconds (usually a pretty good guess).
--- NOTE: grid_fdda is 0 for domain      1, setting gfdda interval and ending time to 0 for that domain.
--- NOTE: both grid_sfdda and pxlsm_soil_nudge are 0 for domain      1, setting sgfdda interval and ending time to 0 for that domain.
--- NOTE: obs_nudge_opt is 0 for domain      1, setting obs nudging interval and ending time to 0 for that domain.
--- NOTE: grid_fdda is 0 for domain      2, setting gfdda interval and ending time to 0 for that domain.
--- NOTE: both grid_sfdda and pxlsm_soil_nudge are 0 for domain      2, setting sgfdda interval and ending time to 0 for that domain.
--- NOTE: obs_nudge_opt is 0 for domain      2, setting obs nudging interval and ending time to 0 for that domain.
--- NOTE: bl_pbl_physics /= 4, implies mfshconv must be 0, resetting
Need MYNN PBL for icloud_bl = 1, resetting to 0
--- NOTE: RRTMG radiation is not used, setting:  o3input=0 to avoid data pre-processing
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1532
NOTE:       3 namelist settings are wrong. Please check and reset these options
```
- [x] Reggie 3.07