### PR TITLE
Change default hill2d_x nml to hybrid_opt=0

### DIFF
--- a/test/em_hill2d_x/namelist.input
+++ b/test/em_hill2d_x/namelist.input
@@ -77,8 +77,6 @@
  h_sca_adv_order                     = 5,
  v_sca_adv_order                     = 3,
  non_hydrostatic                     = .true.,
- hybrid_opt                          = 2
- etac                                = 0.2
  /
 
  &bdy_control


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: hill2d_x, namelist, hybrid_opt

### SOURCE: problem found by Kelly

### DESCRIPTION OF CHANGES:
The hybrid vertical coordinate option is available, but is not the default. Remove the hybrid_opt=2 (and etac=0.2) from the default hill2d_x namelist.input file.

### LIST OF MODIFIED FILES: 
M       test/em_hill2d_x/namelist.input

TESTS CONDUCTED:
No tests conducted for removing these two lines.