### PR TITLE
Fix for GF to avoid double-counting radiative clouds

### DIFF
--- a/phys/module_cu_gf_wrfdrv.F
+++ b/phys/module_cu_gf_wrfdrv.F
@@ -712,11 +712,17 @@ CONTAINS
                    if(t2d(i,k).lt.258.)then
                       RQICUTEN(I,K,J)=outqcm(i,k)+outqcs(i,k)+outqc(I,K)*cuten(i)
                       RQCCUTEN(I,K,J)=0.
-                      IF ( PRESENT( GDC2 ) ) GDC2(I,K,J)=cupclwm(i,k)+cupclws(i,k)+CUPCLW(I,K)*cuten(i)
+                      IF ( PRESENT( GDC2 ) ) THEN
+                        GDC2(I,K,J)=cupclwm(i,k)+cupclws(i,k)+CUPCLW(I,K)*cuten(i)
+                        GDC(I,K,J) = 0.
+                      ENDIF
                    else
                       RQICUTEN(I,K,J)=0.
                       RQCCUTEN(I,K,J)=outqcm(i,k)+outqcs(i,k)+outqc(I,K)*cuten(i)
-                      IF ( PRESENT( GDC ) ) GDC(I,K,J)=cupclwm(i,k)+cupclws(i,k)+CUPCLW(I,K)*cuten(i)
+                      IF ( PRESENT( GDC ) ) THEN
+                        GDC(I,K,J)=cupclwm(i,k)+cupclws(i,k)+CUPCLW(I,K)*cuten(i)
+                        GDC2(I,K,J) = 0.
+                      ENDIF
                    endif
                 ENDDO
                 ENDDO


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: GF cumulus, cloud-radiation feedback

SOURCE: Laura Fowler (NCAR)

DESCRIPTION OF CHANGES: 
GDC and GDC2 which are water and ice cloud amounts used in cu_rad_feedback has some incorrect logic that meant that water and ice clouds were both added instead of one or the other when ice is present. The change resets one of them to zero when the other is set.

LIST OF MODIFIED FILES: 
M       phys/module_cu_gf_wrfdrv.F

TESTS CONDUCTED: 
No WTF.
January test case. No diffs if cu_rad_feedback = .false. (default). Small diffs if .true.