### PR TITLE
integrated MPAS and WRF code for module_cu_ntiedtke.F

### DIFF
--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -227,9 +227,7 @@ contains
 #if defined(mpas)
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         dx
-#endif
-
-#if defined(wrfmodel)
+#elif defined(wrfmodel)
       real,    intent(in) ::            dx
 #endif
 
@@ -583,9 +581,7 @@ contains
       real pqvf(lq,km),    ptf(lq,km)
 #if defined(mpas)
       real dx(lq)
-#endif
-
-#if defined(wrfmodel)
+#elif defined(wrfmodel)
       real dx
 #endif
       integer icbot(lq),   ictop(lq),     ktype(lq),   lndj(lq)
@@ -801,9 +797,7 @@ contains
       real     upbl(klon)
 #if defined(mpas)
       real     dx(klon)
-#endif
-
-#if defined(wrfmodel)
+#elif defined(wrfmodel)
       real     dx
 #endif
       real     pmfude_rate(klon,klev), pmfdde_rate(klon,klev)
@@ -1035,9 +1029,7 @@ contains
            ikt = kctop(jl)
 #if defined(mpas)
            ztau = ztauc(jl) * (1.+1.33e-5*dx(jl))
-#endif
-
-#if defined(wrfmodel)
+#elif defined(wrfmodel)
            ztau = ztauc(jl) * (1.+1.33e-5*dx)
 #endif
            ztau = max(ztmst,ztau)


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: module_cu_ntiedtke.F, MPAS, wrf, integration, physics, shared

SOURCE: Internal

DESCRIPTION OF CHANGES: Took the MPAS-specific code from MPAS HWT top-of-repo (27Feb2018) and added them into the WRF top-of-repo (18March2018) for module_cu_ntiedtke.F.
It was necessary to add several MPAS if-def's for now, since the dimension of dx is different between the 2 models. Once we decide how to handle the dimensioning, this can be modified again. 

LIST OF MODIFIED FILES:
M phys/module_cu_ntiedtke.F

TESTS CONDUCTED: Conducted a test, using a fairly basic test case (2 domains, March 2016 snow event over Colorado). The "soon-to-be" TROPICAL physics suite (wsm6, New Tiedtke, RRTMG, YSU, Noah and old MM5, gwd_opt) was used. Verified that the results, after 6 hours, for both domains, were bit-for-bit with unmodified code. WTF passed.

**need a decision regarding lines how to handle dx dimensions between 2 models