### PR TITLE
Allow tc.exe to run when number of DM tasks = 1

### DIFF
--- a/main/tc_em.F
+++ b/main/tc_em.F
@@ -35,6 +35,7 @@ PROGRAM tc_data
    TYPE(domain) , POINTER :: grid_ptr , grid_ptr2
    TYPE (grid_config_rec_type)              :: config_flags
    INTEGER                :: number_at_same_level
+   INTEGER :: myproc, nproc
 
    INTEGER :: max_dom, domain_id , grid_id , parent_id , parent_id1 , id
    INTEGER :: e_we , e_sn , i_parent_start , j_parent_start
@@ -55,6 +56,7 @@ PROGRAM tc_data
    INTEGER :: sibling_count , parent_id_hold , dom_loop
 
    CHARACTER (LEN=80)     :: message
+   CHARACTER(LEN=256)     :: some_string
 
    INTEGER :: start_year , start_month , start_day , start_hour , start_minute , start_second
    INTEGER ::   end_year ,   end_month ,   end_day ,   end_hour ,   end_minute ,   end_second
@@ -79,13 +81,6 @@ PROGRAM tc_data
 !  The TC bogus algorithm assumes that the user defines a central point, and then
 !  allows the program to remove a typhoon based on a distance in km.  This is
 !  implemented on a single processor only.
-
-#ifdef DM_PARALLEL
-   IF ( .NOT. wrf_dm_on_monitor() ) THEN
-      CALL wrf_error_fatal( 'TC bogus must run with a single processor only, re-run with num procs set to 1' )
-   END IF
-#endif
-
 #ifdef DM_PARALLEL
    CALL disable_quilting
 #endif
@@ -103,6 +98,21 @@ PROGRAM tc_data
    CALL WRFU_Initialize( defaultCalKind=WRFU_CAL_GREGORIAN, rc=rc )
 #endif
    CALL init_modules(2)   ! Phase 2 resumes after MPI_INIT() (if it is called)
+
+#if defined( DM_PARALLEL ) && !defined( STUBMPI )
+   IF ( wrf_dm_on_monitor () ) THEN
+       CALL wrf_get_myproc (myproc)
+       CALL wrf_get_nproc  (nproc)
+       IF ( nproc .GT. 1 ) THEN
+       WRITE (some_string,*) 'My MPI processor number   = ',myproc
+       CALL wrf_debug ( 0 , TRIM(some_string) )
+       WRITE (some_string,*) 'Total MPI requested tasks = ',nproc
+       CALL wrf_debug ( 0 , TRIM(some_string) )
+          CALL wrf_error_fatal( 'MPI TC bogus must run with a single processor only, re-run with num procs set to 1' )
+       END IF
+   END IF
+#endif
+
 
    !  The configuration switches mostly come from the NAMELIST input.
 


### PR DESCRIPTION
#### TYPE: bug fix

#### KEYWORDS: TC, DM, MPI

#### SOURCE: internal

#### DESCRIPTION OF CHANGES:
The main program for the tropical cyclone bogus capability did not permit a distributed memory build. Since both the DM build with np=1 and the serial build with a nesting option work, the IF test logic now permits these build choices for the TC program.

#### LIST OF MODIFIED FILES:
M	main/tc_em.F

#### TESTS CONDUCTED:
- [x] Following give bit-for-bit results
1. Serial build with nesting option not activated during build
2. Serial build with nesting option activated during build
3. DM parallel build with np=1
- [x] Following cleanly aborts
```
>> mpirun -np 4 tc.exe

taskid: 0 hostname: etotheipi.local
   My MPI processor number   =            0
   Total MPI requested tasks =            4
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:      96
MPI TC bogus must run with a single processor only, re-run with num procs set to 1
-------------------------------------------
```