### PR TITLE
Fix to enable aerosol optical properties calculations for chem_opt=109

### DIFF
--- a/chem/optical_driver.F
+++ b/chem/optical_driver.F
@@ -113,7 +113,7 @@
    select case (config_flags%chem_opt)
    case ( RADM2SORG,           RADM2SORG_KPP,      RADM2SORG_AQ, RADM2SORG_AQCHEM, &
           GOCART_SIMPLE,       RACMSORG_KPP,       RACMSORG_AQ,  RACMSORG_AQCHEM_KPP, &
-          RACM_ESRLSORG_AQCHEM_KPP, RACM_SOA_VBS_KPP,                                      &
+          RACM_ESRLSORG_AQCHEM_KPP, RACM_SOA_VBS_KPP, RACM_SOA_VBS_AQCHEM_KPP,        &
           GOCARTRACM_KPP,      GOCARTRADM2,  &
           RACM_ESRLSORG_KPP,   MOZCART_KPP,                      &
           CBMZ_MOSAIC_4BIN,    CBMZ_MOSAIC_8BIN, CBMZ_MOSAIC_KPP,   &
@@ -144,7 +144,7 @@
    case ( RADM2SORG, RACM_ESRLSORG_KPP, RADM2SORG_KPP, RADM2SORG_AQ, RADM2SORG_AQCHEM, &
           GOCARTRACM_KPP,      GOCARTRADM2,      &
           GOCART_SIMPLE,       RACMSORG_KPP,       RACMSORG_AQ,      RACMSORG_AQCHEM_KPP, &
-          RACM_ESRLSORG_AQCHEM_KPP, RACM_SOA_VBS_KPP,                                          &
+          RACM_ESRLSORG_AQCHEM_KPP, RACM_SOA_VBS_KPP, RACM_SOA_VBS_AQCHEM_KPP,            &
           CBMZSORG,            CBMZSORG_AQ,        MOZCART_KPP,       &
           CBMZ_CAM_MAM3_NOAQ,  CBMZ_CAM_MAM7_NOAQ,  CBMZ_CAM_MAM3_AQ,  CBMZ_CAM_MAM7_AQ, &
           CB05_SORG_AQ_KPP, CB05_SORG_VBS_AQ_KPP )


### PR DESCRIPTION
TYPE: bug fix


KEYWORDS: aerosol optical properties, RACM_SOA_VBS_AQCHEM_KPP


SOURCE: Megan Bela (NOAA-ESRL)


DESCRIPTION OF CHANGES:
Add RACM_SOA_VBS_AQCHEM_KPP chemical mechanism to call to optical driver in order to calculate/output aerosol optical properties (TAUAER*).

LIST OF MODIFIED FILES:

M       chem/optical_driver.F

TESTS CONDUCTED:
WTF on Yellowstone passed.
Multi-day simulations with these changes to V3.9 conducted and evaluated against observations and other aerosol scheme
