### PR TITLE
Fix incorrect calculation of variable cv_size_domain_jb

### DIFF
--- a/var/da/da_setup_structures/da_setup_cv.inc
+++ b/var/da/da_setup_structures/da_setup_cv.inc
@@ -120,8 +120,7 @@ subroutine da_setup_cv(be)
          ij = size(be%wsd,1)*size(be%wsd,2)
       endif
       cv_size_domain_jb = ij * (be % v1 % mz + be % v2 % mz + be % v3 % mz + &
-             be % v4 % mz + be % v5 % mz + be % v6 % mz + be % v7 % mz + &
-             be % v8 % mz + be % v9 % mz + be % v10 % mz + be % v11 % mz )
+             be % v4 % mz + be % v5 % mz )
       if ( cloud_cv_options >= 2 ) then
          cv_size_domain_jb = cv_size_domain_jb + ij * (be % v6 % mz + &
              be % v7 % mz + be % v8 % mz + be % v9 % mz + be % v10 % mz )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, control variables

SOURCE: Jake Liu (NCAR MMM)

DESCRIPTION OF CHANGES: Jake passed along this minor bug fix for me to commit. There is a section in da_setup_cv.inc that computes the size of the control variable arrays based on the domain size and number of control variables. The current logic incorrectly counts control variables that are not used if cloud_cv_options=1, and double-counts several control variables if cloud_cv_options=2 or 3. This fix simply removes the extra additions.

This variable is not actually used anywhere right now, so this change should have no impact. But the current value is incorrect so it should be fixed.

LIST OF MODIFIED FILES: 
M       var/da/da_setup_structures/da_setup_cv.inc

TESTS CONDUCTED: WRFDA Regtest passes (gnu and intel) as expected. No change in results.
