### PR TITLE
bug fix for canwat - off by 1000. CMC in meters, CANWAT in mm

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -847,7 +847,8 @@ CONTAINS
             SOILTYP=7
           ENDIF
           SNOALB1 = SNOALB(I,J)
-          CMC=CANWAT(I,J)/1000.  !Bugfix for CMC unit correction (JOB/PCC 2017):  CMC is in meters in SFLX, but CANWAT is in millimeters 
+! converts canwat in mm to CMC in meters
+          CMC=CANWAT(I,J)/1000.
 
 !-------------------------------------------
 !*** convert snow depth from mm to meter
@@ -1111,7 +1112,7 @@ CONTAINS
 #endif
 
 !***  UPDATE STATE VARIABLES
-          CANWAT(I,J)=CMC*1000.  !Bugfix for CMC unit correction (JOB/PCC 2017):  CMC is in meters in SFLX, but CANWAT is in millimeters
+          CANWAT(I,J)=CMC*1000.
           SNOW(I,J)=SNEQV*1000.
 !          SNOWH(I,J)=SNOWHK*1000.
           SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
@@ -3127,7 +3128,8 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   SOILTYP=7
                 ENDIF
                 SNOALB1 = SNOALB(I,J)
-                CMC=CANWAT(I,J)/1000.   !Bugfix for CMC unit correction (JOB/PCC 2017):  CMC is in meters in SFLX, but CANWAT is in millimeters
+! converts canwat in mm to CMC in meters
+                CMC=CANWAT(I,J)/1000.
       
       !-------------------------------------------
       !*** convert snow depth from mm to meter
@@ -3396,7 +3398,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 #endif
       
       !***  UPDATE STATE VARIABLES
-                CANWAT(I,J)=CMC*1000.   !Bugfix for CMC unit correction (JOB/PCC 2017):  CMC is in meters in SFLX, but CANWAT is in millimeters
+                CANWAT(I,J)=CMC*1000.
                 SNOW(I,J)=SNEQV*1000.
       !          SNOWH(I,J)=SNOWHK*1000.
                 SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
@@ -4039,7 +4041,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   SOILTYP=7
                 ENDIF
                 SNOALB1 = SNOALB(I,J)
-                CMC=CANWAT(I,J)/1000.   !Bugfix for CMC unit correction (JOB/PCC 2017):  CMC is in meters in SFLX, but CANWAT is in millimeters
+                CMC=CANWAT(I,J)/1000.
       
       !-------------------------------------------
       !*** convert snow depth from mm to meter
@@ -4272,7 +4274,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 #endif
       
       !***  UPDATE STATE VARIABLES
-                CANWAT(I,J)=CMC*1000.   !Bugfix for CMC unit correction (JOB/PCC 2017):  CMC is in meters in SFLX, but CANWAT is in millimeters
+                CANWAT(I,J)=CMC*1000.
                 SNOW(I,J)=SNEQV*1000.
       !          SNOWH(I,J)=SNOWHK*1000.
                 SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CANWAT, CMC, Noah LSM

SOURCE: Patrick Campbell (EPA)

DESCRIPTION OF CHANGES: 

This PR corrects a unit conversion error between CMC in units of meters from the Noah LSM surface physics routine (i.e., SFLX), and the associated canopy water (CANWAT) variable in units of millimeters in the WRF/Noah driver. While the impact of this change on WRF/Noah predictions may be small, it can have impacts on WRF/Noah-CMAQ predictions of dry deposition of certain gas species that are highly soluble and have a strong dependence on surface wetness (e.g., sulfur dioxide; SO2). Consequently, this led to estimates of canopy moisture that are three orders of magnitude too small when used in the current WRF/Noah-CMAQ configuration, which in turn can lead to underpredictions in gas dry deposition.  

LIST OF MODIFIED FILES: 

M phys/module_sf_noahdrv.F

TESTS CONDUCTED: regtest is ongoing.