### PR TITLE
Changes for RAP/HRRR using cycling option

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -269,7 +269,6 @@
 
     if(config_flags%cycling) then
 ! Clear the buckets for diagnostics at initial time
-    print *,'zero out buckets'
        DO j = jts,min(jte,jde-1)
        DO i = its, min(ite,ide-1)
             grid%prec_acc_nc(i,j) = 0.


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: surface pressure, diagnostic arrays

SOURCE: Tanya Smirnova, GSD

DESCRIPTION OF CHANGES: 
There are two changes in this PR: one is to reset diagnostic arrays to 0 when cycling option is on. The other is to recompute surface pressure in rebalance_cycl routine.

LIST OF MODIFIED FILES:
dyn_em/start_em.F

TESTS CONDUCTED:
Reg tested using WTF 3.06. 
