### PR TITLE
Bug Fix for Obs Nudging with >100 Levels

### DIFF
--- a/phys/module_fddaobs_rtfdda.F
+++ b/phys/module_fddaobs_rtfdda.F
@@ -1690,7 +1690,7 @@ SUBROUTINE errob(inest, ub, vb, tb, t0, qvb, pbase, pp, rovcp,  &
   real :: wtsig(kms:kme),wt(ims:ime,kms:kme),wt2err(ims:ime,kms:kme)
   real :: rscale(ims:ime)           ! For converting to rho-coupled units.
   real :: wtij(ims:ime)             ! For holding weights in i-loop
-  real :: reserf(100)
+  real :: reserf(kms:kme)
   character*40 name
   character*3 chr_hr
   character(len=200) :: msg            ! Argument to wrf_message


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: obs nudging

SOURCE: Brian Reen (Army Research Laboratory)

DESCRIPTION OF CHANGES: 
The variable reserf in the obs nudging code was previously dimensioned to have 100 elements, but this would result in attempts to apply out-of-bounds indices to reserf if the simulation had more than 100 vertical levels.  Now, reserf is dimensioned based on the number of vertical levels.

LIST OF MODIFIED FILES: 
M phys/module_fddaobs_rtfdda.F

TESTS CONDUCTED: Ran with obs nudging while using 130 vertical levels (including with bounds checking enabled).
