### PR TITLE
Fixes for Volcano, SOA_VBS and CB05 chemistry options

### DIFF
--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -391,18 +391,18 @@ CONTAINS
              
 ! volcanic emissions
 !       
-        ashz_above_vent=emiss_ash_height - z_at_w(i,kts,j)                              ! MARCUS
+        ashz_above_vent=emiss_ash_height - z_at_w(i,kts,j)                              
       write(message,'("Found and adjusted active volcano at j,kts,kpe = ",3i8)') j,kts,kte 
       call wrf_message (message)
 !            write(0,*)emiss_ash_height,emiss_ash_mass,ashz_above_vent
         do k=kte-1,kts,-1
-           if(z_at_w(i,k,j) < emiss_ash_height)then                                     ! MARCUS
+           if(z_at_w(i,k,j) < emiss_ash_height)then                                    
              k_final=k+1
              exit
            endif 
         enddo
         do k=kte-1,kts,-1
-          if(z_at_w(i,k,j) < ((1.-base_umbrel)*ashz_above_vent)+z_at_w(i,kts,j))then    ! MARCUS
+          if(z_at_w(i,k,j) < ((1.-base_umbrel)*ashz_above_vent)+z_at_w(i,kts,j))then  
              k_initial=k
              exit
            endif
@@ -1491,7 +1491,6 @@ CONTAINS
             its,ite, jts,jte, kts,kte                                   )
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!! TUCCELLA
     CASE (RACM_SOA_VBS_KPP,RACM_SOA_VBS_AQCHEM_KPP)
        call wrf_debug(15,'emissions_driver calling soa_vbs_addemiss')
        call soa_vbs_addemiss( id, dtstep, u10, v10, alt, dz8w, xland, chem,  &

--- a/chem/module_aerosols_soa_vbs.F
+++ b/chem/module_aerosols_soa_vbs.F
@@ -6751,17 +6751,10 @@ SUBROUTINE soa_vbs_addemiss( id, dtstep, u10, v10, alt, dz8w, xland, chem,      
           ims,ime, jms,jme, kms,kme,                             &
           its,ite, jts,jte, kts,kte                              )
   end if
-  if( seasalt_emiss_active == 2 ) then
-!     call Monahan_seasalt_emiss(                                 &
-!          dtstep, u10, v10, alt, dz8w, xland, chem,              &
-!          ids,ide, jds,jde, kds,kde,                             &
-!          ims,ime, jms,jme, kms,kme,                             &
-!          its,ite, jts,jte, kts,kte                              )
-  end if
+ ! if( seasalt_emiss_active == 2 ) then
+ ! end if
   if( dust_opt == 2 ) then
-    !czhao+++++++++++++++++++++++++++
     call wrf_message("WARNING: You are calling DUSTRAN dust emission scheme with MOSAIC, which is highly experimental and not recommended for use. Please use dust_opt==13")
-    !czhao---------------------------
       call soa_vbs_dust_emiss(                                     &
            slai, ust, smois, ivgtyp, isltyp,                      &
            id, dtstep, u10, v10, alt, dz8w,                       &
@@ -6770,7 +6763,6 @@ SUBROUTINE soa_vbs_addemiss( id, dtstep, u10, v10, alt, dz8w, xland, chem,      
            ims,ime, jms,jme, kms,kme,                             &
            its,ite, jts,jte, kts,kte                              )
   end if
-   !czhao ++++++++++++++++++++++++++
  !     dust_opt changed to 13 since it conflicts with gocart/afwa
   if( dust_opt == 13 ) then
    !czhao -------------------------- 

--- a/chem/module_bioemi_megan2.F
+++ b/chem/module_bioemi_megan2.F
@@ -268,10 +268,6 @@ CONTAINS
     !...Some light-dependent factor (dimensionless)
     REAL :: ldf
 
-    !...conversion factor to convert emissions rates in 
-    !...mol km-2 hr-1 to concentrations in ppm
-    ! REAL :: emis2ppm
-
     !...conversion factor from mol km-2 hr-1 to ppm m min-1
     REAL :: convert2
 
@@ -769,14 +765,6 @@ CONTAINS
           ! the gas-phase mechanism species
 
 
-          !...conversion factor to convert emissions rates in 
-          !...mol km-2 hr-1 to concentrations in ppm
-          !         0.02897 kg/mol is molecular of air
-          !         rho_phy is air density in kg air/m3
-          !         dz8w is layer height in meters
-          !         dtstep is time step in seconds
-          ! emis2ppm = 0.02897*dtstep/(rho_phy(i,kts,j)*dz8w(i,kts,j)*3600.)
-
           !...conversion factor from mol km-2 hr-1 to ppm m min-1
           !...(e_bio is in units of ppm m min-1)
           convert2 = 0.02897/(rho_phy(i,kts,j)*60.)
@@ -1154,30 +1142,6 @@ is_mozm_species : &
                       ! Emission rate for mechanism species in mol km-2 hr-1
                       gas_emis = cb05_per_megan(icount) * E_megan2(p_of_megan2cb05(icount))
 
-                      ! Increase gas-phase concentrations (in ppmv) due to
-                      ! biogenic emissions
-                      ! fixed a bug when bioemt>chemdt
-                      !chem(i,kts,j,p_in_chem) = chem(i,kts,j,p_in_chem) + gas_emis*emis2ppm
-
-                      !IF ( p_in_chem .EQ. p_apin ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_bpin ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_hum ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_lim ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_oci ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_ter ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-
                       ! Add emissions to diagnostic output variables.
                       ! ebio_xxx (mol km-2 hr-1) were originally used by the
                       ! BEIS3.11 biogenic emissions module.
@@ -1199,11 +1163,9 @@ is_mozm_species : &
                       END IF
                       IF ( p_in_chem .EQ. p_apin ) THEN
                          ebio_api(i,j)        = ebio_api(i,j)       + gas_emis
-                         !e_bio(i,j,p_apin-1)  = e_bio(i,j,p_apin-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)  = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_bpin ) THEN
-                         !e_bio(i,j,p_bpin-1)  = e_bio(i,j,p_bpin-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)  = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_ch4 ) THEN
@@ -1230,7 +1192,6 @@ is_mozm_species : &
                          e_bio(i,j,p_form-1)  = e_bio(i,j,p_form-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_hum ) THEN
-                         !e_bio(i,j,p_hum-1)   = e_bio(i,j,p_hum-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)  = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_iole ) THEN
@@ -1238,7 +1199,6 @@ is_mozm_species : &
                       END IF
                       IF ( p_in_chem .EQ. p_lim ) THEN
                          ebio_lim(i,j)        = ebio_lim(i,j)       + gas_emis
-                         !e_bio(i,j,p_lim-1)   = e_bio(i,j,p_lim-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)  = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_meoh ) THEN
@@ -1252,7 +1212,6 @@ is_mozm_species : &
                          e_bio(i,j,p_no-1)    = e_bio(i,j,p_no-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_oci ) THEN
-                         !e_bio(i,j,p_oci-1)   = e_bio(i,j,p_oci-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)  = e_bio(i,j,p_terp-1) + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_ole ) THEN
@@ -1295,30 +1254,6 @@ is_mozm_species : &
                       ! Emission rate for mechanism species in mol km-2 hr-1
                       gas_emis = cb05vbs_per_megan(icount) * E_megan2(p_of_megan2cb05vbs(icount))
 
-                      ! Increase gas-phase concentrations (in ppmv) due to
-                      ! biogenic emissions
-                      ! fixed the bug when bioemt>chemdt
-                      !chem(i,kts,j,p_in_chem) = chem(i,kts,j,p_in_chem) + gas_emis*emis2ppm
-
-                      !IF ( p_in_chem .EQ. p_apin ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_bpin ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_hum ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_lim ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_oci ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-                      !IF ( p_in_chem .EQ. p_ter ) THEN
-                      !   chem(i,kts,j,p_terp) = chem(i,kts,j,p_terp) + gas_emis*emis2ppm
-                      !END IF
-
                       ! Add emissions to diagnostic output variables.
                       ! ebio_xxx (mol km-2 hr-1) were originally used by the
                       ! BEIS3.11 biogenic emissions module.
@@ -1340,11 +1275,9 @@ is_mozm_species : &
                       END IF
                       IF ( p_in_chem .EQ. p_apin ) THEN
                          ebio_api(i,j)        = ebio_api(i,j)       + gas_emis
-                         !e_bio(i,j,p_apin-1)  = e_bio(i,j,p_apin-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)   = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_bpin ) THEN
-                         !e_bio(i,j,p_bpin-1)  = e_bio(i,j,p_bpin-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)   = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_ch4 ) THEN
@@ -1371,7 +1304,6 @@ is_mozm_species : &
                          e_bio(i,j,p_form-1)  = e_bio(i,j,p_form-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_hum ) THEN
-                         !e_bio(i,j,p_hum-1)   = e_bio(i,j,p_hum-1)  + gas_emis*convert2
                           e_bio(i,j,p_terp-1)   = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_iole ) THEN
@@ -1379,7 +1311,6 @@ is_mozm_species : &
                       END IF
                       IF ( p_in_chem .EQ. p_lim ) THEN
                          ebio_lim(i,j)        = ebio_lim(i,j)       + gas_emis
-                         !e_bio(i,j,p_lim-1)   = e_bio(i,j,p_lim-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)   = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_meoh ) THEN
@@ -1393,7 +1324,6 @@ is_mozm_species : &
                          e_bio(i,j,p_no-1)    = e_bio(i,j,p_no-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_oci ) THEN
-                         !e_bio(i,j,p_oci-1)   = e_bio(i,j,p_oci-1)  + gas_emis*convert2
                          e_bio(i,j,p_terp-1)   = e_bio(i,j,p_terp-1)  + gas_emis*convert2
                       END IF
                       IF ( p_in_chem .EQ. p_ole ) THEN


### PR DESCRIPTION
TYPE: bug fixes

KEYWORDS: volcanoes, dust for SOA_VBS, MEGAN for CB05

SOURCE: internal, C.Zhao (China), M.Hirtl (Austria), K.Wang (NCSU) 

DESCRIPTION OF CHANGES: Following bug fixes:
   In chem/emissions_driver.F: fix the bug with injection height for volcano emissions
       chem/module_aerosols_soa_vbs.F: minor fix for dust option
       chem/module_bioemi_megan2.F : fix to correctly read the MEGAN emissions in CB05 options

LIST OF MODIFIED FILES: 
    emissions_driver.F
    module_aerosols_soa_vbs.F
    module_bioemi_megan2.F

TESTS CONDUCTED: it passed WTF3.07