### PR TITLE
If <phys>_opt=0, WRF nml does not need to match real.exe value

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -644,24 +644,26 @@
     ! Test here to check that config_flags%sf_surface_physics in namelist
     ! is equal to what is in the global attributes of the wrfinput files
 
-    IF ( switch .EQ. input_only  ) THEN
-       CALL wrf_get_dom_ti_integer ( fid, 'SF_SURFACE_PHYSICS', itmp, 1, icnt, ierr )
-       IF ( ierr .EQ. 0 ) THEN
-          WRITE(wrf_err_message,*)'input_wrf: global attribute SF_SURFACE_PHYSICS returns ', itmp
-          CALL wrf_debug ( 300 , wrf_err_message )
-          IF ( config_flags%sf_surface_physics /= itmp ) THEN
-             IF ( ( config_flags%sf_surface_physics == LSMSCHEME ) .and. ( itmp == NOAHMPSCHEME ) ) then
-                ! All is well.  Noah-MP and Noah have compatible wrfinput files.
-             ELSE IF ( ( config_flags%sf_surface_physics == NOAHMPSCHEME ) .and. ( itmp == LSMSCHEME ) ) then
-                ! All is well.  Noah-MP and Noah have compatible wrfinput files.
-             ELSE
-                call wrf_message("----------------- ERROR -------------------")
-                WRITE(wrf_err_message,'("namelist    : sf_surface_physics = ",I10)') config_flags%sf_surface_physics
-                call wrf_message(wrf_err_message)
-                WRITE(wrf_err_message,'("input files : SF_SURFACE_PHYSICS = ",I10, " (from wrfinput files).")') itmp
-                call wrf_message(wrf_err_message)
-                CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute SF_SURFACE_PHYSICS")
-                count_fatal_error = count_fatal_error + 1
+    IF ( config_flags%sf_surface_physics /= 0 ) THEN
+       IF ( switch .EQ. input_only  ) THEN
+          CALL wrf_get_dom_ti_integer ( fid, 'SF_SURFACE_PHYSICS', itmp, 1, icnt, ierr )
+          IF ( ierr .EQ. 0 ) THEN
+             WRITE(wrf_err_message,*)'input_wrf: global attribute SF_SURFACE_PHYSICS returns ', itmp
+             CALL wrf_debug ( 300 , wrf_err_message )
+             IF ( config_flags%sf_surface_physics /= itmp ) THEN
+                IF ( ( config_flags%sf_surface_physics == LSMSCHEME ) .and. ( itmp == NOAHMPSCHEME ) ) then
+                   ! All is well.  Noah-MP and Noah have compatible wrfinput files.
+                ELSE IF ( ( config_flags%sf_surface_physics == NOAHMPSCHEME ) .and. ( itmp == LSMSCHEME ) ) then
+                   ! All is well.  Noah-MP and Noah have compatible wrfinput files.
+                ELSE
+                   call wrf_message("----------------- ERROR -------------------")
+                   WRITE(wrf_err_message,'("namelist    : sf_surface_physics = ",I10)') config_flags%sf_surface_physics
+                   call wrf_message(wrf_err_message)
+                   WRITE(wrf_err_message,'("input files : SF_SURFACE_PHYSICS = ",I10, " (from wrfinput files).")') itmp
+                   call wrf_message(wrf_err_message)
+                   CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute SF_SURFACE_PHYSICS")
+                   count_fatal_error = count_fatal_error + 1
+                END IF
              END IF
           END IF
        END IF
@@ -671,19 +673,21 @@
     ! Test here to check that config_flags%gwd_opt in namelist
     ! is equal to what is in the global attributes of the wrfinput files
 
-    IF ( switch .EQ. input_only  ) THEN
-       CALL wrf_get_dom_ti_integer ( fid, 'GWD_OPT', itmp, 1, icnt, ierr )
-       IF ( ierr .EQ. 0 ) THEN
-          WRITE(wrf_err_message,*)'input_wrf: global attribute GWD_OPT returns ', itmp
-          CALL wrf_debug ( 300 , wrf_err_message )
-          IF ( config_flags%gwd_opt /= itmp ) THEN
-             call wrf_message("----------------- ERROR -------------------")
-             WRITE(wrf_err_message,'("namelist    : gwd_opt            = ",I10)') config_flags%gwd_opt
-             call wrf_message(wrf_err_message)
-             WRITE(wrf_err_message,'("input files : GWD_OPT            = ",I10, " (from wrfinput files).")') itmp
-             call wrf_message(wrf_err_message)
-             call wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute GWD_OPT")
-             count_fatal_error = count_fatal_error + 1
+    IF ( config_flags%gwd_opt /= 0 ) THEN
+       IF ( switch .EQ. input_only  ) THEN
+          CALL wrf_get_dom_ti_integer ( fid, 'GWD_OPT', itmp, 1, icnt, ierr )
+          IF ( ierr .EQ. 0 ) THEN
+             WRITE(wrf_err_message,*)'input_wrf: global attribute GWD_OPT returns ', itmp
+             CALL wrf_debug ( 300 , wrf_err_message )
+             IF ( config_flags%gwd_opt /= itmp ) THEN
+                call wrf_message("----------------- ERROR -------------------")
+                WRITE(wrf_err_message,'("namelist    : gwd_opt            = ",I10)') config_flags%gwd_opt
+                call wrf_message(wrf_err_message)
+                WRITE(wrf_err_message,'("input files : GWD_OPT            = ",I10, " (from wrfinput files).")') itmp
+                call wrf_message(wrf_err_message)
+                call wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute GWD_OPT")
+                count_fatal_error = count_fatal_error + 1
+             END IF
           END IF
        END IF
     END IF
@@ -693,19 +697,21 @@
     ! Test here to check that config_flags%sf_ocean_physics in namelist
     ! is equal to what is in the global attributes of the wrfinput files
 
-    IF ( switch .EQ. input_only  ) THEN
-       CALL wrf_get_dom_ti_integer ( fid, 'SF_OCEAN_PHYSICS', itmp, 1, icnt, ierr )
-       IF ( ierr .EQ. 0 ) THEN
-          WRITE(wrf_err_message,*)'input_wrf: global attribute SF_OCEAN_PHYSICS returns ', itmp
-          CALL wrf_debug ( 300 , wrf_err_message )
-          IF ( config_flags%sf_ocean_physics /= itmp ) THEN
-             call wrf_message("----------------- ERROR -------------------")
-             WRITE(wrf_err_message,'("namelist    : sf_ocean_physics   = ",I10)') config_flags%sf_ocean_physics
-             call wrf_message(wrf_err_message)
-             WRITE(wrf_err_message,'("input files : SF_OCEAN_PHYSICS   = ",I10, " (from wrfinput files).")') itmp
-             call wrf_message(wrf_err_message)
-             call wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute SF_OCEAN_PHYSICS")
-             count_fatal_error = count_fatal_error + 1
+    IF ( config_flags%sf_ocean_physics /= 0 ) THEN
+       IF ( switch .EQ. input_only  ) THEN
+          CALL wrf_get_dom_ti_integer ( fid, 'SF_OCEAN_PHYSICS', itmp, 1, icnt, ierr )
+          IF ( ierr .EQ. 0 ) THEN
+             WRITE(wrf_err_message,*)'input_wrf: global attribute SF_OCEAN_PHYSICS returns ', itmp
+             CALL wrf_debug ( 300 , wrf_err_message )
+             IF ( config_flags%sf_ocean_physics /= itmp ) THEN
+                call wrf_message("----------------- ERROR -------------------")
+                WRITE(wrf_err_message,'("namelist    : sf_ocean_physics   = ",I10)') config_flags%sf_ocean_physics
+                call wrf_message(wrf_err_message)
+                WRITE(wrf_err_message,'("input files : SF_OCEAN_PHYSICS   = ",I10, " (from wrfinput files).")') itmp
+                call wrf_message(wrf_err_message)
+                call wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute SF_OCEAN_PHYSICS")
+                count_fatal_error = count_fatal_error + 1
+             END IF
           END IF
        END IF
     END IF


### PR DESCRIPTION
#### TYPE: enhancement ####

#### KEYWORDS: GWD, surface, ocean ####

#### SOURCE: internal ####

#### DESCRIPTION OF CHANGES: #### 
If the user has selected to turn off an option (gwd_opt, sf_surface_physics, sf_ocean_physics), then the value in the namelist does not have to match the value in the input file coming from the real program.

#### LIST OF MODIFIED FILES: ####
M   input_wrf.F

#### TESTS CONDUCTED: ####
- [x] Swap values of GWD, Urban, and OML to zero when running WRF, and the model runs fine.
```
>grep -E 'sf_urban|sf_ocean|gwd' namelist.input
 sf_urban_physics                    = 1,     0,     0,
 sf_ocean_physics                    = 1
 gwd_opt                             = 1,

>real.exe >& foo ; tail -1 foo
d01 2000-01-25_12:00:00 real_em: SUCCESS COMPLETE REAL_EM INIT

>vi namelist.input

>grep -E 'sf_urban|sf_ocean|gwd' namelist.input
 sf_urban_physics                    = 0,     0,     0,
 sf_ocean_physics                    = 0
 gwd_opt                             = 0,

>wrf.exe >& foo ; tail -1 foo
d01 2000-01-24_12:05:00 wrf: SUCCESS COMPLETE WRF
```
 - [x] WTF v4.04, passes.