### PR TITLE
Script to help identify NML entries added since last release that are not described in the README.namelist

### DIFF
--- a/tools/any_updates_in_registry.csh
+++ b/tools/any_updates_in_registry.csh
@@ -11,7 +11,11 @@ if ( -e newbies ) then
 endif
 touch newbies
 
-foreach f ( Registry* registry* )
+pushd ../Registry >& /dev/null
+set Registry_files = `ls -1 Registry* registry*`
+popd >& /dev/null
+
+foreach f ( $Registry_files )
 	if ( ( $f == Registry.CONVERT ) || \
 	     ( $f == Registry.EM_COMMON.var ) || \
 	     ( $f == Registry.NMM ) || \


### PR DESCRIPTION
### TYPE: no impact

### KEYWORDS: README.namelist, script 

### SOURCE: internal

### DESCRIPTION OF CHANGES:
Script that compares the ARW (non DA, non Chem) registry files with the versions from the last release. Any new additions to the rconfig entries that are not described in the README.namelist file are flagged. Any entirely new registry files are just reported (as not every variable has to be in the README.namelist).

### LIST OF MODIFIED FILES:
A       tools/any_updates_in_registry.csh

### TESTS CONDUCTED: 
- [x] This script found the same files that Wei found manually.
