### PR TITLE
Fix a problem for slow recompile (introduced in PR370)

### DIFF
--- a/compile
+++ b/compile
@@ -218,7 +218,7 @@ else
       set overwrite=1
     else
       head -2 Registry/Registry | tail -1 | grep EM > /dev/null
-      if ( $status == 0 ) then
+      if ( $status ) then
         set overwrite=1
       else
         set em_time=`ls -1tr Registry | cat -n | grep -w 'Registry\.EM' | grep -v 'Registry.EM.' | awk '{print $1}'`


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile, slow

SOURCE: internal

DESCRIPTION OF CHANGES: 
A single line in compile script causes the recompilation for EM CORE to be very, very slow because it nearly recompiles every routine. Changing it from
      if ( $status == 0 ) then
to
      if ( $status ) then
solves the problem. Thanks to Mike Barlage who found it.

LIST OF MODIFIED FILES: 
M       compile

TESTS CONDUCTED: 
Manual test shows it resolves the issue. Regression tests on March 9 mostly passed. A few that failed can be attributed to the Cheyenne problem.