### PR TITLE
Correct erroneous dimension for IRR output array

### DIFF
--- a/chem/KPP/kpp/kpp-2.1/src/gen.c
+++ b/chem/KPP/kpp/kpp-2.1/src/gen.c
@@ -52,6 +52,7 @@ int DC;
 int ARP, JVRP, NJVRP, CROW_JVRP, IROW_JVRP, ICOL_JVRP;
 int V, F, VAR, FIX;
 int RCONST, RCT;
+int IRR;
 int Vdot, P_VAR, D_VAR;
 int KR, A, BV, BR, IV;
 int JV, UV, JUV, JTUV, JVS; 
@@ -155,6 +156,7 @@ int i,j;
  
   RCONST = DefvElm( "RCONST", real, -NREACT, "Rate constants (global)" );
   RCT    = DefvElm( "RCT",    real, -NREACT, "Rate constants (local)" );
+  IRR    = DefvElm( "IRR",    real, -NREACT, "Accumulated reaction rate" );
 
   Vdot = DefvElm( "Vdot", real, -NVAR, "Time derivative of variable species concentrations" );
   P_VAR = DefvElm( "P_VAR", real, -NVAR, "Production term" );
@@ -775,9 +777,9 @@ char buf1[100], buf2[100];
     }
   
   if( useAggregate )
-    FunctionBegin( F_VAR, V, F, RCT, Vdot );
+    FunctionBegin( F_VAR, V, F, RCT, IRR );
   else
-    FunctionBegin( FSPLIT_VAR, V, F, RCT, P_VAR, D_VAR );
+    FunctionBegin( FSPLIT_VAR, V, F, IRR, P_VAR, D_VAR );
 
   if ( (useLang==MATLAB_LANG)&&(!useAggregate) )
      printf("\nWarning: in the function definition move P_VAR to output vars\n");
@@ -809,12 +811,12 @@ char buf1[100], buf2[100];
       for ( ; i < SpcNr; i++) 
         for (k = 1; k <= (int)Stoich_Left[i][j]; k++ )
           prod = Mul( prod, Elm( F, i - VarNr ) );
-      Assign( Elm( Vdot, j ), prod );
+      Assign( Elm( IRR, j ), prod );
     }
   }
 
   if( useAggregate )
-    MATLAB_Inline("\n   Vdot = Vdot(:);\n");
+    MATLAB_Inline("\n   IRR = IRR(:);\n");
   else
     MATLAB_Inline("\n   P_VAR = P_VAR(:);\n   D_VAR = D_VAR(:);\n");
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: IRR, compile, kpp-2.1/src/gen.c

SOURCE: internal

DESCRIPTION OF CHANGES:

Modify gen.c source file to change the output array from the
subroutine IRRFun dimension NVAR to NREACT.

LIST OF MODIFIED FILES:

M   chem/KPP/kpp/kpp-2.1/src/gen.c

TESTS CONDUCTED:

The change has been validated, the IRR array argument to
the *_IRRFun subroutines is dimenstiond NREACT and WRFChem
compiles with array bounds checking turned on.

Use this template to give a detailed message describing the change you want to make to the code.
If you are unclear on what should be written here, see  https://github.com/wrf-model/WRF/wiki/Making-a-good-pull-request-message for more guidance

The title of this pull request should be a brief "purpose" for this change.

--- Delete this line and those above before hitting "Create pull request" ---

TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]

KEYWORDS: approximately 3 to 6 words (more is always better) related to your commit, separated by commas

SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member

DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
