### PR TITLE
Bug fix for WRFDA radar null echo assimilation

### DIFF
--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -465,16 +465,14 @@ END IF
                         if ( bg_rf >= 20.0 .and. iv%radar(n)%height(k) > model_lcl(n) ) then
                            iv % radar(n) % rqv(k) % qc = 0
 
-                           radar_non_precip_rh_w = radar_non_precip_rh_w*0.01 ! percentage to ratio
-                           radar_non_precip_rh_i = radar_non_precip_rh_i*0.01 ! percentage to ratio
                            if ( model_tc(k,n) > 5.0 ) then
-                              iv%radar(n)%rqvo(k) =  radar_non_precip_rh_w*model_qs(k,n)
+                              iv%radar(n)%rqvo(k) =  0.01*radar_non_precip_rh_w*model_qs(k,n)
                            else if ( model_tc(k,n) < -5.0 ) then
-                              iv%radar(n)%rqvo(k) =  radar_non_precip_rh_i*model_qs_ice(k,n)
+                              iv%radar(n)%rqvo(k) =  0.01*radar_non_precip_rh_i*model_qs_ice(k,n)
                            else
                               cwr = (model_tc(k,n)+5.0)/10.0
                               cws = 1.0 - cwr
-                              iv%radar(n)%rqvo(k) =  cwr*radar_non_precip_rh_w*model_qs(k,n) + cws*radar_non_precip_rh_i*model_qs_ice(k,n)
+                              iv%radar(n)%rqvo(k) =  cwr*0.01*radar_non_precip_rh_w*model_qs(k,n) + cws*0.01*radar_non_precip_rh_i*model_qs_ice(k,n)
                            end if
 
                            iv % radar(n) % rqv(k) % inv = iv % radar(n) % rqvo(k) - model_qv(k,n)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, radar, null-echo, QVAPOR

SOURCE: Ki-Hong Min (Kyungpook National University)

DESCRIPTION OF CHANGES: The developer spotted a bug in the released code, where in certain circumstances WRFDA would give an extremely negative QVAPOR increment, causing QVAPOR to approach zero. This occurred because the namelist values radar_non_precip_rh_w and radar_non_precip_rh_i need a scaling factor (times 0.01) to convert them from percentage to ratio. This scaling factor was unintentionally applied within a loop over vertical levels, so this scaling factor was applied *many* times, to the point where the values for these namelist variables eventually trended towards zero. Since these namelist variables were multiplied by other variables to acquire the value for the water vapor increment, the increment approached zero at the points where this scaling factor was applied.

The solution is to simply multiply each instance where these variables are used by a factor of 0.01, rather than modifying the original namelist values (which is bad practice anyway). This results in much better and more realistic moisture increments, as shown in the plot below:

![radar_null_echo_bug_fix](https://cloud.githubusercontent.com/assets/12705538/25467895/cb50156a-2ace-11e7-8df9-d1f25583d454.png)


LIST OF MODIFIED FILES:
M       var/da/da_radar/da_get_innov_vector_radar.inc

TESTS CONDUCTED: WRFDA regtest passed for gnu and intel. Developer reports bug is fixed.