### PR TITLE
Registry info for auto_levels_opt

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2104,7 +2104,7 @@ rconfig   logical   cycle_x         namelist,domains    max_domains    .false. r
 rconfig   logical   cycle_y         namelist,domains    max_domains    .false. rh    "cycle_y"            ""      ""
 rconfig   logical   reorder_mesh    namelist,domains    1              .false. rh    "reorder_mesh"       ""      ""
 rconfig   logical   perturb_input   namelist,domains    1              .false. h     "" "" ""
-rconfig   real      eta_levels      namelist,domains    max_eta        -1
+rconfig   real      eta_levels      namelist,domains    max_eta        -1.
 rconfig   integer   auto_levels_opt namelist,domains    1               2      -     "auto_levels_opt" "automatic levels, 1=old, 2=new"
 rconfig   real      max_dz          namelist,domains    1               1000.  -     "max_dz"   "maximum thickness limit for eta calc" "m"
 rconfig   real      dzbot           namelist,domains    1               50.    -     "dzbot"    "surface dz thickness for eta calc" "m"


### PR DESCRIPTION

TYPE: no impact, text only

KEYWORDS: auto_levels_opt, Registry

SOURCE: internal

DESCRIPTION OF CHANGES: 
Add description text to auto_levels_opt Registry entry

LIST OF MODIFIED FILES: 
Registry/Registry.EM_COMMON

TESTS CONDUCTED: none