### PR TITLE
Remove duplicate definition of gwd_opt in Registry.NMM for HWRF compile

### DIFF
--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1471,10 +1471,7 @@ rconfig   logical rdlai2d                 namelist,physics      1            .fa
 rconfig   logical ua_phys                 namelist,physics      1            .false.   h     "ua_phys"     "activate UA Noah changes"   ""
 rconfig   integer opt_thcnd               namelist,physics      1            1         h     "opt_thcnd" "thermal conductivity option in Noah LSM"   ""
 
-ifdef HWRF=1
 rconfig   integer  gwd_opt                namelist,physics    max_domains    2       irh    "gwd_opt"      "activate gravity wave drag: 0=off, 1=ARW, 2=NMM"   ""
-endif
-rconfig   integer  gwd_opt                namelist,physics    max_domains    0       irh    "gwd_opt"      "activate gravity wave drag: 0=off, 1=ARW, 2=NMM"   ""
 
 rconfig   integer iz0tlnd                 namelist,physics      1            0         h     "iz0tlnd"    "switch to control land thermal roughness length"   ""
 rconfig   real    sas_pgcon               namelist,physics      max_domains  0.55      irh0123   "sas_pgcon"   "convectively forced pressure gradient factor (SAS scheme)" ""


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: HWRF, NMM, gwd_opt

SOURCE: internal

DESCRIPTION OF CHANGES: 

When compiling for HWRF, the variable gwd_opt was defined twice in
Registry.NMM

Remove one definition, and the "ifdef HWRF" - the same definition can be used
for HWRF or non-HWRF NMM.

LIST OF MODIFIED FILES: 

M      Registry/Registry.NMM

TESTS CONDUCTED: WTF v3.07 successful