### PR TITLE
Allow non-scalar array 4d arrays to be properly shifted for moving nests

### DIFF
--- a/frame/loop_based_x_shift_code.h
+++ b/frame/loop_based_x_shift_code.h
@@ -64,21 +64,33 @@
             IF (      p%MemoryOrder(1:1) .EQ. 'X' .AND.  p%MemoryOrder(3:3) .EQ.  'Y' ) THEN
               IF      ( p%Type .EQ. 'r' ) THEN
                 IF ( SIZE(p%rfield_4d,1)*SIZE(p%rfield_4d,3) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%rfield_4d(ips:ipf,:,jms:jme,itrace) = p%rfield_4d(ips+px:ipf+px,:,jms:jme,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%rfield_4d(ips:ipf,:,jms:jme,itrace) = p%rfield_4d(ips+px:ipf+px,:,jms:jme,itrace)
+                    ENDDO
+                  ELSE
+                    p%rfield_4d(ips:ipf,:,jms:jme,:) = p%rfield_4d(ips+px:ipf+px,:,jms:jme,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'd' ) THEN
                 IF ( SIZE(p%dfield_4d,1)*SIZE(p%dfield_4d,3) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%dfield_4d(ips:ipf,:,jms:jme,itrace) = p%dfield_4d(ips+px:ipf+px,:,jms:jme,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%dfield_4d(ips:ipf,:,jms:jme,itrace) = p%dfield_4d(ips+px:ipf+px,:,jms:jme,itrace)
+                    ENDDO
+                  ELSE
+                    p%dfield_4d(ips:ipf,:,jms:jme,:) = p%dfield_4d(ips+px:ipf+px,:,jms:jme,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'i' ) THEN
                 IF ( SIZE(p%ifield_4d,1)*SIZE(p%ifield_4d,3) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%ifield_4d(ips:ipf,:,jms:jme,itrace) = p%ifield_4d(ips+px:ipf+px,:,jms:jme,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%ifield_4d(ips:ipf,:,jms:jme,itrace) = p%ifield_4d(ips+px:ipf+px,:,jms:jme,itrace)
+                    ENDDO
+                  ELSE
+                    p%ifield_4d(ips:ipf,:,jms:jme,:) = p%ifield_4d(ips+px:ipf+px,:,jms:jme,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'l' ) THEN
                 CALL wrf_error_fatal( '4D logical arrays cannot be shifted for moving nests' )
@@ -86,21 +98,33 @@
             ELSE IF (  p%MemoryOrder(1:2) .EQ. 'XY' ) THEN
               IF      ( p%Type .EQ. 'r' ) THEN
                 IF ( SIZE(p%rfield_4d,1)*SIZE(p%rfield_4d,2) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%rfield_4d(ips:ipf,jms:jme,:,itrace) = p%rfield_4d(ips+px:ipf+px,jms:jme,:,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%rfield_4d(ips:ipf,jms:jme,:,itrace) = p%rfield_4d(ips+px:ipf+px,jms:jme,:,itrace)
+                    ENDDO
+                  ELSE
+                    p%rfield_4d(ips:ipf,jms:jme,:,:) = p%rfield_4d(ips+px:ipf+px,jms:jme,:,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'd' ) THEN
                 IF ( SIZE(p%dfield_4d,1)*SIZE(p%dfield_4d,2) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%dfield_4d(ips:ipf,jms:jme,:,itrace) = p%dfield_4d(ips+px:ipf+px,jms:jme,:,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%dfield_4d(ips:ipf,jms:jme,:,itrace) = p%dfield_4d(ips+px:ipf+px,jms:jme,:,itrace)
+                    ENDDO
+                  ELSE
+                    p%dfield_4d(ips:ipf,jms:jme,:,:) = p%dfield_4d(ips+px:ipf+px,jms:jme,:,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'i' ) THEN
                 IF ( SIZE(p%ifield_4d,1)*SIZE(p%ifield_4d,2) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%ifield_4d(ips:ipf,jms:jme,:,itrace) = p%ifield_4d(ips+px:ipf+px,jms:jme,:,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%ifield_4d(ips:ipf,jms:jme,:,itrace) = p%ifield_4d(ips+px:ipf+px,jms:jme,:,itrace)
+                    ENDDO
+                  ELSE
+                    p%ifield_4d(ips:ipf,jms:jme,:,:) = p%ifield_4d(ips+px:ipf+px,jms:jme,:,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'l' ) THEN
                 CALL wrf_error_fatal( '4D logical arrays cannot be shifted for moving nests' )

--- a/frame/loop_based_y_shift_code.h
+++ b/frame/loop_based_y_shift_code.h
@@ -65,21 +65,33 @@
             IF (      p%MemoryOrder(1:1) .EQ. 'X' .AND.  p%MemoryOrder(3:3) .EQ.  'Y' ) THEN
               IF      ( p%Type .EQ. 'r' ) THEN
                 IF ( SIZE(p%rfield_4d,1)*SIZE(p%rfield_4d,3) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%rfield_4d(ims:ime,:,jps:jpf,itrace) = p%rfield_4d(ims:ime,:,jps+py:jpf+py,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%rfield_4d(ims:ime,:,jps:jpf,itrace) = p%rfield_4d(ims:ime,:,jps+py:jpf+py,itrace)
+                    ENDDO
+                  ELSE
+                    p%rfield_4d(ims:ime,:,jps:jpf,:) = p%rfield_4d(ims:ime,:,jps+py:jpf+py,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'd' ) THEN
                 IF ( SIZE(p%dfield_4d,1)*SIZE(p%dfield_4d,3) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%dfield_4d(ims:ime,:,jps:jpf,itrace) = p%dfield_4d(ims:ime,:,jps+py:jpf+py,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%dfield_4d(ims:ime,:,jps:jpf,itrace) = p%dfield_4d(ims:ime,:,jps+py:jpf+py,itrace)
+                    ENDDO
+                  ELSE
+                    p%dfield_4d(ims:ime,:,jps:jpf,:) = p%dfield_4d(ims:ime,:,jps+py:jpf+py,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'i' ) THEN
                 IF ( SIZE(p%ifield_4d,1)*SIZE(p%ifield_4d,3) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%ifield_4d(ims:ime,:,jps:jpf,itrace) = p%ifield_4d(ims:ime,:,jps+py:jpf+py,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%ifield_4d(ims:ime,:,jps:jpf,itrace) = p%ifield_4d(ims:ime,:,jps+py:jpf+py,itrace)
+                    ENDDO
+                  ELSE
+                    p%ifield_4d(ims:ime,:,jps:jpf,:) = p%ifield_4d(ims:ime,:,jps+py:jpf+py,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'l' ) THEN
                 CALL wrf_error_fatal( '4D logical arrays cannot be shifted for moving nests' )
@@ -87,21 +99,33 @@
             ELSE IF (  p%MemoryOrder(1:2) .EQ. 'XY' ) THEN
               IF      ( p%Type .EQ. 'r' ) THEN
                 IF ( SIZE(p%rfield_4d,1)*SIZE(p%rfield_4d,2) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%rfield_4d(ims:ime,jps:jpf,:,itrace) = p%rfield_4d(ims:ime,jps+py:jpf+py,:,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%rfield_4d(ims:ime,jps:jpf,:,itrace) = p%rfield_4d(ims:ime,jps+py:jpf+py,:,itrace)
+                    ENDDO
+                  ELSE
+                    p%rfield_4d(ims:ime,jps:jpf,:,:) = p%rfield_4d(ims:ime,jps+py:jpf+py,:,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'd' ) THEN
                 IF ( SIZE(p%dfield_4d,1)*SIZE(p%dfield_4d,2) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%dfield_4d(ims:ime,jps:jpf,:,itrace) = p%dfield_4d(ims:ime,jps+py:jpf+py,:,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%dfield_4d(ims:ime,jps:jpf,:,itrace) = p%dfield_4d(ims:ime,jps+py:jpf+py,:,itrace)
+                    ENDDO
+                  ELSE
+                    p%dfield_4d(ims:ime,jps:jpf,:,:) = p%dfield_4d(ims:ime,jps+py:jpf+py,:,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'i' ) THEN
                 IF ( SIZE(p%ifield_4d,1)*SIZE(p%ifield_4d,2) .GT. 1 ) THEN
-                  DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
-                    p%ifield_4d(ims:ime,jps:jpf,:,itrace) = p%ifield_4d(ims:ime,jps+py:jpf+py,:,itrace)
-                  ENDDO
+                  IF ( p%scalar_array ) THEN
+                    DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+                      p%ifield_4d(ims:ime,jps:jpf,:,itrace) = p%ifield_4d(ims:ime,jps+py:jpf+py,:,itrace)
+                    ENDDO
+                  ELSE
+                    p%ifield_4d(ims:ime,jps:jpf,:,:) = p%ifield_4d(ims:ime,jps+py:jpf+py,:,:)
+                  ENDIF
                 ENDIF
               ELSE IF ( p%Type .EQ. 'l' ) THEN
                 CALL wrf_error_fatal( '4D logical arrays cannot be shifted for moving nests' )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: moving nest, 4d scalar array

SOURCE: internal

DESCRIPTION OF CHANGES: The code to handle shifts of a moving nest in the x-
or y-directions previously assumed that any array with four dimensions whose first
and third dimensions were X and Y, or whose first and second dimensions were X
and Y, was a scalar array. The logic for shifting scalar arrays relies on the 'num_table'
member of the 'fieldlist' type (defined in module_domain_type.F) to be allocated;
however, this is not the case for non-scalar array 4d arrays.

Now, when shifting 4d arrays, we first check whether the 'scalar_array' member
of a 'fieldlist' type is true before applying scalar array-specific logic;
otherwise, the two non-horizontal dimensions (i.e., the dimensions other than
X and Y) of a 4d array are simply shifted as a whole.

Note that, following the logic in lines 352-355 of gen_allocs.c, we are
guaranteed that 'num_table' is associated only if 'scalar_array' is true.

LIST OF MODIFIED FILES:
M frame/loop_based_x_shift_code.h
M frame/loop_based_y_shift_code.h

TESTS CONDUCTED: The issue that is addressed in this PR was originally uncovered by 
proposed changes to add a new 4d array in the Registry like
```
state  real   aeropcu   i{lsc}jm        misc        1    -   -      "AEROPCU"     "PRESSURE LEVEL OF AEROSOL DATA"  "millibar"
```
Without the changes in this PR, moving nests fail with an out-of-bounds reference to `num_table`
in the affected code; with these changes (plus changes to address another, unrelated bug),
this case runs successfully.
[ ] WTF pending.
