### PR TITLE
integrated MPAS and WRF code for module_sf_sfclay.F

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -240,13 +240,13 @@ CONTAINS
                 P1000mb,                                           &
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
-                its,ite, jts,jte, kts,kte,                         &
+                its,ite, jts,jte, kts,kte                          &
 #if defined(mpas) 
-                isftcflx,iz0tlnd,scm_force_flux,                   &
+                ,isftcflx,iz0tlnd,scm_force_flux,                  &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
                 CD(ims,j),CDA(ims,j),dxCell(ims,j)                 &
 #elif ( EM_CORE == 1)
-                isftcflx,iz0tlnd,scm_force_flux,                   &
+                ,isftcflx,iz0tlnd,scm_force_flux,                  &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
                 CD(ims,j),CDA(ims,j)                               & 
 #endif


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: module_sf_sfclay.F, MPAS, wrf, integration, physics, shared

SOURCE: Internal

DESCRIPTION OF CHANGES: Took the MPAS-specific code from MPAS HWT top-of-repo (27Feb2018) and added them into the WRF top-of-repo (28Feb2018) for module_sf_sfclay.F.
Removed all MPAS notes and if-def's where it was okay. Modified declaration for QSFC variable to intent(INOUT) - mpas had that in one subroutine in their file, but it should be in both subroutines for both models.

LIST OF MODIFIED FILES:
M phys/module_sf_sfclay.F

TESTS CONDUCTED: Conducted a test, using a fairly basic test case (2 domains, March 2016 snow event over Colorado). The "soon-to-be" TROPICAL physics suite (wsm6, New Tiedtke, RRTMG, YSU, Noah and old MM5, gwd_opt) was used. Verified that the results, after 6 hours, for both domains, were bit-for-bit with unmodified code. WTF passed.

**need a decision regarding lines 243-251 - how to handle dimensions between 2 models
