### PR TITLE
NSSL dbl-moment bug fix - incorrect limit on ice deposition in mixed-phased conditions

### DIFF
--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -14323,10 +14323,6 @@ END SUBROUTINE nssl_2mom_driver
 !        qitmp(mgs) = qx(mgs,li)
         fracl(mgs) = 0.0
         fraci(mgs) = 1.0
-        if ( temg(mgs) .lt. tfr .and. temg(mgs) .gt. thnuc ) then
-!          fracl(mgs) = max(min(1.,(temg(mgs)-233.15)/(20.)),0.0)
-!          fraci(mgs) = 1.0-fracl(mgs)
-        end if
         if ( temg(mgs) .le. thnuc ) then
            fraci(mgs) = 1.0
            fracl(mgs) = 0.0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: nssl, 2moment, deposition, crystal, growth

SOURCE: Ted Mansell (National Severe Storms Laboratory)

DESCRIPTION OF CHANGES: 
A recent bug fix (#367) that corrected a sublimation problem inadvertently introduced an incorrect limit on ice deposition in mixed-phase conditions. It was not very noticeable in deep convective clouds - only in a specialized application that is more sensitive to ice crystal growth.

LIST OF MODIFIED FILES: 
M       phys/module_mp_nssl_2mom.F

TESTS CONDUCTED: 
 - [x] Verified that modified code compiles and runs with the NSSL 2-moment scheme turned on. 
 - [x] WTF passed.
