### PR TITLE
Add new automatic eta levels option

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2085,7 +2085,7 @@ rconfig   logical   cycle_y         namelist,domains    max_domains    .false. r
 rconfig   logical   reorder_mesh    namelist,domains    1              .false. rh    "reorder_mesh"       ""      ""
 rconfig   logical   perturb_input   namelist,domains    1              .false. h     "" "" ""
 rconfig   real      eta_levels      namelist,domains    max_eta        -1.
-rconfig   integer   auto_levels_opt namelist,domains    1               0
+rconfig   integer   auto_levels_opt namelist,domains    1               2
 rconfig   real      max_dz          namelist,domains    1               1000.  -     "max_dz"   "maximum thickness limit for eta calc" "m"
 rconfig   real      dzbot           namelist,domains    1               50.    -     "dzbot"    "surface dz thickness for eta calc" "m"
 rconfig   real      dzstretch_s     namelist,domains    1               1.1    -     "dzstretch_s"  "surface dz stretching factor for eta calc"    ""

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7123,7 +7123,7 @@ end program foo
       !  Compute eta levels assuming a constant delta z above the PBL.
 
       ELSE
-       IF( auto_levels_opt == 0 ) THEN
+       IF( auto_levels_opt == 1 ) THEN
          print *,'using old automatic levels program'
          !  Compute top of the atmosphere with some silly levels.  We just want to
          !  integrate to get a reasonable value for ztop.  We use the planned PBL-esque
@@ -7339,7 +7339,7 @@ print *,'namelist p_top (Pa) = ',p_top
          END DO
          phb(kte) = phb(kte-1) - (znw(kte)-znw(kte-1)) * mub*alb(kte-1)
 
-       ELSE IF (auto_levels_opt == 1) THEN
+       ELSE IF (auto_levels_opt == 2) THEN
          print *,'using new automatic levels program'
          CALL levels(kte-1, p_top, znw, max_dz, dzbot, dzstretch_s, dzstretch_u, r_d, g )
          p_surf = p00
@@ -7360,6 +7360,9 @@ print *,'namelist p_top (Pa) = ',p_top
             phb(k) = phb(k-1) - (znw(k)-znw(k-1)) * mub*alb(k-1)
          END DO
          phb(kte) = phb(kte-1) - (znw(kte)-znw(kte-1)) * mub*alb(kte-1)
+       ELSE
+         print *,'auto_levels_opt=',auto_levels_opt
+         CALL wrf_error_fatal ( 'auto_levels_opt needs to be 1 or 2')
        ENDIF
 k=1
 WRITE (*,FMT='("Full level index = ",I4,"     Height = ",F7.1," m")') k,phb(1)/g

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -277,17 +277,17 @@ Namelist variables specifically for the WPS input for real:
 Users may explicitly define full eta levels.  Given are two distributions for 28 and 35 levels.  The number
 of levels must agree with the number of eta surfaces allocated (e_vert).  Users may alternatively request 
 only the number of levels (with e_vert), and the real program will compute values.  From V4.0 there are
-two methods selected with auto_levels_opt = 0 (old) or 1 (new). The old computation assumes
+two methods selected with auto_levels_opt = 1 (old) or 2 (new). The old computation assumes
 a known first several layers, then generates equi-height spaced levels up to the top of the model.
 The new method has a stretching factor (dz_stretch_s and dz_stretch_u) to stretch levels according to
 log p up to where it reaches the maximum thickness (max_dz) and starting from thickness dzbot.
 
  max_dz                              = 1000.     ; maximum level thickness allowed (m)
- auto_levels_opt                     = 0         ; old
-                                     = 1         ; new (also set dzstretch_s, dzstretch_u, dzbot, max_dz)
- dzbot                               = 50.       ; thickness of lowest layer (m) for auto_levels_opt=1
- dzstretch_s                         = 1.1       ; surface stretch factor for auto_levels_opt=1
- dzstretch_u                         = 1.1       ; upper stretch factor for auto_levels_opt=1
+ auto_levels_opt                     = 1         ; old
+                                     = 2         ; new default (also set dzstretch_s, dzstretch_u, dzbot, max_dz)
+ dzbot                               = 50.       ; thickness of lowest layer (m) for auto_levels_opt=2
+ dzstretch_s                         = 1.1       ; surface stretch factor for auto_levels_opt=2
+ dzstretch_u                         = 1.1       ; upper stretch factor for auto_levels_opt=2
 
  eta_levels                          = 1.000, 0.990, 0.978, 0.964, 0.946,
                                        0.922, 0.894, 0.860, 0.817, 0.766,


### PR DESCRIPTION
TYPE: new feature
KEYWORDS: WRF levels computation, auto_levels_opt
SOURCE: internal
DESCRIPTION OF CHANGES: 
New method of automatically computing levels: auto_levels_opt=1 (old method), auto_levels_opt=2 (new method and default). New method has additional namelist controls
max_dz (was there before), dzbot (thickness of lowest level in meters), dzstretch_s (surface stretch factor, 1.1 default), dzstretch_u (upper stretch factor, 1.1 default). The new method stretches based on log p (not the base state) until it reaches the target maximum max_dz where it becomes uniform.
Need to add these to a namelist.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/module_initialize_real.F
M       run/README.namelist

TESTS CONDUCTED: 
No WTF yet. Tested parameters and January 2000 case with new levels. Little effect on results.