### PR TITLE
WRFDA registry.var fixes for packaging moist variables and for non-4DVAR

### DIFF
--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -61,8 +61,8 @@ state   real    a_qs           ijkft   a_moist     1         -     rh   "A_QSNOW
 state   real    g_qs           ijkft   g_moist     1         -     rh   "G_QSNOW"            "Snow mixing ratio"             "kg kg-1"
 state   real    a_qg           ijkft   a_moist     1         -     rh   "A_QGRAUP"           "Graupel mixing ratio"          "kg kg-1"
 state   real    g_qg           ijkft   g_moist     1         -     rh   "G_QGRAUP"           "Graupel mixing ratio"          "kg kg-1"
-state   real    a_qh           ijkft   a_moist     1         -     rh   "A_QHAIL"            "Hail mixing ratio"             "kg kg-1"
-state   real    g_qh           ijkft   g_moist     1         -     rh   "G_QHAIL"            "Hail mixing ratio"             "kg kg-1"
+#state   real    a_qh           ijkft   a_moist     1         -     rh   "A_QHAIL"            "Hail mixing ratio"             "kg kg-1"
+#state   real    g_qh           ijkft   g_moist     1         -     rh   "G_QHAIL"            "Hail mixing ratio"             "kg kg-1"
 # Other Misc State Variables                                            
 state   real    g_h_diabatic   ijk     misc         1         -      rdu      "g_h_diabatic"          "MICROPHYSICS LATENT HEATING"         "K s-1"      
 state   real    a_h_diabatic   ijk     misc         1         -      rdu      "a_h_diabatic"          "MICROPHYSICS LATENT HEATING"         "K s-1"      
@@ -472,6 +472,8 @@ rconfig   logical var4d_run                 namelist,perturbation  1  .true.  - 
 rconfig   integer  mp_physics_ad            namelist,physics   max_domains   98   -      "mp_physics_ad"            ""      ""
 # NAMELIST DERIVED
 rconfig   integer mp_physics_4dvar        derived                  max_domains   -1       -        "mp_physics_4dvar"     ""      "-1 = no 4dvar and so no need to allocate a_ and g_ moist and scalar variables, >0 = running 4dvar, so allocate a_ and g_ moist and scalar variables appropriate for selected microphysics package"
+rconfig   integer mp_physics_da           derived                  max_domains    1       -        "mp_physics_da"        ""      "1 when mp_physics>0 for allocating moist variables"
+rconfig   integer mp_physics_da_4dvar     derived                  max_domains   -1       -        "mp_physics_da_4dvar"  ""      "1 when mp_physics>0 for allocating g_/a_moist variables"
 #
 #---------------------------------------------------------------------------------------------------------------------------------------
 # Package Declarations
@@ -486,39 +488,15 @@ package   dyn_em_ad    dyn_opt==302                 -             -
 package   dyn_em_tst   dyn_opt==402                 -             -
 package   dyn_em_var   dyn_opt==502                 -             -
 
-package   not_set         mp_physics==-1               -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
-package   passiveqv       mp_physics==0                -             moist:qv;g_moist:g_qv;a_moist:a_qv
-package   kesslerscheme   mp_physics==1                -             moist:qv,qc,qr;g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
-package   linscheme       mp_physics==2                -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
-package   wsm3scheme      mp_physics==3                -             moist:qv,qc,qr;g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
-package   wsm5scheme      mp_physics==4                -             moist:qv,qc,qr,qi,qs;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs
-package   fer_mp_hires    mp_physics==5                -             moist:qv,qc,qr,qi;g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi;scalar:qt
-package   fer_mp_hires_advect  mp_physics==15          -             moist:qv,qc,qr,qi;g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
-package   wsm6scheme      mp_physics==6                -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
-package   gsfcgcescheme   mp_physics==7                -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
-package   thompson        mp_physics==8                -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg;scalar:qni,qnr
-package   milbrandt2mom   mp_physics==9                -             moist:qv,qc,qr,qi,qs,qg,qh;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh;scalar:qnc,qnr,qni,qns,qng,qnh
-package   morr_two_moment mp_physics==10               -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg;scalar:qni,qns,qnr,qng
-package   cammgmpscheme   mp_physics==11               -             moist:qv,qc,qi,qr,qs;g_moist:g_qv,g_qc,g_qi,g_qr,g_qs;a_moist:a_qv,a_qc,a_qi,a_qr,a_qs;scalar:qnc,qni,qnr,qns
-#package   milbrandt3mom   mp_physics==12               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnc,qnr,qni,qns,qng,qnh,qzr,qzi,qzs,qzg,qzh
-package   sbu_ylinscheme  mp_physics==13               -             moist:qv,qc,qr,qi,qs;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs
-package   wdm5scheme      mp_physics==14               -             moist:qv,qc,qr,qi,qs;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs;scalar:qnn,qnc,qnr
-package   wdm6scheme      mp_physics==16               -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg;scalar:qnn,qnc,qnr
-package   nssl_2mom       mp_physics==17               -             moist:qv,qc,qr,qi,qs,qg,qh;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh;scalar:qnc,qnr,qni,qns,qng,qnh,qvolg
-package   nssl_2momccn    mp_physics==18               -             moist:qv,qc,qr,qi,qs,qg,qh;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh;scalar:qnn,qnc,qnr,qni,qns,qng,qnh,qvolg
-package   nssl_1mom       mp_physics==19               -             moist:qv,qc,qr,qi,qs,qg,qh;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh;scalar:qvolg
-package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
-package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg;scalar:qndrop,qnr,qni,qns,qng,qvolg
-package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg;scalar:qni,qnr,qnc
-package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
-package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
-package   etampnew        mp_physics==95               -             moist:qv,qc,qr,qs;g_moist:g_qv,g_qc,g_qr,g_qs;a_moist:a_qv,a_qc,a_qr,a_qs;scalar:qt
-package   lscondscheme    mp_physics==98               -             moist:qv;g_moist:g_qv;a_moist:a_qv
-package   mkesslerscheme   mp_physics==99              -             moist:qv,qc,qr;g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
+package   mp_phys_zero     mp_physics_da==0         -             moist:qv
+package   mp_phys_set      mp_physics_da==1         -             moist:qv,qc,qr,qi,qs,qg
+
+package   nomoist_4dvar    mp_physics_da_4dvar==-1  -             -
+package   passiveqv_4dvar  mp_physics_da_4dvar==0   -             g_moist:g_qv;a_moist:a_qv
+package   warmrain_4dvar   mp_physics_da_4dvar==1   -             g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
 
 package   surfdragscheme bl_pbl_physics==98          -             -
 package   ducuscheme     cu_physics==98              -             -
-
 
 # only need to specify these once; not for every io_form* variable
 # Placeholders for additional packages (we can go beyond zzz
@@ -841,13 +819,24 @@ state real dummy i dyn_em 1
 #
 #Set state
 state vp_type vv - -
-state vp_type vv6 - -
 state vp_type vp - -
-state vp_type vp6 - -
 state ep_type ep - -
 state xb_type xb - -
 state x_type xa - -
 state x_subtype xa_ens - -
 state x_type xa_static - -
-state x_type x6a - -
 state xpose_type xp - -
+
+ifdef VAR4D
+state vp_type vv6 - -
+state vp_type vp6 - -
+state x_type x6a - -
+endif
+
+rconfig   integer adj_sens_used           derived               1             0       -     "adj_sens_used"   "turn on if adj_sens=true"
+rconfig   integer var4d_used              derived               1             0       -     "var4d_used"      "turn on if var4d=true"
+
+package   no_adj_sens    adj_sens_used==0            -             -
+package   do_adj_sens    adj_sens_used==1            -             state:a_u,a_v,a_t,a_mu,a_ph,g_u,g_v,g_t,g_mu,g_ph;a_moist:a_qv;g_moist:g_qv
+package   no_var4d       var4d_used==0               -             -
+package   do_var4d       var4d_used==1               -             state:a_u,a_v,a_w,a_ph,a_t,a_mu,a_p,a_z,g_u,g_v,g_w,g_ph,g_t,g_mu,g_p,g_z,a_h_diabatic,g_h_diabatic,a_rainc,g_rainc,a_rainnc,g_rainnc,a_raincv,g_raincv,a_rainncv,g_rainncv

--- a/var/da/da_main/da_solve.inc
+++ b/var/da/da_main/da_solve.inc
@@ -577,8 +577,10 @@
       call da_zero_vp_type (grid%vp)
   
       if ( var4d ) then
+#ifdef VAR4D
          call da_zero_vp_type (grid%vv6)
          call da_zero_vp_type (grid%vp6)
+#endif
       end if
 
    !---------------------------------------------------------------------------

--- a/var/da/da_main/da_wrfvar_init2.inc
+++ b/var/da/da_main/da_wrfvar_init2.inc
@@ -76,6 +76,35 @@ subroutine da_wrfvar_init2
       call da_message(message(1:1))
    endif
 
+   !mp_physics_da can be 0/1, used for allocating moist variables
+   !allocate all moist variables (excluding qh) used in DA when mp_physics is on
+   do i = 1, model_config_rec%max_dom
+      if ( mp_physics(i) > 0 ) then
+         model_config_rec%mp_physics_da(i) = 1
+      else if ( mp_physics(i) == 0 ) then
+         model_config_rec%mp_physics_da(i) = 0
+      else if ( mp_physics(i) == -1 ) then
+         !for DA, if physics_suite is set and mp_physics is not set, mp_physics will be -1
+         !in this case, also allocate all moist variables
+         model_config_rec%mp_physics_da(i) = 1
+      end if
+   end do
+
+   if ( var4d ) then
+      model_config_rec%var4d_used = 1
+      !mp_physics_da_4dvar can be 0/1, used for allocating a_moist and g_moist variables
+      do i = 1, model_config_rec%max_dom
+         if ( mp_physics(i) > 0 ) then
+            model_config_rec%mp_physics_da_4dvar(i) = 1
+         else
+            model_config_rec%mp_physics_da_4dvar(i) = 0
+         end if
+      end do
+   end if
+
+   if ( adj_sens ) then
+      model_config_rec%adj_sens_used = 1
+   end if
 
    !<DESCRIPTION>
    ! Among the configuration variables read from the namelist is

--- a/var/da/da_minimisation/da_calculate_gradj.inc
+++ b/var/da/da_minimisation/da_calculate_gradj.inc
@@ -77,14 +77,29 @@ subroutine da_calculate_gradj(it, iter, cv_size, cv_size_jb, cv_size_je, cv_size
    if (present(re)) then
       call da_calculate_grady(iv, re, jo_grad_y)   
       if ( iter > 0 .and. test_gradient ) jcdf_flag = .true.
+#ifdef VAR4D
       call da_transform_vtoy_adj(cv_size, be, grid%ep, grad_jo, iv, &
-              grid%vp, grid%vv, grid%vp6, grid%vv6, xbx, jo_grad_y, grid, config_flags, jcdf_flag)
+               grid%vp, grid%vv, xbx, jo_grad_y, grid, config_flags, jcdf_flag, grid%vp6, grid%vv6)
+#else
+      call da_transform_vtoy_adj(cv_size, be, grid%ep, grad_jo, iv, &
+               grid%vp, grid%vv, xbx, jo_grad_y, grid, config_flags, jcdf_flag)
+#endif
    else
+#ifdef VAR4D
       call da_transform_vtoy(cv_size, be, grid%ep, cv, iv, grid%vp, &
-              grid%vv, grid%vp6, grid%vv6, xbx, y, grid, config_flags)
+              grid%vv, xbx, y, grid, config_flags, grid%vp6, grid%vv6)
+#else
+      call da_transform_vtoy(cv_size, be, grid%ep, cv, iv, grid%vp, &
+              grid%vv, xbx, y, grid, config_flags)
+#endif
       call da_calculate_grady(iv, y, jo_grad_y)   
+#ifdef VAR4D
       call da_transform_vtoy_adj(cv_size, be, grid%ep, grad_jo, iv, &
-              grid%vp, grid%vv, grid%vp6, grid%vv6, xbx, jo_grad_y, grid, config_flags, .true.)
+              grid%vp, grid%vv, xbx, jo_grad_y, grid, config_flags, .true., grid%vp6, grid%vv6)
+#else
+      call da_transform_vtoy_adj(cv_size, be, grid%ep, grad_jo, iv, &
+              grid%vp, grid%vv, xbx, jo_grad_y, grid, config_flags, .true.)
+#endif
       grad_jo = - grad_jo    !! Compensate for sign in calculation of grad_v (Jo)
    end if
       

--- a/var/da/da_minimisation/da_calculate_j.inc
+++ b/var/da/da_minimisation/da_calculate_j.inc
@@ -68,10 +68,17 @@ subroutine da_calculate_j(it, iter, cv_size, cv_size_jb, cv_size_je, cv_size_jp,
 
    ! [1.1] transform from control variable to model grid space:
 
-   if (iter > 0) &
+   if (iter > 0) then
+#ifdef VAR4D
       call da_transform_vtoy(cv_size, be, grid%ep, xhat, iv, grid%vp, grid%vv,&
-                              grid%vp6, grid%vv6, xbx, y, &
-                              grid, config_flags                      )
+                              xbx, y,                                         &
+                              grid, config_flags, grid%vp6, grid%vv6)
+#else
+      call da_transform_vtoy(cv_size, be, grid%ep, xhat, iv, grid%vp, grid%vv,&
+                              xbx, y,                                         &
+                              grid, config_flags)
+#endif
+   end if
 
    ! [1.2] compute residual (o-a) = (o-b) - h x~
 

--- a/var/da/da_minimisation/da_sensitivity.inc
+++ b/var/da/da_minimisation/da_sensitivity.inc
@@ -58,8 +58,13 @@ subroutine da_sensitivity(grid, config_flags, it, cv_size, xbx, be, iv, xhat, qh
       call da_allocate_y  (iv, ktr)
 
     ! Apply observation operator H 
+#ifdef VAR4D
       call da_transform_vtoy(cv_size, be, grid%ep, amat, iv, grid%vp, grid%vv, &
-           grid%vp6, grid%vv6, xbx, ktr, grid, config_flags)
+           xbx, ktr, grid, config_flags, grid%vp6, grid%vv6)
+#else
+      call da_transform_vtoy(cv_size, be, grid%ep, amat, iv, grid%vp, grid%vv, &
+           xbx, ktr, grid, config_flags)
+#endif
 
     ! Apply R-1 (for Observation Sensitivity) and then Dot Product with initial innovations (for Observation Impact)
       call da_obs_sensitivity(ktr, iv)

--- a/var/da/da_minimisation/da_transform_vtoy.inc
+++ b/var/da/da_minimisation/da_transform_vtoy.inc
@@ -1,5 +1,5 @@
-subroutine da_transform_vtoy(cv_size, be, ep, cv, iv, vp, vv, vp6, vv6, xbx, &
-                              y, grid, config_flags)
+subroutine da_transform_vtoy(cv_size, be, ep, cv, iv, vp, vv, xbx, &
+                              y, grid, config_flags, vp6, vv6)
 
    !----------------------------------------------------------------------
    ! Purpose:  Does transform of control variable (V) to Obs-space (Y)
@@ -13,13 +13,15 @@ subroutine da_transform_vtoy(cv_size, be, ep, cv, iv, vp, vv, vp6, vv6, xbx, &
    real,                       intent(in)    :: cv(1:cv_size)     ! control variables.
    type(iv_type),              intent(inout) :: iv     ! innovation vector (o-b).
    type(vp_type),              intent(inout) :: vp     ! Grdipt/level CV.
-   type(vp_type),              intent(inout) :: vp6     ! Grdipt/level CV for 6h.
    type(vp_type),              intent(inout) :: vv     ! Grdipt/EOF CV.
-   type(vp_type),              intent(inout) :: vv6     ! Grdipt/EOF CV for 6h.
    type(xbx_type),             intent(inout) :: xbx    ! For header & non-grid arrays.
    type(y_type),               intent(inout) :: y      ! y = H(x_inc).
    type(domain),               intent(inout) :: grid
    type(grid_config_rec_type), intent(inout) :: config_flags
+
+   ! vp6 and vv6 are defined only when the code is configured and compiled for 4dvar
+   type(vp_type), optional,    intent(inout) :: vp6     ! Grdipt/level CV for 6h.
+   type(vp_type), optional,    intent(inout) :: vv6     ! Grdipt/EOF CV for 6h.
 
    type(x_type) :: shuffle
    integer :: nobwin, jl_start, jl_end, time_step_seconds

--- a/var/da/da_minimisation/da_transform_vtoy_adj.inc
+++ b/var/da/da_minimisation/da_transform_vtoy_adj.inc
@@ -1,5 +1,5 @@
-subroutine da_transform_vtoy_adj(cv_size, be, ep, cv, iv, vp, vv, vp6, vv6, xbx, y, &
-   grid, config_flags, jcdf_flag)
+subroutine da_transform_vtoy_adj(cv_size, be, ep, cv, iv, vp, vv, xbx, y, &
+   grid, config_flags, jcdf_flag, vp6, vv6)
 
    !-------------------------------------------------------------------------
    ! Purpose:  Does Adjoint of control variable (V) transform to Obs-space(Y)
@@ -13,14 +13,16 @@ subroutine da_transform_vtoy_adj(cv_size, be, ep, cv, iv, vp, vv, vp6, vv6, xbx,
    real,                       intent(out)   :: cv(1:cv_size) ! control variables.
    type(iv_type),              intent(inout) :: iv     ! innovation vector (o-b).
    type(vp_type),              intent(inout) :: vp     ! Grdipt/level CV.
-   type(vp_type),              intent(inout) :: vp6    ! Grdipt/level CV for 6h.
    type(vp_type),              intent(inout) :: vv     ! Grdipt/EOF CV.
-   type(vp_type),              intent(inout) :: vv6    ! Grdipt/EOF CV for 6h.
    type(xbx_type),             intent(inout) :: xbx    ! For header & non-grid arrays.
    type(y_type),               intent(inout) :: y      ! y = H(x_inc).
    type(domain),               intent(inout) :: grid
    type(grid_config_rec_type), intent(inout) :: config_flags
    logical,                    intent(in)    :: jcdf_flag       ! additional flag to switch off JcDF, used to switch off JcDF in calculation of J.
+
+   ! vp6 and vv6 are defined only when the code is configured and compiled for 4dvar
+   type(vp_type), optional,    intent(inout) :: vp6    ! Grdipt/level CV for 6h.
+   type(vp_type), optional,    intent(inout) :: vv6    ! Grdipt/EOF CV for 6h.
 
    type(x_type)  :: shuffle
    real          :: cv_local(1:cv_size) ! control variables

--- a/var/da/da_test/da_check_vtoy_adjoint.inc
+++ b/var/da/da_test/da_check_vtoy_adjoint.inc
@@ -41,7 +41,7 @@ subroutine da_check_vtoy_adjoint(cv_size,grid, config_flags, vp, vv, xbx, be, ep
    call da_zero_vp_type(vp)
    call da_zero_vp_type(vv)
 
-   call da_transform_vtoy(cv_size, be, ep, cv, iv, vp, vv, vp, vv, xbx, y, grid, config_flags)
+   call da_transform_vtoy(cv_size, be, ep, cv, iv, vp, vv, xbx, y, grid, config_flags, vp, vv)
 
    !-------------------------------------------------------------------------
    ! [3.0] Calculate LHS of adjoint test equation and
@@ -57,8 +57,8 @@ subroutine da_check_vtoy_adjoint(cv_size,grid, config_flags, vp, vv, xbx, be, ep
    ! call da_zero_vp_type(vv)
    ! call da_zero_x(grid%xa)      
 
-   call da_transform_vtoy_adj(cv_size, be, ep, cv, iv, vp, vv, vp, vv, xbx, y, grid, &
-      config_flags, .true.)
+   call da_transform_vtoy_adj(cv_size, be, ep, cv, iv, vp, vv, xbx, y, grid, &
+      config_flags, .true., vp, vv)
 
    adj_rhs = sum(cv(1:cv_size) * cv_2(1:cv_size))
 

--- a/var/da/da_test/da_check_xtoy_adjoint.inc
+++ b/var/da/da_test/da_check_xtoy_adjoint.inc
@@ -531,7 +531,9 @@ print*,__FILE__,jte,' grid%xa%v.grid%x%%v for row= ',jte+1,sum(grid%xa%v(its:ite
       + sum (grid%xa%p(ims:ime, jms:jme, kms:kme) * xa2_p(ims:ime, jms:jme, kms:kme))          &
       + sum (grid%xa%q(ims:ime, jms:jme, kms:kme) * xa2_q(ims:ime, jms:jme, kms:kme))          &
       + sum (grid%xa%rh(ims:ime, jms:jme, kms:kme)* xa2_rh(ims:ime, jms:jme, kms:kme))         &
-      + sum (grid%xa%psfc(ims:ime, jms:jme) * xa2_psfc(ims:ime, jms:jme))                      &
+      + sum (grid%xa%psfc(ims:ime, jms:jme) * xa2_psfc(ims:ime, jms:jme))
+#ifdef VAR4D
+   pertile_rhs = pertile_rhs &
       + sum (grid%x6a%u(ims:ime, jms:jme, kms:kme) * x6a2_u(ims:ime, jms:jme, kms:kme))        &
       + sum (grid%x6a%v(ims:ime, jms:jme, kms:kme) * x6a2_v(ims:ime, jms:jme, kms:kme))        &
       + sum (grid%x6a%w(ims:ime, jms:jme, kms:kme) * x6a2_w(ims:ime, jms:jme, kms:kme))        &
@@ -540,17 +542,21 @@ print*,__FILE__,jte,' grid%xa%v.grid%x%%v for row= ',jte+1,sum(grid%xa%v(its:ite
       + sum (grid%x6a%q(ims:ime, jms:jme, kms:kme) * x6a2_q(ims:ime, jms:jme, kms:kme))        &
       + sum (grid%x6a%rh(ims:ime, jms:jme, kms:kme)* x6a2_rh(ims:ime, jms:jme, kms:kme))       &
       + sum (grid%x6a%psfc(ims:ime, jms:jme) * x6a2_psfc(ims:ime, jms:jme))
+#endif
    pertile_rhs = pertile_rhs &
       + sum (grid%xa%qcw(ims:ime, jms:jme, kms:kme) * xa2_qcw(ims:ime, jms:jme, kms:kme))      &
       + sum (grid%xa%qci(ims:ime, jms:jme, kms:kme) * xa2_qci(ims:ime, jms:jme, kms:kme))      &
       + sum (grid%xa%qrn(ims:ime, jms:jme, kms:kme) * xa2_qrn(ims:ime, jms:jme, kms:kme))      &
       + sum (grid%xa%qsn(ims:ime, jms:jme, kms:kme) * xa2_qsn(ims:ime, jms:jme, kms:kme))      &
-      + sum (grid%xa%qgr(ims:ime, jms:jme, kms:kme) * xa2_qgr(ims:ime, jms:jme, kms:kme))      &
+      + sum (grid%xa%qgr(ims:ime, jms:jme, kms:kme) * xa2_qgr(ims:ime, jms:jme, kms:kme))
+#ifdef VAR4D
+   pertile_rhs = pertile_rhs &
       + sum (grid%x6a%qcw(ims:ime, jms:jme, kms:kme) * x6a2_qcw(ims:ime, jms:jme, kms:kme))    &
       + sum (grid%x6a%qci(ims:ime, jms:jme, kms:kme) * x6a2_qci(ims:ime, jms:jme, kms:kme))    &
       + sum (grid%x6a%qrn(ims:ime, jms:jme, kms:kme) * x6a2_qrn(ims:ime, jms:jme, kms:kme))    &
       + sum (grid%x6a%qsn(ims:ime, jms:jme, kms:kme) * x6a2_qsn(ims:ime, jms:jme, kms:kme))    &
       + sum (grid%x6a%qgr(ims:ime, jms:jme, kms:kme) * x6a2_qgr(ims:ime, jms:jme, kms:kme))
+#endif
 
 
    !----------------------------------------------------------------------
@@ -564,7 +570,9 @@ print*,__FILE__,jte,' grid%xa%v.grid%x%%v for row= ',jte+1,sum(grid%xa%v(its:ite
       + sum (grid%xa%p(its:ite, jts:jte, kts:kte) * xa2_p(its:ite, jts:jte, kts:kte))          &
       + sum (grid%xa%q(its:ite, jts:jte, kts:kte) * xa2_q(its:ite, jts:jte, kts:kte))          &
       + sum (grid%xa%rh(its:ite, jts:jte, kts:kte)* xa2_rh(its:ite, jts:jte, kts:kte))         &
-      + sum (grid%xa%psfc(its:ite, jts:jte) * xa2_psfc(its:ite, jts:jte))                      &
+      + sum (grid%xa%psfc(its:ite, jts:jte) * xa2_psfc(its:ite, jts:jte))
+#ifdef VAR4D
+   partial_rhs = partial_rhs &
       + sum (grid%x6a%u(its:ite, jts:jte, kts:kte) * x6a2_u(its:ite, jts:jte, kts:kte))        &
       + sum (grid%x6a%v(its:ite, jts:jte, kts:kte) * x6a2_v(its:ite, jts:jte, kts:kte))        &
       + sum (grid%x6a%w(its:ite, jts:jte, kts:kte+1) * x6a2_w(its:ite, jts:jte, kts:kte+1))    &
@@ -573,18 +581,22 @@ print*,__FILE__,jte,' grid%xa%v.grid%x%%v for row= ',jte+1,sum(grid%xa%v(its:ite
       + sum (grid%x6a%q(its:ite, jts:jte, kts:kte) * x6a2_q(its:ite, jts:jte, kts:kte))        &
       + sum (grid%x6a%rh(its:ite, jts:jte, kts:kte)* x6a2_rh(its:ite, jts:jte, kts:kte))       &
       + sum (grid%x6a%psfc(its:ite, jts:jte) * x6a2_psfc(its:ite, jts:jte)) 
+#endif
 
    partial_rhs = partial_rhs &
       + sum (grid%xa%qcw(its:ite, jts:jte, kts:kte) * xa2_qcw(its:ite, jts:jte, kts:kte))   &
       + sum (grid%xa%qci(its:ite, jts:jte, kts:kte) * xa2_qci(its:ite, jts:jte, kts:kte))   & 
       + sum (grid%xa%qrn(its:ite, jts:jte, kts:kte) * xa2_qrn(its:ite, jts:jte, kts:kte))   & 
       + sum (grid%xa%qsn(its:ite, jts:jte, kts:kte) * xa2_qsn(its:ite, jts:jte, kts:kte))   & 
-      + sum (grid%xa%qgr(its:ite, jts:jte, kts:kte) * xa2_qgr(its:ite, jts:jte, kts:kte))   & 
+      + sum (grid%xa%qgr(its:ite, jts:jte, kts:kte) * xa2_qgr(its:ite, jts:jte, kts:kte))
+#ifdef VAR4D
+   partial_rhs = partial_rhs &
       + sum (grid%x6a%qcw(its:ite, jts:jte, kts:kte) * x6a2_qcw(its:ite, jts:jte, kts:kte)) &
       + sum (grid%x6a%qci(its:ite, jts:jte, kts:kte) * x6a2_qci(its:ite, jts:jte, kts:kte)) &
       + sum (grid%x6a%qrn(its:ite, jts:jte, kts:kte) * x6a2_qrn(its:ite, jts:jte, kts:kte)) &
       + sum (grid%x6a%qsn(its:ite, jts:jte, kts:kte) * x6a2_qsn(its:ite, jts:jte, kts:kte)) &
       + sum (grid%x6a%qgr(its:ite, jts:jte, kts:kte) * x6a2_qgr(its:ite, jts:jte, kts:kte))
+#endif
 
 #ifdef A2C
     if( ite == ide ) then

--- a/var/da/da_transfer_model/da_transfer_model.f90
+++ b/var/da/da_transfer_model/da_transfer_model.f90
@@ -10,9 +10,11 @@ module da_transfer_model
    use module_io_domain, only : open_r_dataset, close_dataset, input_auxinput17, &
       output_auxinput7, open_w_dataset
    use module_state_description, only : dyn_em_ad, dyn_em, dyn_em_tl, &
-      p_qv, p_qh, p_qr, p_qi, p_qs, p_qg, p_qc, param_first_scalar, num_moist, &
-      p_g_qv, p_g_qh, p_g_qr, p_g_qi, p_g_qs, p_g_qg, p_g_qc, &
-      p_a_qv, p_a_qh, p_a_qr, p_a_qi, p_a_qs, p_a_qg, p_a_qc
+      p_qv, p_qr, p_qi, p_qs, p_qg, p_qc, param_first_scalar, num_moist, &
+      p_g_qv, p_g_qr, p_g_qi, p_g_qs, p_g_qg, p_g_qc, &
+      p_a_qv, p_a_qr, p_a_qi, p_a_qs, p_a_qg, p_a_qc, num_g_moist, num_a_moist, &
+      f_qc, f_qr, f_qi, f_qs, f_qg, f_g_qc, f_g_qr, f_g_qi, f_g_qs, f_g_qg, &
+      f_a_qc, f_a_qr, f_a_qi, f_a_qs, f_a_qg
    use module_dm, only : wrf_dm_sum_real, wrf_dm_sum_reals
 #ifdef DM_PARALLEL
    use module_dm, only : local_communicator, &

--- a/var/da/da_transfer_model/da_transfer_wrftltoxa.inc
+++ b/var/da/da_transfer_model/da_transfer_wrftltoxa.inc
@@ -61,7 +61,7 @@ subroutine da_transfer_wrftltoxa(grid, config_flags, filnam, timestr)
       grid%g_rainc = model_grid%g_rainc
       grid%g_raincv = model_grid%g_raincv
 
-      do i = PARAM_FIRST_SCALAR, num_moist
+      do i = PARAM_FIRST_SCALAR, num_g_moist
          call kj_swap_reverse (model_grid%g_moist(:,:,:,i), grid%g_moist(:,:,:,i), &
                        grid%xp%ims, grid%xp%ime, grid%xp%jms, grid%xp%jme, grid%xp%kms, grid%xp%kme)
       enddo
@@ -168,53 +168,23 @@ subroutine da_transfer_wrftltoxa(grid, config_flags, filnam, timestr)
       end do
    end do
 
-   if(var4d)then
-    if (size(grid%g_moist,dim=4) >= 4) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%xa%qcw(i,j,k)=grid%g_moist(i,j,k,p_g_qc)
-               grid%xa%qrn(i,j,k)=grid%g_moist(i,j,k,p_g_qr)
-            end do
-         end do
-      end do
-    end if
-   endif
-
-#ifdef VAR4D_MICROPHYSICS
-   ! New code needed once we introduce the microphysics to 4dvar in 2008
-   if (size(grid%moist,dim=4) >= 4) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%xa%qcw(i,j,k)=grid%g_moist(i,j,k,p_qcw)
-               grid%xa%qrn(i,j,k)=grid%g_moist(i,j,k,p_qrn)
-            end do
-         end do
-      end do
+   if ( var4d ) then
+      if ( f_g_qc ) then
+         grid%xa%qcw(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qc)
+      end if
+      if ( f_g_qr ) then
+         grid%xa%qrn(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qr)
+      end if
+      if ( f_g_qi ) then
+         grid%xa%qci(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qi)
+      end if
+      if ( f_g_qs ) then
+         grid%xa%qsn(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qs)
+      end if
+      if ( f_g_qg ) then
+         grid%xa%qgr(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qg)
+      end if
    end if
-
-   if (size(grid%moist,dim=4) >= 6) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%xa%qci(i,j,k)=grid%g_moist(i,j,k,p_qci)
-               grid%xa%qsn(i,j,k)=grid%g_moist(i,j,k,p_qsn)
-            end do
-         end do
-      end do
-   end if
-
-   if (size(grid%moist_2,dim=4) >= 7) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%xa%qgr(i,j,k)=grid%g_moist(i,j,k,p_qgr) 
-            end do
-         end do
-      end do
-   end if
-#endif
 
 #ifdef DM_PARALLEL
 #include "HALO_XA.inc"

--- a/var/da/da_transfer_model/da_transfer_wrftltoxa_adj.inc
+++ b/var/da/da_transfer_model/da_transfer_wrftltoxa_adj.inc
@@ -63,54 +63,23 @@ subroutine da_transfer_wrftltoxa_adj(grid, config_flags, filnam, timestr)
    end do
    grid%xa%w(is:ie,js:je,ks:ke+1) = 0.0
 
-   if(var4d)then
-    if (size(grid%g_moist,dim=4) >= 4) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%g_moist(i,j,k,p_g_qc)=grid%xa%qcw(i,j,k)
-               grid%g_moist(i,j,k,p_g_qr)=grid%xa%qrn(i,j,k)
-            end do
-         end do
-      end do
-    end if
+   if ( var4d ) then
+      if ( f_g_qc ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qc)=grid%xa%qcw(is:ie,js:je,ks:ke)
+      end if
+      if ( f_g_qr ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qr)=grid%xa%qrn(is:ie,js:je,ks:ke)
+      end if
+      if ( f_g_qi ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qi)=grid%xa%qci(is:ie,js:je,ks:ke)
+      end if
+      if ( f_g_qs ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qs)=grid%xa%qsn(is:ie,js:je,ks:ke)
+      end if
+      if ( f_g_qg ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qg)=grid%xa%qgr(is:ie,js:je,ks:ke)
+      end if
    end if
-
-#ifdef VAR4D_MICROPHYSICS
-   ! New code needed once we introduce the microphysics to 4dvar in 2008
-   if (size(grid%moist,dim=4) >= 4) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%g_moist(i,j,k,p_qcw) =  grid%xa%qcw(i,j,k)
-               grid%g_moist(i,j,k,p_qrn) =  grid%xa%qrn(i,j,k)
-            end do
-         end do
-      end do
-   end if
-
-   if (size(grid%moist,dim=4) >= 6) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%g_moist(i,j,k,p_qci) =  grid%xa%qci(i,j,k)
-               grid%g_moist(i,j,k,p_qsn) =  grid%xa%qsn(i,j,k)
-            end do
-         end do
-      end do
-   end if
-
-   if (size(grid%moist,dim=4) >= 7) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%g_moist(i,j,k,p_qgr) =  grid%xa%qgr(i,j,k)
-            end do
-         end do
-      end do
-   end if
-
-#endif
 
    !----------------------------------------------------------------------------
    ! [5.0] convert from c-grid to a-grid
@@ -272,7 +241,7 @@ subroutine da_transfer_wrftltoxa_adj(grid, config_flags, filnam, timestr)
          model_grid%g_rainc = grid%g_rainc
          model_grid%g_raincv = grid%g_raincv
 
-         do i = PARAM_FIRST_SCALAR, num_moist
+         do i = PARAM_FIRST_SCALAR, num_g_moist
             call kj_swap (grid%g_moist(:,:,:,i), model_grid%g_moist(:,:,:,i), &
                           grid%xp%ims, grid%xp%ime, grid%xp%jms, grid%xp%jme, grid%xp%kms, grid%xp%kme)
          enddo

--- a/var/da/da_transfer_model/da_transfer_xatowrftl.inc
+++ b/var/da/da_transfer_model/da_transfer_xatowrftl.inc
@@ -50,17 +50,6 @@ subroutine da_transfer_xatowrftl(grid, config_flags, filnam, timestr)
       end do
    end do
 
-   if (size(grid%g_moist,dim=4) >= 4) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               grid%g_moist(i,j,k,P_G_QC) =  grid%xa%qcw(i,j,k)
-               grid%g_moist(i,j,k,P_G_QR) =  grid%xa%qrn(i,j,k)
-            end do
-         end do
-      end do
-   end if
-
    !---------------------------------------------------------------------------
    ! [2.0] COMPUTE increments of dry-column air mass per unit area
    !---------------------------------------------------------------------------
@@ -269,45 +258,21 @@ subroutine da_transfer_xatowrftl(grid, config_flags, filnam, timestr)
       end do
    end do
 
-   !---------------------------------------------------------------------------
-   ! [5.0] save inCREMENT 
-   !---------------------------------------------------------------------------
-
-#ifdef VAR4D_MICROPHYSICS
-   ! New code needed once we introduce the microphysics to 4dvar in 2008
-   if (size(moist,dim=4) >= 4) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               g_moist(i,j,k,p_qcw) =  grid%xa%qcw(i,j,k)
-               g_moist(i,j,k,p_qrn) =  grid%xa%qrn(i,j,k)
-            end do
-         end do
-      end do
+   if ( f_g_qc ) then
+      grid%g_moist(is:ie,js:je,ks:ke,p_g_qc) = grid%xa%qcw(is:ie,js:je,ks:ke)
    end if
-
-   if (size(moist,dim=4) >= 6) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               g_moist(i,j,k,p_qci) =  grid%xa%qci(i,j,k)
-               g_moist(i,j,k,p_qsn) =  grid%xa%qsn(i,j,k)
-            end do
-           end do
-      end do
+   if ( f_g_qr ) then
+      grid%g_moist(is:ie,js:je,ks:ke,p_g_qr) = grid%xa%qrn(is:ie,js:je,ks:ke)
    end if
-
-   if (size(moist,dim=4) >= 7) then
-      do k=ks,ke
-         do j=js,je
-            do i=is,ie
-               g_moist(i,j,k,p_qgr) =  grid%xa%qgr(i,j,k)
-            end do
-         end do
-      end do
+   if ( f_g_qi ) then
+      grid%g_moist(is:ie,js:je,ks:ke,p_g_qi) = grid%xa%qci(is:ie,js:je,ks:ke)
    end if
-
-#endif
+   if ( f_g_qs ) then
+      grid%g_moist(is:ie,js:je,ks:ke,p_g_qs) = grid%xa%qsn(is:ie,js:je,ks:ke)
+   end if
+   if ( f_g_qg ) then
+      grid%g_moist(is:ie,js:je,ks:ke,p_g_qg) = grid%xa%qgr(is:ie,js:je,ks:ke)
+   end if
 
    call da_transfer_wrftl_lbc_t0 ( grid )
 
@@ -333,7 +298,7 @@ subroutine da_transfer_xatowrftl(grid, config_flags, filnam, timestr)
    model_grid%g_rainc  = 0.0
    model_grid%g_raincv = 0.0
 
-   do i = PARAM_FIRST_SCALAR, num_moist
+   do i = PARAM_FIRST_SCALAR, num_g_moist
       call kj_swap (grid%g_moist(:,:,:,i), model_grid%g_moist(:,:,:,i), &
                     grid%xp%ims, grid%xp%ime, grid%xp%jms, grid%xp%jme, grid%xp%kms, grid%xp%kme)
    enddo

--- a/var/da/da_transfer_model/da_transfer_xatowrftl_adj.inc
+++ b/var/da/da_transfer_model/da_transfer_xatowrftl_adj.inc
@@ -58,7 +58,7 @@ subroutine da_transfer_xatowrftl_adj(grid, config_flags, filnam)
    grid%a_rainc  = model_grid%a_rainc
    grid%a_raincv = model_grid%a_raincv
 
-   do i = PARAM_FIRST_SCALAR, num_moist
+   do i = PARAM_FIRST_SCALAR, num_a_moist
       call kj_swap_reverse (model_grid%a_moist(:,:,:,i), grid%a_moist(:,:,:,i), &
                     grid%xp%ims, grid%xp%ime, grid%xp%jms, grid%xp%jme, grid%xp%kms, grid%xp%kme)
    enddo
@@ -110,41 +110,6 @@ subroutine da_transfer_xatowrftl_adj(grid, config_flags, filnam)
 
    grid%a_w_2 = 0.0
 
-#ifdef VAR4D_MICROPHYSICS
-   ! New code needed once we introduce the microphysics to 4dvar in 2008
-   if (size(grid%moist,dim=4) >= 4) then
-      do k=kts,kte
-         do j=jts,jte
-            do i=its,ite
-               grid%xa%qcw(i,j,k)=grid%a_moist(i,j,k,p_qcw)
-               grid%xa%qrn(i,j,k)=grid%a_moist(i,j,k,p_qrn)
-            end do
-         end do
-      end do
-   end if
-
-   if (size(grid%moist,dim=4) >= 6) then
-      do k=kts,kte
-         do j=jts,jte
-            do i=its,ite
-               grid%xa%qci(i,j,k)=grid%a_moist(i,j,k,p_qci)
-               grid%xa%qsn(i,j,k)=grid%a_moist(i,j,k,p_qsn)
-            end do
-         end do
-      end do
-   end if
-
-   if (size(grid%moist,dim=4) >= 7) then
-      do k=kts,kte
-         do j=jts,jte
-            do i=its,ite
-               grid%xa%qgr(i,j,k)=grid%a_moist(i,j,k,p_qgr) 
-            end do
-         end do
-      end do
-   end if
-
-#endif
 #ifndef A2C
    !---------------------------------------------------------------------------
    ! [5.0] Adjoint of CONVERT FROM A-GRID TO C-GRID
@@ -331,15 +296,20 @@ subroutine da_transfer_xatowrftl_adj(grid, config_flags, filnam)
       end do
    end do
 
-   if (size(grid%a_moist,dim=4) >= 4) then
-      do k=kts,kte
-         do j=jts,jte
-            do i=its,ite
-             grid%xa%qcw(i,j,k)=grid%xa%qcw(i,j,k) + grid%a_moist(i,j,k,P_A_QC)
-             grid%xa%qrn(i,j,k)=grid%xa%qrn(i,j,k) + grid%a_moist(i,j,k,P_A_QR)
-            end do
-         end do
-      end do
+   if ( f_a_qc ) then
+      grid%xa%qcw(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qc)
+   end if
+   if ( f_a_qr ) then
+      grid%xa%qrn(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qr)
+   end if
+   if ( f_a_qi ) then
+      grid%xa%qci(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qi)
+   end if
+   if ( f_a_qs ) then
+      grid%xa%qsn(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qs)
+   end if
+   if ( f_a_qg ) then
+      grid%xa%qgr(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qg)
    end if
 
    grid%a_moist = 0.0


### PR DESCRIPTION
TYPE: bug fix/enhancement

KEYWORDS: WRFDA, registry.var, package

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

Main changes are in registry.var.
All others are for complementing registry changes.

1. Simply the packaging for moist variables.
   When mp_physics is on, allocate all 5 (qc, qr, qi, qs, qg, excluding qh)
   moist variables that DA uses.
   This fixes some incorrect cloud DA analyses when certain mp_physics is used.
2. Pacakge vp6, vv6, x6a and a_/g_ variables for 4DVAR use only.
   This reduces the non-4DVAR memory usage by ~35%.

LIST OF MODIFIED FILES:
M       Registry/registry.var
M       var/da/da_main/da_solve.inc
M       var/da/da_main/da_wrfvar_init2.inc
M       var/da/da_minimisation/da_calculate_gradj.inc
M       var/da/da_minimisation/da_calculate_j.inc
M       var/da/da_minimisation/da_sensitivity.inc
M       var/da/da_minimisation/da_transform_vtoy.inc
M       var/da/da_minimisation/da_transform_vtoy_adj.inc
M       var/da/da_test/da_check_vtoy_adjoint.inc
M       var/da/da_test/da_check_xtoy_adjoint.inc
M       var/da/da_transfer_model/da_transfer_model.f90
M       var/da/da_transfer_model/da_transfer_wrftltoxa.inc
M       var/da/da_transfer_model/da_transfer_wrftltoxa_adj.inc
M       var/da/da_transfer_model/da_transfer_xatowrftl.inc
M       var/da/da_transfer_model/da_transfer_xatowrftl_adj.inc

TESTS CONDUCTED:
WRFDA regtests on cheyenne with intel/17.0.1 passed.
A few 3DVAR and 4DVAR tests on Mac with gnu/5.2.0 gave identical results after the changes.