### PR TITLE
Modify linker command arguments in chem/KPP/kpp/kpp-2.1/src/Makefile

### DIFF
--- a/chem/KPP/kpp/kpp-2.1/src/Makefile
+++ b/chem/KPP/kpp/kpp-2.1/src/Makefile
@@ -63,8 +63,8 @@ OBJS  = \
 	debug.o
 
 kpp:    $(OBJS)
-	@echo "  "$(SCC) $(CC_FLAGS) $(CLFLAGS) $(CFLAGS) $(OBJS) -L$(FLEX_LIB_DIR) -lfl -ll -o kpp
-	@$(SCC) $(CC_FLAGS) $(CFLAGS) $(CLFLAGS) $(OBJS) -L$(FLEX_LIB_DIR) -lfl -ll -o kpp
+	@echo "  "$(SCC) $(CC_FLAGS) $(CFLAGS) $(OBJS) $(CLFLAGS) -L$(FLEX_LIB_DIR) -lfl -o kpp
+	@$(SCC) $(CC_FLAGS) $(CFLAGS) $(OBJS) $(CLFLAGS) -L$(FLEX_LIB_DIR) -lfl -o kpp
 	@mv kpp ../bin
 
 clean:  


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: KPP Makefile

SOURCE: internal

DESCRIPTION OF CHANGES:

Altered argument list to linker command so that the libraries are a contiguous
group at the end of the command.  Before this change the object files where
in the middle of the library specifications.

LIST OF MODIFIED FILES:

M	chem/KPP/kpp/kpp-2.1/src/Makefile

TESTS CONDUCTED:

WTF reg test, version 3.07 successfully completed.