### PR TITLE
Horizontal diffusion fix for slope term

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2687,10 +2687,10 @@ SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
 !      titau1avg(i,k,j)=titau1avg(i,k,j)*zx(i,k,j)*tmpzeta_z
 !      titau2avg(i,k,j)=titau2avg(i,k,j)*tmpzy    *tmpzeta_z
 
-      zx_at_u(i, kts, j) = 0.5 * (zx(i, kts, j) + zx(i, kts + 1 , j))
-      zy_at_u(i, kts, j) = 0.125 * (zy(i - 1, kts, j) + zy(i, kts, j) + &
-          zy(i - 1, kts, j + 1) + zy(i, kts, j + 1) + zy(i - 1, kts + 1, j) + &
-          zy(i, kts + 1, j) + zy(i - 1, kts + 1, j + 1) + zy(i, kts + 1, j + 1))
+      zx_at_u(i, k, j) = 0.5 * (zx(i, k, j) + zx(i, k + 1 , j))
+      zy_at_u(i, k, j) = 0.125 * (zy(i - 1, k, j) + zy(i, k, j) + &
+          zy(i - 1, k, j + 1) + zy(i, k, j + 1) + zy(i - 1, k + 1, j) + &
+          zy(i, k + 1, j) + zy(i - 1, k + 1, j + 1) + zy(i, k + 1, j + 1))
 
 !     titau1avg(i,k,j)=titau1avg(i,k,j)*zx(i,k,j)
 !     titau2avg(i,k,j)=titau2avg(i,k,j)*tmpzy


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: diff_opt=2, horizontal diffusion slope term

SOURCE: Pedro Jimenez and internal

DESCRIPTION OF CHANGES: In the code and ARW description (e.g. Eq. 4.2 - 4.5) the zx (slope) term is inside a vertical derivative when it should be outside. This is now fixed. Effect on results is small because the vertical derivative of zx is small. This code goes back to early WRF days.

LIST OF MODIFIED FILES: 
M       dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
No WTF.
Tested 2d hill case with and without hybrid vertical coordinate. Effect is small and random. 
