### PR TITLE
fix for melting small amounts of snow in Noah LSM

### DIFF
--- a/phys/module_sf_noahlsm.F
+++ b/phys/module_sf_noahlsm.F
@@ -3254,6 +3254,7 @@ CONTAINS
 ! ABOVE FREEZING BLOCK
 ! ----------------------------------------------------------------------
       ELSE
+!     From V3.9 original code (commented) replaced to allow complete melting of small snow amounts
 !        T1 = TFREEZ * SNCOVR ** SNOEXP + T12 * (1.0- SNCOVR ** SNOEXP)
          T1 = TFREEZ * max(0.01,SNCOVR ** SNOEXP) + T12 * (1.0- max(0.01,SNCOVR ** SNOEXP))
          BETA = 1.0


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: Noah LSM, snow melt

SOURCE: internal, Mike Barlage

DESCRIPTION OF CHANGES: 
One-line fix. Problem was that when snow water equivalent was very small (<~0.01 mm)
it did not melt because small snow-cover fraction limited melt rate too much. 
Fix is to limit the snow fraction effect from getting too small in this part of the code.

LIST OF MODIFIED FILES: 
M       phys/module_sf_noahlsm.F

TESTS CONDUCTED: 
WTF 3.06 passed expected tests
