### PR TITLE
Allows oml to use climatological mixed layer depth

### DIFF
--- a/phys/module_sf_oml.F
+++ b/phys/module_sf_oml.F
@@ -216,7 +216,7 @@ CONTAINS
           TMOML(I,J)=TSK(I,J)-5.
         ENDDO
         ENDDO
-     ELSE IF (oml_hml0 .eq. 0) THEN
+     ELSE IF (oml_hml0 .eq. 0.) THEN
 ! initializing with climatological mixed layer depth only
         DO J=jts,jtf
         DO I=its,itf


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: oml, initialization from climatology

SOURCE: internal

DESCRIPTION OF CHANGES: 
This change allows the simple ocean mixed layer model to initialize from climatological monthly ocean mixed layer depth by setting oml_hml0 = 0.

LIST OF MODIFIED FILES:
phys/module_sf_oml.F

TESTS CONDUCTED:
Reg tested using 3.06. Also used in MPAS.
