### PR TITLE
fix WRFDA reading of global attributes from netcdf input

### DIFF
--- a/var/da/da_main/da_med_initialdata_input.inc
+++ b/var/da/da_main/da_med_initialdata_input.inc
@@ -119,14 +119,14 @@ subroutine da_med_initialdata_input (grid, config_flags, filename, in_date)
 
    ! mp_physics is used in da_transfer_wrftoxb.inc
    ! get the setting from the input file
-   call ext_ncd_get_dom_ti_integer (fid, 'MP_PHYSICS', grid%mp_physics, 1, icnt, ierr)
+   call wrf_get_dom_ti_integer (fid, 'MP_PHYSICS', grid%mp_physics, 1, icnt, ierr)
 
    ! sf_surface_physics is used in da_transfer_xatowrf.inc
    ! get the setting from the input file
-   call ext_ncd_get_dom_ti_integer (fid, 'SF_SURFACE_PHYSICS', grid%sf_surface_physics, 1, icnt, ierr)
+   call wrf_get_dom_ti_integer (fid, 'SF_SURFACE_PHYSICS', grid%sf_surface_physics, 1, icnt, ierr)
 
    !global attribute HYBRID_OPT exists in WRF V3.9 and later
-   call ext_ncd_get_dom_ti_integer (fid, 'HYBRID_OPT', grid%hybrid_opt, 1, icnt, ierr)
+   call wrf_get_dom_ti_integer (fid, 'HYBRID_OPT', grid%hybrid_opt, 1, icnt, ierr)
    if ( ierr /= 0 ) then
       grid%hybrid_opt = 0
       write(unit=message(1),fmt='(A,A)') trim(filename), ' appears to be from earlier than WRF V3.9'

--- a/var/da/da_main/da_wrfvar_io.f90
+++ b/var/da/da_main/da_wrfvar_io.f90
@@ -8,6 +8,7 @@ module da_wrfvar_io
       input_input, open_w_dataset,output_input, &
       input_boundary, output_boundary, output_auxhist4, &
       input_auxhist6, input_auxhist4
+   use module_io, only: wrf_get_dom_ti_integer
    use module_state_description, only : p_qv
 
    use da_control, only : trace_use, ierr, var4d, var4d_lbc, num_fgat_time, rootproc


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, wrf_get_dom_ti_integer, ncd_ext_get_dom_ti_integer

SOURCE: internal

DESCRIPTION OF CHANGES:
When using ncd_ext_get_dom_ti_integer to get the global attribute,
only root processor gets the correct value, other processors returns
with the WRF_WARN_BAD_DATA_HANDLE error.
The problem is fixed by calling wrf_get_dom_ti_integer instead.

For HYBRID_OPT=2 case, root processor gets hybrid_opt=2 while other
processors end up with hybrid_opt=0.

LIST OF MODIFIED FILES:
M       var/da/da_main/da_med_initialdata_input.inc
M       var/da/da_main/da_wrfvar_io.f90

TESTS CONDUCTED:
Before the fix, the 3dvar/hybrid_opt=2 system have been cycled for ~3 weeks
until I 'accidentally' look at rsl.out from non-root processors...