### PR TITLE
Fix uninitialized variable in Noah-MP surface exchange option

### DIFF
--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -3479,6 +3479,7 @@ contains
         MOZ    = 0.
         MOZSGN = 0
         MOZOLD = 0.
+        FH2    = 0.
         HG     = 0.
         H      = 0.
         QFX    = 0.
@@ -3931,6 +3932,7 @@ contains
         MOZ    = 0.
         MOZSGN = 0
         MOZOLD = 0.
+        FH2    = 0.
         H      = 0.
         QFX    = 0.
         FV     = 0.1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah-MP

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

A variable only used in SFC_DIF = 1 needs to be initialized to zero for case SFC_DIF = 2

LIST OF MODIFIED FILES:

M       phys/module_sf_noahmplsm.F

TESTS CONDUCTED:
1. Regression test with WTF-3.07
2. Summer and winter 24-hr case