### PR TITLE
Fix for map factors on lat/long grid

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2723,7 +2723,7 @@ SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
       tendency(i,k,j)=tendency(i,k,j) +  g*tmpdz/dnw(k) *             &
            (mrdx*(titau1(i,k,j  ) - titau1(i-1,k,j)) +                &
             mrdy*(titau2(i,k,j+1) - titau2(i  ,k,j)) -                &
-            msfuy(i,j)*zx_at_u(i,k,j)*(titau1avg(i,k+1,j)-titau1avg(i,k,j)) / tmpdz - &
+            msfux(i,j)*zx_at_u(i,k,j)*(titau1avg(i,k+1,j)-titau1avg(i,k,j)) / tmpdz - &
             msfuy(i,j)*zy_at_u(i,k,j)*(titau2avg(i,k+1,j)-titau2avg(i,k,j)) / tmpdz   &
                                                                   )
    ENDDO
@@ -2918,7 +2918,7 @@ SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
       tendency(i,k,j)=tendency(i,k,j) +    g*tmpdz/dnw(k) *           &
            (mrdy*(titau2(i,k,j  ) - titau2(i,k,j-1)) +                &
             mrdx*(titau1(i+1,k,j) - titau1(i  ,k,j)) -                &
-            msfvy(i,j)*zx_at_v(i,k,j)*(titau1avg(i,k+1,j)-titau1avg(i,k,j)) / tmpdz - &
+            msfvx(i,j)*zx_at_v(i,k,j)*(titau1avg(i,k+1,j)-titau1avg(i,k,j)) / tmpdz - &
             msfvy(i,j)*zy_at_v(i,k,j)*(titau2avg(i,k+1,j)-titau2avg(i,k,j)) / tmpdz   &
                                                                   )
 


### PR DESCRIPTION

TYPE: bug-fix

KEYWORDS: diff_opt=2, lat/long grid

SOURCE: internal

DESCRIPTION OF CHANGES: 
Code error was noticed by GSD. Some map factors were not the correct ones in the diffusion terms. This only affects lat/long grids where dx and dy may differ.

LIST OF MODIFIED FILES: 
M       dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
None yet.
