### PR TITLE
Fix NDOWN with hybrid vertical coordinate

### DIFF
--- a/main/ndown_em.F
+++ b/main/ndown_em.F
@@ -223,6 +223,10 @@ real :: cf1_c,cf2_c,cf3_c,cfn_c,cfn1_c
    model_config_rec % e_vert(2) = k_dim_n
    ALLOCATE(znw_c(k_dim_c))
    ALLOCATE(znu_c(k_dim_c))
+   ALLOCATE(c3h(k_dim_c))
+   ALLOCATE(c4h(k_dim_c))
+   ALLOCATE(c3f(k_dim_c))
+   ALLOCATE(c4f(k_dim_c))
    WRITE ( message , FMT = '(A,3I5)' ) 'KDIM_C', k_dim_c , model_config_rec % e_vert(1) , model_config_rec % e_vert(2)
    CALL       wrf_debug (  99,message )
 !!!!!!!!!!!!!!! mousta
@@ -1770,7 +1774,7 @@ END SUBROUTINE init_domain_constants_em_ptr
 #if  !( HYBRID_COORD==1 )
          pre_c = mu_m * znw_c(k) + p_top_m
 #elif ( HYBRID_COORD==1 )
-         pre_c = mu_m * c3f(1) + c4f(1) + p_top_m
+         pre_c = mu_m * c3f(k) + c4f(k) + p_top_m
 #endif
          alt_w_c(k) =  -hsca_m * alog(pre_c/p_surf_m)
          enddo
@@ -1778,7 +1782,7 @@ END SUBROUTINE init_domain_constants_em_ptr
 #if  !( HYBRID_COORD==1 )
          pre_c = mu_m * znu_c(k) + p_top_m
 #elif ( HYBRID_COORD==1 )
-         pre_c = mu_m * c3h(1) + c4h(1) + p_top_m
+         pre_c = mu_m * c3h(k) + c4h(k) + p_top_m
 #endif
          alt_u_c(k+1) =  -hsca_m * alog(pre_c/p_surf_m)
          enddo
@@ -1789,7 +1793,7 @@ END SUBROUTINE init_domain_constants_em_ptr
 #if  !( HYBRID_COORD==1 )
          pre_n = mu_m * parent_grid%znw(k) + p_top_m
 #elif ( HYBRID_COORD==1 )
-         pre_n = mu_m * parent_grid%c3f(1) + parent_grid%c4f(1) + p_top_m
+         pre_n = mu_m * parent_grid%c3f(k) + parent_grid%c4f(k) + p_top_m
 #endif
          alt_w_n(k) =  -hsca_m * alog(pre_n/p_surf_m)
          enddo
@@ -1797,7 +1801,7 @@ END SUBROUTINE init_domain_constants_em_ptr
 #if  !( HYBRID_COORD==1 )
          pre_n = mu_m * parent_grid%znu(k) + p_top_m
 #elif ( HYBRID_COORD==1 )
-         pre_n = mu_m * parent_grid%c3h(1) + parent_grid%c4h(1) + p_top_m
+         pre_n = mu_m * parent_grid%c3h(k) + parent_grid%c4h(k) + p_top_m
 #endif
          alt_u_n(k+1) =  -hsca_m * alog(pre_n/p_surf_m)
          enddo


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: ndown, hybrid, hvc, stupid-freaking-indexes-again

### SOURCE: internal, problem spotted by Kelly Keene

### DESCRIPTION OF CHANGES:
The pressure computation inside of ndown already had the correct ifdefs so that the HVC pressures were computed as
pres = c3 * mu + c4 + ptop
where
pres is 3d pres(i,k,j),
c3 and c4 are 1d c3(k), c4(k),
mu is 2d mu(i,j), and
ptop is a 0d value.

Fixes
-----
1. The four 1d arrays (c3h, c4h, c3f, and c4f) needed to be allocated.
2. The four 1d arrays, inside of the "DO k loop", needed to be indexed with "k", not "1".

### LIST OF MODIFIED FILES:
M       main/ndown_em.F

### TESTS CONDUCTED:
1. Test with mods, 24 h simulation (our dear friend Jan 2000)
- [x] NDOWN with -hyb build, with hybrid_opt=0: OK
- [x] NDOWN with -hyb build, with hybrid_opt=2: OK
- [x] NDOWN without -hyb build: OK
2. Test without mods - anticipate failures due to non-allocated arrays being accessed
- [x] NDOWN with -hyb build, with hybrid_opt=0: successfully fails
- [x] NDOWN with -hyb build, with hybrid_opt=2: successfully fails
- [x] NDOWN without -hyb build: successfully fails
3. Bit-for-bit identical test
     - Test 1: configure
     - Test 2: configure -hyb, then hybrid_opt=0
- [x] d02 after 24-h (via ndown) is identical between Test 1 and Test 2
4. Reggie
- [x] 3.07 pass