### PR TITLE
Correct conversion from ozone column density to Dobson units

### DIFF
--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -550,7 +550,7 @@ has_daylight : &
            aircol(n_tuv_z-1) = aircol(n_tuv_z-1) + o2col(n_tuv_z-1)/o2vmr
          endif
          if( config_flags%scale_o3_to_grnd_exo_coldens ) then
-           dobsi = real( o3_exo_col_at_grnd(i,j),4 )
+           dobsi = real( o3_exo_col_at_grnd(i,j),4 )/2.687e16
          endif
 
          so2col(:) = 0.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: TUV, Dobson

SOURCE: internal

DESCRIPTION OF CHANGES:

Add proper divisor to convert ozone column density( molecules/cm**2 ) to
Dobson units.

LIST OF MODIFIED FILES:

M   chem/module_phot_tuv.F

TESTS CONDUCTED:

The change has been validated with a brief run.  The change
is too narrow to warrant a reg test.

