### PR TITLE
Cray build assumes OpenMP always ON, modify stanza to accommodate

### DIFF
--- a/arch/configure_new.defaults
+++ b/arch/configure_new.defaults
@@ -1275,15 +1275,15 @@ CC_TOOLS        =      $(SCC)
 DESCRIPTION     =       CRAY CCE ($SFC/$SCC): Cray XE and XC
 # OpenMP is enabled by default for Cray CCE compiler
 # This turns it off
-OMP             =       -hnoomp
+NOOMP           =       -hnoomp
 DMPARALLEL      =       # 1
 OMPCPP          =       # -D_OPENMP
 OMP             =       # -homp
 OMPCC           =       # -homp
-SFC             =       ftn
+SFC             =       ftn $(NOOMP)
 SCC             =       cc 
 CCOMP           =       gcc 
-DM_FC           =       ftn
+DM_FC           =       ftn $(NOOMP)
 DM_CC           =       cc
 FC              =       $(DM_FC)
 CC              =       $(DM_CC)
@@ -1295,7 +1295,7 @@ CFLAGS_LOCAL    =       -O3
 LDFLAGS_LOCAL   =       
 CPLUSPLUSLIB    =       
 ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-FCOPTIM         =       
+FCOPTIM         =       # -Ofp3 
 FCREDUCEDOPT	=       $(FCOPTIM)
 FCNOOPT		=       -O1 -Ofp1 -Oipa0 -Onomodinline
 FCDEBUG         =       # -g -O0 # -K trap=fp -R bc


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: Cray, OpenMP, OMP, build, stanza

### SOURCE: Pete Johnsen (Cray, Inc.)

### DESCRIPTION OF CHANGES:
The Cray compilers assume that OpenMP is turned on. The flag in the configure_new.defaults for the Cray machine is swapped from *OMP* to *NOOMP*. Also, an optimization switch for Cray is provided as a suggestion (commented out).

### LIST OF MODIFIED FILES:
M       arch/configure_new.defaults

### TESTS CONDUCTED:
This stanza has been supplied by the vendor, and we have no way to test out this build stanza.