### PR TITLE
Standardizing the "Description" for new Open MPI configure options

### DIFF
--- a/arch/configure_new.defaults
+++ b/arch/configure_new.defaults
@@ -1696,7 +1696,7 @@ CC_TOOLS        =      cc
 ###########################################################
 #ARCH    Darwin (MACOS) intel compiler with icc #serial smpar dmpar dm+sm
 #
-DESCRIPTION     =       INTEL ($SFC/$SCC/openmpi)
+DESCRIPTION     =       INTEL ($SFC/$SCC): Open MPI
 DMPARALLEL      =       # 1
 OMPCPP          =       # -D_OPENMP
 OMP             =       # -openmp -fpp -auto
@@ -1742,7 +1742,7 @@ CC_TOOLS        =      cc
 ###########################################################
 #ARCH    Darwin (MACOS) gfortran with gcc openmpi #serial smpar dmpar dm+sm
 #
-DESCRIPTION     =       GNU ($SFC/$SCC/openmpi)
+DESCRIPTION     =       GNU ($SFC/$SCC): Open MPI
 DMPARALLEL      =       # 1
 OMPCPP          =       # -D_OPENMP
 OMP             =       # -fopenmp


### PR DESCRIPTION
TYPE: text only

KEYWORDS: configure

SOURCE: internal

DESCRIPTION OF CHANGES: 
When I re-wrote the configure setup back in 2013, every configure option was set up to follow this format when displayed by the configure script:

     1. (serial)   2. (smpar)   3. (dmpar)   4. (dm+sm)   COMPILERNAME (fortran_compiler_command/c_compiler_command)[: Extra information]

Where the content in brackets is optional. While this was primarily meant to make the configure script output easier to read for humans, this was also an attempt to make it easier for users to have a script parse the output to automatically select the appropriate option (myself included).

Currently the new options appear like this:

     29. (serial)  30. (smpar)  31. (dmpar)  32. (dm+sm)   INTEL (ifort/icc/openmpi)
     33. (serial)  34. (smpar)  35. (dmpar)  36. (dm+sm)   GNU (gfortran/gcc/openmpi)

My proposal is to make the new options appear like this:

     29. (serial)  30. (smpar)  31. (dmpar)  32. (dm+sm)   INTEL (ifort/icc): Open MPI
     33. (serial)  34. (smpar)  35. (dmpar)  36. (dm+sm)   GNU (gfortran/gcc): Open MPI

LIST OF MODIFIED FILES: 
 M    arch/configure_new.defaults

TESTS CONDUCTED: Ran configure script on Mac machine, configure output now appears as expected.
