### PR TITLE
Add "clean sky" diagnostic outputs

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -421,7 +421,6 @@ state   integer number_at_same_level    -         -         -     -          -  
 state   real    radtacttime    -        -         -         -     r         "radtacttime"              "RADTACTTIME"         "LW SW ACTIVATION TIME in s"
 state   real    bldtacttime    -        -         -         -     r         "bldtacttime"              "BLDTACTTIME"         "PBL   ACTIVATION TIME in s"
 state   real    cudtacttime    -        -         -         -     r         "cudtacttime"              "CUDTACTTIME"         "CPS   ACTIVATION TIME in s"
-state   real    ltngacttime    -        -         -         -     r         "ltngacttime"              "LTNGACTTIME"         "LTNG  ACTIVATION TIME in s"
 state   real    power          ij       misc      1         -     irh       "Power"                   "Power production"         "W"
 
 
@@ -470,8 +469,6 @@ state   real    qr             ikjftb   moist       1         -     \
    i0rhusdf=(bdy_interp:dt)  "QRAIN"            "Rain water mixing ratio"       "kg kg-1"
 state   real    qi             ikjftb   moist       1         -     \
    i0rhusdf=(bdy_interp:dt)  "QICE"             "Ice mixing ratio"              "kg kg-1"
-state   real    qi2             ikjftb   moist       1         -     \
-   i0rhusdf=(bdy_interp:dt)  "QICE2"             "Ice mixing ratio cat 2"              "kg kg-1"
 state   real    qs             ikjftb   moist       1         -     \
    i0rhusdf=(bdy_interp:dt)  "QSNOW"            "Snow mixing ratio"             "kg kg-1"
 state   real    qg             ikjftb   moist       1         -     \
@@ -487,8 +484,6 @@ state   real    dfi_qr         ikjftb   dfi_moist       1         -     \
    rusdf=(bdy_interp:dt)  "DFI_QRAIN"        "Rain water mixing ratio"       "kg kg-1"
 state   real    dfi_qi         ikjftb   dfi_moist       1         -     \
    rusdf=(bdy_interp:dt)  "DFI_QICE"         "Ice mixing ratio"              "kg kg-1"
-state   real    dfi_qi2         ikjftb   dfi_moist       1         -     \
-   rusdf=(bdy_interp:dt)  "DFI_QICE2"         "Ice mixing ratio cat 2"              "kg kg-1"
 state   real    dfi_qs         ikjftb   dfi_moist       1         -     \
    rusdf=(bdy_interp:dt)  "DFI_QSNOW"        "Snow mixing ratio"             "kg kg-1"
 state   real    dfi_qg         ikjftb   dfi_moist       1         -     \
@@ -514,8 +509,6 @@ state   real    qndrop         ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QNDROP"        "Droplet number mixing ratio"        "# kg-1"
 state   real    qni            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QNICE"         "Ice Number concentration" "# kg-1"
-state   real    qni2            ikjftb  scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)    "QNICE2"         "Ice Number concentration cat 2" "# kg-1"
 state   real    qt             ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "CWM"           "Total condensate mixing ratio"      "kg kg-1"
 state   real    qns            ikjftb  scalar      1         -     \
@@ -540,18 +533,12 @@ state   real    qir            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QIR"           "Rime ice mass-1 mixing ratio" "kg kg(-1)"
 state   real    qib            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QIB"           "Rime ice volume-1 mixing ratio" "m(3) kg(-1)"
-state   real    qir2            ikjftb  scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)    "QIR2"           "Rime ice mass-2 mixing ratio" "kg kg(-1)"
-state   real    qib2            ikjftb  scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)    "QIB2"           "Rime ice volume-2 mixing ratio" "m(3) kg(-1)"
 
 state   real    -              ikjftb  dfi_scalar      1         -     -   -
 state   real    dfi_qndrop     ikjftb  dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)    "DFI_QNDROP"    "DFI Droplet number mixing ratio"        "# kg-1"
 state   real    dfi_qni        ikjftb  dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)    "DFI_QNICE"     "DFI Ice Number concentration" "# kg-1"
-state   real    dfi_qni2        ikjftb  dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)    "DFI_QNICE2"     "DFI Ice Number concentration cat 2" "# kg-1"
 state   real    dfi_qt         ikjftb  dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)    "DFI_CWM"       "DFI Total condensate mixing ratio"      "kg kg-1"
 state   real    dfi_qns        ikjftb  dfi_scalar      1         -     \
@@ -574,10 +561,6 @@ state   real    dfi_qir        ikjftb  dfi_scalar      1         -     \
    rhusdf=(bdy_interp:dt)    "DFI_QIR"    "DFI Rime ice mass-1 mixing ratio" "kg kg(-1)"
 state   real    dfi_qib        ikjftb  dfi_scalar      1         -     \
    rhusdf=(bdy_interp:dt)    "DFI_QIB"    "DFI Rime ice volume-1 mixing ratio" "m(3) kg(-1)"
-state   real    dfi_qir2        ikjftb  dfi_scalar      1         -     \
-   rhusdf=(bdy_interp:dt)    "DFI_QIR2"    "DFI Rime ice mass-2 mixing ratio" "kg kg(-1)"
-state   real    dfi_qib2        ikjftb  dfi_scalar      1         -     \
-   rhusdf=(bdy_interp:dt)    "DFI_QIB2"    "DFI Rime ice volume-2 mixing ratio" "m(3) kg(-1)"
 state   real    dfi_qke_adv   ikjftb  dfi_scalar      1         -      \
    rusdf=(bdy_interp:dt) "dfi_qke_adv"   "DFI twice TKE from MYNN"      "m2 s-2"
 
@@ -1311,12 +1294,9 @@ state    real  HAILNCV          ij      misc        1         -      r        "H
 state    real    refl_10cm      ikj     dyn_em      1         -      hdu       "refl_10cm"             "Radar reflectivity (lamda = 10 cm)"  "dBZ"
 state    real    th_old          ikj      misc        1         -      rusd        "TH_OLD"              "Old Value of Th"   "K"
 state    real    qv_old          ikj      misc        1         -      rusd        "QV_OLD"              "Old Value of qv"   "kg kg-1"
-state    real    vmi3d          ikj     misc        1         -     hdu       "v_ice"                 "Mass-weighted ice fallspeed cat 1"  "m s-1"
-state    real    di3d           ikj     misc        1         -     hdu       "d_ice"                 "Mass-weighted mean ice size cat 1"  "m"
-state    real    rhopo3d        ikj     misc        1         -     hdu       "rho_ice"               "Mass-weighted mean ice density cat 1"  "kg m-3"
-state    real    vmi3d_2          ikj     misc        1         -     hdu     "v_ice2"                 "Mass-weighted ice fallspeed cat 2"  "m s-1"
-state    real    di3d_2           ikj     misc        1         -     hdu     "d_ice2"                 "Mass-weighted mean ice size cat 2"  "m"
-state    real    rhopo3d_2        ikj     misc        1         -     hdu     "rho_ice2"               "Mass-weighted mean ice density cat 2"  "kg m-3"
+state    real    vmi3d          ikj     misc        1         -     hdu       "v_ice"                 "Mass-weighted ice fallspeed"  "m s-1"
+state    real    di3d           ikj     misc        1         -     hdu       "d_ice"                 "Mass-weighted mean ice size"  "m"
+state    real    rhopo3d        ikj     misc        1         -     hdu       "rho_ice"               "Mass-weighted mean ice density"  "kg m-3"
 # LIGHTNING NUDGING
 #state    real    ltg_dat        ij      misc        1         -      r         "ltg_dat"               "gridded lightning data"  "Flash per xkm x xkm per LAD_INT sec"
 # END LIGHTNING NUDGING
@@ -1482,21 +1462,28 @@ state integer  I_ACLWDNB        ij      misc        1         -      rhd=(interp
 state integer  I_ACLWDNBC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWDNBC"    "BUCKET FOR DOWNWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "J m-2"
 state    real  SWUPT            ij      misc        1         -      rhdu     "SWUPT"                 "INSTANTANEOUS UPWELLING SHORTWAVE FLUX AT TOP"          "W m-2"
 state    real  SWUPTC           ij      misc        1         -      rhdu     "SWUPTC"                "INSTANTANEOUS UPWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "W m-2"
+state    real  SWUPTCLN         ij      misc        1         -      rhdu     "SWUPTCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY SHORTWAVE FLUX AT TOP" "W m-2"
 state    real  SWDNT            ij      misc        1         -      rhdu     "SWDNT"                 "INSTANTANEOUS DOWNWELLING SHORTWAVE FLUX AT TOP"          "W m-2"
 state    real  SWDNTC           ij      misc        1         -      rhdu     "SWDNTC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "W m-2"
+state    real  SWDNTCLN         ij      misc        1         -      rhdu     "SWDNTCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY SHORTWAVE FLUX AT TOP" "W m-2"
 state    real  SWUPB            ij      misc        1         -      rhdu     "SWUPB"                 "INSTANTANEOUS UPWELLING SHORTWAVE FLUX AT BOTTOM"          "W m-2"
 state    real  SWUPBC           ij      misc        1         -      rhdu     "SWUPBC"                "INSTANTANEOUS UPWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
+state    real  SWUPBCLN         ij      misc        1         -      rhdu     "SWUPBCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
 state    real  SWDNB            ij      misc        1         -      rhdu     "SWDNB"                 "INSTANTANEOUS DOWNWELLING SHORTWAVE FLUX AT BOTTOM"          "W m-2"
 state    real  SWDNBC           ij      misc        1         -      rhdu     "SWDNBC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
+state    real  SWDNBCLN         ij      misc        1         -      rhdu     "SWDNBCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
 state    real  LWUPT            ij      misc        1         -      rhdu     "LWUPT"                 "INSTANTANEOUS UPWELLING LONGWAVE FLUX AT TOP"          "W m-2"
 state    real  LWUPTC           ij      misc        1         -      rhdu     "LWUPTC"                "INSTANTANEOUS UPWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "W m-2"
+state    real  LWUPTCLN         ij      misc        1         -      rhdu     "LWUPTCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY LONGWAVE FLUX AT TOP" "W m-2"
 state    real  LWDNT            ij      misc        1         -      rhdu     "LWDNT"                 "INSTANTANEOUS DOWNWELLING LONGWAVE FLUX AT TOP"          "W m-2"
 state    real  LWDNTC           ij      misc        1         -      rhdu     "LWDNTC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "W m-2"
+state    real  LWDNTCLN         ij      misc        1         -      rhdu     "LWDNTCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY LONGWAVE FLUX AT TOP" "W m-2"
 state    real  LWUPB            ij      misc        1         -      rhdu     "LWUPB"                 "INSTANTANEOUS UPWELLING LONGWAVE FLUX AT BOTTOM"          "W m-2"
 state    real  LWUPBC           ij      misc        1         -      rhdu     "LWUPBC"                "INSTANTANEOUS UPWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
+state    real  LWUPBCLN         ij      misc        1         -      rhdu     "LWUPBCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
 state    real  LWDNB            ij      misc        1         -      rhdu     "LWDNB"                 "INSTANTANEOUS DOWNWELLING LONGWAVE FLUX AT BOTTOM"          "W m-2"
 state    real  LWDNBC           ij      misc        1         -      rhdu     "LWDNBC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
-
+state    real  LWDNBCLN         ij      misc        1         -      rhdu     "LWDNBCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
 state    real  SWCF             ij      misc        1         -      r        "SWCF"                  "SHORT WAVE CLOUD FORCING AT TOA"                     "W m-2"
 state    real  LWCF             ij      misc        1         -      r        "LWCF"                  "LONG WAVE CLOUD FORCING AT TOA"                      "W m-2"
 state    real  OLR              ij      misc        1         -      rh        "OLR"                   "TOA OUTGOING LONG WAVE"                              "W m-2"
@@ -2652,7 +2639,6 @@ package   nssl_2momg      mp_physics==22               -             moist:qv,qc
 package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa;state:re_cloud,re_ice,re_snow,qnwfa2d,taod5503d,taod5502d
 package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;scalar:qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
 package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;scalar:qnc,qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
-package   p3_2category    mp_physics==52               -             moist:qv,qc,qr,qi,qi2;scalar:qnc,qni,qnr,qir,qib,qni2,qir2,qib2;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,vmi3d_2,rhopo3d_2,di3d_2,refl_10cm,th_old,qv_old
 package   etampnew        mp_physics==95               -             moist:qv,qc,qr,qs;scalar:qt;state:f_ice_phy,f_rain_phy,f_rimef_phy
 
 package   radar_refl      compute_radar_ref==1         -             state:refl_10cm,refd_max
@@ -2681,7 +2667,6 @@ package   nssl_1momlfo_dfi  mp_physics_dfi==21       -             dfi_moist:dfi
 package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   p3_1category_dfi  mp_physics_dfi==50       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
 package   p3_1category_nc_dfi  mp_physics_dfi==51    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
-package   p3_2category_dfi  mp_physics_dfi==52    -                dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qi2;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib,dfi_qni2,dfi_qir2,dfi_qib2;state:dfi_re_cloud,dfi_re_ice
 package   etampnew_dfi      mp_physics_dfi==95       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qs;dfi_scalar:dfi_qt
 
 package   noprogn       progn==0                     -             -

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -3760,6 +3760,7 @@ rconfig   integer     aer_ra_feedback     namelist,chem          max_domains    
 rconfig   integer     aer_op_opt          namelist,chem          max_domains    1       rh    "aer_op_opt"          ""      ""
 rconfig   integer     opt_pars_out        namelist,chem          1    0       h    "opt_pars_out"          ""      ""
 rconfig   integer     diagnostic_dep      namelist,chem          max_domains    0       rh    "diagnostic_dep"     ""      ""
+rconfig   integer     clean_atm_diag      namelist,chem          1              0       rh    "clean_atm_diag"     ""      ""
 
 # aircraft emissions
 rconfig   integer    aircraft_emiss_opt           namelist,chem    max_domains  0                                     rh    "aircraft_emiss_opt"                      ""    ""

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -60,8 +60,6 @@
 
    USE module_cam_mam_wetscav, only:wetscav_cam_mam_driver_init
    USE module_cam_support, only: numgas_mam, gas_pcnst_modal_aero,gas_pcnst_modal_aero_pos !BSINGH - Fix for non-MAM simulations
-   USE module_HLawConst, only: init_HLawConst
-   USE module_ctrans_grell, only: conv_tr_wetscav_init
 
 !!! TUCCELLA (BUG)
    USE module_prep_wetscav_sorgam, only: aerosols_sorgam_init_aercld_ptrs, aerosols_soa_vbs_init_aercld_ptrs 
@@ -141,7 +139,6 @@
    integer :: i,j,k,l,numgas,ixhour,n,ndystep,kk,nv
    real, DIMENSION (1,1) :: sza,cosszax
    real :: xtime,xhour,xmin,gmtp,xlonn,rlat
-   logical :: is_moz_chm
 #include "version_decl"
 #ifdef CHEM_DBG_I
     call print_chem_species_index( config_flags%chem_opt )
@@ -272,12 +269,10 @@ call wrf_message("**************************************************************
        CALL wrf_debug(15,'calling biomass burning for GHGs')
    endif
 
-   is_moz_chm = config_flags%chem_opt == MOZCART_KPP .or. &
-                config_flags%chem_opt == MOZART_KPP .or. &
-                config_flags%chem_opt == MOZART_MOSAIC_4BIN_KPP .or. &
-                config_flags%chem_opt == MOZART_MOSAIC_4BIN_AQ_KPP
-
-   if( is_moz_chm ) then
+   if( config_flags%chem_opt == MOZCART_KPP .or. &
+       config_flags%chem_opt == MOZART_KPP .or. &
+       config_flags%chem_opt == MOZART_MOSAIC_4BIN_KPP .or. &
+       config_flags%chem_opt == MOZART_MOSAIC_4BIN_AQ_KPP) then
        write(message_txt,*) 'chem_init: calling mozcart_lbc_init for domain ',id
        call wrf_message( trim(message_txt) )
        call mozcart_lbc_init( chem, num_chem, id, &
@@ -297,20 +292,13 @@ call wrf_message("**************************************************************
      endif
    endif
 
-   if( is_moz_chm .and. id == 1 ) then
-     write(message_txt,*) 'chem_init: calling init_HLawConst for domain ',id
-     call wrf_message( trim(message_txt) )
-!  Initialize Henrys Law constants
-     call init_HLawConst( id )
-     if( config_flags%conv_tr_wetscav == 1 ) then
-!  Initialize Henrys Law constants
-       call conv_tr_wetscav_init( numgas, num_chem )
-     endif
-   endif
-
 !!! TUCCELLA
    if ( config_flags%wetscav_onoff == 1 ) then
-     if( .not. is_moz_chm ) then
+
+     if( config_flags%chem_opt /= MOZART_KPP .and. &
+         config_flags%chem_opt /= MOZCART_KPP .and. &
+         config_flags%chem_opt /= MOZART_MOSAIC_4BIN_KPP .and. &
+         config_flags%chem_opt /= MOZART_MOSAIC_4BIN_AQ_KPP  ) then
        if(  ( config_flags%chem_opt >= 8 .AND. config_flags%chem_opt <= 13) .OR.  &
             ( config_flags%chem_opt >= 31 .AND. config_flags%chem_opt <= 36) .OR. &
             ( config_flags%chem_opt >= 41 .AND. config_flags%chem_opt <= 43) .OR. &
@@ -413,6 +401,10 @@ call wrf_message("**************************************************************
     IF ( config_flags%chem_opt == 0 .AND. config_flags%aer_ra_feedback .NE. 0 ) THEN
 !       config_flags%aer_ra_feedback = 0
         call wrf_error_fatal(" ERROR: CHEM_INIT: FOR CHEM_OPT = 0, AER_RA_FEEDBACK MUST = 0 ")
+    ENDIF
+
+    IF ( config_flags%clean_atm_diag .gt. 0 .AND. config_flags%aer_ra_feedback .EQ. 0 ) THEN
+    	call wrf_error_fatal("ERROR: clean_atm_diag > 0 requires aer_ra_feedback > 0")
     ENDIF
 
     IF ( config_flags%aer_ra_feedback .EQ. 1   .AND.   &
@@ -1573,6 +1565,7 @@ end if
 
    END SELECT kpp_select
    endif
+
 
 !! Initialize some greenhouse gas species for 16th and 17th chemistry options:
 !! CO2 mixing ratios for the background GHG tracers are set as a constant value.

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -334,7 +334,6 @@ BENCH_START(rad_driver_tim)
      &        , QC=moist(ims,kms,jms,P_QC), F_QC=F_QC                     &
      &        , QR=moist(ims,kms,jms,P_QR), F_QR=F_QR                     &
      &        , QI=moist(ims,kms,jms,P_QI), F_QI=F_QI                     &
-     &        , QI2=moist(ims,kms,jms,P_QI2), F_QI2=F_QI2                 & ! for P3
      &        , QS=moist(ims,kms,jms,P_QS), F_QS=F_QS                     &
      &        , QG=moist(ims,kms,jms,P_QG), F_QG=F_QG                     &
      &        , QNDROP=scalar(ims,kms,jms,P_QNDROP), F_QNDROP=F_QNDROP    &
@@ -348,14 +347,14 @@ BENCH_START(rad_driver_tim)
      &        ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc            &
      &        ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc            &
      &        ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc            &
-     &        ,SWUPT=grid%swupt    ,SWUPTC=grid%swuptc                    &
-     &        ,SWDNT=grid%swdnt    ,SWDNTC=grid%swdntc                    &
-     &        ,SWUPB=grid%swupb    ,SWUPBC=grid%swupbc                    &
-     &        ,SWDNB=grid%swdnb    ,SWDNBC=grid%swdnbc                    &
-     &        ,LWUPT=grid%lwupt    ,LWUPTC=grid%lwuptc                    &
-     &        ,LWDNT=grid%lwdnt    ,LWDNTC=grid%lwdntc                    &
-     &        ,LWUPB=grid%lwupb    ,LWUPBC=grid%lwupbc                    &
-     &        ,LWDNB=grid%lwdnb    ,LWDNBC=grid%lwdnbc                    &
+     &        ,SWUPT=grid%swupt,SWUPTC=grid%swuptc,SWUPTCLN=grid%swuptcln &
+     &        ,SWDNT=grid%swdnt,SWDNTC=grid%swdntc,SWDNTCLN=grid%swdntcln &
+     &        ,SWUPB=grid%swupb,SWUPBC=grid%swupbc,SWUPBCLN=grid%swupbcln &
+     &        ,SWDNB=grid%swdnb,SWDNBC=grid%swdnbc,SWDNBCLN=grid%swdnbcln &
+     &        ,LWUPT=grid%lwupt,LWUPTC=grid%lwuptc,LWUPTCLN=grid%lwuptcln &
+     &        ,LWDNT=grid%lwdnt,LWDNTC=grid%lwdntc,LWDNTCLN=grid%lwdntcln &
+     &        ,LWUPB=grid%lwupb,LWUPBC=grid%lwupbc,LWUPBCLN=grid%lwupbcln &
+     &        ,LWDNB=grid%lwdnb,LWDNBC=grid%lwdnbc,LWDNBCLN=grid%lwdnbcln &
      &        ,LWCF=grid%lwcf                                                  &
      &        ,SWCF=grid%swcf                                                  &
      &        ,OLR=grid%olr                                                    &
@@ -368,6 +367,7 @@ BENCH_START(rad_driver_tim)
      &        ,ICLOUD_CU=config_flags%ICLOUD_CU                            &
      &        ,QC_CU=grid%QC_CU , QI_CU=grid%QI_CU                         &
 #if (WRF_CHEM == 1)
+     &        ,CLEAN_ATM_DIAG=config_flags%clean_atm_diag                  &
      &        ,AER_RA_FEEDBACK=config_flags%aer_ra_feedback                &
      &        ,PM2_5_DRY=grid%pm2_5_dry, PM2_5_WATER=grid%pm2_5_water               &
      &        ,PM2_5_DRY_EC=grid%pm2_5_dry_ec                                  &

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -5984,12 +5984,10 @@ contains
 
 ! ------- Modules -------
 
-      use parrrtm, only : ngs5
-!     use parrrtm, only : ng6, ngs5
+      use parrrtm, only : ng6, ngs5
       use rrlw_ref, only : chi_mls
-      use rrlw_kg06
-!     use rrlw_kg06, only : fracrefa, absa, ka, ka_mco2, &
-!                           selfref, forref, cfc11adj, cfc12
+      use rrlw_kg06, only : fracrefa, absa, ka, ka_mco2, &
+                            selfref, forref, cfc11adj, cfc12
 
 ! ------- Declarations -------
 
@@ -8764,13 +8762,11 @@ contains
 ! old band 6:  820-980 cm-1 (low - h2o; high - nothing)
 !***************************************************************************
 
-      use parrrtm, only : mg, nbndlw, ngptlw
-!     use parrrtm, only : mg, nbndlw, ngptlw, ng6
-      use rrlw_kg06
-!     use rrlw_kg06, only: fracrefao, kao, kao_mco2, cfc11adjo, cfc12o, &
-!                          selfrefo, forrefo, &
-!                          fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12, &
-!                          selfref, forref
+      use parrrtm, only : mg, nbndlw, ngptlw, ng6
+      use rrlw_kg06, only: fracrefao, kao, kao_mco2, cfc11adjo, cfc12o, &
+                           selfrefo, forrefo, &
+                           fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12, &
+                           selfref, forref
 
 ! ------- Local -------
       integer(kind=im) :: jt, jp, igc, ipr, iprsm 
@@ -10587,7 +10583,8 @@ contains
              inflglw ,iceflglw,liqflglw,cldfmcl , &
              taucmcl ,ciwpmcl ,clwpmcl , cswpmcl ,reicmcl ,relqmcl , resnmcl , &
              tauaer  , &
-             uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc)
+             uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
+             uflxcln ,dflxcln, clean_atm_diag_local )
 
 ! -------- Description --------
 
@@ -10768,6 +10765,7 @@ contains
                                                       !    Dimensions: (ncol,nlay,nbndlw)
                                                       !   for future expansion 
                                                       !   (lw aerosols/scattering not yet available)
+      integer, intent(in) :: clean_atm_diag_local     ! Control for clean air diagnositic calls for WRF-Chem
 
 ! ----- Output -----
 
@@ -10783,6 +10781,10 @@ contains
                                                       !    Dimensions: (ncol,nlay+1)
       real(kind=rb), intent(out) :: hrc(:,:)          ! Clear sky longwave radiative heating rate (K/d)
                                                       !    Dimensions: (ncol,nlay)
+      real(kind=rb), intent(out) :: uflxcln(:,:)      ! Clean sky longwave upward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real(kind=rb), intent(out) :: dflxcln(:,:)      ! Clean sky longwave downward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
 
 ! ----- Local -----
 
@@ -10894,6 +10896,10 @@ contains
       real(kind=rb) :: totdclfl(0:nlay+1)     ! clear sky downward longwave flux (w/m2)
       real(kind=rb) :: fnetc(0:nlay+1)        ! clear sky net longwave flux (w/m2)
       real(kind=rb) :: htrc(0:nlay+1)         ! clear sky longwave heating rate (k/day)
+      real(kind=rb) :: totuclnlfl(0:nlay+1)   ! clean sky upward longwave flux (w/m2)
+      real(kind=rb) :: totdclnlfl(0:nlay+1)   ! clean sky downward longwave flux (w/m2)
+      real(kind=rb) :: fnetcln(0:nlay+1)      ! clean sky net longwave flux (w/m2)
+      real(kind=rb) :: htrcln(0:nlay+1)       ! clean sky longwave heating rate (k/day)
 
 !
 ! Initializations
@@ -11008,6 +11014,29 @@ contains
 ! to be used.  Clear sky calculation is done simultaneously.
 ! For McICA, RTRNMC is called for clear and cloudy calculations.
 
+#if (WRF_CHEM == 1)
+        ! Call the radiative transfer routine for "clean" sky first,
+        ! passing taug rather than taut so we have no aerosol influence.
+        ! We will keep totuclnlfl, totdclnlfl, fnetcln, and htrcln, 
+        ! and then overwrite the rest with the second call to rtrnmc.
+         if(clean_atm_diag_local .gt. 0)then
+             call rtrnmc(nlayers, istart, iend, iout, pz, semiss, ncbands, &
+                     cldfmc, taucmc, planklay, planklev, plankbnd, &
+                     pwvcm, fracs, taug, &
+                     totuclnlfl, totdclnlfl, fnetcln, htrcln, &
+                     totuclfl, totdclfl, fnetc, htrc )
+         else
+            do k = 0, nlayers
+                totuclnlfl(k) = 0.0
+                totdclnlfl(k) = 0.0
+            end do
+         end if
+#else
+         do k = 0, nlayers
+            totuclnlfl(k) = 0.0
+            totdclnlfl(k) = 0.0
+         end do
+#endif
          call rtrnmc(nlayers, istart, iend, iout, pz, semiss, ncbands, &
                      cldfmc, taucmc, planklay, planklev, plankbnd, &
                      pwvcm, fracs, taut, &
@@ -11022,6 +11051,8 @@ contains
             dflx(iplon,k+1) = totdflux(k)
             uflxc(iplon,k+1) = totuclfl(k)
             dflxc(iplon,k+1) = totdclfl(k)
+            uflxcln(iplon,k+1) = totuclnlfl(k)
+            dflxcln(iplon,k+1) = totdclnlfl(k)
          enddo
          do k = 0, nlayers-1
             hr(iplon,k+1) = htr(k)
@@ -11419,8 +11450,8 @@ CONTAINS
 !------------------------------------------------------------------
    SUBROUTINE RRTMG_LWRAD(                                        &
                        rthratenlw,                                &
-                       lwupt, lwuptc, lwdnt, lwdntc,              &
-                       lwupb, lwupbc, lwdnb, lwdnbc,              &
+                       lwupt, lwuptc, lwuptcln, lwdnt, lwdntc, lwdntcln, &
+                       lwupb, lwupbc, lwupbcln, lwdnb, lwdnbc, lwdnbcln, &
 !                      lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
                        glw, olr, lwcf, emiss,                     &
                        p8w, p3d, pi3d,                            &
@@ -11442,7 +11473,7 @@ CONTAINS
                        tauaerlw13,tauaerlw14,tauaerlw15,tauaerlw16,   & ! czhao 
                        aer_ra_feedback,                           & !czhao
 !jdfcz                 progn,prescribe,                           & !czhao
-                       progn,                                     & !czhao
+                       progn,clean_atm_diag,                      & !czhao
                        qndrop3d,f_qndrop,                         & !czhao
 !ccc added for time varying gases.
                        yr,julian,                                 &
@@ -11451,7 +11482,7 @@ CONTAINS
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte,                 &
-                       lwupflx, lwupflxc, lwdnflx, lwdnflxc       &
+                       lwupflx, lwupflxc, lwupflxcln, lwdnflx, lwdnflxc, lwdnflxcln &
                                                                   )
 !------------------------------------------------------------------
 !ccc To use clWRF time varying trace gases
@@ -11546,6 +11577,8 @@ CONTAINS
    INTEGER,    INTENT(IN  ), OPTIONAL   ::       aer_ra_feedback
 !jdfcz   INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn,prescribe
    INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn
+   INTEGER,    INTENT(IN  ), OPTIONAL   ::       clean_atm_diag
+   integer :: clean_atm_diag_local
 !  Ozone
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          OPTIONAL                                               , &
@@ -11560,14 +11593,15 @@ CONTAINS
 ! Top of atmosphere and surface longwave fluxes (W m-2)
    REAL, DIMENSION( ims:ime, jms:jme ),                           &
          OPTIONAL, INTENT(INOUT) ::                               &
-                                       LWUPT,LWUPTC,LWDNT,LWDNTC, &
-                                       LWUPB,LWUPBC,LWDNB,LWDNBC
+                      LWUPT,LWUPTC,LWUPTCLN,LWDNT,LWDNTC,LWDNTCLN,&
+                      LWUPB,LWUPBC,LWUPBCLN,LWDNB,LWDNBC,LWDNBCLN 
 
 ! Layer longwave fluxes (including extra layer above model top)
 ! Vertical ordering is from bottom to top (W m-2)
    REAL, DIMENSION( ims:ime, kms:kme+2, jms:jme ),                &
          OPTIONAL, INTENT(OUT) ::                                 &
-                               LWUPFLX,LWUPFLXC,LWDNFLX,LWDNFLXC
+                               LWUPFLX,LWUPFLXC,LWDNFLX,LWDNFLXC, &
+                               LWUPFLXCLN, LWDNFLXCLN
 
 !  LOCAL VARS
  
@@ -11648,7 +11682,10 @@ CONTAINS
     real, dimension( 1, kts:nlayers+1 )  ::                 uflx, &
                                                             dflx, &
                                                            uflxc, &
-                                                           dflxc
+                                                           dflxc, &
+                                                         uflxcln, &
+                                                         dflxcln
+                                                           
     real, dimension( 1, kts:nlayers )  ::                    hr, &
                                                              hrc
 
@@ -11807,6 +11844,12 @@ CONTAINS
       ENDIF
       ENDIF
 #endif
+
+	if(present(clean_atm_diag))then
+		clean_atm_diag_local = clean_atm_diag
+	else
+		clean_atm_diag_local = 0
+	end if
 
 
 !-----CALCULATE LONG WAVE RADIATION
@@ -12595,7 +12638,8 @@ CONTAINS
              inflglw ,iceflglw,liqflglw,cldfmcl , &
              taucmcl ,ciwpmcl ,clwpmcl ,cswpmcl, reicmcl ,relqmcl ,resnmcl , &
              tauaer  , &
-             uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc)
+             uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
+             uflxcln ,dflxcln, clean_atm_diag_local )
 
 ! Output downard surface flux, and outgoing longwave flux and cloud forcing 
 ! at the top of atmosphere (W/m2)
@@ -12619,6 +12663,12 @@ CONTAINS
             lwupbc(i,j)    = uflxc(1,1)
             lwdnb(i,j)     = dflx(1,1)
             lwdnbc(i,j)    = dflxc(1,1)
+! Output up and down toa fluxes for clean sky
+            lwuptcln(i,j)  = uflxcln(1,nlayers+1)
+            lwdntcln(i,j)  = dflxcln(1,nlayers+1)
+! Output up and down surface fluxes for clean sky
+            lwupbcln(i,j)  = uflxcln(1,1)
+            lwdnbcln(i,j)  = dflxcln(1,1)
          endif
 
 ! Output up and down layer fluxes for total and clear sky.
@@ -12629,6 +12679,8 @@ CONTAINS
             lwupflxc(i,k,j) = uflxc(1,k)
             lwdnflx(i,k,j)  = dflx(1,k)
             lwdnflxc(i,k,j) = dflxc(1,k)
+            lwupflxcln(i,k,j) = uflxcln(1,k)
+            lwdnflxcln(i,k,j) = dflxcln(1,k)
          enddo
          endif
 
@@ -13377,9 +13429,8 @@ IMPLICIT NONE
       subroutine lw_kgb06(rrtmg_unit)
 ! **************************************************************************
 
-      use rrlw_kg06
-!     use rrlw_kg06, only : fracrefao, kao, kao_mco2, selfrefo, forrefo, &
-!                           cfc11adjo, cfc12o
+      use rrlw_kg06, only : fracrefao, kao, kao_mco2, selfrefo, forrefo, &
+                            cfc11adjo, cfc12o
 
       implicit none
       save

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -8494,6 +8494,7 @@
                zomcc(jk) = (zomcc(jk) - zwf) / (1.0_rb - zwf)
                zgcc (jk) = (zgcc(jk) - zf) / (1.0_rb - zf)
 
+
 ! Total sky optical parameters (cloud properties already delta-scaled)
 !   Use this code if cloud properties are derived in rrtmg_sw_cldprop       
                if (icpr .ge. 1) then
@@ -8736,12 +8737,13 @@
              taucmcl ,ssacmcl ,asmcmcl ,fsfcmcl , &
              ciwpmcl ,clwpmcl ,cswpmcl ,reicmcl ,relqmcl ,resnmcl, &
              tauaer  ,ssaaer  ,asmaer  ,ecaer   , &
-             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, aer_opt,  &
+             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, swuflxcln ,swdflxcln , aer_opt,  &
 ! --------- Add the following four compenants for ssib shortwave down radiation ---!
 ! -------------------      by Zhenxin 2011-06-20      --------------------------------!
              sibvisdir, sibvisdif, sibnirdir, sibnirdif,         &
 ! ----------------------  End,  Zhenxin 2011-06-20    --------------------------------!
              swdkdir,swdkdif                                & ! jararias, 2013/08/10
+             ,clean_atm_diag_local                          &
                                                                 )
 
 
@@ -8939,6 +8941,7 @@
       real(kind=rb), intent(in) :: ecaer(:,:,:)       ! Aerosol optical depth at 0.55 micron (iaer=6 only)
                                                       !    Dimensions: (ncol,nlay,naerec)
                                                       ! (non-delta scaled)      
+      integer, intent(in)       :: clean_atm_diag_local! Control for clean air diagnositic calls for WRF-Chem
 
 ! ----- Output -----
 
@@ -8962,6 +8965,10 @@
                                                       !    Dimensions: (ncol,nlay+1)
       real(kind=rb), intent(out) :: swhrc(:,:)        ! Clear sky shortwave radiative heating rate (K/d)
                                                       !    Dimensions: (ncol,nlay)
+      real(kind=rb), intent(out) :: swuflxcln(:,:)    ! Clean sky shortwave upward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real(kind=rb), intent(out) :: swdflxcln(:,:)    ! Clean sky shortwave downward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
 
       integer, intent(in)        :: aer_opt
       real(kind=rb), intent(out) :: &
@@ -9086,6 +9093,7 @@
                                                 !  (first moment of phase function)
       real(kind=rb) :: zomgc(nlay+1,nbndsw)     ! cloud single scattering albedo
       real(kind=rb) :: ztaua(nlay+1,nbndsw)     ! total aerosol optical depth
+      real(kind=rb) :: ztauacln(nlay+1,nbndsw)  ! dummy total aerosol optical depth for clean case (=zero)
       real(kind=rb) :: zasya(nlay+1,nbndsw)     ! total aerosol asymmetry parameter 
       real(kind=rb) :: zomga(nlay+1,nbndsw)     ! total aerosol single scattering albedo
 
@@ -9109,6 +9117,13 @@
       real(kind=rb) :: znicd(nlay+2)          ! temporary clear sky near-IR downward shortwave flux (w/m2)
       real(kind=rb) :: znifddir(nlay+2)       ! temporary near-IR downward direct shortwave flux (w/m2)
       real(kind=rb) :: znicddir(nlay+2)       ! temporary clear sky near-IR downward direct shortwave flux (w/m2)
+      real(kind=rb) :: zbbclnu(nlay+2)        ! temporary clean sky upward shortwave flux (w/m2)
+      real(kind=rb) :: zbbclnd(nlay+2)        ! temporary clean sky downward shortwave flux (w/m2)
+      real(kind=rb) :: zbbclnddir(nlay+2)     ! temporary clean sky downward direct shortwave flux (w/m2)
+      real(kind=rb) :: zuvclnd(nlay+2)        ! temporary clean sky UV downward shortwave flux (w/m2)
+      real(kind=rb) :: zuvclnddir(nlay+2)     ! temporary clean sky UV downward direct shortwave flux (w/m2)
+      real(kind=rb) :: zniclnd(nlay+2)        ! temporary clean sky near-IR downward shortwave flux (w/m2)
+      real(kind=rb) :: zniclnddir(nlay+2)     ! temporary clean sky near-IR downward direct shortwave flux (w/m2)
 
 ! Optional output fields 
       real(kind=rb) :: swnflx(nlay+2)         ! Total sky shortwave net flux (W/m2)
@@ -9320,6 +9335,7 @@
             do i = 1 ,nlayers
                do ib = 1 ,nbndsw
                   ztaua(i,ib) = taua(i,ib)
+                  ztauacln(i,ib) = 0.0
                   zasya(i,ib) = asma(i,ib)
                   zomga(i,ib) = ssaa(i,ib)
                enddo
@@ -9407,6 +9423,57 @@
          swhrc(iplon,nlayers) = 0._rb
          swhr(iplon,nlayers) = 0._rb
 
+#if (WRF_CHEM == 1)
+         !  Repeat call to 2-stream radiation model using "clean sky" 
+         !  variables and aerosol tau set to 0
+         if(clean_atm_diag_local .gt. 0)then
+            do i=1,nlayers+1
+                zbbcu(i) = 0._rb
+                zbbcd(i) = 0._rb
+                zbbclnu(i) = 0._rb
+                zbbclnd(i) = 0._rb
+                zbbcddir(i) = 0._rb
+                zbbclnddir(i) = 0._rb
+                zuvcd(i) = 0._rb
+                zuvclnd(i) = 0._rb
+                zuvcddir(i) = 0._rb
+                zuvclnddir(i) = 0._rb
+                znicd(i) = 0._rb
+                zniclnd(i) = 0._rb
+                znicddir(i) = 0._rb
+                zniclnddir(i) = 0._rb
+             enddo         
+
+             call spcvmc_sw &
+                 (nlayers, istart, iend, icpr, iout, &
+                  pavel, tavel, pz, tz, tbound, albdif, albdir, &
+                  zcldfmc, ztaucmc, zasycmc, zomgcmc, ztaormc, &
+                  ztauacln, zasya, zomga, cossza, coldry, wkl, adjflux, &	 
+                  laytrop, layswtch, laylow, jp, jt, jt1, &
+                  co2mult, colch4, colco2, colh2o, colmol, coln2o, colo2, colo3, &
+                  fac00, fac01, fac10, fac11, &
+                  selffac, selffrac, indself, forfac, forfrac, indfor, &
+                  zbbclnd, zbbclnu, zbbcd, zbbcu, zuvclnd, zuvcd, zniclnd, znicd, &
+                  zbbclnddir, zbbcddir, zuvclnddir, zuvcddir, zniclnddir, znicddir)
+
+            do i = 1, nlayers+1
+               swuflxcln(iplon,i) = zbbclnu(i) 
+               swdflxcln(iplon,i) = zbbclnd(i)
+            enddo
+         else
+            do i = 1, nlayers+1
+               swuflxcln(iplon,i) = 0.0 
+               swdflxcln(iplon,i) = 0.0
+            enddo
+         end if
+
+#else
+         do i = 1, nlayers+1
+            swuflxcln(iplon,i) = 0.0 
+            swdflxcln(iplon,i) = 0.0
+         enddo
+
+#endif
 ! End longitude loop
       enddo
 
@@ -9823,8 +9890,8 @@ CONTAINS
 !------------------------------------------------------------------
    SUBROUTINE RRTMG_SWRAD(                                        &
                        rthratensw,                                &
-                       swupt, swuptc, swdnt, swdntc,              &
-                       swupb, swupbc, swdnb, swdnbc,              &
+                       swupt, swuptc, swuptcln, swdnt, swdntc, swdntcln, &
+                       swupb, swupbc, swupbcln, swdnb, swdnbc, swdnbcln, &
 !                      swupflx, swupflxc, swdnflx, swdnflxc,      &
                        swcf, gsw,                                 &
                        xtime, gmt, xlat, xlong,                   &
@@ -9854,13 +9921,14 @@ CONTAINS
                        waer300,waer400,waer600,waer999,           & ! czhao 
                        aer_ra_feedback,                           &
 !jdfcz                 progn,prescribe,                           &
-                       progn,                                     &
+                       progn,clean_atm_diag,                      &
                        qndrop3d,f_qndrop,                         & !czhao
                        mp_physics,                                & !wang 2014/12
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte,                 &
-                       swupflx, swupflxc, swdnflx, swdnflxc,      &
+                       swupflx, swupflxc, swupflxcln,             &
+                       swdnflx, swdnflxc, swdnflxcln,             &
                        tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
                        swddir, swddni, swddif,                    & ! jararias 2013/08
                        xcoszen,julian                             & ! jararias 2013/08
@@ -9984,6 +10052,8 @@ CONTAINS
    INTEGER,    INTENT(IN  ), OPTIONAL   ::       aer_ra_feedback
 !jdfcz   INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn,prescribe
    INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn
+   INTEGER,    INTENT(IN  ), OPTIONAL   ::       clean_atm_diag
+   integer :: clean_atm_diag_local
 !  Ozone
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          OPTIONAL                                               , &
@@ -10011,14 +10081,15 @@ CONTAINS
 ! Top of atmosphere and surface shortwave fluxes (W m-2)
    REAL, DIMENSION( ims:ime, jms:jme ),                           &
          OPTIONAL, INTENT(INOUT) ::                               &
-                                       SWUPT,SWUPTC,SWDNT,SWDNTC, &
-                                       SWUPB,SWUPBC,SWDNB,SWDNBC
+                    SWUPT,SWUPTC,SWUPTCLN,SWDNT,SWDNTC,SWDNTCLN,  &
+                    SWUPB,SWUPBC,SWUPBCLN,SWDNB,SWDNBC,SWDNBCLN
 
 ! Layer shortwave fluxes (including extra layer above model top)
 ! Vertical ordering is from bottom to top (W m-2)
    REAL, DIMENSION( ims:ime, kms:kme+2, jms:jme ),                &
          OPTIONAL, INTENT(OUT) ::                                 &
-                               SWUPFLX,SWUPFLXC,SWDNFLX,SWDNFLXC
+                               SWUPFLX,SWUPFLXC,SWUPFLXCLN,       &
+                               SWDNFLX,SWDNFLXC,SWDNFLXCLN
 
 !  LOCAL VARS
  
@@ -10103,6 +10174,8 @@ CONTAINS
                                                           swdflx, &
                                                          swuflxc, &
                                                          swdflxc, &
+                                                       swuflxcln, &
+                                                       swdflxcln, &
                                                        sibvisdir, &  ! Zhenxin 2011-06-20
                                                        sibvisdif, &
                                                        sibnirdir, &
@@ -10221,6 +10294,12 @@ CONTAINS
       ENDIF
       ENDIF
 #endif
+
+	if(present(clean_atm_diag))then
+		clean_atm_diag_local = clean_atm_diag
+	else
+		clean_atm_diag_local = 0
+	end if
 
 !-----CALCULATE SHORT WAVE RADIATION
 !                                                              
@@ -11022,11 +11101,12 @@ CONTAINS
              taucmcl ,ssacmcl ,asmcmcl ,fsfcmcl , &
              ciwpmcl ,clwpmcl ,cswpmcl, reicmcl ,relqmcl ,resnmcl, &
              tauaer  ,ssaaer  ,asmaer  ,ecaer   , &
-             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, aer_opt, &
+             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, swuflxcln, swdflxcln, aer_opt, &
 ! -----      Zhenxin added for ssib coupiling 2011-06-20 --------!
              sibvisdir, sibvisdif, sibnirdir, sibnirdif,         &
 ! --------------------   End of addiation by Zhenxin 2011-06-20 ------!
              swdkdir, swdkdif                      &  ! jararias, 2012/08/10
+             ,clean_atm_diag_local                 &
                                                    )
 
 
@@ -11039,11 +11119,14 @@ CONTAINS
 ! Output up and down toa fluxes for total and clear sky
             swupt(i,j)     = swuflx(1,kte+2)
             swuptc(i,j)    = swuflxc(1,kte+2)
+            swuptcln(i,j)  = swuflxcln(1,kte+2)
             swdnt(i,j)     = swdflx(1,kte+2)
             swdntc(i,j)    = swdflxc(1,kte+2)
+            swdntcln(i,j)  = swdflxcln(1,kte+2)
 ! Output up and down surface fluxes for total and clear sky
             swupb(i,j)     = swuflx(1,1)
             swupbc(i,j)    = swuflxc(1,1)
+            swupbcln(i,j)  = swuflxcln(1,1)
             swdnb(i,j)     = swdflx(1,1)
 ! Added by Zhenxin for 4 compenants of swdown radiation
             swvisdir(i,j)  = sibvisdir(1,1)
@@ -11052,6 +11135,7 @@ CONTAINS
             swnirdif(i,j)  = sibnirdif(1,1)
 !  Ended, Zhenxin (2011/06/20)
             swdnbc(i,j)    = swdflxc(1,1)
+            swdnbcln(i,j)  = swdflxcln(1,1)
          endif
             swddir(i,j)    = swdkdir(1,1)          ! jararias 2013/08/10
             swddni(i,j)    = swddir(i,j) / coszrs  ! jararias 2013/08/10
@@ -11063,8 +11147,10 @@ CONTAINS
          do k=kts,kte+2
             swupflx(i,k,j)  = swuflx(1,k)
             swupflxc(i,k,j) = swuflxc(1,k)
+            swupflxcln(i,k,j) = swuflxcln(1,k) 
             swdnflx(i,k,j)  = swdflx(1,k)
             swdnflxc(i,k,j) = swdflxc(1,k)
+            swdnflxcln(i,k,j) = swdflxcln(1,k)
          enddo
          endif
 
@@ -11079,13 +11165,17 @@ CONTAINS
 ! Output up and down toa fluxes for total and clear sky
             swupt(i,j)     = 0.
             swuptc(i,j)    = 0.
+            swuptcln(i,j)  = 0.
             swdnt(i,j)     = 0.
             swdntc(i,j)    = 0.
+            swdntcln(i,j)  = 0.
 ! Output up and down surface fluxes for total and clear sky
             swupb(i,j)     = 0.
             swupbc(i,j)    = 0.
+            swupbcln(i,j)  = 0.
             swdnb(i,j)     = 0.
             swdnbc(i,j)    = 0.
+            swdnbcln(i,j)  = 0.
             swvisdir(i,j)  = 0.  ! Add by Zhenxin (2011/06/20)
             swvisdif(i,j)  = 0.
             swnirdir(i,j)  = 0.

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -74,7 +74,6 @@ CONTAINS
               , QC, F_QC                     &
               , QR, F_QR                     &
               , QI, F_QI                     &
-              , QI2, F_QI2                   & ! for P3
               , QS, F_QS                     &
               , QG, F_QG                     &
               , QNDROP, F_QNDROP    &
@@ -88,14 +87,14 @@ CONTAINS
               ,ACLWDNT   ,ACLWDNTC            &
               ,ACLWUPB   ,ACLWUPBC            &
               ,ACLWDNB   ,ACLWDNBC            &
-              ,SWUPT ,SWUPTC                  &
-              ,SWDNT ,SWDNTC                  &
-              ,SWUPB ,SWUPBC                  &
-              ,SWDNB ,SWDNBC                  &
-              ,LWUPT ,LWUPTC                  &
-              ,LWDNT ,LWDNTC                  &
-              ,LWUPB ,LWUPBC                  &
-              ,LWDNB ,LWDNBC                  &
+              ,SWUPT ,SWUPTC, SWUPTCLN        &
+              ,SWDNT ,SWDNTC, SWDNTCLN        &
+              ,SWUPB ,SWUPBC, SWUPBCLN        &
+              ,SWDNB ,SWDNBC, SWDNBCLN        &
+              ,LWUPT ,LWUPTC, LWUPTCLN        &
+              ,LWDNT ,LWDNTC, LWDNTCLN        &
+              ,LWUPB ,LWUPBC, LWUPBCLN        &
+              ,LWDNB ,LWDNBC, LWDNBCLN        &
               ,LWCF                           &
               ,SWCF                           &
               ,OLR                            &
@@ -105,6 +104,7 @@ CONTAINS
               ,AEROSOLC_2, M_HYBI0            &
               ,ABSTOT, ABSNXT, EMSTOT         &
               ,ICLOUD_CU                      &
+              ,CLEAN_ATM_DIAG                 &
               ,AER_RA_FEEDBACK                &
               ,QC_CU , QI_CU                  &
               ,icloud_bl,qc_bl,cldfra_bl     & !JOE-subgrid bl clouds
@@ -466,6 +466,7 @@ CONTAINS
 
    INTEGER, INTENT(IN   ), OPTIONAL  ::   icloud_bl
    INTEGER, INTENT(IN   ), OPTIONAL  ::   aer_ra_feedback
+   INTEGER, INTENT(IN   ), OPTIONAL  ::   clean_atm_diag
 
 !jdfcz   INTEGER, OPTIONAL, INTENT(IN   )    :: progn,prescribe
    INTEGER, OPTIONAL, INTENT(IN   )    :: progn
@@ -498,18 +499,23 @@ CONTAINS
                       ACLWUPT,ACLWUPTC,ACLWDNT,ACLWDNTC,          &
                       ACLWUPB,ACLWUPBC,ACLWDNB,ACLWDNBC
 
-! TOA and surface, upward and downward, total and clear fluxes
+! TOA and surface, upward and downward, total, clear (no cloud), and clean (no aerosol) fluxes
    REAL, DIMENSION( ims:ime, jms:jme ), OPTIONAL, INTENT(INOUT) ::&
-                        SWUPT,  SWUPTC,  SWDNT,  SWDNTC,          &
-                        SWUPB,  SWUPBC,  SWDNB,  SWDNBC,          &
-                        LWUPT,  LWUPTC,  LWDNT,  LWDNTC,          &
-                        LWUPB,  LWUPBC,  LWDNB,  LWDNBC
+              SWUPT,  SWUPTC, SWUPTCLN,  SWDNT,  SWDNTC, SWDNTCLN,&
+              SWUPB,  SWUPBC, SWUPBCLN,  SWDNB,  SWDNBC, SWDNBCLN,&
+              LWUPT,  LWUPTC, LWUPTCLN,  LWDNT,  LWDNTC, LWDNTCLN,&
+              LWUPB,  LWUPBC, LWUPBCLN,  LWDNB,  LWDNBC, LWDNBCLN
+
 
 ! Upward and downward, total and clear sky layer fluxes (W m-2)
    REAL, DIMENSION( ims:ime, kms:kme+2, jms:jme ),                &
          OPTIONAL, INTENT(INOUT) ::                               &
                                SWUPFLX,SWUPFLXC,SWDNFLX,SWDNFLXC, &
                                LWUPFLX,LWUPFLXC,LWDNFLX,LWDNFLXC
+! Up/down clean sky fluxes (W m-2), not currently passed out from this subroutine
+   REAL, DIMENSION( ims:ime, kms:kme+2, jms:jme ) ::              &
+          SWUPFLXCLN,SWDNFLXCLN,                                  &
+          LWUPFLXCLN,LWDNFLXCLN
 
    REAL, DIMENSION( ims:ime, jms:jme ),          OPTIONAL ,       &
          INTENT(INOUT)  ::                                  SWCF, &
@@ -658,12 +664,10 @@ CONTAINS
          INTENT(INOUT ) ::                                        &
                                                                pb &
                                         ,qv,qc,qr,qi,qs,qg,qndrop,      &
-                                                      qnifa,qnwfa,      & ! Trude
-                                                      qi2        ! for P3
+                                                      qnifa,qnwfa        ! Trude
 
    LOGICAL, OPTIONAL ::     f_qv,f_qc,f_qr,f_qi,f_qs,f_qg,f_qndrop,     &
-                                                f_qnifa,f_qnwfa,        &  ! trude
-                                                f_qi2            ! for P3
+                                                f_qnifa,f_qnwfa          ! trude
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                  &
          OPTIONAL,                                                &
@@ -1109,19 +1113,6 @@ CONTAINS
           ENDDO
           ENDDO
      ENDIF
-#if (EM_CORE == 1)
-! temporarily modify hydrometeors (for P3, if 2 cat then add ice from both categories)
-!
-     IF ( F_QI2) THEN
-          DO j=jts,jte
-          DO k=kts,kte
-          DO i=its,ite
-             qi(i,k,j) = qi(i,k,j) + qi2(i,k,j)
-          ENDDO
-          ENDDO
-          ENDDO
-     ENDIF
-#endif
 
 ! Choose how to compute cloud fraction (since 3.6)
 ! Initialize to zero 
@@ -1536,10 +1527,10 @@ CONTAINS
              CALL wrf_debug (100, 'CALL rrtmg_lw')
              CALL RRTMG_LWRAD(                                      &
                   RTHRATENLW=RTHRATEN,                              &
-                  LWUPT=LWUPT,LWUPTC=LWUPTC,                        &
-                  LWDNT=LWDNT,LWDNTC=LWDNTC,                        &
-                  LWUPB=LWUPB,LWUPBC=LWUPBC,                        &
-                  LWDNB=LWDNB,LWDNBC=LWDNBC,                        &
+                  LWUPT=LWUPT,LWUPTC=LWUPTC,LWUPTCLN=LWUPTCLN,      &
+                  LWDNT=LWDNT,LWDNTC=LWDNTC,LWDNTCLN=LWDNTCLN,      &
+                  LWUPB=LWUPB,LWUPBC=LWUPBC,LWUPBCLN=LWUPBCLN,      &
+                  LWDNB=LWDNB,LWDNBC=LWDNBC,LWDNBCLN=LWDNBCLN,      &
                   GLW=GLW,OLR=RLWTOA,LWCF=LWCF,                     &
                   EMISS=EMISS,                                      &
                   P8W=p8w,P3D=p,PI3D=pi,DZ8W=dz8w,TSK=tsk,T3D=t,    &
@@ -1572,7 +1563,7 @@ CONTAINS
                   TAUAERLW15=tauaerlw15,TAUAERLW16=tauaerlw16,      & ! jcb
                   aer_ra_feedback=aer_ra_feedback,                  &
 !jdfcz            progn=progn,prescribe=prescribe,                   &
-                  progn=progn,                                      &
+                  progn=progn,clean_atm_diag=clean_atm_diag,        &
 #endif
                   QNDROP3D=qndrop,F_QNDROP=f_qndrop,                &
 !ccc Added for time-varying trace gases.
@@ -1581,8 +1572,8 @@ CONTAINS
                   IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde,&
                   IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme,&
                   ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte,&
-                  LWUPFLX=LWUPFLX,LWUPFLXC=LWUPFLXC,                &
-                  LWDNFLX=LWDNFLX,LWDNFLXC=LWDNFLXC,                &
+                  LWUPFLX=LWUPFLX,LWUPFLXC=LWUPFLXC,LWUPFLXCLN=LWUPFLXCLN, &
+                  LWDNFLX=LWDNFLX,LWDNFLXC=LWDNFLXC,LWDNFLXCLN=LWDNFLXCLN,  &
                   mp_physics=mp_physics                             )
 
         CASE (RRTMG_LWSCHEME_FAST)
@@ -1952,10 +1943,10 @@ CONTAINS
              CALL wrf_debug(100, 'CALL rrtmg_sw')
              CALL RRTMG_SWRAD(                                         &
                      RTHRATENSW=RTHRATENSW,                            &
-                     SWUPT=SWUPT,SWUPTC=SWUPTC,                        &
-                     SWDNT=SWDNT,SWDNTC=SWDNTC,                        &
-                     SWUPB=SWUPB,SWUPBC=SWUPBC,                        &
-                     SWDNB=SWDNB,SWDNBC=SWDNBC,                        &
+                     SWUPT=SWUPT,SWUPTC=SWUPTC,SWUPTCLN=SWUPTCLN,      &
+                     SWDNT=SWDNT,SWDNTC=SWDNTC,SWDNTCLN=SWDNTCLN,      &
+                     SWUPB=SWUPB,SWUPBC=SWUPBC,SWUPBCLN=SWUPBCLN,      &
+                     SWDNB=SWDNB,SWDNBC=SWDNBC,SWDNBCLN=SWDNBCLN,      &
                      SWCF=SWCF,GSW=GSW,                                &
                      XTIME=XTIME,GMT=GMT,XLAT=XLAT,XLONG=XLONG,        &
                      RADT=RADT,DEGRAD=DEGRAD,DECLIN=DECLIN,            &
@@ -1995,14 +1986,14 @@ CONTAINS
                      WAER600=waer600,WAER999=waer999,                  & ! jcb
                      aer_ra_feedback=aer_ra_feedback,                  &
 !jdfcz               progn=progn,prescribe=prescribe,                  &
-                     progn=progn,                                      &
+                     progn=progn,clean_atm_diag=clean_atm_diag,        &
 #endif
                      QNDROP3D=qndrop,F_QNDROP=f_qndrop,                &
                      IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde,&
                      IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme,&
                      ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte,&
-                     SWUPFLX=SWUPFLX,SWUPFLXC=SWUPFLXC,                &
-                     SWDNFLX=SWDNFLX,SWDNFLXC=SWDNFLXC,                &
+                     SWUPFLX=SWUPFLX,SWUPFLXC=SWUPFLXC,SWUPFLXCLN=SWUPFLXCLN, &
+                     SWDNFLX=SWDNFLX,SWDNFLXC=SWDNFLXC,SWDNFLXCLN=SWDNFLXCLN, &
                      tauaer3d_sw=tauaer_sw,                             & ! jararias 2013/11
                      ssaaer3d_sw=ssaaer_sw,                             & ! jararias 2013/11
                      asyaer3d_sw=asyaer_sw,                             & ! jararias 2013/11


### PR DESCRIPTION
    TYPE: new feature
    
    KEYWORDS: clean sky diagnostic

    SOURCE: Douglas Lowe (University of Manchester)

    DESCRIPTION OF CHANGES:
    Coding work to add "clean sky" diagnostic outputs to WRF-Chem

    1) diagnostic variables are defined in "Registry/Registry.EM_COMMON"
    --- Add new variables for output: SWUPTN; SWUPBN; etc (using "CLN" for clean sky variables)

    2) diagnostic variables are passed to the "grid" array during the call to the "radiation_driver"
    subroutine in "dyn_em/module_first_rk_step_part1.F". So need to add the new diagnostic variables
    to the subroutine interface here.

    3) "radiation_driver" is in "phys/module_radiation_driver.F" - this calls the subroutines
    "RRTMG_SWRAD" and "RRTMG_LWRAD", which calculate the short and long wave fluxes for our
    radiative scheme of interest. The new diagnostic variables will need to be added to these
    call interfaces here too.

    4) Short wave diagnostics ("phys/module_ra_rrtmg_sw.F"):
    "RRTMG_SWRAD" calls "rrtmg_sw": this call interface will need the new diagnostic
    variables adding. -> also need new local variables swuflxcln etc.

    5) "rrtmg_sw" calls "spcvmc_sw", passing it the bulk aerosol properties (ztaua, zasya, zamga).
    The call to "spcvmc_sw" should be duplicated, with the aerosol bulk properties set to zero,
    so that we can take the output "clear sky" variables and save them as our "clean sky" variables.

    6) Long wave diagnostics ("phys/module_ra_rrtmg_lw.F"):
    "RRTMG_LWRAD" calls "rrtmg_lw": this call interface will need the new diagnostic
    variables adding (and flx variables).
    "rrtmg_lw" calls "rtrnmc", passing it a combined gaseous and aerosol optical depth variable.
    The call to "rtrnmc" should be duplicated, with only gaseous optical depth information passed,
    so that we can take the output "clear sky" variables and save them as our "clean sky" variables.

    LIST OF MODIFIED FILES:
    M       Registry/Registry.EM_COMMON
    M       Registry/registry.chem
    M       chem/chemics_init.F
    M       dyn_em/module_first_rk_step_part1.F
    M       phys/module_ra_rrtmg_lw.F
    M       phys/module_ra_rrtmg_sw.F
    M       phys/module_radiation_driver.F

    (line numbers given below refer to the modified files for v3.9.1)
    =========================================================================

    1. registry.chem

    1) control flag "clean_atm_diag" for switching on/off diagnostic code is added at line 3763
    --- default value 0 switches off calculation, values of 1+ switch it on

    2. Registry.EM_COMMON

    1) diagnostic variables are defined in "Registry/Registry.EM_COMMON"
    --- Add new variables for output: SWUPTN; SWUPBN; etc (using "CLN" for clear sky variables)
    around lines 1465--1486

    3. module_first_rk_step_part1.F

    1) new diagnostic variables are passed to the "grid" array during the call to the "radiation_driver"
    subroutine in "dyn_em/module_first_rk_step_part1.F" (lines 350--357)

    2) control variable "clean_atm_diag" is passed from config_flags within the WRF_CHEM only
    section of the code (line 370).

    4. module_radiation_driver.F

    1) new diagnostic variables, and the control variable, are added to the subroutine interface
    (lines 90--97 and 107)

    2) new control variable is declared as an optional input (line 469)

    3) new diagnostic variables are declared as optional, intent inout, variables (lines 502--507)

    4) extra diagnostic variables, for the clean fluxes, are declared as local variables (we
    don't use these for the analysis, so aren't outputting them at the moment) (lines 515--518)

    5) new diagnostic variables are passed to rrtmg_lwrad and rrtmg_swrad
    subroutines (lines 1530--1533 & 1575--1576, and 1946--1948 & 1995--1996)

    6) new control variable is passed (within the wrfchem only code) to rrtmg_lwrad and rrtmg_sward
    too (lines 1566 and 1989).

    5. module_ra_rrtmg_sw.F

    1) new diagnostic variables, and control variable, added to rrtmg_swrad interface
    (lines 9893--9894, 9924, 9930--9931)

    2) control variable declared as optional (intent in), and a local control variable (clean_atm_diag_local)
    also declared (lines 10055--10056)

    3) new diagnostic variables declared as intent out (lines 10084--10085, 10091--10092)

    4) local temporary variables added for fluxes (lines 10177--10178)

    5) if statement checking for presence of control variable added - copies value to local
    control variable (or sets to 0 if not present) (lines 10298--10302)

    6) local temporary variables and control variable passed added to rrtmg_sw call (lines 11104 and 11109)

    7) flux values passed from local variables to output variables after this call (lines 11122 -- 11153)

    8) flux variables and control variable added to rrtmg_sw interface (lines 8740 and 8746)

    9) declaration of these variables (lines 8944 & 8968--8971)

    10) declaration of new internal "clean sky" variables for optical depth (line 9106) and
    fluxes (lines 9120--9126)

    11) "clean sky" aerosol optical depth is set to 0.0 (line 9338)

    12) a new call to the spcvmc_sw subroutine is added (passing the clean sky aerosol optical depth
    this time) - with a preprocessing statement so that it is only added for WRF-Chem. This call is
    also within an if statement, so can be switched off using the control variable when running WRF-Chem
    if desired. (lines 9426--9476)

    6. module_ra_rrtmg_lw.F

    1) new diagnostic variables, and control variable, added to rrtmg_lwrad interface
    (lines 11453--11454, 11476, 11485)

    2) control variable declared as optional (intent in), and a local control variable (clean_atm_diag_local)
    also declared (lines 11580--11581)

    3) new diagnostic variables declared as intent inout (lines 11596--11597, 11603--11604)

    4) local temporary variables added for fluxes (lines 11686--11688)

    5) if statement checking for presence of control variable added - copies value to local
    control variable (or sets to 0 if not present) (lines 11848--11852)

    6) local temporary variables and control variable passed added to rrtmg_lw call (lines 12642-12643)

    7) flux values passed from local variables to output variables after this call
    (lines 12666--12671 and 12682--12683)

    8) flux variables and control variable added to rrtmg_sw interface (lines 10586--10587)

    9) declaration of these variables (lines 10768 & 10784--10787)

    10) declaration of new internal "clean sky" variables for fluxes (lines 10899--10902)

    11) a new call to the rtrnmc subroutine is added (passing only the gaseous optical depth, taug,
    instead of the combined gas and aerosol optical depth, taut) - with a preprocessing statement
    so that it is only added for WRF-Chem. This call is also within an if statement, so can be
    switched off using the control variable when running WRF-Chem if desired. (lines 11017--11039)

    12) new fluxes are copied to the clean sky output variables (lines 11054--11055)

    7. chemics_init.F

    1) added check to ensure that aer_ra_feedback is on when clean_atm_diag is used
    (lines 406--408)

    TESTS CONDUCTED:
    Regression test in process.