### PR TITLE
Mods to allow WRFDA/CRTM_2.2.3 to build with CRAY CCE

### DIFF
--- a/arch/configure_new.defaults
+++ b/arch/configure_new.defaults
@@ -1289,10 +1289,13 @@ FC              =       $(DM_FC)
 CC              =       $(DM_CC)
 LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
-PROMOTION       =       -s integer32
+PROMOTION       =       -s integer32 -s real`expr 8 \* $(RWORDSIZE)`
 ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
 CFLAGS_LOCAL    =       -O3 
 LDFLAGS_LOCAL   =       
+# uncomment this for wrfda build
+#LIB_LOCAL       =       -L$(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5 -lfftpack \
+#                        -L$(WRF_SRC_ROOT_DIR)/external/RSL_LITE -lrsl_lite
 CPLUSPLUSLIB    =       
 ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
 FCOPTIM         =       # -Ofp3 

--- a/var/external/crtm_2.2.3/libsrc/CRTM_AtmOptics_Define.f90
+++ b/var/external/crtm_2.2.3/libsrc/CRTM_AtmOptics_Define.f90
@@ -304,7 +304,8 @@ CONTAINS
 
   CONTAINS
 
-    PURE SUBROUTINE AtmOptics_Allocate(self,alloc_stat)
+!cray/pkb add elemental
+    ELEMENTAL PURE SUBROUTINE AtmOptics_Allocate(self,alloc_stat)
       TYPE(CRTM_AtmOptics_type), INTENT(OUT) :: self
       INTEGER                  , INTENT(OUT) :: alloc_stat
       ! Allocate object


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, Cray CCE, build

SOURCE: Patricia Balle (Cray Inc.)

DESCRIPTION OF CHANGES:

arch/configure_new.defaults:
  edit PROMOTION to take into account RWORDSIZE=8.
  Also need to explicitly add links of rsl_lite and fftpack libraries to LIB_LOCAL.
  We are not entirely sure why this is necessary for the WRF DA build for CCE (and not Intel)
  and so have left this LIB_LOCAL specification commented out - it can be switched on if necessary.

var/external/crtm_2.2.3/libsrc/CRTM_AtmOptics_Define.f90:
  add elemental to subroutine AtmOptics_Allocate
 (Jamie's note: subroutine AtmOptics_Allocate is contained inside ELEMENTAL SUBROUTINE CRTM_AtmOptics_Create.)

LIST OF MODIFIED FILES:
M       arch/configure_new.defaults
M       var/external/crtm_2.2.3/libsrc/CRTM_AtmOptics_Define.f90

TESTS CONDUCTED:
1. WRFDA regtests
2. CRTM still compiles with GNU, INTEL and PGI compilers