### PR TITLE
Fix TC indexing to stay within bounds

### DIFF
--- a/main/tc_em.F
+++ b/main/tc_em.F
@@ -2183,7 +2183,7 @@ END SUBROUTINE mass2_Vstag
   end do
 
 !Fill in U's along the left and right side.
- do j = 1,ns
+ do j = 1,ns-1
     utcp(1,:,j)  = utcp(2,:,j)
     utcp(ew,:,j) = utcp(ew-1,:,j)
  end do
@@ -2199,7 +2199,7 @@ END SUBROUTINE mass2_Vstag
   end do
 
 !Fill in V's along the bottom and bottom.   
-  do i = 1,ew
+  do i = 1,ew-1
      vtcp(i,:,1)  = vtcp(i,:,2)
      vtcp(i,:,ns) = vtcp(i,:,ns-1)
   end do


### PR DESCRIPTION
### TYPE: bug fix

### KEYWORDS: TC, stagger

### SOURCE: internal

### DESCRIPTION OF CHANGES:
For U and V variables in TC scheme (utcp, vtcp), loop only over the horizontal computational extent of the arrays.

### LIST OF MODIFIED FILES:
M       main/tc_em.F

### TESTS CONDUCTED:
- [x] Compile with configure -D passes