### PR TITLE
OOPS! fix hill2d_x nml files after bad sed command

### DIFF
--- a/test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
+++ b/test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
@@ -78,7 +78,7 @@
  v_sca_adv_order                     = 3,
  non_hydrostatic                     = .true.,
  hybrid_opt                          = 2,
- run_hours                           = 0.2,
+ etac                                = 0.2,
  /
 
  &bdy_control

--- a/test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
+++ b/test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
@@ -78,7 +78,7 @@
  v_sca_adv_order                     = 3,
  non_hydrostatic                     = .true.,
  hybrid_opt                          = 2,
- run_hours                           = 0.2,
+ etac                                = 0.2,
  /
 
  &bdy_control

--- a/test/em_hill2d_x/extras/namelist.input-HILL
+++ b/test/em_hill2d_x/extras/namelist.input-HILL
@@ -78,7 +78,7 @@
  v_sca_adv_order                     = 3,
  non_hydrostatic                     = .true.,
  hybrid_opt                          = 2,
- run_hours                           = 0.2,
+ etac                                = 0.2,
  /
 
  &bdy_control

--- a/test/em_hill2d_x/extras/namelist.input-HILL-51
+++ b/test/em_hill2d_x/extras/namelist.input-HILL-51
@@ -78,7 +78,7 @@
  v_sca_adv_order                     = 3,
  non_hydrostatic                     = .true.,
  hybrid_opt                          = 2,
- run_hours                           = 0.2,
+ etac                                = 0.2,
  /
 
  &bdy_control

--- a/test/em_hill2d_x/extras/namelist.input-HILL-schar
+++ b/test/em_hill2d_x/extras/namelist.input-HILL-schar
@@ -78,7 +78,7 @@
  v_sca_adv_order                     = 3,
  non_hydrostatic                     = .true.,
  hybrid_opt                          = 2,
- run_hours                           = 0.2,
+ etac                                = 0.2,
  /
 
  &bdy_control


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: hill2d_x, etac

### SOURCE: internal

### DESCRIPTION OF CHANGES:
For all of the nml files in the hill2d_x/extras directory, swap the incorrect namelist value (run_hours) for the correct one (etac) in the dynamics section.

### LIST OF MODIFIED FILES: 
M       test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
M       test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
M       test/em_hill2d_x/extras/namelist.input-HILL
M       test/em_hill2d_x/extras/namelist.input-HILL-51
M       test/em_hill2d_x/extras/namelist.input-HILL-schar

### TESTS CONDUCTED:
No tests conducted