### PR TITLE
Detect too many MPI tasks, or poor MPI decomposition

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1690,7 +1690,7 @@
             WRITE ( wrf_err_message , * ) 'For domain ',i,', the domain size is too small for this many processors, ', & 
                                           'or the decomposition aspect ratio is poor.'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-            WRITE ( wrf_err_message , * ) 'Minimum decomposed computational patch size, either x-dir or y-dir, is < 10 grid cells.'
+            WRITE ( wrf_err_message , * ) 'Minimum decomposed computational patch size, either x-dir or y-dir, is 10 grid cells.'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
             WRITE ( wrf_err_message , fmt='(a,i5,a,i4,a,i4)' ) &
                                           'e_we = ', model_config_rec % e_we(i),', nproc_x = ',model_config_rec % nproc_x, &


### PR DESCRIPTION
### TYPE: new feature ### 
    
### KEYWORDS: MPI ###
    
### SOURCE: internal ###
    
### DESCRIPTION OF CHANGES: ###
Determine the resultant x- and y-direction computational patch sizes based
on the full domain size and the number of MPI ranks used in each direction.
If the patch size < 10 grid cells in either direction, stop.
    
### LIST OF MODIFIED FILES: ###
M   share/module_check_a_mundo.F
    
### TESTS CONDUCTED: ###
 - [x] WTF v4.04 passed
 - [x] Code continues to work with reasonable decompositions.
 - [x] Code detects bad MPI counts or distributions.
```
For domain            1 , the domain size is too small for this many processors, or the decomposition aspect ratio is poor.
Minimum decomposed computational patch size, either x-dir or y-dir, is 10 grid cells.
e_we =    74, nproc_x =    1, with cell width in x-direction =   74
e_sn =    61, nproc_y =    7, with cell width in y-direction =    8
--- ERROR: Reduce the MPI rank count, or redistribute the tasks.
-------------- FATAL CALLED ---------------
```
