### PR TITLE
Bug fix for MP=28 freezeH2O static look-up table

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -4152,7 +4152,7 @@
                do n2 = nbr, 1, -1
                   N_r(n2) = N0_r*Dr(n2)**mu_r*DEXP(-lamr*Dr(n2))*dtr(n2)
                   vol = massr(n2)*orho_w
-                  prob = 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp)
+                  prob = MAX(0.0D0, 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp))
                   if (massr(n2) .lt. xm0g) then
                      sumn1 = sumn1 + prob*N_r(n2)
                      sum1 = sum1 + prob*N_r(n2)*massr(n2)
@@ -4178,7 +4178,7 @@
                sumn2 = 0.0d0
                do n = nbc, 1, -1
                   vol = massc(n)*orho_w
-                  prob = 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp)
+                  prob = MAX(0.0D0, 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp))
                   N_c(n) = N0_c*Dc(n)**nu_c*EXP(-lamc*Dc(n))*dtc(n)
                   sumn2 = MIN(t_Nc(j), sumn2 + prob*N_c(n))
                   sum1 = sum1 + prob*N_c(n)*massc(n)


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: Thompson mp, option 28, table file freezeH2O.dat

SOURCE: Greg Thompson, RAL

DESCRIPTION OF CHANGES: 
There is an adjustment with the aerosol-aware scheme to account for number concentration of dust to alter from physical air temperature to the 'effective temperature' that gets used as part of the probability of freezing water drops into either cloud ice or graupel.  The bug could create a negative number for something that should remain always positive. The *total* overall effect of the bug is quite limited due to the small temperature range of about zero to 3 degrees C and for specific range of the incoming ice nuclei variable (QNIFA).

The change is in subroutine freezeH2O, which creates a static look-up table, freezeH2O.dat, also placed in the run directory.  For WRF version 3.7 or later, a user should remove existing freezeH2O.dat file in the run directory, and let the model re-create it after making code change. For 3.6 and 3.6.1, a user should modify the code and rerun.

LIST OF MODIFIED FILES:
phys/module_mp_thompson.F

TESTS CONDUCTED:
Reg tested using 3.06. Results from two test cases were compared. The attached ncview plot shows the 6 hr rainc (left) and rainnc diff plots from the Jan 2000 case.
![mp28_diff](https://cloud.githubusercontent.com/assets/12705680/24226329/75159f4e-0f2b-11e7-82c6-cb319a92d33a.png)
