### PR TITLE
Add -Dwrfmodel for eventual use with WRF/MPAS shared physics

### DIFF
--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -5,13 +5,7 @@
 #  define VREC vrec
 #  define VSQRT vsqrt
 #endif
-module dashDwrf_is_OK
-integer :: xxyyz
-#ifdef wrfmodel
-end module dashDwrf_is_OK
-#else
-end module dashDwrf_is_baroque
-#endif
+
 MODULE module_mp_wsm6
 !
    USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: cpp, wrfmodel, shared physics

SOURCE: internal

DESCRIPTION OF CHANGES:
Hard coded an extra cpp flag. This is to help identify areas for specific model processing within shared physics routines.

LIST OF MODIFIED FILES:
M   arch/postamble_new

TESTS CONDUCTED:
 - [x] No reg test required, since this is just adding an unused (at this time) cpp flag.
 - [x] Tests were conducted to verify that the cpp flag would indeed impact physics schemes. The following code was added to the top of the WSM6 code:
```
module dashDwrf_is_OK
integer :: xxyyz
#ifdef wrfmodel
end module dashDwrf_is_OK
#else
end module dashDwrf_is_baroque
#endif
```
After the code was pre-processed, the WSM6 f90 file had this at the top:
```
module dashDwrf_is_OK
integer :: xxyyz
end module dashDwrf_is_OK
```