### PR TITLE
HWRF update for Scale-aware SAS scheme

### DIFF
--- a/phys/module_cu_scalesas.F
+++ b/phys/module_cu_scalesas.F
@@ -1,6 +1,9 @@
 !!
 !! LOG
 !!  2015-12-10  Weiguo Wang  added gfs scale-aware SAS scheme to HWRF
+!!    A description of this updated Scale-aware SAS can be found in the HWRF Scientific Documentation:  
+!!    https://dtcenter.org/HurrWRF/users/docs/scientific_documents/HWRFv3.9a_ScientificDoc.pdf
+
 
 MODULE module_cu_scalesas 
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: HWRF, 2017, cumulus, Scale-aware SAS

SOURCE: NCEP/EMC HWRF team

DESCRIPTION OF CHANGES: 

    HWRF only: Update Scale-aware SAS cumulus scheme
    to 2017 operational version.

   A description of this updated Scale-aware SAS can be found in the HWRF Scientific Documentation:  
https://dtcenter.org/HurrWRF/users/docs/scientific_documents/HWRFv3.9a_ScientificDoc.pdf

LIST OF MODIFIED FILES: 

M       phys/module_cu_scalesas.F

TESTS CONDUCTED: 

WTF 4.04 completed.

