### PR TITLE
Correct erroneous format in chemics_init.F TUV logic "gate"

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -293,7 +293,7 @@ call wrf_message("**************************************************************
          config_flags%chem_opt /= mozart_mosaic_4bin_aq_kpp .and. &
          config_flags%chem_opt /= mozcart_kpp .and. &
          config_flags%chem_opt /= t1_mozcart_kpp) THEN
-       write(message_txt,'(''--- ERROR: chem_opt '',a,'' not setup for TUV photolysis at this time'')') &
+       write(message_txt,'(''--- ERROR: chem_opt '',i3,'' not setup for TUV photolysis at this time'')') &
               config_flags%chem_opt
        CALL wrf_error_fatal( trim(message_txt) )
      endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: TUV, chemics_init

SOURCE: internal

DESCRIPTION OF CHANGES:

Change mistaken 'a' format to 'i3' in wrf_error_fatal message.

LIST OF MODIFIED FILES:

M   chem/chemics_init.F

TESTS CONDUCTED:

The change has been validated with a brief run.  The change
is too narrow to warrant a reg test.

Use this template to give a detailed message describing the change you want to make to the code.
If you are unclear on what should be written here, see  https://github.com/wrf-model/WRF/wiki/Making-a-good-pull-request-message for more guidance

The title of this pull request should be a brief "purpose" for this change.

--- Delete this line and those above before hitting "Create pull request" ---

TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]

KEYWORDS: approximately 3 to 6 words (more is always better) related to your commit, separated by commas

SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member

DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
