### PR TITLE
Bug fix for DA radar radial velocity operator

### DIFF
--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -8,6 +8,7 @@ subroutine da_get_innov_vector_radar (it, grid, ob, iv)
    !    08/08/2016 - Updated to include null-echo assimilation
    !                 (Yu-Shin Kim and Ki-Hong Min, School of Earth System
    !                  Sciences/Kyungpook National University, Daegu, S.Korea)
+   !    08/2017 - bug fix for Vr operator (Siou-Ying Jiang, CWB, Taiwan)
    !-----------------------------------------------------------------------
 
    implicit none
@@ -323,9 +324,11 @@ END IF
                   if (abs(ob % radar(n) % rv(k) - missing_r) > 1.0 .AND. &
                        iv % radar(n) % rv(k) % qc >= obs_qc_pointer) then
 
+                     !reference: Sun and Crook (1997)
                      call da_radial_velocity(model_rv(k,n), model_p(k,n),  &
                         model_u(k,n), model_v(k,n), model_w(k,n),          &
-                        model_qrn(k,n), model_ps(n), xr, yr, zr)
+                        model_qrn(k,n), model_ps(n), xr, yr, zr,           &
+                        model_rho(k,n))
 
                      iv % radar(n) % rv(k) % inv = ob % radar(n) % rv(k) - model_rv(k,n)
                   end if
@@ -343,7 +346,7 @@ END IF
             if (use_radar_rhv .or. use_radar_rqv) then
                if ( echo_rf_good ) then
                   call da_radar_rf (model_qrn(k,n),model_qsn(k,n),model_qgr(k,n),model_tc(k,n),model_rho(k,n),bg_rze)
-                  bg_rf = 10.0*log(bg_rze)  ! Z to dBZ
+                  bg_rf = 10.0*log10(bg_rze)  ! Z to dBZ
                end if
             end if
 

--- a/var/da/da_radar/da_radial_velocity.inc
+++ b/var/da/da_radar/da_radial_velocity.inc
@@ -1,19 +1,24 @@
-subroutine da_radial_velocity(rv,p,u,v,w,qrn,ps,x,y,z)
+subroutine da_radial_velocity(rv,p,u,v,w,qrn,ps,x,y,z,rho)
 
    !-----------------------------------------------------------------------
-   ! Purpose: TBD
+   ! Purpose: calculate radial velocity following Sun and Crook (1997)
+   ! History:
+   !    08/2017 - bug fix for Vt (Siou-Ying Jiang, CWB, Taiwan)
    !-----------------------------------------------------------------------
 
    implicit none
 
    real, intent(in)  :: x, y, z
    real, intent(in)  :: p, u, v, w, qrn, ps
+   real, intent(in)  :: rho
    real, intent(out) :: rv
 
    real :: r, alpha, vt
-   real    :: qrrc
+   real :: qrrc
+   real :: qrn_g
 
-   qrrc = 1.0e-3
+   qrn_g= qrn*1000. ! kg/kg -> g/kg
+   qrrc = 0.01      ! g/kg
    vt = 0.0
 
    if (trace_use) call da_trace_entry("da_radial_velocity")
@@ -21,16 +26,12 @@ subroutine da_radial_velocity(rv,p,u,v,w,qrn,ps,x,y,z)
    r=sqrt(x*x+y*y+z*z)
    alpha=(ps/p)**0.4
 
-!   if (qrn <= 0.0) vt=0.0
-!   if (qrn >  0.0) vt=5.4*alpha*qrn**0.125
-
-   if (use_radar_rf .or. use_radar_rhv)then
-      if (qrn <= qrrc)then
-         vt=0.0
-      else
-         vt=5.4*alpha*qrn**0.125
-      end if
+   if (qrn_g <= qrrc)then
+      vt=0.0
+   else
+      vt=5.4*alpha*qrn_g**0.125*rho**0.125
    end if
+
    rv=u*x+v*y+(w-vt)*z
    rv=rv/r
 

--- a/var/da/da_radar/da_radial_velocity_adj.inc
+++ b/var/da/da_radar/da_radial_velocity_adj.inc
@@ -1,7 +1,9 @@
-subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9)
+subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9,rho)
 
    !-----------------------------------------------------------------------
-   ! Purpose: TBD
+   ! Purpose: adjoint of da_radial_velocity_lin
+   ! History:
+   !    08/2017 - bug fix for Vt (Siou-Ying Jiang, CWB, Taiwan)
    !-----------------------------------------------------------------------
 
    implicit none
@@ -9,14 +11,18 @@ subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9)
    real, intent(in)    :: x, y, z
    real, intent(in)    :: p
    real, intent(in)    :: qrn9
+   real, intent(in)    :: rho
    real, intent(in)    :: ps
    real, intent(inout) :: rv
    real, intent(inout) :: u, v, w, qrn
 
    real :: r, alpha, vt
    real :: qrrc
+   real :: qrn_g, qrn9_g
 
-   qrrc = 1.0e-3
+   qrn_g = qrn *1000. ! kg/kg -> g/kg
+   qrn9_g= qrn9*1000. ! kg/kg -> g/kg
+   qrrc = 0.01        ! g/kg
 
    if (trace_use) call da_trace_entry("da_radial_velocity_adj")
 
@@ -29,14 +35,11 @@ subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9)
    w  = w + rv*z
    vt = -rv*z
 
-  if (use_radar_rf .or. use_radar_rhv)then
-!   if (qrn9 >  0.0) then
-!      qrn = qrn + vt*0.675*alpha*qrn9**(-0.875)
-!   end if
-   if (qrn9 >  qrrc) then
-      qrn = qrn + vt*0.675*alpha*qrn9**(-0.875)
+   if (qrn9_g >  qrrc) then
+      qrn_g = qrn_g + vt*0.675*alpha*qrn9_g**(-0.875)*rho**0.125
+      qrn   = qrn_g * 0.001  ! g/kg -> kg/kg
    end if
-  end if
+
    if (trace_use) call da_trace_exit("da_radial_velocity_adj")
 
 end subroutine da_radial_velocity_adj

--- a/var/da/da_radar/da_radial_velocity_lin.inc
+++ b/var/da/da_radar/da_radial_velocity_lin.inc
@@ -1,7 +1,9 @@
-subroutine da_radial_velocity_lin(rv,p,u,v,w,qrn,ps,x,y,z,qrn9)
+subroutine da_radial_velocity_lin(rv,p,u,v,w,qrn,ps,x,y,z,qrn9,rho)
 
    !-----------------------------------------------------------------------
-   ! Purpose: TBD
+   ! Purpose: Tangent linear of da_radial_velocity
+   ! History:
+   !    08/2017 - bug fix for Vt (Siou-Ying Jiang, CWB, Taiwan)
    !-----------------------------------------------------------------------
 
    implicit none
@@ -9,12 +11,16 @@ subroutine da_radial_velocity_lin(rv,p,u,v,w,qrn,ps,x,y,z,qrn9)
    real, intent(in)  :: x, y, z
    real, intent(in)  :: p, u, v, w, qrn, ps
    real, intent(in)  :: qrn9
+   real, intent(in)  :: rho
    real, intent(out) :: rv
 
    real    :: r, alpha, vt
    real    :: qrrc
+   real    :: qrn_g, qrn9_g
 
-   qrrc = 1.0e-3
+   qrn_g = qrn *1000. ! kg/kg -> g/kg
+   qrn9_g= qrn9*1000. ! kg/kg -> g/kg
+   qrrc = 0.01        ! g/kg
    vt = 0.0
 
    if (trace_use) call da_trace_entry("da_radial_velocity_lin")
@@ -22,22 +28,11 @@ subroutine da_radial_velocity_lin(rv,p,u,v,w,qrn,ps,x,y,z,qrn9)
    r     = sqrt(x*x+y*y+z*z)
    alpha = (ps/p)**0.4
 
-
-   if (use_radar_rf .or. use_radar_rhv)then
-      if (qrn9 <= qrrc)then
-         vt=0.0
-      else
-         vt=0.675*alpha*qrn9**(-0.875)*qrn
-      end if
+   if (qrn9_g <= qrrc)then
+      vt=0.0
+   else
+      vt=0.675*alpha*qrn9_g**(-0.875)*qrn_g*rho**0.125
    end if
-
-!   if (qrn9 <= 0.0) then
-!      vt=0.0
-!   end if
-
-!   if (qrn9 >  0.0) then
-!      vt=0.675*alpha*qrn9**(-0.875)*qrn
-!   end if
 
    rv = u*x+v*y+(w-vt)*z
    rv = rv/r

--- a/var/da/da_radar/da_transform_xtoy_radar.inc
+++ b/var/da/da_radar/da_transform_xtoy_radar.inc
@@ -4,8 +4,10 @@ subroutine da_transform_xtoy_radar (grid, iv, y)
    ! Purpose: calculate the Doppler radial velocity and 
    ! reflectivity at the observation location from the first guess.
    ! It is linearized. 
+   ! History:
    !    Updated for Analysis on Arakawa-C grid
    !    Author: Syed RH Rizvi,  MMM/ESSL/NCAR,  Date: 10/22/2008
+   !    08/2017 - bug fix for Vr operator (Siou-Ying Jiang, CWB, Taiwan)
    !---------------------------------------------------------------------
  
    implicit none
@@ -17,6 +19,7 @@ subroutine da_transform_xtoy_radar (grid, iv, y)
    integer :: n, k
 
    real, allocatable :: model_p(:,:)
+   real, allocatable :: model_rho(:,:)
    real, allocatable :: model_u(:,:)
    real, allocatable :: model_v(:,:)
    real, allocatable :: model_w(:,:)
@@ -39,6 +42,7 @@ subroutine da_transform_xtoy_radar (grid, iv, y)
    alog_10 = alog(10.0)
 
    allocate (model_p(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
+   allocate (model_rho(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
    allocate (model_u(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
    allocate (model_v(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
    allocate (model_w(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
@@ -56,6 +60,7 @@ subroutine da_transform_xtoy_radar (grid, iv, y)
       do k = 1, iv%info(radar)%levels(n)
          model_qrnb(k,n) = iv%radar(n)%model_qrn(k)
          model_p(k,n)    = iv%radar(n)%model_p(k)
+         model_rho(k,n)  = iv%radar(n)%model_rho(k)
       end do
 
       model_ps(n) = iv%radar(n)%model_ps
@@ -103,7 +108,7 @@ subroutine da_transform_xtoy_radar (grid, iv, y)
                   call da_radial_velocity_lin(y%radar(n)%rv(k), &
                      model_p(k,n), &
                      model_u(k,n), model_v(k,n), model_w(k,n), model_qrn(k,n),    &
-                     model_ps(n), xr, yr, zr, model_qrnb(k,n))
+                     model_ps(n), xr, yr, zr, model_qrnb(k,n), model_rho(k,n))
                end if
             end if
 
@@ -155,6 +160,7 @@ subroutine da_transform_xtoy_radar (grid, iv, y)
    deallocate (model_qvb)
    deallocate (model_t)
    deallocate (model_tb)
+   deallocate (model_rho)
 
    if (trace_use) call da_trace_exit("da_transform_xtoy_radar")
 

--- a/var/da/da_radar/da_transform_xtoy_radar_adj.inc
+++ b/var/da/da_radar/da_transform_xtoy_radar_adj.inc
@@ -1,9 +1,11 @@
 subroutine da_transform_xtoy_radar_adj(grid, iv, jo_grad_y, jo_grad_x)
 
    !-----------------------------------------------------------------------
-   ! Purpose: TBD
+   ! Purpose: Adjoint of da_transform_xtoy_radar
+   ! History:
    !    Updated for Analysis on Arakawa-C grid
    !    Author: Syed RH Rizvi,  MMM/ESSL/NCAR,  Date: 10/22/2008
+   !    08/2017 - bug fix for Vr operator (Siou-Ying Jiang, CWB, Taiwan)
    !-----------------------------------------------------------------------
 
    !------------------------------------------------------------------------
@@ -22,6 +24,7 @@ subroutine da_transform_xtoy_radar_adj(grid, iv, jo_grad_y, jo_grad_x)
    integer :: n
 
    real, allocatable :: model_p(:,:)
+   real, allocatable :: model_rho(:,:)
    real, allocatable :: model_u(:,:)
    real, allocatable :: model_v(:,:)
    real, allocatable :: model_w(:,:)
@@ -45,6 +48,7 @@ subroutine da_transform_xtoy_radar_adj(grid, iv, jo_grad_y, jo_grad_x)
    alog10= alog(10.0)
 
    allocate (model_p(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
+   allocate (model_rho(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
    allocate (model_u(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
    allocate (model_v(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
    allocate (model_w(iv%info(radar)%max_lev,iv%info(radar)%n1:iv%info(radar)%n2))
@@ -87,6 +91,7 @@ subroutine da_transform_xtoy_radar_adj(grid, iv, jo_grad_y, jo_grad_x)
 
       model_qrnb(1:iv%info(radar)%levels(n),n) = iv%radar(n)%model_qrn(1:iv%info(radar)%levels(n))
       model_p   (1:iv%info(radar)%levels(n),n) = iv%radar(n)%model_p(1:iv%info(radar)%levels(n))
+      model_rho (1:iv%info(radar)%levels(n),n) = iv%radar(n)%model_rho(1:iv%info(radar)%levels(n))
 
       do k = 1,iv%info(radar)%levels(n)
          if (iv % radar(n) % height_qc(k) /= below_model_surface .and.  &
@@ -125,7 +130,8 @@ subroutine da_transform_xtoy_radar_adj(grid, iv, jo_grad_y, jo_grad_x)
 
                   call da_radial_velocity_adj(jo_grad_y%radar(n)%rv(k), &
                      model_p(k,n), model_u(k,n), model_v(k,n), model_w(k,n),  &
-                     model_qrn(k,n), model_ps(n), xr, yr, zr, model_qrnb(k,n))
+                     model_qrn(k,n), model_ps(n), xr, yr, zr, model_qrnb(k,n),&
+                     model_rho(k,n))
 
                end if
             end if
@@ -172,6 +178,7 @@ subroutine da_transform_xtoy_radar_adj(grid, iv, jo_grad_y, jo_grad_x)
    deallocate (model_tb)
    deallocate (model_qsn)
    deallocate (model_qgr)
+   deallocate (model_rho)
 
    if (trace_use) call da_trace_exit("da_transform_xtoy_radar_adj")
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, radar, radial velocity

SOURCE: Siou-Ying Jiang (Central Weather Bureau, Taiwan)

DESCRIPTION OF CHANGES:
Fix the calculation of Vt (terminal velocity) component of Vr (radial velocity)
by adding density term in the Vt calculation and making qrain unit consistent.

LIST OF MODIFIED FILES:
M       var/da/da_radar/da_get_innov_vector_radar.inc
M       var/da/da_radar/da_radial_velocity.inc
M       var/da/da_radar/da_radial_velocity_adj.inc
M       var/da/da_radar/da_radial_velocity_lin.inc
M       var/da/da_radar/da_transform_xtoy_radar.inc
M       var/da/da_radar/da_transform_xtoy_radar_adj.inc

TESTS CONDUCTED:
1. WRFDA regtests passed with intel 17.0.1 on cheyenne.
2. Extensive tests done by CWB. Small impact on the results.