### PR TITLE
Bug-fix for diffusion slope term (recently added)

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2904,7 +2904,7 @@ SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
       zx_at_v(i, kts, j) = 0.125 * (zx(i, kts, j) + zx(i + 1, kts, j) +     &
           zx(i, kts, j - 1) + zx(i + 1, kts, j - 1) + zx(i, kts + 1, j) + &
           zx(i + 1, kts + 1, j) + zx(i, kts + 1, j - 1) + zx(i + 1, kts + 1, j - 1))
-      zy_at_v(i, kts, j) = 0.5 * (zy(i, k, j) + zy(i, k + 1 , j))
+      zy_at_v(i, kts, j) = 0.5 * (zy(i, kts, j) + zy(i, kts + 1 , j))
    ENDDO
    ENDDO
 !


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: diff_opt=2, slope term

SOURCE: internal after notification by Joe Olson (ESRL)

DESCRIPTION OF CHANGES: Some undefined k indices were used outside k loops instead of kts. This happened in one line of the recently changed code to fix the slope terms in diff_opt=2. This affects the v-wind component computation in the y direction at the surface over sloped terrain.

LIST OF MODIFIED FILES: 
M       dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
No WTF yet. 
Test on real-data case with fix shows differences of comparable size to previous small effect of adding slope term correction. Note this has no effect in the hill2d_x case because only y gradients are affected.
