### PR TITLE
Set shdfac=0 for 25-27 categories only if it is USGS or ISURBAN=1 in Noah driver

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -833,9 +833,12 @@ CONTAINS
           ! Land-ice or land points use the usual deep-soil temperature.
           TBOT=TMN(I,J)
 
+          IF(ISURBAN.EQ.1) THEN
+! assumes these only need to be set for USGS land data
           IF(VEGTYP.EQ.25) SHDFAC=0.0000
           IF(VEGTYP.EQ.26) SHDFAC=0.0000
           IF(VEGTYP.EQ.27) SHDFAC=0.0000
+          ENDIF
           IF(SOILTYP.EQ.14.AND.XICE(I,J).EQ.0.)THEN
 #if 0
          IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'


### PR DESCRIPTION
TYPE: Bug fix
    
KEYWORDS: variable shdfac, 25-27 cat USGS
    
SOURCE: internal
    
DESCRIPTION OF CHANGES:
    
The variable SHDFAC is set to 0 for categories 25 - 27. But this is only true if the landuse type is USGS. For other land types, such as the 40 category NLCD, this is not correct. The fix checks if ISURBAN is 1, and if so, set these SHDFAC for these three categories to 0. This is ok so far, as most other land types has ISURBAN = 13.
    
LIST OF MODIFIED FILES:
    
modified:   phys/module_sf_noahdrv.F
    
TESTS CONDUCTED: Passed combined WTF with other changes. 