### PR TITLE
Bug fix for ZTD with 4DVAR when there are ZTD obs in non-first time…

### DIFF
--- a/var/da/da_gpspw/da_transform_xtoy_gpsztd.inc
+++ b/var/da/da_gpspw/da_transform_xtoy_gpsztd.inc
@@ -33,7 +33,7 @@ subroutine da_transform_xtoy_gpsztd ( grid, iv, y )
 !--
    if (trace_use_dull) call da_trace_entry("da_transform_xtoy_gpsztd")
 
-      y % gpspw(:)% tpw = 0.0
+      !bugfix-for-4dvar y % gpspw(:)% tpw = 0.0
 
       do n=iv%info(gpspw)%n1,iv%info(gpspw)%n2
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, ZTD

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Commented out a falsely zeroed out array to fix the problem of 4DVAR cost function
becoming negative when there are ZTD observations in non-first time slots.
No impact on ZTD 3DVAR applications.

LIST OF MODIFIED FILES:
M       var/da/da_gpspw/da_transform_xtoy_gpsztd.inc

TESTS CONDUCTED:
A ZTD test case. 3DVAR produces identical results after the change.
Negative 4DVAR cost function is fixed.