### PR TITLE
wrf_io.F90, index 0 invalid

### DIFF
--- a/external/io_netcdf/wrf_io.F90
+++ b/external/io_netcdf/wrf_io.F90
@@ -3221,7 +3221,7 @@ subroutine ext_ncd_get_previous_time(DataHandle, DateStr, Status)
     if(DH%CurrentTime.GT.0) then
       DH%CurrentTime     = DH%CurrentTime -1
     endif
-    DateStr            = DH%Times(DH%CurrentTime)
+    DateStr            = DH%Times(MAX(1,DH%CurrentTime))
     DH%CurrentVariable = 0
     Status = WRF_NO_ERR
   else


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: IO, netcdf, wrf_io.F90, index

### SOURCE: internal

### DESCRIPTION OF CHANGES:
When using -D, the ndown program fails instantly with an index of zero, where the minimum allowed index is one. The real and ideal pre-processors, and the WRF model do not trip up in this case (do not get into this part of the IF test). The ndown program does fail.

The change is to essentially put a minimum bound on the value: MAX(1,_joe_index_), as the array index _joe_index_ should have a minimum allowable value of 1 based on the array's declarations.

**NOTE**: This type of change might be required in other external I/O directories. We do not typically have users doing Grib or Binary for the netcdf files, and it seems unrealistic to assume that those I/O formats would work for input.

### LIST OF MODIFIED FILES:
M       external/io_netcdf/wrf_io.F90

### TESTS CONDUCTED:
 - [x] With the fix, the ndown output results are identical between two cases using GNU 6.3.0 on Darwin:
1. Run ndown without -D
2. Run ndown with -D and also with the I/O mod

 - [x] Works with the sequence real, WRF (cg), and ndown. I ran two different setups for WRF into ndown:
1. frames_per_outfile = 1
2. frames_per_outfile=1000
Both were successful for ndown, and both generated bit-for-bit wrfinput_d02 and wrfbdy_d02 files.

 - [x] Works with the sequence real, WRF (cg), ndown, and WRF (fg). I ran 8 different scenarios for WRF (fg), and then compared each of those setups to the output from a restart using those namelist settings.

| Test | Restart Interval | History Interval | Times per File |
| --- | --- | --- | --- | 
| 1  |   6    |   6  |   1000   |
| 2  |   6    |   30  |   1000   |
| 3  |   30    |  6   |   1000   |
| 4  |   30    |  30   |   1000   |
| 5  |   6    |   6  |   1   |
| 6  |   6    |   30  |   1   |
| 7  |   30    |  6   |   1   |
| 8  |   30    |  30   |   1   |

From the restart files WRF (fg) manufactures, I then compared the subsequent restart files produced at the end of the WRF (fg) simulation (10 time steps/30 minutes later). 
1. Each of the original 8 restart files were bit-wise identical to the newly created restart files.
2. Each of the restart files (16 of them) were bit-wise identical to each other (using the diffwrf utility).

 - [x] WTF 4.01: The following is considered OK
1. No PGI at all, now this is standard due to licensing issues
2. GNU and Intel fail compile of WRF KPP, something to do with library "l"
3. GNU failure for WRFDA build, looks like multiple build attempts?
4. A few stochastic run-time failures for GNU
  
  