### PR TITLE
Fixing print issue for radar observations outside of domain when print_detail_radar = .true.

### DIFF
--- a/var/da/da_obs_io/da_read_obs_radar.inc
+++ b/var/da/da_obs_io/da_read_obs_radar.inc
@@ -220,7 +220,7 @@ subroutine da_read_obs_radar (iv, filename, grid)
          if( outside_all ) then
             if (print_detail_radar) then
                write(unit=stdout, fmt='(a)') '*** Report is outside of domain:'
-               write(unit=stdout, fmt='(2x,a,2(2x,f7.3),2x,a)') &
+               write(unit=stdout, fmt='(2x,a,2(2x,f8.3),2x,a)') &
                      platform%info%platform,    &
                      platform%info%lat,   &
                      platform%info%lon,   &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, radar, rsl.out, print_detail_radar

SOURCE: internal

DESCRIPTION OF CHANGES: For radar assimilation in WRFDA, if print_detail_radar = .true., and there are observations outside of the domain, WRFDA will print out the details of each observation to log files, including the latitude and longitude. While investigating some other problems, I noticed that for radar assimilation, some observations printed out like this:
`*** Report is outside of domain:`
`  FM-128 RADAR   34.302  *******      KAMA`
While others printed normally:
`*** Report is outside of domain:`
`  FM-128 RADAR   34.060  -99.842      KAMA`
The reason for this is that the write format statements for these messages for lat and lon used "f7.3", while the read statements used "f8.3". The latter is correct, since you need 4 characters before the decimal for longitudes of -100 or less: this was the case for the longitudes which were printing incorrectly.

The fix was simply to change the write format to use "f8.3", as it was elsewhere in the subroutine.

LIST OF MODIFIED FILES: 
M       var/da/da_obs_io/da_read_obs_radar.inc

TESTS CONDUCTED: WRFDA regression test passes before and after changes. Write statements now print correctly for the above conditions:
`*** Report is outside of domain:`
`  FM-128 RADAR    34.302  -100.074      KAMA`

