### PR TITLE
Add commented out perl command on how to zap ^M added by windows machines

### DIFF
--- a/tools/non_ascii_finder.F
+++ b/tools/non_ascii_finder.F
@@ -1,3 +1,9 @@
+! To remove the DOS carriage returns from Windows machines:
+! perl -pi -e 's/\r\n|\n|\r/\n/g'   file-to-convert  # Convert to UNIX
+! This program is not required for that.
+! For completeness, from stackoverflow:
+! perl -pi -e 's/\r\n|\n|\r/\r\n/g' file-to-convert  # Convert to DOS
+!
 ! The purpose of this program is to scan through all of the 
 ! lines of a Fortran file to detect if there are any character
 ! codes (excluding the ubiquitously used tab character) outside


### PR DESCRIPTION
### TYPE: text only

### KEYWORDS: windows, linux, dos2unix, ^M, perl

### SOURCE: internal

### DESCRIPTION OF CHANGES:
In the leading comments of the file non_ascii_finder.F, add in the one-line perl command to remove the extra carriage return inserted by windows machines.

### LIST OF MODIFIED FILES:
M       tools/non_ascii_finder.F

### TESTS CONDUCTED: 
1. No WRF build or run tests conducted, this is only a comment.
2. The file with the ^M at the end of each line worked after using the command.