### PR TITLE
Remove undefined/unnecessary variable from OBSPROC routines

### DIFF
--- a/var/obsproc/src/module_write.F90
+++ b/var/obsproc/src/module_write.F90
@@ -57,7 +57,7 @@ SUBROUTINE output_ssmi_31 (max_number_of_obs, obs, number_of_obs, index, &
   INTEGER,                                      INTENT (in) :: nssmis
 
   INTEGER                       :: n, loop_index, fm, i, ssmi_125, ssmi_126
-  INTEGER                       :: nvalids, nwrites1, nwrites2
+  INTEGER                       :: nwrites1, nwrites2
   LOGICAL                       :: connected
   CHARACTER (LEN = 80)          :: filename1, filename2
   CHARACTER (LEN = 120)         :: fmt_info, &
@@ -284,7 +284,6 @@ counts: &
 
       nwrites1 = 0
       nwrites2 = 0
-      nvalids = 0
 
 
 ! 2.1  Loop over stations
@@ -311,8 +310,6 @@ stations_valid: &
       READ (obs (loop_index) % info % platform (4:6), '(I3)') fm
 
       if ((fm /= 125) .AND. (fm /= 126))  CYCLE stations
-
-      nvalids = nvalids + 1
 
 ! 2.4 Write station info
 !     ------------------
@@ -508,7 +505,7 @@ SUBROUTINE output_gts_31 (max_number_of_obs, obs, number_of_obs, windex,&
   TYPE (measurement ) , POINTER :: current
   INTEGER                       :: loop_index
   INTEGER                       :: i, ii, n, ntotal, k_levels
-  INTEGER                       :: nvalids, nmultis, nsingles, nlevels, nwrites
+  INTEGER                       :: nmultis, nsingles, nlevels, nwrites
   INTEGER                       :: is_sound, fm
   LOGICAL                       :: connected
   CHARACTER (LEN = 80)          :: filename
@@ -731,8 +728,6 @@ stations_valid: &
       READ (obs (loop_index) % info % platform (4:6), '(I3)') fm
 
       if ((fm == 125) .OR. (fm == 126))  CYCLE stations
-
-      nvalids = nvalids + 1
 
 ! SATEM reference pressure is assigned to slp:
 
@@ -1086,7 +1081,7 @@ SUBROUTINE output_prep (max_number_of_obs, obs, number_of_obs, windex,&
   TYPE (measurement ) , POINTER :: current
   INTEGER                       :: bfout, bftable, loop_index
   INTEGER                       :: i, n, nlv, nmax, ntotal
-  INTEGER                       :: nvalids, nmultis, nsingles, nlevels, nwrites
+  INTEGER                       :: nmultis, nsingles, nlevels, nwrites
   INTEGER                       :: is_sound, fm, idate
   INTEGER                       :: year, month, day, hour, minute, second
   INTEGER                       :: mxmn, kx
@@ -1215,8 +1210,6 @@ stations_valid: &
       READ (obs (loop_index) % info % platform (4:6), '(I3)') fm
       IF (fm == 126 .OR. cfm(fm) == 'UNKNOW') &
           CYCLE stations
-
-      nvalids = nvalids + 1
 
 ! SATEM reference pressure is assigned to slp:
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, OBSPROC, debug, intel

SOURCE: internal

DESCRIPTION OF CHANGES: 
Tests on local linux machine result in failure for one obsproc case when compiled with the intel compiler in debug mode. This is due to variable "nvalids", which is used without being defined in some subroutines within the file var/obsproc/src/module_write.F90 (it is defined in the parent subroutine, but not explicitly passed to the child subroutine). Since this variable is not actually used within any of these subroutines in this file, the easiest solution is just to remove it altogether.

LIST OF MODIFIED FILES:
M    var/obsproc/src/module_write.F90

TESTS CONDUCTED: WRFDA Regtest now passes this one particular test for intel on local linux machine in debug mode. Other regtests are unaffected as they never reported this error in the first place.

