### PR TITLE
Bug fix for map factor assignment in module_initialize_real.F

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -465,7 +465,7 @@ integer::oops1,oops2
                grid%msfvx_inv(i,jte) = 0.
             END DO
          END IF
-       ELSE IF ( ( config_flags%map_proj .EQ. PROJ_CASSINI ) .AND. ( flag_mf_xy .EQ. 1 ) ) THEN 
+      ELSE IF ( ( config_flags%map_proj .EQ. PROJ_CASSINI ) .AND. ( flag_mf_xy .EQ. 1 ) ) THEN 
          DO j=jts,jte
             DO i=its,min(ide-1,ite)
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: map factor assignment, module_initialize_real.F, polar, global, regional lat-lon

SOURCE: internal

DESCRIPTION OF CHANGES: Within the section of module_initialize_real.F where we assigned map factors (from what they were, to what they need to be), for backward compatibility, there were 2 identical checks that tested for a polar (a.k.a., global) projection.  One of those should have been testing for a regional lat-lon projection.  This is a result of a previous attempt to correct the projection types in certain areas of the code (see commit from March 6, 2017), and this was one location that did not need to be updated before.  Corrected this new problem.

LIST OF MODIFIED FILES: 
M     dyn_em/module_initialize_real.F

TESTS CONDUCTED: Created separate global and regional lat-lon projection cases.  Added print statements in the if-tests to determine what loops were being entered for the runs.  Determined the code was working correctly, as I only entered the global loop for the global run, and only entered the regional loop for the regional lat-lon run.  Passed combined WTF with other changes. 