### PR TITLE
Fix a typo introduced in 6c1ba90 commit to make the code compile

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -646,7 +646,7 @@
 !-----------------------------------------------------------------------
 
       IF ( model_config_rec%sst_update .EQ. 1 ) THEN
-         IF ( model_config_rec%io_form_auxinput4 ) .EQ. 0 ) THEN
+         IF ( model_config_rec%io_form_auxinput4 .EQ. 0 ) THEN
             wrf_err_message = '--- ERROR: If sst_update /= 0, io_form_auxinput4 must be /= 0'
             CALL wrf_debug ( 0, TRIM(wrf_err_message) )
             wrf_err_message = '--- Set io_form_auxinput4 in the time_control namelist (probably to 2).'


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: check_a_mundo, sst_update, io_form_auxinput4, build

SOURCE: internal

DESCRIPTION OF CHANGES:
Make the code compile by removing an extra parenthesis.

LIST OF MODIFIED FILES:
M share/module_check_a_mundo.F

TESTS CONDUCTED: