### PR TITLE
integrated MPAS-specific code and WRF code for module_mp_wsm6.F

### DIFF
--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -136,7 +136,7 @@ CONTAINS
                                                           re_ice, &
                                                          re_snow
 !+---+-----------------------------------------------------------------+
-  REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT), OPTIONAL::     &  ! GT
+  REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT) ::     &  ! GT
                                                        refl_10cm
 !+---+-----------------------------------------------------------------+
 


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: module_mp_wsm6.F, MPAS, wrf, integration, physics, shared

SOURCE: Internal

DESCRIPTION OF CHANGES: Took the MPAS-specific code from MPAS HWT top-of-repo (27Feb2018) and added them into the WRF top-of-repo (28Feb2018) for module_mp_wsm6.F.
Added note at top of file, regarding modifications - not sure if we want to include this.

LIST OF MODIFIED FILES: 
M     phys/module_mp_wsm6.F

TESTS CONDUCTED: Conducted a test, using a fairly basic test case (2 domains, March 2016 snow event over Colorado). The "soon-to-be" TROPICAL physics suite (wsm6, New Tiedtke, RRTMG, YSU, Noah and old MM5) was used. Verified that the results, after 6 hours, for both domains, were bit-for-bit with unmodified code. WTF passed.