### PR TITLE
modify RASM Diags namelist variables to be more WRF-like

### DIFF
--- a/Registry/registry.rasm_diag
+++ b/Registry/registry.rasm_diag
@@ -9,7 +9,13 @@ dimspec    dc      2     constant=8                        z     diurnal_cycles
 
 rconfig   integer  mean_diag              namelist,time_control   1              0      -    "mean diagnostics flag"
 rconfig   integer  mean_freq              namelist,time_control   1              0      -    "mean output frequency"
-rconfig   integer  mean_interval          namelist,time_control   1              0      -    "mean output interval"
+rconfig   integer  mean_interval          namelist,time_control   max_domains    0      -    "mean output interval"
+rconfig   integer  mean_diag_interval     namelist,time_control   max_domains    0      -    "mean output interval m"
+rconfig   integer  mean_diag_interval_s   namelist,time_control   max_domains    0      -    "mean output interval s"
+rconfig   integer  mean_diag_interval_m   namelist,time_control   max_domains    0      -    "mean output interval m"
+rconfig   integer  mean_diag_interval_h   namelist,time_control   max_domains    0      -    "mean output interval h"
+rconfig   integer  mean_diag_interval_d   namelist,time_control   max_domains    0      -    "mean output interval d"
+rconfig   integer  mean_diag_interval_mo  namelist,time_control   max_domains    0      -    "mean output interval mo"
 rconfig   integer  diurnal_diag           namelist,time_control   1              0      -    "diurnal diagnostics flag"
 
 # Climate: Mean - output arrays of averages

--- a/run/README.rasm_diag
+++ b/run/README.rasm_diag
@@ -1,12 +1,14 @@
 The RASM Climate Diagnostics provides time-step averaging output for surface 
-meteorology (PSFC, TSK, PMSL, T2, TH2, Q2, U10, V10) and fluxes at the surface 
-(HFX, LH, SWDNB, GLW, LWUPB, SWUPB) and fluxes at the TOA (SWUPT, SWDNT, LWUPT, 
+meteorology (PSFC, TSK, PMSL, T2, TH2, Q2, U10, V10), fluxes at the surface 
+(HFX, LH, SWDNB, GLW, LWUPB, SWUPB), and fluxes at the TOA (SWUPT, SWDNT, LWUPT, 
 LWDNT). The averaging can be set by the user with some interval of seconds, 
 minutes, hours, days, or month. The average output file is set to use auxhist5. 
 
-Additionally, diurnal averaging is provide which creates monthly averages for 
+Additionally, diurnal averaging is provided which creates monthly averages for 
 three hour periods of time during the day (00-03, 03-06, etc.). The diurnal 
-average output is set to use auxhist6. 
+average output is set to use auxhist6. This diurnal averaging output is only 
+created in monthly files (the simulation has to be longer than a month to see
+the output).
 
 The intended application for the RASM Diagnostics is for regional climate
 simulations and the elimination of the need to produce the high-volume and I/O
@@ -15,34 +17,35 @@ intenstive instantaneous WRF history files for long duration simulations.
 namelist.input settings for RASM Climate Diagnostics in &time_control
 -settings for RASM diagnostic mean output:
  -flag to turn on the mean diagnostic output (1 = on, 0 = off)
- mean_diag                           = 1,
- -flag indicating the type of time interval for the mean frequency
-  1 = seconds, 2 = minutes, 3 = hours, 4 = days, 5 = monthly
- mean_freq                           = 4,
- -quanity of interval based on mean_freq
- mean_interval                       = 1,
+   mean_diag                           = 1,
+ -set the time interval for the frequency of mean calculations
+   mean_diag_interval                  = 1440, (minutes)
+   mean_diag_interval_s                = 3600, (seconds)
+   mean_diag_interval_m                = 1440, (minutes)
+   mean_diag_interval_h                = 6, (hours)
+   mean_diag_interval_d                = 1, (days)
+   mean_diag_interval_mo               = 1, (month)
  -use the standard WRF namelist settings for auxhist5:
- auxhist5_outname                    = "wrf_mean_d<domain>_<date>.nc",
- io_form_auxhist5                    = 2,
- frames_per_auxhist5                 = 1,
+   auxhist5_outname                    = "wrf_mean_d<domain>_<date>.nc",
+   io_form_auxhist5                    = 2,
+   frames_per_auxhist5                 = 1,
+Notes:
+ -a time interval must be set
+ -only one of the time intervals can be set (cominbations do not work)
 
 -settings for RASM diagnostic dirunal output:
  -flag to turn on the diurnal diagnostic output (1 = on, 0 = off)
- diurnal_diag                        = 1,
--use the standard WRF namelist settings for auxhist5 and auxhist6:
- auxhist6_outname                    = "wrf_diurnal_d<domain>_<date>.nc",
- io_form_auxhist6                    = 2,
- frames_per_auxhist6                 = 1,
-Note: Currently, the dirunal output is hard coded for three-hourly intervals
-(8 values in a day) and output in monthly files. Future modifications to
-the namelist.input settings will provide more flexibility.
-
-WARNING: These namelist.input settings are temporary and will be updated to
-new more WRF-like namelist settings in the near future.
+   diurnal_diag                        = 1,
+ -use the standard WRF namelist settings for auxhist5 and auxhist6:
+   auxhist6_outname                    = "wrf_diurnal_d<domain>_<date>.nc",
+   io_form_auxhist6                    = 2,
+   frames_per_auxhist6                 = 1,
+Note: The dirunal output is hard coded for three-hourly intervals
+(8 values in a day) and output in monthly files.
 
 Acknoledgement:
 The RASM Climate Diagnostics for WRF was developed and implemented as a part
 of the Regional Arctic System Model (RASM) project funded by the United States 
 Department of Energy - Regional and Global Climate Modeling Program.
 
-09 January 2017
+04 April 2017

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -53,6 +53,8 @@
       LOGICAL , EXTERNAL :: wrf_dm_on_monitor
       INTEGER :: i, j, oops, d1_value
       LOGICAL :: km_opt_already_done , diff_opt_already_done
+      INTEGER :: count_opt
+
 !TWG2015
 !
 !FASDAS
@@ -1044,6 +1046,88 @@
          END DO
       END IF
 
+!-----------------------------------------------------------------------
+! For RASM Diagnostics
+! -verify that only one time interval is specified
+! -change the intervals to values used in RASM Diagnotics
+! -verify that a time interval has been set
+!-----------------------------------------------------------------------
+
+! 1. Only one time interval type specified
+
+      DO i = 1, model_config_rec % max_dom
+         count_opt = 0
+         IF ( model_config_rec%mean_diag_interval_s (i) .GT. 0 ) THEN
+            count_opt = count_opt + 1
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_m (i) .GT. 0 ) THEN
+            count_opt = count_opt + 1
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_h (i) .GT. 0 ) THEN
+            count_opt = count_opt + 1
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_d (i) .GT. 0 ) THEN
+            count_opt = count_opt + 1
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_mo(i) .GT. 0 ) THEN
+            count_opt = count_opt + 1
+         END IF 
+         IF ( model_config_rec%mean_diag_interval   (i) .GT. 0 ) THEN
+            count_opt = count_opt + 1
+         END IF 
+         IF ( count_opt .GT. 1 ) THEN
+            wrf_err_message = '--- ERROR:  Only use one of: mean_diag_interval, _s, _m, _h, _d, _mo '
+            CALL wrf_message ( wrf_err_message )
+            count_fatal_error = count_fatal_error + 1
+         END IF
+      END DO
+
+! 2. Put canonical intervals into RASM expected form
+
+      DO i = 1, model_config_rec % max_dom
+         IF ( model_config_rec%mean_diag_interval_s (i) .GT. 0 ) THEN
+            model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval_s (i)
+            model_config_rec%mean_freq = 1
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_m (i) .GT. 0 ) THEN
+            model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval_m (i)
+            model_config_rec%mean_freq = 2
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_h (i) .GT. 0 ) THEN
+            model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval_h (i)
+            model_config_rec%mean_freq = 3
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_d (i) .GT. 0 ) THEN
+            model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval_d (i)
+            model_config_rec%mean_freq = 4
+         END IF 
+         IF ( model_config_rec%mean_diag_interval_mo(i) .GT. 0 ) THEN
+            model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval_mo(i)
+            model_config_rec%mean_freq = 5
+         END IF 
+         IF ( model_config_rec%mean_diag_interval   (i) .GT. 0 ) THEN
+            model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval   (i)
+            model_config_rec%mean_freq = 2
+         END IF 
+      END DO
+
+! 3. If requested, need an interval.
+
+      IF ( model_config_rec%mean_diag .EQ. 1 ) THEN
+         count_opt = 0
+         DO i = 1, model_config_rec % max_dom
+            IF ( model_config_rec%mean_interval   (i) .GT. 0 ) THEN
+               count_opt = count_opt + 1
+            END IF 
+         END DO
+         IF ( count_opt .LT. 1 ) THEN
+            wrf_err_message = '--- ERROR:  mean_diag = 1, but no computation interval given'
+            CALL wrf_message ( wrf_err_message )
+            wrf_err_message = '            Use one of: mean_diag_interval, _s, _m, _h, _d, _mo '
+            CALL wrf_message ( wrf_err_message )
+            count_fatal_error = count_fatal_error + 1
+         END IF
+      END IF
 
 !-----------------------------------------------------------------------
 ! For nwp_diagnostics = 1, history_interval must be used.           


### PR DESCRIPTION
Modify RASM Diagnostics to have more WRF-like namelist variables

TYPE: enhancement

KEYWORDS: RASM

SOURCE: Mark Seefeldt (CU) and Jose Renteria (NPS)

DESCRIPTION OF CHANGES:
The initial implementation of RASM Diagnostics had namelist variables that
were not "WRF-like". The modifications in this pull request adds a new
namelist variables and a section to module_check_a_mundo.F to verify the 
namelist settings and to set the values as RASM expects. The README.rasm_diag
file was also updated to match the new WRF-like namelist variables.

LIST OF MODIFIED FILES: list of changed files
M       Registry/registry.rasm_diag
M       run/README.rasm_diag
M       share/module_check_a_mundo.F

TESTS CONDUCTED:
1. Verified that all namelist settings for interval frequency (_s, _m, _h,
   _d, and _mo) work as expected.
2. Verified that check_a_mundo exits when more than one interval frequency
   is set
3. Verified that check_a_mundo exits when no interval frequency is set