### PR TITLE
NDOWN fix for physics suites

### DIFF
--- a/main/ndown_em.F
+++ b/main/ndown_em.F
@@ -205,6 +205,7 @@ real :: cf1_c,cf2_c,cf3_c,cfn_c,cfn1_c
 #endif
 
    CALL check_nml_consistency
+   CALL setup_physics_suite
    CALL set_physics_rconfigs
 
    !  If we are running ndown, and that is WHERE we are now, make sure that we account


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: ndown, suites, physics

### SOURCE: internal

### DESCRIPTION OF CHANGES:
With the introduction of the physics suites capability, a new subroutine was called during the WRF model initialization (aptly named setup_physics_suite). This routine interpreted the suite information contained in the phyics namelist, the "-1" values and the user's choice of suite, to construct the actual WRF model settings for the major physical parameterization scheme options.

The ndown program needs to also call this new subroutine.

When running ndown without this fix, the subsequent finer-grid WRF model stops immediately with this message:
```
----------------- ERROR -------------------
namelist    : sf_surface_physics =          2
input files : SF_SURFACE_PHYSICS =         -1 (from wrfinput files).
  ---- ERROR: Mismatch between namelist and global attribute SF_SURFACE_PHYSICS
NOTE:       1 namelist vs input data inconsistencies found.
-------------- FATAL CALLED ---------------
```

### LIST OF MODIFIED FILES:
M       main/ndown_em.F

### TESTS CONDUCTED:
- [x] Ran the WPS, REAL, WRF for d01, NDOWN, WRF for d02 set with the mods using a suite. Now the code works OK.
- [x] Passed combined WTF with other changes. 