### PR TITLE
bug fix for an inconsistency in the radiation code

### DIFF
--- a/phys/module_ra_clWRF_support.F
+++ b/phys/module_ra_clWRF_support.F
@@ -112,8 +112,9 @@ CONTAINS
     LOGICAL, EXTERNAL                                :: wrf_dm_on_monitor
     INTEGER, EXTERNAL                                :: get_unused_unit
       
-    INTEGER                                          :: istatus, iunit, idata        
-    INTEGER, SAVE                             :: VARCAM_in_years
+    INTEGER                                          :: istatus, iunit, idata
+!ccc VARCAM_in_years is a module variable, needs something else here!        
+    INTEGER, SAVE                             :: max_years 
     integer                                          :: nyrm, nyrp, njulm, njulp
     LOGICAL                                          :: exists
     LOGICAL, SAVE                                    :: READtrFILE=.FALSE.
@@ -167,11 +168,11 @@ CONTAINS
                 PRINT *,"   Not normal ending of 'CAMtr_volume_mixing_ratio' file"
                 PRINT *,"   Lecture ends with 'IOSTAT'=",istatus
              END IF
-             VARCAM_in_years = idata - 1
+             max_years = idata - 1
              CLOSE(iunit)
 
              ! Calculate the julian day for each month.
-             DO idata=1,VARCAM_in_years
+             DO idata=1,max_years
                 mondayi = monday
                 MY1=MOD(yrdata(idata),4)
                 MY2=MOD(yrdata(idata),100)
@@ -190,6 +191,8 @@ CONTAINS
           ! With negative mixing ratios in co2r, n2or and ch4r, no interpolation
           ! is done and we use the constant mixing ratios that were used before
           ! CLWRF modifications.
+          max_years = VARCAM_in_years ! Set max number of years to the table size
+                                      ! used for CAM.
           yrdata = yr + 1
           juldata = 1
           co2r   = -9999.999
@@ -200,8 +203,8 @@ CONTAINS
 
           ! For CAM model, recovers original data sets.
           IF (model .eq. "CAM") THEN
-             yrdata(1:VARCAM_in_years) = yr_CAM
-             co2r(1:VARCAM_in_years)   = co2r_CAM
+             yrdata(1:max_years) = yr_CAM
+             co2r(1:max_years)   = co2r_CAM
           ENDIF
        ENDIF ! CAMtr_volume_mixing_ratio exists
        
@@ -224,8 +227,8 @@ CONTAINS
     
     ! Prevent yr > last year in data
 !    IF (yearIN .ge. VARCAM_in_years) yearIN=VARCAM_in_years-1
-    IF (iyear .ge. VARCAM_in_years) then
-       yearIN=VARCAM_in_years-1
+    IF (iyear .ge. max_years) then
+       yearIN=max_years-1
        found_yearIN = 1
     ENDIF
     
@@ -241,9 +244,9 @@ CONTAINS
        co2vmr=-9999.999
        if (found_yearIN /= 0) then
           ! Interpolate data only if we have at least 2 valid concentrations.
-          tot_valid = count(co2r(1:VARCAM_in_years) > 0)
+          tot_valid = count(co2r(1:max_years) > 0)
           IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, co2r, VARCAM_in_years,yr1, yr2)
+             CALL valid_years(yearIN, co2r, max_years,yr1, yr2)
 
              ! Set nyrm, njulm, nyrp, njulp
              nyrm = yrdata(yr1)
@@ -269,9 +272,9 @@ CONTAINS
     IF (PRESENT(n2ovmr)) THEN
        n2ovmr=-9999.999
        if (found_yearIN /= 0) then
-          tot_valid = count(n2or(1:VARCAM_in_years) > 0)
+          tot_valid = count(n2or(1:max_years) > 0)
           IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, n2or, VARCAM_in_years,yr1, yr2)
+             CALL valid_years(yearIN, n2or, max_years,yr1, yr2)
 
              ! Set nyrm, njulm, nyrp, njulp
              nyrm = yrdata(yr1)
@@ -296,9 +299,9 @@ CONTAINS
     IF (PRESENT(ch4vmr)) THEN
        ch4vmr=-9999.999
        if (found_yearIN /= 0) then
-          tot_valid = count(ch4r(1:VARCAM_in_years) > 0)
+          tot_valid = count(ch4r(1:max_years) > 0)
           IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, ch4r, VARCAM_in_years,yr1, yr2)
+             CALL valid_years(yearIN, ch4r, max_years,yr1, yr2)
 
              ! Set nyrm, njulm, nyrp, njulp
              nyrm = yrdata(yr1)
@@ -322,9 +325,9 @@ CONTAINS
     IF (PRESENT(cfc11vmr)) THEN
        cfc11vmr = -9999.999
        if (found_yearIN /= 0) then
-          tot_valid = count(cfc11r(1:VARCAM_in_years) > 0)
+          tot_valid = count(cfc11r(1:max_years) > 0)
           IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, cfc11r, VARCAM_in_years,yr1, yr2)
+             CALL valid_years(yearIN, cfc11r, max_years,yr1, yr2)
 
              ! Set nyrm, njulm, nyrp, njulp
              nyrm = yrdata(yr1)
@@ -346,9 +349,9 @@ CONTAINS
     IF (PRESENT(cfc12vmr)) THEN
        cfc12vmr = -9999.999
        if (found_yearIN /= 0) then
-          tot_valid = count(cfc12r(1:VARCAM_in_years) > 0)
+          tot_valid = count(cfc12r(1:max_years) > 0)
           IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, cfc12r, VARCAM_in_years,yr1, yr2)
+             CALL valid_years(yearIN, cfc12r, max_years,yr1, yr2)
 
              ! Set nyrm, njulm, nyrp, njulp
              nyrm = yrdata(yr1)
@@ -560,21 +563,8 @@ CONTAINS
           ENDIF
        ENDIF
 
-    ELSE IF (model .eq. "RRTM") THEN
-       IF (tracer .eq. "CO2") THEN
-          out = 3.300e-4
-
-       ELSE IF ((tracer .eq. "N2O") .or. &
-                (tracer .eq. "CH4")) THEN
-          out = 0.
-       ELSE
-          IF ( wrf_dm_on_monitor() ) THEN
-             WRITE(message,*) 'CLWRF : Trace gas ',tracer,' not valid for scheme ',model
-             CALL wrf_error_fatal(message)
-          ENDIF
-       ENDIF
-
-    ELSE IF (model .eq. "RRTMG") THEN
+    ELSE IF ((model .eq. "RRTM") .or. &
+             (model .eq. "RRTMG")) THEN
        IF (tracer .eq. "CO2") THEN
           out = 379.e-6
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CLWRFGHG

SOURCE: Claire Carouge (ARC Centre of Excellence for Climate Systems Science, Australia)

DESCRIPTION OF CHANGES:
(1) When compiled with the CLWRFGHG preprocessor directive, WRF expects a CAMtr_volume_mixing_ratio file providing variable GHG concentrations to be updated during the simulation. When this file is missing, the safest behaviour is to fall back to the default WRF behaviour. In version 3.6 the RRTM radiation code updated some constants, but these were not updated in the clWRF_support routine. This fix makes the routines consistent again.
(2) The variable "VARCAM_in_years" was declared twice in module_ra_clWRF_support.F, which is creating issues. This variable is renamed.

LIST OF MODIFIED FILES:
M phys/module_ra_clWRF_support.F
TESTS CONDUCTED: pending

