### PR TITLE
bugfix - fixed an incorrect map factor in diff_opt 2 in the subroutin…

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -3392,7 +3392,7 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags, var,           &
       tendency(i,k,j)=tendency(i,k,j) +   g/(dnw(k)*rdzw(i,k,j)) * &
            (mrdx*(H1(i+1,k,j)-H1(i  ,k,j)) +                       &
             mrdy*(H2(i,k,j+1)-H2(i,k,j  )) -                       &
-            msfty(i,j)*zx_at_m(i, k, j)*(H1avg(i,k+1,j)-H1avg(i,k,j))*rdzw(i,k,j) - &
+            msftx(i,j)*zx_at_m(i, k, j)*(H1avg(i,k+1,j)-H1avg(i,k,j))*rdzw(i,k,j) - &
             msfty(i,j)*zy_at_m(i, k, j)*(H2avg(i,k+1,j)-H2avg(i,k,j))*rdzw(i,k,j)   &
            )
    ENDDO


### PR DESCRIPTION
TYPE: bug fix
KEYWORDS: diff_opt 2, horizontal diffusion, map factors
SOURCE: Katherine Lundquist (LLNL)
DESCRIPTION OF CHANGES: A map factor for x was incorrectly coded as one for y
LIST OF MODIFIED FILES: M       dyn_em/module_diffusion_em.F
TESTS CONDUCTED: none
