### PR TITLE
Bug fix: NO2 emissions correction for CRI-Mech

### DIFF
--- a/chem/module_emissions_anthropogenics.F
+++ b/chem/module_emissions_anthropogenics.F
@@ -166,7 +166,6 @@ is_mozart:if( is_moz_chm ) then
                    config_flags%chem_opt == CRI_MOSAIC_8BIN_AQ_KPP .or. &
                    config_flags%chem_opt == CRI_MOSAIC_4BIN_AQ_KPP) then
             do i=its,ite  
-              chem(i,k,j,p_no2) = chem(i,k,j,p_no2) + emis_ant(i,k,j,p_e_no2)*conv_rho(i)
               chem(i,k,j,p_c2h6) = chem(i,k,j,p_c2h6) + emis_ant(i,k,j,p_e_c2h6)*conv_rho(i)
               chem(i,k,j,p_c2h4) = chem(i,k,j,p_c2h4) + emis_ant(i,k,j,p_e_c2h4)*conv_rho(i)
               chem(i,k,j,p_c5h8) = chem(i,k,j,p_c5h8) + emis_ant(i,k,j,p_e_c5h8)*conv_rho(i)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: wrf-chem, crimech, emissions

SOURCE: Andreas Hilboll (University of Bremen) 

DESCRIPTION OF CHANGES: 
Deleted CRImech specific code for adding NO2 emissions to the chem array, because this is already done in the generic code (and so means we are, essentially, double counting the NO2 emissions).

This change affects only WRF-Chem code (and only CRI-Mech specific code at that). 


LIST OF MODIFIED FILES:
chem/module_emissions_anthropogenics.F

TESTS CONDUCTED: 
None.
