### PR TITLE
BF: K-index fix for diagnostic print for auto eta levels

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7332,9 +7332,8 @@ print *,'namelist p_top (Pa) = ',p_top
             END IF
             t_init = temp*(p00/pb)**(r_d/cp) - t0
             alb(k) = (r_d/p1000mb)*(t_init+t0)*(pb/p1000mb)**cvpm
-            phb(k) = phb(k-1) - (znw(k)-znw(k-1)) * mub*alb(k-1)
+            phb(k+1) = phb(k) - (znw(k+1)-znw(k)) * mub*alb(k)
          END DO
-         phb(kte) = phb(kte-1) - (znw(kte)-znw(kte-1)) * mub*alb(kte-1)
        ELSE
          print *,'auto_levels_opt=',auto_levels_opt
          CALL wrf_error_fatal ( 'auto_levels_opt needs to be 1 or 2')


### PR DESCRIPTION
### TYPE: bug fix ###

### KEYWORDS: k, bounds check ###

### SOURCE: internal ### 

### DESCRIPTION OF CHANGES: ###
After the eta levels are computed with the new method, a diagnostic
print had the k-index off by one. This led to a vertical index of zero,
found by bounds checking (and seeing NaNs in the print out).

Fixes #359 

### LIST OF MODIFIED FILES: ###
M	module_initialize_real.F

### TESTS CONDUCTED: ###
 - [x] WTF v4.04 passed
 - [x] Passes bounds check
 - [x] No NaNs in the diagnostic print out