### PR TITLE
Fix to make consistent calculation of PSIT and PSIQ when COARE formula is used in the revised surface layer scheme

### DIFF
--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -756,11 +756,6 @@ CONTAINS
               PSIQ=ALOG((ZA(I)+z0q)/Z0q)-PSIH(I)
               PSIQ2=ALOG((2.+z0q)/Z0q)-PSIH2(I)
               PSIQ10=ALOG((10.+z0q)/Z0q)-PSIH10(I)
-!             PSIQ=max(ALOG((ZA(I)+Z0Q)/Z0Q)-PSIH(I), 2.)
-!             PSIT=max(ALOG((ZA(I)+Z0T)/Z0T)-PSIH(I), 2.)
-!             PSIQ2=max(ALOG((2.+Z0Q)/Z0Q)-PSIH2(I), 2.)
-!             PSIT2=max(ALOG((2.+Z0T)/Z0T)-PSIH2(I), 2.)
-!             PSIQ10=max(ALOG((10.+Z0Q)/Z0Q)-PSIH10(I), 2.)
         ENDIF
 
         IF ( PRESENT(ISFTCFLX) ) THEN


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: integrated similarity functions, PSIT, PSIQ

SOURCE: Internal

DESCRIPTION OF CHANGES:

When COARE 3 formula was introduced to the revised surface layer scheme (sf_sfclay_physics=1), the modified thermal roughness was not used consistently with the new formulation of the PSIT, PSIQ calculations. This has a small effect in an idealized tropical cyclone test and a real-data hurricane test in terms of track and intensity.

LIST OF MODIFIED FILES:

modified:   phys/module_sf_sfclayrev.F

TESTS CONDUCTED: idealized tropical cyclone case at 3km and a real-data typhoon case.