### PR TITLE
P3 MP requires using RRTMG LW and SW radiation schemes

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1994,19 +1994,22 @@
       CALL wrf_message ( wrf_err_message )
 
 !-----------------------------------------------------------------------
-!  The Morrison 2-moment MP scheme is not to be used with any of the 
-!  RRTMG radiation schemes.
+!  The P3 MP schemes must be used with the RRTMG radiation schemes.
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
-         IF ( ( ( model_config_rec % ra_lw_physics(i) .EQ. RRTMG_LWSCHEME      )   .OR.  &
-                ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME      )   .OR.  &
-                ( model_config_rec % ra_lw_physics(i) .EQ. RRTMG_LWSCHEME_FAST )   .OR.  &
-                ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME_FAST ) ) .AND. &
-              (   model_config_rec % mp_physics   (i) .EQ. MORR_TWO_MOMENT       ) ) THEN
-            wrf_err_message = '--- ERROR: Morrison (mp_physics=10) not compatible with RRTMG schemes'
-            CALL wrf_error_fatal ( TRIM( wrf_err_message ) )
-            EXIT
+         IF ( ( model_config_rec % mp_physics(i) .EQ. P3_1CATEGORY    )   .OR.  &
+              ( model_config_rec % mp_physics(i) .EQ. P3_1CATEGORY_NC ) ) THEN
+
+            IF ( ( ( model_config_rec % ra_lw_physics(i) .EQ. RRTMG_LWSCHEME      )   .OR.   &
+                   ( model_config_rec % ra_lw_physics(i) .EQ. RRTMG_LWSCHEME_FAST ) ) .AND.  &
+                 ( ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME      )   .OR.   &
+                   ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME_FAST ) ) ) THEN
+               !  No op, everything is fine. This is just easier logic to understand
+            ELSE
+               wrf_err_message = '--- ERROR: P3 MP (mp_physics=50 or 51) requires using RRTMG LW and SW schemes.'
+               CALL wrf_error_fatal ( TRIM( wrf_err_message ) )
+            END IF
          END IF
       END DO
 


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: P3, RRTMG

### SOURCE: Hugh Morrison (NCAR)

### DESCRIPTION OF CHANGES:
The developer has requested the P3 MP scheme only be used in conjunction with the RRTMG radiation schemes (both SW and LW are required). The RRTMG scheme has code that handles the special particle properties provided by P3. 

A test is put into check_a_mundo to enforce this combination: if a user selects P3 (either mp_physics = 50 or 51), then the user must have one of the two RRTMG radiation options selected at run-time.

### LIST OF MODIFIED FILES:
M       share/module_check_a_mundo.F

### TESTS CONDUCTED:
- [x] Successfully continues when the correct combinations are selected. Successfully stops when requesting the non-permitted combinations. 
```
 &physics
 mp_physics    = 51
 ra_lw_physics = 1
 ra_sw_physics = 1
```
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1922
--- ERROR: P3 MP (mp_physics=50 or 51) requires using RRTMG LW and SW schemes.
-------------------------------------------
```
- [x] Passed combined WTF with other changes. 