### PR TITLE
Thompson MP: fix rate_max calculation, initialize snow moment variables

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -36,7 +36,7 @@
 !.. Remaining values should probably be left alone.
 !..
 !..Author: Greg Thompson, NCAR-RAL, gthompsn@ucar.edu, 303-497-2805
-!..Last modified: 01 Aug 2016   Aerosol additions to v3.5.1 code 9/2013
+!..Last modified: 04 Aug 2017   Aerosol additions to v3.5.1 code 9/2013
 !..                 Cloud fraction additions 11/2014 part of pre-v3.7
 !+---+-----------------------------------------------------------------+
 !wrft:model_layer:physics
@@ -2527,7 +2527,7 @@
 !.. supersat again.
          sump = pri_inu(k) + pri_ide(k) + prs_ide(k) &
               + prs_sde(k) + prg_gde(k) + pri_iha(k)
-         rate_max = (qv(k)-qvsi(k))*odts*0.999
+         rate_max = (qv(k)-qvsi(k))*rho(k)*odts*0.999
          if ( (sump.gt. eps .and. sump.gt. rate_max) .or. &
               (sump.lt. -eps .and. sump.lt. rate_max) ) then
           ratio = rate_max/sump
@@ -2877,6 +2877,12 @@
 !.. intercepts/slopes of graupel and rain.
 !+---+-----------------------------------------------------------------+
       if (.not. iiwarm) then
+      do k = kts, kte
+         smo2(k) = 0.
+         smob(k) = 0.
+         smoc(k) = 0.
+         smod(k) = 0.
+      enddo
       do k = kts, kte
          if (.not. L_qs(k)) CYCLE
          tc0 = MIN(-0.1, temp(k)-273.15)


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: rate_max, density, snow moments, initialization, zero

### SOURCE: Greg Thompson (NCAR)

### DESCRIPTION OF CHANGES:
My actual bug fixes are miniscule:
 1)  rate_max calculation was missing a factor of air density - possible mass conservation violation without this fix. This impacts all frozen categories.
 2)  variables beginning with smo are "snow moments" and could possibly be uninitialized since there is a premature DO-loop exit using the CYCLE command.  So the certainty of initializing those moments which was pointed out a few months ago by Tanya Smirnova caused me to be extra careful with these variables being set to zero.

### LIST OF MODIFIED FILES:
M       phys/module_mp_thompson.F

### TESTS CONDUCTED:
- [x] 1. scheme behavior tested by Greg
- [x] 2. piece-wise reggie completed
