### PR TITLE
BF: Saltation flux eqn, wrong term is squared

### DIFF
--- a/chem/module_qf03.F
+++ b/chem/module_qf03.F
@@ -408,7 +408,7 @@ MODULE qf03
         qwhite_out = 0.d0
       ELSE
         b = ust/ustar 
-        qwhite_out = c*a*ustar**3.*(1.-b)*(1.+b*b)
+        qwhite_out = c*a*ustar**3.*(1.-b)*(1.+b)**2.
       ENDIF
 
       END subroutine qwhite


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: UoC dust module, White saltation flux equation

SOURCE: Martina Klose (Barcelona Supercomputing Center, Spain)

DESCRIPTION OF CHANGES: Bug found for the saltation flux equation used as input to the dust emission schemes.

LIST OF MODIFIED FILES: 
M        chem/module_qf03.F

TESTS CONDUCTED: 
 - [x] Code passed WTF on Cheyenne
 - [x]  Tested by Ka Yee Wong.