### PR TITLE
New script to help determine what is wrong with a namelist.input file

### DIFF
--- a/tools/test_nml_domains.csh
+++ b/tools/test_nml_domains.csh
@@ -95,6 +95,12 @@ foreach f ( $Reg_Dir/Registry.* $Reg_Dir/registry.* )
 	grep -i ^rconfig $f | grep -vi max_        | awk '{print $3}' >> list_of_all_one_dom_vars
 end
 
+#	Pick up the KNOWN namelist variable max_dom
+
+foreach f ( $Reg_Dir/Registry.* $Reg_Dir/registry.* )
+	grep -i ^rconfig $f | grep -iw max_dom     | awk '{print $3}' >> list_of_all_one_dom_vars
+end
+
 sort -u list_of_all_max_dom_vars > list_of_all_max_dom_vars_sorted
 sort -u list_of_all_one_dom_vars > list_of_all_one_dom_vars_sorted
 


### PR DESCRIPTION
### TYPE: new feature

### KEYWORDS: namelist, column, max_dom

### SOURCE: internal

### DESCRIPTION OF CHANGES:
New script that checks the user's namelist.input file for consistency with the Registry.
1. Is the namelist variable in one of the Registry files
2. For single entry values, is there more than one column in the namelist.input file
3. For max_domains entry values, are there at least max_dom entries listed

There are some gotchas, which is why this is recommended as an in-house tool for now. There are some namelist entries that are automatically manufactured (such as auxinput4 items), and there are some namelist values that are not defined in any registry (quilting). Before release to general users, these scenarios would need to be handled. However, for the wrfhelp folks, the information is easily understood.

### LIST OF MODIFIED FILES: 
M       tools/commit_nml_check.txt

### TESTS CONDUCTED:
1. Picks up obvious problems in test namelists
2. Mostly for use by wrfhelp, not individual users