### PR TITLE
Add CH4 to convert emiss

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -3938,7 +3938,7 @@ package   cri_mosaic_4bin_aq_kpp  chem_opt==611          -             chem:dms,
 #emission package definitions
 #
 package   eradm           emiss_opt==2                   -             emis_ant:e_iso,e_so2,e_no,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3
-package   eradmsorg       emiss_opt==3                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_pm25i,e_pm25j,e_pm_10,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_naaj,e_naai,e_orgi_a,e_orgj_a,e_orgi_bb,e_orgj_bb
+package   eradmsorg       emiss_opt==3                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_ch4,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_pm25i,e_pm25j,e_pm_10,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_naaj,e_naai,e_orgi_a,e_orgj_a,e_orgi_bb,e_orgj_bb
 package   ecbmz_mosaic    emiss_opt==4                   -             emis_ant:e_iso,e_so2,e_no,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_no2,e_ch3oh,e_c2h5oh,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_so4c,e_no3c,e_orgc,e_ecc
 package   ecptec          emiss_opt==5                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_pm_25,e_pm_10,e_oc,e_sulf,e_bc
 package   gocart_ecptec   emiss_opt==6                   -             emis_ant:e_so2,e_sulf,e_bc,e_oc,e_pm_25,e_pm_10
@@ -4084,4 +4084,3 @@ package  lnox_opt_none      lnox_opt==0    -   -
 package  lnox_opt_ott       lnox_opt==1    -   tracer:lnox_total
 package  lnox_opt_decaria   lnox_opt==2    -   tracer:lnox_ic,lnox_cg
 
-rconfig   integer    irr_opt  namelist,chem     max_domains        0     rh     "IRR_OPT"            "" ""

--- a/chem/convert_emiss.F
+++ b/chem/convert_emiss.F
@@ -129,7 +129,7 @@ PROGRAM convert_emissions
    INTEGER :: iswaterr,itest,beg_yr,beg_mon,beg_jul,beg_day,beg_hour
    INTEGER :: itime = 0
    INTEGER :: inew_nei = 0
-   INTEGER :: inew_ch4 = 0      ! set to 1 if using 2011 NEI emissions
+   INTEGER :: inew_ch4 = 1      ! set to 0 if the emission inventory doesn't include CH4 
    INTEGER :: nv = 0
    INTEGER :: nv_f = 0
    INTEGER :: nv_g = 0
@@ -1898,7 +1898,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-!        grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ch4)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ch4)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )
      ENDIF
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
@@ -2407,8 +2407,8 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-!        grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ch4)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )
-     endif
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ch4)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )
+     ENDIF
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: Convert emiss, CH4 emission

SOURCE: Ravan Ahmadov (CIRES)

DESCRIPTION OF CHANGES:
Methane (CH4) emissions are added to the convert_emiss program to be able to process the CH4 emissions.

LIST OF MODIFIED FILES:
Registry/registry.chem
chem/convert_emiss.F

TESTS CONDUCTED:
Passed WTF on Cheyenne, except for Intel mpi WRFPLUS.