### PR TITLE
bug fix in module_ra_clWRF_support.F

### DIFF
--- a/phys/module_ra_clWRF_support.F
+++ b/phys/module_ra_clWRF_support.F
@@ -191,19 +191,6 @@ CONTAINS
           ELSE
              CALL wrf_error_fatal("CLWRF: 'CAMtr_volume_mixing_ratio' does not exist")
           ENDIF
-          
-          !ccc Fake yrdata. Won't be use but a value > yr is needed so that
-          ! everything work.
-          ! With negative mixing ratios in co2r, n2or and ch4r, no interpolation
-          ! is done and we use the constant mixing ratios that were used before
-          ! CLWRF modifications.
-          !yrdata = yr + 1
-          !juldata = 1
-          !co2r   = -9999.999
-          !n2or   = -9999.999
-          !ch4r   = -9999.999
-          !cfc11r = -9999.999
-          !cfc12r = -9999.999
 
        ENDIF ! CAMtr_volume_mixing_ratio exists
        


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CLWRFGHG

SOURCE: Claire Carouge (ARC Centre of Excellence for Climate Systems Science, Australia)

DESCRIPTION OF CHANGES:
1. When compiled with the CLWRFGHG preprocessor directive, WRF expects a CAMtr_volume_mixing_ratio file providing variable GHG concentrations to be updated during the simulation. When this file is missing, WRF will stop with the error message: 
```
CLWRF: 'CAMtr_volume_mixing_ratio' does not exists
```
2. Some trace gas concentrations are set to be the same for in RRTM and RRTMG radiation codes
3. The variable "VARCAM_in_years" is both a local variable and accessible through module USE association. The local variable "VARCAM_in_years" is renamed "max_years" to prevent the name space collision.

LIST OF MODIFIED FILES:
M phys/module_ra_clWRF_support.F

TESTS CONDUCTED: regressison test passed
  