### PR TITLE
BF: vertical bound exceeded in GF deep

### DIFF
--- a/phys/module_cu_gf_deep.F
+++ b/phys/module_cu_gf_deep.F
@@ -1166,7 +1166,7 @@ contains
             if(ierr(i).eq.0)then
 
                !- only for convection rooting in the PBL
-               if(zo_cup(i,kbcon(i))-z1(i) > zo(i,kpbl(i)+1)) then 
+               if(zo_cup(i,kbcon(i))-z1(i) > zo(i,min(kte,kpbl(i)+1))) then 
                   aa1_bl(i) = 0.0
                else
                !- multiply aa1_bl the " time-scale" - tau_bl


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: GF, deep, bound

SOURCE: internal

DESCRIPTION OF CHANGES:
For an array that exceeded the dimension limit due to vertical index computation, limit extent to model top.

LIST OF MODIFIED FILES:
M   phys/module_cu_gf_deep.F

TESTS CONDUCTED:
 - [x] Passes multiple cases found by -D configure
 - [x] WTF v4.04 passes.