### PR TITLE
Increase chs lower limits to 1.e-2 from 1.e-4 for urban areas in Noah and NoahMP

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -1271,14 +1271,14 @@ CONTAINS
 !
 !
 !      Limits to avoid dividing by small number
-            if (CHS(I,J) < 1.0E-04) then
-               CHS(I,J)  = 1.0E-04
+            if (CHS(I,J) < 1.0E-02) then
+               CHS(I,J)  = 1.0E-02
             endif
-            if (CHS2(I,J) < 1.0E-04) then
-               CHS2(I,J)  = 1.0E-04
+            if (CHS2(I,J) < 1.0E-02) then
+               CHS2(I,J)  = 1.0E-02
             endif
-            if (CQS2(I,J) < 1.0E-04) then
-               CQS2(I,J)  = 1.0E-04
+            if (CQS2(I,J) < 1.0E-02) then
+               CQS2(I,J)  = 1.0E-02
             endif
 !
             CHS_URB  = CHS(I,J)
@@ -3566,14 +3566,14 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   XXXC_URB = XXXC_URB2D(I,J)
       !
       !      Limits to avoid dividing by small number
-                  if (CHS(I,J) < 1.0E-04) then
-                     CHS(I,J)  = 1.0E-04
+                  if (CHS(I,J) < 1.0E-02) then
+                     CHS(I,J)  = 1.0E-02
                   endif
-                  if (CHS2(I,J) < 1.0E-04) then
-                     CHS2(I,J)  = 1.0E-04
+                  if (CHS2(I,J) < 1.0E-02) then
+                     CHS2(I,J)  = 1.0E-02
                   endif
-                  if (CQS2(I,J) < 1.0E-04) then
-                     CQS2(I,J)  = 1.0E-04
+                  if (CQS2(I,J) < 1.0E-02) then
+                     CQS2(I,J)  = 1.0E-02
                   endif
       !
                   CHS_URB  = CHS(I,J)
@@ -4409,14 +4409,14 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   XXXC_URB = XXXC_URB2D(I,J)
       !
       !      Limits to avoid dividing by small number
-                  if (CHS(I,J) < 1.0E-04) then
-                     CHS(I,J)  = 1.0E-04
+                  if (CHS(I,J) < 1.0E-02) then
+                     CHS(I,J)  = 1.0E-02
                   endif
-                  if (CHS2(I,J) < 1.0E-04) then
-                     CHS2(I,J)  = 1.0E-04
+                  if (CHS2(I,J) < 1.0E-02) then
+                     CHS2(I,J)  = 1.0E-02
                   endif
-                  if (CQS2(I,J) < 1.0E-04) then
-                     CQS2(I,J)  = 1.0E-04
+                  if (CQS2(I,J) < 1.0E-02) then
+                     CQS2(I,J)  = 1.0E-02
                   endif
       !
                   CHS_URB  = CHS(I,J)

--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -2405,14 +2405,14 @@ ILOOP : DO I = its, ite
     XXXC_URB = XXXC_URB2D(I,J)
 
 ! Limits to avoid dividing by small number
-    IF (CHS(I,J) < 1.0E-04) THEN
-      CHS(I,J)  = 1.0E-04
+    IF (CHS(I,J) < 1.0E-02) THEN
+      CHS(I,J)  = 1.0E-02
     ENDIF
-    IF (CHS2(I,J) < 1.0E-04) THEN
-      CHS2(I,J)  = 1.0E-04
+    IF (CHS2(I,J) < 1.0E-02) THEN
+      CHS2(I,J)  = 1.0E-02
     ENDIF
-    IF (CQS2(I,J) < 1.0E-04) THEN
-      CQS2(I,J)  = 1.0E-04
+    IF (CQS2(I,J) < 1.0E-02) THEN
+      CQS2(I,J)  = 1.0E-02
     ENDIF
 
     CHS_URB  = CHS(I,J)


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: Noah and NoahMP, urban

SOURCE: internal, Mike Barlage

DESCRIPTION OF CHANGES: 
For stability reasons, CHS needs a lower limit in urban areas. Previous releases had 
reduced it to 1.e-4 in Noah urban since V3.7, but kept older value of 
1.e-2 in Noah mosaic.  V3.9 will revert to older value of 1.e-2 and 
also add this to new NoahMP urban capability. [This reverses a change
made in the repository after the last release.]

LIST OF MODIFIED FILES: 
M       phys/module_sf_noahdrv.F
M       phys/module_sf_noahmpdrv.F

TESTS CONDUCTED: 
WTF 3.06 passed all expected
