### PR TITLE
Remove binary CRTM Coefficient files: message correction

### DIFF
--- a/var/run/crtm_coeffs_2.2.3/README
+++ b/var/run/crtm_coeffs_2.2.3/README
@@ -1,4 +1,5 @@
-These CRTM coefficient files are binary and cannot be tracked by git and will be put in WRFDA website for download 
-from the release 4.0. A copy will also be made available under ~wrfhelp on the NCAR cheyenne supercomputer 
-(for internal use). The full set of CRTM coefficient files can also be downloaded from the official CRTM ftp site 
-http://ftp.emc.ncep.noaa.gov/jcsda/CRTM/.
+This folder holds a subset of CRTM coefficient files, which are binary files and cannot be tracked by git
+and will be put in WRFDA website for download from the release 4.0. A copy of the whole folder is also made
+available under /glade/p/work/wrfhelp/WRFDA_files/crtm_coeffs_2.2.3 on the NCAR Cheyenne supercomputer 
+(for internal use). The full set of CRTM coefficient files can also be downloaded from the official CRTM 
+ftp site http://ftp.emc.ncep.noaa.gov/jcsda/CRTM/.


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: CRTM, Coefficient, Binary

SOURCE: internal (Jake Liu)

DESCRIPTION OF CHANGES: 
Merge #329 on 29 Dec. 2017 was not done properly. This is to amend the commit message for the merge #329 . 

The size of CRTM coefficient folder can be big when more and more satellite radiance data are added to WRFDA interface. Moreover, these coefficient files are binary and can not be tracked by git.

Starting with release 4.0:
1. these binary files will be put in WRFDA website for download
2. a copy of the whole folder is also made available under /glade/p/work/wrfhelp/WRFDA_files/crtm_coeffs_2.2.3 on NCAR Cheyenne supercomputer for internal use. 
3. the full set of CRTM coefficient files can be downloaded from the official CRTM ftp site http://ftp.emc.ncep.noaa.gov/jcsda/CRTM/.

LIST OF MODIFIED FILES: 
All files under ~var/run/crtm_coeffs_2.2.3 are removed in #329 . It will be a long list of files! A temporary README file is added in the empty folder and to be updated before release. For this commit, ~var/run/crtm_coeffs_2.2.3/README is modified to inform the location of the folder under /glade/p/work/wrfhelp.

TESTS CONDUCTED: 
No impact, so no test conducted. But note that this will affect WRFDA regression test for radiance related tests. From now on, 'crtm_coeffs_2.2.3' folder must be manually copied back under ~var/run before running WRFDA regression tests.
