### PR TITLE
KLUGE for GNU 7.2.0: re-arrange ONLY clause for rrlw_kg06 usage

### DIFF
--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -5984,10 +5984,12 @@ contains
 
 ! ------- Modules -------
 
-      use parrrtm, only : ng6, ngs5
+      use parrrtm, only : ngs5
+!     use parrrtm, only : ng6, ngs5
       use rrlw_ref, only : chi_mls
-      use rrlw_kg06, only : fracrefa, absa, ka, ka_mco2, &
-                            selfref, forref, cfc11adj, cfc12
+      use rrlw_kg06
+!     use rrlw_kg06, only : fracrefa, absa, ka, ka_mco2, &
+!                           selfref, forref, cfc11adj, cfc12
 
 ! ------- Declarations -------
 
@@ -8762,11 +8764,13 @@ contains
 ! old band 6:  820-980 cm-1 (low - h2o; high - nothing)
 !***************************************************************************
 
-      use parrrtm, only : mg, nbndlw, ngptlw, ng6
-      use rrlw_kg06, only: fracrefao, kao, kao_mco2, cfc11adjo, cfc12o, &
-                           selfrefo, forrefo, &
-                           fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12, &
-                           selfref, forref
+      use parrrtm, only : mg, nbndlw, ngptlw
+!     use parrrtm, only : mg, nbndlw, ngptlw, ng6
+      use rrlw_kg06
+!     use rrlw_kg06, only: fracrefao, kao, kao_mco2, cfc11adjo, cfc12o, &
+!                          selfrefo, forrefo, &
+!                          fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12, &
+!                          selfref, forref
 
 ! ------- Local -------
       integer(kind=im) :: jt, jp, igc, ipr, iprsm 
@@ -13373,8 +13377,9 @@ IMPLICIT NONE
       subroutine lw_kgb06(rrtmg_unit)
 ! **************************************************************************
 
-      use rrlw_kg06, only : fracrefao, kao, kao_mco2, selfrefo, forrefo, &
-                            cfc11adjo, cfc12o
+      use rrlw_kg06
+!     use rrlw_kg06, only : fracrefao, kao, kao_mco2, selfrefo, forrefo, &
+!                           cfc11adjo, cfc12o
 
       implicit none
       save


### PR DESCRIPTION
#### TYPE: bug fix

#### KEYWORDS: RRTMG, LW, GNU, KLUGE

#### SOURCE: internal

#### DESCRIPTION OF CHANGES:
Remove the ONLY clause when the rrtm_kg06 module is used in three subroutines. Without this mod, there is an internal compiler error for GNU 7.2.0. There appears to be nothing wrong with the code. REPEAT - this mod appears to be something that should be completely unnecessary. Commented out code is left on purpose with the eventual intent that the original code gets put back in. 

The parameterized variable ng6 is defined in two modules. Removing the ONLY for rrlw_kg06 allows ng6 to be within the scope provided from two separate modules. The ng6 value is replicated already, so we just take that information (symbol, value, etc) from rrtm_kg06. Quite a few other modules in this file have the ONLY clause without any troubles. Hopefully, with a newer GNU release, we can put all of this temporary "don't use the ONLY clause for rrlw_kg06" back to the way it originally was ...

#### LIST OF MODIFIED FILES:
M   phys/module_ra_rrtmg_lw.F

#### TESTS CONDUCTED:
 - [x] On OSX 10.13 with GNU 7.2.0, the WRF code fails to compile with an internal compiler error. 
```
module_ra_rrtmg_lw.f90:5981:0:

       use rrlw_kg06, only : fracrefa, absa, ka, ka_mco2, &

internal compiler error: in gfc_trans_use_stmts, at fortran/trans-decl.c:4920

module_ra_rrtmg_lw.f90:5981:0: internal compiler error: Abort trap: 6
gfortran: internal compiler error: Abort trap: 6 (program f951)
Please submit a full bug report,
with preprocessed source if appropriate.
```
 - [x] With this mod, the code compiles and runs.
 - [x] WTF 4.01 passes most of what we want