### PR TITLE
WRF Release info in version.decl: v3.9

### DIFF
--- a/inc/version_decl
+++ b/inc/version_decl
@@ -1,1 +1,1 @@
-   CHARACTER (LEN=10) :: release_version = 'V3.9pre#2 '
+   CHARACTER (LEN=10) :: release_version = 'V3.9      '


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: version

SOURCE: internal

DESCRIPTION OF CHANGES:
Usual update of text string version information for the major release. Now at v3.9.

LIST OF MODIFIED FILES:
M       inc/version_decl

TESTS CONDUCTED:
- [x] Code compiles

- [x] Info in the real program is correct
```
// global attributes:
		:TITLE = " OUTPUT FROM REAL_EM V3.9 PREPROCESSOR" ;
```

- [x] Info in the WRF model output is correct
```
// global attributes:
		:TITLE = " OUTPUT FROM WRF V3.9 MODEL" ;
```