### PR TITLE
Make lanczos eigenpair filename a namelist option

### DIFF
--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -254,6 +254,7 @@ rconfig   real      precondition_factor     namelist,wrfvar6  1  1.0      -  "pr
 rconfig   logical   use_lanczos             namelist,wrfvar6  1  .false.  - "use_lanczos"              ""  ""
 rconfig   logical   read_lanczos            namelist,wrfvar6  1  .false.  - "read_lanczos"             ""  ""
 rconfig   logical   write_lanczos           namelist,wrfvar6  1  .false.  - "write_lanczos"            ""  ""
+rconfig   character lanczos_ep_filename     namelist,wrfvar6  1  "../lanczos_eigenpairs"  - "lanczos_ep_filename" "File name for lanczos eigenpairs"  ""
 rconfig   logical   orthonorm_gradient      namelist,wrfvar6  1  .false.  - "orthonorm_gradient"       ""  ""
 rconfig   integer   cv_options              namelist,wrfvar7  1  5        - "cv_options"               ""  ""
 rconfig   integer   cloud_cv_options        namelist,wrfvar7  1  0        - "cloud_cv_options"         "0: off, 1: qt, 3: specified qc,qr,qi,qs,qg BE"  ""

--- a/var/da/da_minimisation/da_lanczos_io.inc
+++ b/var/da/da_minimisation/da_lanczos_io.inc
@@ -27,12 +27,12 @@ subroutine da_lanczos_io (io_config, cv_size, ntmaxit, neign, eignvec, eignval, 
    if (trace_use) call da_trace_entry("da_lanczos_io")
    
    write(cproc,fmt='(i4.4)') myproc
-   filename = '../lanczos_eigenpairs.'//trim(adjustl(cproc))
+   filename = trim(lanczos_ep_filename)//'.'//trim(adjustl(cproc))
 
    call da_get_unit (ep_unit)
 
    if (io_config == 'r') then
-      write(*,*) 'Reading Lanczos eigenpairs'
+      write(*,*) 'Reading Lanczos eigenpairs from file '//filename
       open (unit=ep_unit, file = filename, form = 'unformatted', status = 'old')
       read(unit=ep_unit) neign, cv_size
       do i = 1, neign
@@ -42,7 +42,7 @@ subroutine da_lanczos_io (io_config, cv_size, ntmaxit, neign, eignvec, eignval, 
       end do
       close(unit=ep_unit)
    else if (io_config == 'w') then
-      write(*,*) 'Writing Lanczos eigenpairs'
+      write(*,*) 'Writing Lanczos eigenpairs to file '//filename
       open (unit=ep_unit, file = filename, form = 'unformatted', status = 'replace')
       write(unit=ep_unit) neign, cv_size
       do i = 1, neign
@@ -52,7 +52,7 @@ subroutine da_lanczos_io (io_config, cv_size, ntmaxit, neign, eignvec, eignval, 
       end do
       close(unit=ep_unit)
    else
-      write(*,*) 'Unknow configuration for Lanczos I/O routine'
+      write(*,*) 'Unknown configuration for Lanczos I/O routine'
    end if
 
    call da_free_unit (ep_unit)

--- a/var/da/da_minimisation/da_minimisation.f90
+++ b/var/da/da_minimisation/da_minimisation.f90
@@ -53,8 +53,8 @@ module da_minimisation
       orthonorm_gradient, its, ite, jts, jte, kts, kte, ids, ide, jds, jde, kds, kde, cp, &
       use_satcv, sensitivity_option, print_detail_outerloop, adj_sens, filename_len, &
       ims, ime, jms, jme, kms, kme, ips, ipe, jps, jpe, kps, kpe, fgat_rain_flags, var4d_bin_rain, freeze_varbc, &
-      use_wpec, wpec_factor, use_4denvar, anal_type_hybrid_dual_res, alphacv_method, alphacv_method_xa
-   use da_control, only: write_detail_grad_fn, pseudo_uvtpq
+      use_wpec, wpec_factor, use_4denvar, anal_type_hybrid_dual_res, alphacv_method, alphacv_method_xa, &
+      write_detail_grad_fn, pseudo_uvtpq, lanczos_ep_filename
    use da_define_structures, only : iv_type, y_type,  j_type, be_type, &
       xbx_type, jo_type, da_allocate_y,da_zero_x,da_zero_y,da_deallocate_y, &
       da_zero_vp_type, qhat_type


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, FSO, lanczos, namelist

SOURCE: internal

DESCRIPTION OF CHANGES: When activating the "lanczos" minimization algorithm you have the option to write the calculated lanczos eigenpairs for future reading (this capability is used in the FSO system). Currently, when that option is activated, these eigenpairs are written by each processor according to the filename pattern "../lanczos_eigenpairs.####". Notice the ".." at the beginning of the filename; this means that the files will be written in the directory ABOVE the current working directory. While this may make sense for the FSO system (which is guided by a number of script in a strict directory hierarchy), running this ability stand-alone (which I am currently doing for debugging purposes) is extremely inconvenient.

This change adds the ability to specify the filename pattern as a namelist option (I say "pattern" because the files will still be appended with the processor number). Because the FSO system requires this pattern, I will keep the default filename identical for back-compatibility.

LIST OF MODIFIED FILES: 
M       Registry/registry.var
M       var/da/da_minimisation/da_lanczos_io.inc
M       var/da/da_minimisation/da_minimisation.f90

TESTS CONDUCTED: Ran stand-alone test with lanczos algorithm and filename behavior is as expected. Ran WRFDA regtest for GNU and Intel: no changes as expected.
