### PR TITLE
Remove development debug output when compiling

### DIFF
--- a/tools/gen_scalar_indices.c
+++ b/tools/gen_scalar_indices.c
@@ -128,7 +128,6 @@ gen_scalar_indices1 ( FILE * fp, FILE ** fp2 )
 
   for ( p = FourD ; p != NULL ; p = p->next ) {
     if( strncmp( p->name,"irr_diag",8 ) ) {
-      fprintf( stderr,"Checking FourD variable %s\n",p->name );
       for ( memb = p->members ; memb != NULL ; memb = memb->next )
         if ( strcmp(memb->name,"-") ) fprintf(fp,"  P_%s = 1 ; F_%s = .FALSE. \n", memb->name, memb->name ) ; 
     }


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile, tools/gen_scalar_indices.c

SOURCE: internal

DESCRIPTION OF CHANGES:

Remove a single line in tools/gen_scalar_indices.c that produces
volumnous output.  The debug line is harmless from a functional
standpoint but produces greatly expanded output from the compile
command.

LIST OF MODIFIED FILES:

M   tools/gen_scalar_indices.c

TESTS CONDUCTED:

The change has been validated, the offending output removed
when compiling.

