### PR TITLE
Remove double broadcast of landuse categories

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1511,7 +1511,6 @@ integer myproc
       ENDIF
       CALL wrf_dm_bcast_bytes (end_of_file, LWORDSIZE )
       IF ( .NOT. end_of_file ) THEN
-        CALL wrf_dm_bcast_bytes (lucats,  IWORDSIZE )
         CALL wrf_dm_bcast_string(lutype, 256)
         CALL wrf_dm_bcast_bytes (lucats,  IWORDSIZE )
         CALL wrf_dm_bcast_bytes (luseas,  IWORDSIZE )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: landuse, broadcast, bcast

SOURCE: Identified by Greg Thompson (NCAR)

DESCRIPTION OF CHANGES:
Remove the redundant broadcast, as it appears two lines later.

LIST OF MODIFIED FILES:
M      phys/module_physics_init.F

TESTS CONDUCTED:
 - [x] Regression test OK