### PR TITLE
Fixing a compilation failure due to incorrect calling of random_seed in g3

### DIFF
--- a/phys/module_cu_g3.F
+++ b/phys/module_cu_g3.F
@@ -3122,7 +3122,8 @@ CONTAINS
        pcrit,acrit,acritt
 
      integer :: nall2,ixxx,irandom
-     integer,  dimension (12) :: seed
+     integer, allocatable :: seed(:)
+     integer              :: seed_size
 
 
       DATA PCRIT/850.,800.,750.,700.,650.,600.,550.,500.,450.,400.,    &
@@ -3133,6 +3134,9 @@ CONTAINS
       DATA ACRITT/.203,.515,.521,.566,.625,.665,.659,.688,             &
                   .743,.813,.886,.947,1.138,1.377,1.896/
 !
+       call random_seed(size=seed_size)      ! Get size of seed array.
+       allocate(seed(1:seed_size))           ! Allocate according to returned size
+
        seed=0
        seed(2)=j
        seed(3)=ktau


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compilation, gfortran, cumulus, g3

SOURCE: internal

DESCRIPTION OF CHANGES: There is an incorrect implementation of the intrinsic fortran function `random_seed` in the G3 scheme (cu_physics=5). The current code assumes that the random seed vector fed to the `random_seed` function is of size 12, but this is not standardized, nor required by the fortran standard. The newest version of gfortran  (7.1.0) uses 33 elements in its seed vector, so trying to feed it a 12-element vector causes a compilation failure. The correct procedure is to call `random_seed(size=X)`, which will give the correct seed vector size as X. X can then be used to allocate the correct size for the seed vector.

This fix should not impact any results. Per Georg Grell, this code is unused in the current scheme.

LIST OF MODIFIED FILES:
M       phys/module_cu_g3.F

TESTS CONDUCTED: WTF passed. WRF now compiles for gfortran 7.1.0 on Cheyenne. Fix applied for WRFPLUS (which initiated this investigation) also compiles successfully.
