### PR TITLE
Bug Fix for Single-layer UCM Green Roof Option

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1129,14 +1129,12 @@ MODULE module_sf_urban
        end if 
        YY  = TA + (RGRR / RCH - BETGR * EPGR * ELL/ RCH) / RR2  
        ZZ1 = DF1 / (-0.5 * ZSOILR (KZ) * RCH * RR2 ) + 1.0
-       ! Update temperature in soil layer
-       CALL SHFLX (SSOILR,TGRL,SMR,SMCMAX,NGR,TGRP,DELT,YY,ZZ1,ZSOILR,       &
-                  TRLEND,ZBOT,SMCWLT,DF1,QUARTZ,CSOIL,CAPR) 
+
 
        HGR=RHO*CP*CHGR*UA*(TGRP-TA)*100.     
        RUNOFF3 = RUNOFF3/ DELT
        RUNOFF2 = RUNOFF2+ RUNOFF3      
-       G0GR    = SSOILR / 697.7 / 60
+       G0GR    = DF1*(TGRP-TGRL(1))/(DZGR(1)/2.)/697.7/60
 
        FV = SGR + RGR - HGR - ELEGR - G0GR
        DRRDTGR   = (-4.*EPSV*SIG*TGRP**3.)/60.
@@ -1152,7 +1150,9 @@ MODULE module_sf_urban
        EXIT
        ENDIF
      END DO
-    
+       ! Update temperature in soil layer
+       CALL SHFLX (SSOILR,TGRL,SMR,SMCMAX,NGR,TGRP,DELT,YY,ZZ1,ZSOILR,       &
+                  TRLEND,ZBOT,SMCWLT,DF1,QUARTZ,CSOIL,CAPR)     
    FLXTHGR=HGR/RHO/CP/100.
    FLXHUMGR=ELEGR/RHO/EL/100.
 ELSE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: module_sf_urban.F, green_roof option, 

SOURCE: Jiachun Yang, Princeton University

DESCRIPTION OF CHANGES: There was a problem in the green roof option within module_sf_urban.F.  Subsurface temps of the green roof failed to converge at very dry conditions with very small time steps.  The bug occurs because surface and subsurface temps are updated at the same time in the iteration loop, which leads to a surface energy non-closure problem. The modifications provided by the developer of this particular part of the module correct this.

LIST OF MODIFIED FILES: 
M     phys/module_sf_urban.F

TESTS CONDUCTED: regression tests pass.  Per Mike Barlage, we trust this modification and he is okay with implementing it.
