### PR TITLE
Bug fix and clean-up for WRFDA pseudo ob capability

### DIFF
--- a/var/da/da_setup_structures/da_setup_obs_structures.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures.inc
@@ -208,6 +208,10 @@ subroutine da_setup_obs_structures( grid, ob, iv, j_cost)
          pseudo_uvtpq = .false.
       end if
    end if
+   if ( num_pseudo > 0 ) then
+      !to avoid errors when writing out filtered_obs for undefined variables
+      anal_type_qcobs = .false.
+   end if
 
    !---------------------------------------------------------------------------      
    ! [1.0] Setup and read in fields from first guess:

--- a/var/da/da_setup_structures/da_setup_pseudo_obs.inc
+++ b/var/da/da_setup_structures/da_setup_pseudo_obs.inc
@@ -66,6 +66,7 @@ subroutine da_setup_pseudo_obs(grid, iv, ob)
          allocate(iv%gpsref(1:iv%info(gpsref)%nlocal))
          call da_allocate_obs_info(iv, gpsref)
          iv%info(gpsref)%proc_domain(:,:) = .true.
+         iv%info(gpsref)%obs_global_index(iv%info(gpsref)%nlocal) = 1
          allocate(iv%gpsref(num_pseudo)%ref(1:1))
          allocate(iv%gpsref(num_pseudo)%  h(1:1))
          allocate(iv%gpsref(num_pseudo)%  p(1:1))
@@ -85,6 +86,10 @@ subroutine da_setup_pseudo_obs(grid, iv, ob)
          iv%info(gpsref)%dy(:,1)  = pseudo_y-real(iv%info(gpsref)%j(1,1))
          iv%info(gpsref)%dxm(:,1) = 1.0-iv%info(gpsref)%dx(1,1)
          iv%info(gpsref)%dym(:,1) = 1.0-iv%info(gpsref)%dy(1,1)
+         i = iv%info(gpsref)%i(1,1)
+         j = iv%info(gpsref)%j(1,1)
+         iv%info(gpsref)%lat(:,1) = grid%xb%lat(i,j)
+         iv%info(gpsref)%lon(:,1) = grid%xb%lon(i,j)
          iv % gpsref(1) %ref(1) % inv   = pseudo_val
          iv % gpsref(1) %ref(1) % error = pseudo_err
          iv % gpsref(1) %ref(1) % qc    = 0
@@ -108,6 +113,7 @@ subroutine da_setup_pseudo_obs(grid, iv, ob)
          allocate(iv%gpspw(1:iv%info(gpspw)%nlocal))
          call da_allocate_obs_info(iv, gpspw)
          iv%info(gpspw)%proc_domain(:,:) = .true.
+         iv%info(gpspw)%obs_global_index(iv%info(gpspw)%nlocal) = 1
          allocate (ob % gpspw (1:num_pseudo))
          ob % gpspw(1) % tpw   = 0.0
          iv%info(gpspw)%x(:,1)   = pseudo_x
@@ -123,13 +129,15 @@ subroutine da_setup_pseudo_obs(grid, iv, ob)
          iv % gpspw(1) % tpw % inv   = pseudo_val
          iv % gpspw(1) % tpw % error = pseudo_err
          iv % gpspw(1) % tpw % qc    = 0
+         i = iv%info(gpspw)%i(1,1)
+         j = iv%info(gpspw)%j(1,1)
+         iv%info(gpspw)%lat(:,1) = grid%xb%lat(i,j)
+         iv%info(gpspw)%lon(:,1) = grid%xb%lon(i,j)
          if ( pseudo_elv > -999.0 ) then
             ! pseudo_elv is set in the namelist
             iv%info(gpspw)%elv      = pseudo_elv
          else
             ! assign model terrain to ob elv
-            i   = iv%info(gpspw)%i(1,1)
-            j   = iv%info(gpspw)%j(1,1)
             dx  = iv%info(gpspw)%dx(1,1)
             dy  = iv%info(gpspw)%dy(1,1)
             dxm = iv%info(gpspw)%dxm(1,1)
@@ -211,7 +219,8 @@ subroutine da_setup_pseudo_obs(grid, iv, ob)
             iv%pseudo(:) % p % inv = pseudo_val
             iv%pseudo(:) % p % error = pseudo_err
             iv%pseudo(:) % p % qc = 0
-         else if ( trim(adjustl(pseudo_var)) == 'q' ) then
+         !else if ( trim(adjustl(pseudo_var)) == 'q' ) then
+         else if ( pseudo_var(1:1) == 'q' ) then
             iv%pseudo(:) % q % inv = pseudo_val
             iv%pseudo(:) % q % error = pseudo_err
             iv%pseudo(:) % q % qc = 0

--- a/var/da/da_setup_structures/da_setup_structures.f90
+++ b/var/da/da_setup_structures/da_setup_structures.f90
@@ -68,7 +68,7 @@ module da_setup_structures
       use_seviriobs, jds_int, jde_int, anal_type_hybrid_dual_res, use_amsr2obs, nrange, use_4denvar
    use da_control, only: rden_bin
    use da_control, only: use_cv_w
-   use da_control, only: pseudo_tpw, pseudo_ztd, pseudo_ref, pseudo_uvtpq, pseudo_elv
+   use da_control, only: pseudo_tpw, pseudo_ztd, pseudo_ref, pseudo_uvtpq, pseudo_elv, anal_type_qcobs
 
    use da_obs, only : da_fill_obs_structures, da_store_obs_grid_info, da_store_obs_grid_info_rad, &
                       da_fill_obs_structures_rain, da_fill_obs_structures_radar, da_set_obs_missing,da_set_3d_obs_missing


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, pseudo ob

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Mostly minor changes to fix the diagnostic output that do not affect results.
The main fix is in line 223 of the new da_setup_pseudo_obs.inc to restore
the capability of setting pseduo_var=qcw/qrn/qci/qsn/qgr (3DVAR mode only)
that was accidentally removed in commit 5c59961.

LIST OF MODIFIED FILES:
M       var/da/da_setup_structures/da_setup_obs_structures.inc
M       var/da/da_setup_structures/da_setup_pseudo_obs.inc
M       var/da/da_setup_structures/da_setup_structures.f90

TESTS CONDUCTED:
A few pseudo ob cases.