### PR TITLE
Fix dependencies so module_diag_afwa.o is not always rebuilt

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -752,8 +752,6 @@ module_diag_pld.o: \
 module_diag_zld.o: \
 		../share/module_model_constants.o
 
-module_diag_afwa_hail.o :
-
 module_diag_afwa.o: \
 		../frame/module_domain.o 		\
 		../frame/module_dm.o 			\
@@ -761,7 +759,7 @@ module_diag_afwa.o: \
 		../frame/module_configure.o 		\
 		../frame/module_streams.o		\
 		../external/esmf_time_f90/module_utility.o \
-		../share/module_model_constants.o module_diag_afwa_hail.o
+		../share/module_model_constants.o
 
 module_diag_hailcast.o: \
 		../frame/module_configure.o 		\


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: AFWA, diagnostics, dependency, depend.common

### SOURCE: internal

### DESCRIPTION OF CHANGES:
The file phys/module_diag_afwa_hail.F was removed in the previous release. However, the file main/depend.common still listed module_diag_afwa_hail.o as a makefile dependency for module_diag_afwa.o. This caused the file module_diag_afwa.o to be re-compiled ALL THE TIME. There are two small changes:
1. The file module_diag_afwa_hail.o is removed as a dependency for module_diag_afwa.o.
2. The target module_diag_afwa_hail.o is removed.

### LIST OF MODIFIED FILES:
M       main/depend.common

### TESTS CONDUCTED:
- [x] When compiling the code (by adding in a comment into module_initialize_real.F), the original code re-compiled: module_diag_afwa.F, module_diagnostics_driver.F, module_after_all_rk_steps.F, solve_em.F. With the new code, these are not re-compiled.
- [x] Passed combined WTF with other changes. 