### PR TITLE
Corrected Error Message for vert_refine_method in module_check_a_mundo.F

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1558,7 +1558,7 @@
              !  We are OK, I just hate writing backwards / negative / convoluted if tests 
              !  that are not easily comprehensible.
           ELSE
-            wrf_err_message = '--- ERROR: vert_refine_method=2 only works with either RRTM or RRTMG'
+            wrf_err_message = '--- ERROR: vert_refine_method=2 only works with ra_lw_physics=1 (RRTM) and ra_sw_physics=1 (Dudhia)'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
             count_fatal_error = count_fatal_error + 1
           END IF 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: module_check_a_mundo.F, vert_refine_method=2, RRTM, RRTMG, Dudhia, Error

SOURCE: internal

DESCRIPTION OF CHANGES: module_check_a_mundo.F checks that if you have the vert_refine_method=2 option turned on in the namelist, then you can only use SW radiation scheme option 1 (Dudhia), and/or LW radiation scheme option 1 (RRTM); however, the error message printed that the only available options for this switch were RRTM and RRTMG.  The error message has been corrected to display that the only available options are Dudhia (SW) and RRTM (LW), which has been verified with Katie Lundquist (the developer of this option).

LIST OF MODIFIED FILES:
M     share/module_check_a_mundo.F

TESTS CONDUCTED: Tested that the correct error message prints out when either using incorrect LW option, incorrect SW option, or incorrect options for both LW and SW.  Regression tests pass.
