### PR TITLE
Fix incorrect continuation character in WRFDA gen_be_ep2 that did not fail

### DIFF
--- a/var/gen_be/gen_be_ep2.f90
+++ b/var/gen_be/gen_be_ep2.f90
@@ -174,7 +174,7 @@ program gen_be_ep2
       qcloud_mnsq = 0.0
       qrain_mnsq = 0.0
       moist_string = trim(moist_string)//'qcloud, qrain '
-      if ( mp_physics == 2 .or. mp_physics == 4 .or. \
+      if ( mp_physics == 2 .or. mp_physics == 4 .or. &
            mp_physics >= 6 ) then
          has_ice   = .true.
          allocate( qice(1:dim1,1:dim2,1:dim3) )
@@ -194,7 +194,7 @@ program gen_be_ep2
          moist_string = trim(moist_string)//', qsnow '
       end if
       if ( mp_physics == 2 .or. mp_physics >= 6 ) then
-         if ( mp_physics /= 11 .and. mp_physics /= 13 .and. \
+         if ( mp_physics /= 11 .and. mp_physics /= 13 .and. &
               mp_physics /= 14 ) then
             has_graup = .true.
             allocate( qgraup(1:dim1,1:dim2,1:dim3) )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, gen_be_ep2, continuation character

SOURCE: internal

DESCRIPTION OF CHANGES:
The continuation character \ in other languages is accidentally
used in this fortran code. Even though the stand-alone utility
compiles and runs fine with the wrong character, the character
is now changed to &.

LIST OF MODIFIED FILES:
M       var/gen_be/gen_be_ep2.f90

TESTS CONDUCTED: