### PR TITLE
Thompson MP parallelism for .dat computations

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -4054,8 +4054,10 @@
 
 !..Local variables
       INTEGER:: i, j, k, m, n, n2
-      DOUBLE PRECISION, DIMENSION(nbr):: N_r, massr
-      DOUBLE PRECISION, DIMENSION(nbc):: N_c, massc
+      INTEGER:: km, km_s, km_e
+      DOUBLE PRECISION:: N_r, N_c
+      DOUBLE PRECISION, DIMENSION(nbr):: massr
+      DOUBLE PRECISION, DIMENSION(nbc):: massc
       DOUBLE PRECISION:: sum1, sum2, sumn1, sumn2, &
                          prob, vol, Texp, orho_w, &
                          lam_exp, lamr, N0_r, lamc, N0_c, y
@@ -4134,12 +4136,26 @@
          massc(n) = am_r*Dc(n)**bm_r
         enddo
 
+! Need to split loops between MPI processes to speedup
+! (2017Jul26, Jason Do)
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+        CALL wrf_dm_decomp1d ( ntb_IN*45, km_s, km_e )
+#else
+        km_s = 0
+        km_e = ntb_IN*45 - 1
+#endif
+
 !..Freeze water (smallest drops become cloud ice, otherwise graupel).
-        do m = 1, ntb_IN
-        T_adjust = MAX(-3.0, MIN(3.0 - ALOG10(Nt_IN(m)), 3.0))
-        do k = 1, 45
+        do km = km_s, km_e
+         m = km / 45 + 1
+         k = mod( km , 45 ) + 1
+         T_adjust = MAX(-3.0, MIN(3.0 - ALOG10(Nt_IN(m)), 3.0))
 !         print*, ' Freezing water for temp = ', -k
          Texp = DEXP( DFLOAT(k) - T_adjust*1.0D0 ) - 1.0D0
+#ifdef THOMPSON_OMP
+!$OMP PARALLEL DO SCHEDULE(dynamic) &
+!$OMP PRIVATE(j,i,lam_exp,lamr,N0_r,sum1,sum2,sumn1,sumn2,n2,N_r,vol,prob)
+#endif
          do j = 1, ntb_r1
             do i = 1, ntb_r
                lam_exp = (N0r_exp(j)*am_r*crg(1)/r_r(i))**ore1
@@ -4150,15 +4166,15 @@
                sumn1 = 0.0d0
                sumn2 = 0.0d0
                do n2 = nbr, 1, -1
-                  N_r(n2) = N0_r*Dr(n2)**mu_r*DEXP(-lamr*Dr(n2))*dtr(n2)
+                  N_r = N0_r*Dr(n2)**mu_r*DEXP(-lamr*Dr(n2))*dtr(n2)
                   vol = massr(n2)*orho_w
                   prob = MAX(0.0D0, 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp))
                   if (massr(n2) .lt. xm0g) then
-                     sumn1 = sumn1 + prob*N_r(n2)
-                     sum1 = sum1 + prob*N_r(n2)*massr(n2)
+                     sumn1 = sumn1 + prob*N_r
+                     sum1 = sum1 + prob*N_r*massr(n2)
                   else
-                     sumn2 = sumn2 + prob*N_r(n2)
-                     sum2 = sum2 + prob*N_r(n2)*massr(n2)
+                     sumn2 = sumn2 + prob*N_r
+                     sum2 = sum2 + prob*N_r*massr(n2)
                   endif
                   if ((sum1+sum2).ge.r_r(i)) EXIT
                enddo
@@ -4168,7 +4184,12 @@
                tnr_qrfz(i,j,k,m) = sumn2
             enddo
          enddo
+#ifdef THOMPSON_OMP
+!$OMP END PARALLEL DO
 
+!$OMP PARALLEL DO SCHEDULE(dynamic) &
+!$OMP PRIVATE(j,i,nu_c,lamc,N0_c,sum1,sumn2,vol,prob,N_c)
+#endif
          do j = 1, nbc
             nu_c = MIN(15, NINT(1000.E6/t_Nc(j)) + 2)
             do i = 1, ntb_c
@@ -4179,17 +4200,28 @@
                do n = nbc, 1, -1
                   vol = massc(n)*orho_w
                   prob = MAX(0.0D0, 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp))
-                  N_c(n) = N0_c*Dc(n)**nu_c*EXP(-lamc*Dc(n))*dtc(n)
-                  sumn2 = MIN(t_Nc(j), sumn2 + prob*N_c(n))
-                  sum1 = sum1 + prob*N_c(n)*massc(n)
+                  N_c = N0_c*Dc(n)**nu_c*EXP(-lamc*Dc(n))*dtc(n)
+                  sumn2 = MIN(t_Nc(j), sumn2 + prob*N_c)
+                  sum1 = sum1 + prob*N_c*massc(n)
                   if (sum1 .ge. r_c(i)) EXIT
                enddo
                tpi_qcfz(i,j,k,m) = sum1
                tni_qcfz(i,j,k,m) = sumn2
             enddo
          enddo
+#ifdef THOMPSON_OMP
+!$OMP END PARALLEL DO
+#endif
         enddo
-        enddo
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+        CALL wrf_dm_gatherv(tpi_qrfz, ntb_r*ntb_r1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tni_qrfz, ntb_r*ntb_r1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tpg_qrfz, ntb_r*ntb_r1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_qrfz, ntb_r*ntb_r1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tpi_qcfz, ntb_c*nbc, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tni_qcfz, ntb_c*nbc, km_s, km_e, R8SIZE)
+#endif
 
         IF ( write_thompson_tables .AND. wrf_dm_on_monitor() ) THEN
           CALL wrf_message("Writing freezeH2O.dat in Thompson MP init")


### PR DESCRIPTION
### TYPE: enhancement

### KEYWORDS: Thompson, initialization, parallel

### SOURCE: Jason Do (Intel), Greg Thompson (NCAR)

### DESCRIPTION OF CHANGES:
OpenMP directives and MPI ifdefs around look-up table computations.

### LIST OF MODIFIED FILES: 
M       phys/module_mp_thompson.F

### TESTS CONDUCTED:

The following table shows the amount of time (s) to do the initialization of the three *.dat files manufactured by the Thompson MP scheme. The timers were around the thompson_init call. To get around the timing variation on cheyenne, I ran all of the timings on my Darwin desktop with GNU 5.2.0, and tried to remove as many other processes over which I had control. When more than one number is listed (comma separated), this indicates multiple trials. To save space "573, 4" means this was run twice, where the results are 573 and 574 seconds ("584, 79" means 584 and 579 seconds).

| PROCS | SERIAL | OMP CPP=off | OMP CPP=On | MPI | Orig OMP | Orig MPI |
| ------- | ------- | -------------- | -------------- | --- | -----------| --------- |
| 1           | 573, 4  | 584, 84, 79     | 581                 | 575, 5 |   580       |  575 |
| 2           | N/A        |584, 79            | 582                 |301, 0 |      580     | 329  |
| 3           | N/A        |587, 0              | blank               |202, 2 |    567        | 235  | 
| 4           | N/A        | 568                 | 584              |152, 4  |    580         | 190 |

The developer wants this modification included, and there seem to be no negative side effects (results are bit-for-bit the same from the *cmp* utility, no performance penalty for SM or DM, and noticeable performance gain for MPI), compared to the original code. 

- [x] 1. No appreciable speed-up on GNU 5.2 with OpenMP on Darwin. 
- [x] 2. DM speed-up already existed but has been improved. 
- [x] 3. The computed .dat files are all bit-for bit when comparing serial, OpenMP, MPI, and OpenMP+MPI (timings not shown, but tested for completeness). 
- [x] 4. The CPP flag -DTHOMPSON_OMP has no obvious effect on the timings.
- [x] 5. WTF 4.01 OK, with the caveat that it took LOTS of attempts, and PGI is not even considered.
