### PR TITLE
Inquire size of random seed before using in G3

### DIFF
--- a/phys/module_cu_g3.F
+++ b/phys/module_cu_g3.F
@@ -3122,7 +3122,8 @@ CONTAINS
        pcrit,acrit,acritt
 
      integer :: nall2,ixxx,irandom
-     integer,  dimension (12) :: seed
+     integer,  allocatable , dimension(:) :: seed
+     integer :: seed_size
 
 
       DATA PCRIT/850.,800.,750.,700.,650.,600.,550.,500.,450.,400.,    &
@@ -3133,6 +3134,9 @@ CONTAINS
       DATA ACRITT/.203,.515,.521,.566,.625,.665,.659,.688,             &
                   .743,.813,.886,.947,1.138,1.377,1.896/
 !
+       call random_seed(size = seed_size) 
+       allocate(seed(seed_size))
+
        seed=0
        seed(2)=j
        seed(3)=ktau


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: G3, random seed

### SOURCE: Reported by Michael Duda and Michael Kavulich.

### DESCRIPTION OF CHANGES:
Use the standard option for the random_seed routine to return the required size of the seed. Allocate the seed array to be that size. The newer GNU compilers now require this compliance.

### LIST OF MODIFIED FILES:
M       phys/module_cu_g3.F

### TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
- [x] The new code compiles under GNU/7.0.1, and the original code does not. Typical error message:
```
Error: Size of ‘put’ argument of ‘random_seed’ intrinsic at (1) too small (12/33)
```
- [ ] No reggie yet.