### PR TITLE
Correct argument to the mpi_allreduce collective,MPI function.

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -1316,7 +1316,7 @@ CONTAINS
       INCLUDE 'mpif.h'
       INTEGER, intent(in) :: inval
       INTEGER :: ierr, retval
-      CALL mpi_allreduce ( inval, retval , 1, MPI_INT, MPI_MAX, local_communicator, ierr )
+      CALL mpi_allreduce ( inval, retval , 1, MPI_INTEGER, MPI_MAX, local_communicator, ierr )
       wrf_dm_max_int = retval
 #else
       INTEGER, intent(in) :: inval


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MPI_INTEGER, MPI_ALLREDUCE, trajectory

SOURCE: internal

DESCRIPTION:  Change the integer parameter argument MPI_INT to MPI_INTEGER in the call to the function mpi_allreduce in the routine external/RSL_LITE/module_dm.F. The MPI_INT name is the MPI parameter for the C language, and MPI_INTEGER is the parameter for the Fortran language.

LIST OF MODIFIED ROUTINES:

M       external/RSL_LITE/module_dm.F

TESTS CONDUCTED:  passed WTF 4.01 on Cheyenne
  
  