### PR TITLE
Remove hybrid option from most ideal cases (default flat topo)

### DIFF
--- a/dyn_em/module_initialize_b_wave.F
+++ b/dyn_em/module_initialize_b_wave.F
@@ -240,6 +240,11 @@ CONTAINS
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
 
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
    DO k=1, kde
     grid%c3f(k) = grid%znw(k)
     grid%c4f(k) = 0.

--- a/dyn_em/module_initialize_convrad.F
+++ b/dyn_em/module_initialize_convrad.F
@@ -301,6 +301,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_fire.F
+++ b/dyn_em/module_initialize_fire.F
@@ -352,6 +352,23 @@ write(6,*) '*************************************'
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_grav2d_x.F
+++ b/dyn_em/module_initialize_grav2d_x.F
@@ -250,6 +250,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_heldsuarez.F
+++ b/dyn_em/module_initialize_heldsuarez.F
@@ -247,6 +247,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_quarter_ss.F
+++ b/dyn_em/module_initialize_quarter_ss.F
@@ -236,6 +236,11 @@ CONTAINS
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
 
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
    DO k=1, kde
     grid%c3f(k) = grid%znw(k)
     grid%c4f(k) = 0.

--- a/dyn_em/module_initialize_scm_xy.F
+++ b/dyn_em/module_initialize_scm_xy.F
@@ -333,6 +333,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_seabreeze2d_x.F
+++ b/dyn_em/module_initialize_seabreeze2d_x.F
@@ -304,6 +304,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_squall2d_x.F
+++ b/dyn_em/module_initialize_squall2d_x.F
@@ -233,6 +233,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_squall2d_y.F
+++ b/dyn_em/module_initialize_squall2d_y.F
@@ -230,6 +230,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)

--- a/dyn_em/module_initialize_tropical_cyclone.F
+++ b/dyn_em/module_initialize_tropical_cyclone.F
@@ -327,6 +327,23 @@ CONTAINS
     grid%rdnw(k) = 1./grid%dnw(k)
     grid%znu(k) = 0.5*(grid%znw(k+1)+grid%znw(k))
    ENDDO
+
+   IF ( config_flags%hybrid_opt .NE. 0 ) THEN
+      call wrf_error_fatal ( '--- ERROR: Hybrid Vertical Coordinate option not supported with this idealized case' )
+   END IF
+   grid%hybrid_opt = 0
+
+   DO k=1, kde
+    grid%c3f(k) = grid%znw(k)
+    grid%c4f(k) = 0.
+    grid%c3h(k) = grid%znu(k)
+    grid%c4h(k) = 0.
+    grid%c1f(k) = 1.
+    grid%c2f(k) = 0.
+    grid%c1h(k) = 1.
+    grid%c2h(k) = 0.
+   ENDDO 
+
    DO k=2, kde-1
     grid%dn(k) = 0.5*(grid%dnw(k)+grid%dnw(k-1))
     grid%rdn(k) = 1./grid%dn(k)


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: ideal, HVC, hybrid

### SOURCE: internal

### DESCRIPTION OF CHANGES:
For the ideal cases with flat topo, remove the hybrid vertical coordinate option. Fail if the user requests it specifically.

### LIST OF MODIFIED FILES:
M       dyn_em/module_initialize_b_wave.F
M       dyn_em/module_initialize_convrad.F
M       dyn_em/module_initialize_fire.F
M       dyn_em/module_initialize_grav2d_x.F
M       dyn_em/module_initialize_heldsuarez.F
M       dyn_em/module_initialize_quarter_ss.F
M       dyn_em/module_initialize_scm_xy.F
M       dyn_em/module_initialize_seabreeze2d_x.F
M       dyn_em/module_initialize_squall2d_x.F
M       dyn_em/module_initialize_squall2d_y.F
M       dyn_em/module_initialize_tropical_cyclone.F

### TESTS CONDUCTED:
- [x] Reggie 3.07, passed
- [x] Run through all idealized cases, checked when accomplished