### PR TITLE
Bug fix for correctly updating GMT global attribute in wrfvar_output

### DIFF
--- a/var/da/da_main/da_update_firstguess.inc
+++ b/var/da/da_main/da_update_firstguess.inc
@@ -68,6 +68,7 @@ subroutine da_update_firstguess(grid, out_filename)
   character(len=4) ::  fgname
   integer :: julyr, julday
   real    :: gmt
+  real*4  :: gmt4
 
   wrf_real=104
   end_index1=0
@@ -130,7 +131,8 @@ subroutine da_update_firstguess(grid, out_filename)
         CALL ext_ncd_put_dom_ti_char (dh1, 'START_DATE', trim(DateStr1), ierr)
         CALL ext_ncd_put_dom_ti_char (dh1, 'SIMULATION_START_DATE', trim(DateStr1), ierr)
      endif
-     CALL ext_ncd_put_dom_ti_real    (dh1, 'GMT',    gmt,    1, ierr)
+     gmt4 = real(gmt)
+     CALL ext_ncd_put_dom_ti_real    (dh1, 'GMT',    gmt4,   1, ierr)
      CALL ext_ncd_put_dom_ti_integer (dh1, 'JULYR',  julyr,  1, ierr)
      CALL ext_ncd_put_dom_ti_integer (dh1, 'JULDAY', julday, 1, ierr)
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, wrfvar_output, GMT

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
The global attribute GMT in wrfvar_output is always 0 before the fix
due to the real*8/real*4 handling.

The GMT global attribute should have no impact on the subsequent WRF runs
since WRF gets GMT from the full date.

LIST OF MODIFIED FILES:
M       var/da/da_main/da_update_firstguess.inc

TESTS CONDUCTED:
A few non-00z analysis date tests to verify that GMT is consistent
with the analysis date after the fix.