### PR TITLE
(possible) Bug fix for SST history stream in Registry.EM

### DIFF
--- a/Registry/Registry.EM
+++ b/Registry/Registry.EM
@@ -31,7 +31,7 @@ state   real   lakemask            ij    misc          1     -     i012rhd=(inte
 #state    real   SST              ij    misc        1         -     i01245rh05d=(interp_mask_field:lu_index,iswater)f=(p2c_mask:lu_index,tslb,num_soil_layers,iswater)   "SST"              "SEA SURFACE TEMPERATURE" "K"
 # Simple SST interpolation from the CG
 #state    real   SST              ij    misc        1         -     i01245rh05d=(interp_mask_field:lu_index,iswater)f=(p2c)   "SST"              "SEA SURFACE TEMPERATURE" "K"
-state    real   SST              ij     misc        1         -     i01245rh0d=(interp_mask_field:lu_index,iswater)   "SST"              "SEA SURFACE TEMPERATURE" "K"
+state    real   SST              ij     misc        1         -     i01245rh056d=(interp_mask_field:lu_index,iswater)   "SST"              "SEA SURFACE TEMPERATURE" "K"
 state    real   SST_INPUT        ij     misc        1         -     rh   "SST_INPUT"              "SEA SURFACE TEMPERATURE FROM WRFLOWINPUT FILE" "K"
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: rasm diag, Registry.EM, SST, history stream

SOURCE: internal

DESCRIPTION OF CHANGES:
History stream 5 of SST was removed in the 43da3a4 commit.
Should 5 and 6 both be added for SST to be consistent with other changes
in the 43da3a4 commit?

LIST OF MODIFIED FILES:
M       Registry/Registry.EM

TESTS CONDUCTED: