### PR TITLE
Check for small dt, nint(dt) identically = 0, bad MOD comparison in diags

### DIFF
--- a/phys/module_diag_misc.F
+++ b/phys/module_diag_misc.F
@@ -263,6 +263,8 @@ CONTAINS
       REAL:: mvd_r, xslw1, ygra1, zans1
       INTEGER:: ng, n
 
+      LOGICAL :: test_final
+
 !-----------------------------------------------------------------
 ! Handle accumulations with buckets to prevent round-off truncation in long runs
 ! This is done every 360 minutes assuming time step fits exactly into 360 minutes
@@ -1016,7 +1018,13 @@ CONTAINS
        prfreq=10                   ! in min
     endif
    
-    IF (MOD(nint(dt),prfreq) == 0) THEN
+    IF ( nint(dt) .LT. 1 ) THEN
+       test_final = .true.
+    ELSE
+       test_final = MOD(nint(dt),prfreq) == 0
+    END IF 
+
+    IF ( test_final ) THEN
 
 ! COMPUTE THE NUMBER OF MASS GRID POINTS
    no_points = float((ide-ids)*(jde-jds))


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: MOD, diags, timestep, dt

### SOURCE: problem found by Brian Reen (US Army Research Lab)

### DESCRIPTION OF CHANGES:
For the test to determine whether or not to do some diagnostic processing, if the time step is small, do the diagnostics at each step. Already the logic was set up so that the the print frequency was identical to the time step for the diag_print option set to 1. Allow this functional behavior to continue even if the time step is small.

### LIST OF MODIFIED FILES:
M       phys/module_diag_misc.F

### TESTS CONDUCTED: 
- [x] Ming set up case with small dt.  Fails without mod, works with mod.
- [ ] Reggie 3.07, not yet