### PR TITLE
Check for obsolete WRFDA namelist option "use_3dvar_phys"

### DIFF
--- a/frame/module_configure.F
+++ b/frame/module_configure.F
@@ -508,9 +508,9 @@ CONTAINS
         READ   ( UNIT = nml_read_unit , NML = wrfvar4 , iostat=nml_error )
 
         IF ( nml_error .EQ. 0 ) then    ! Successul, rm variables must be problem
-           CALL wrf_debug(0, "-- Is use_eos_radobs or use_3dvar_phy still in your "// &
+           CALL wrf_debug(0, "-- Is use_3dvar_phy or use_eos_radobs still in your "// &
                               TRIM(nml_name)//" namelist?")
-           CALL wrf_debug(0, "-- Remove use_eos_radobs, use_3dvar_phy as they are obsolete.")
+           CALL wrf_debug(0, "-- Remove use_3dvar_phy, use_eos_radobs as they are obsolete.")
         ENDIF
 
 !---------------------------------- wrfvar14 -----------------------------


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: WRFDA, namelist, use_3dvar_phy, wrf_alt_nml_obsolete

SOURCE: internal

DESCRIPTION OF CHANGES: The option "use_3dvar_phy" (which really never should have been included) was removed for this release. However, it was included in the users guide for version 3.8, so it is possible that users have this option in their namelist, which will cause a runtime failure if they try to use the same list with V3.9. By adding this option to the existing subroutine "wrf_alt_nml_obsolete", instead of a generic "ERRORS while reading one or more namelists" error, they will get a helpful message telling them to remove the obsolete "use_3dvar_phy" option from &wrfvar4.

LIST OF MODIFIED FILES:
M       frame/module_configure.F

TESTS CONDUCTED: WRFDA regtest passes; added the obsolete option to a test namelist and got the expected error message.