### PR TITLE
Fix WRFDA 4DVAR compile for PGI 15.1

### DIFF
--- a/var/build/da_name_space.pl
+++ b/var/build/da_name_space.pl
@@ -192,4 +192,5 @@ store_communicators_for_domain
 wrf_get_dm_quilt_comm
 wrf_dm_nestexchange_init
 set_tiles
+wrf_get_dom_ti_integer
 ###########################################################################################


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, compile, PGI

SOURCE: internal

DESCRIPTION OF CHANGES: Commit db7841c (Fix WRFDA reading of global attributes from netcdf input #258) introduced the subroutine "wrf_get_dom_ti_integer" to var/da/da_main/da_med_initialdata_input.inc. Because of naming conflicts with WRFPLUS, the code will not compile  for 4DVAR when using certain PGI compilers (and perhaps others), even though GNU and Intel have no problem with it. This is solved by adding this subroutine to the script `da_name_space.pl`, which is part of the WRFDA build system that addresses this very problem: it renames certain subroutines when compiling for 4DVAR to avoid this conflict and allow the code to compile successfully.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M       var/build/da_name_space.pl

TESTS CONDUCTED: WRFDA 4DVAR now compiles for PGI 15.1 (which is the compiler that exhibited the problem). WTF passes with flying colors.
