### PR TITLE
cp should be cpm for hfx in diffusion

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -3675,7 +3675,7 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
     DO j = j_start, j_end
     DO i = i_start, i_end
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
-       hfx(i,j)=heat_flux*cp*rho(i,kts,j)         ! provided for output only
+       hfx(i,j)=heat_flux*cpm*rho(i,kts,j)         ! provided for output only
        rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
              -g*heat_flux*rho(i,kts,j)/dnw(kts)
     ENDDO


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: module_diffusion_em.F, hfx calculation fix

SOURCE: internal

DESCRIPTION OF CHANGES: 
Only affects diagnostic HFX output in idealized cases with isfflx=0 or 2.
When heat_flux is specified in the namelist, the diffusion module calculates
HFX for output. This calculation used cp instead of cpm (very small difference).
Will not affect results unless a PBL scheme is used with isfflx=0 or 2.

LIST OF MODIFIED FILES: 
M       dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
WTF 3.06 passed
