### PR TITLE
Remove characters that are outside the ASCII range 32 to 127

### DIFF
--- a/phys/module_sf_gecros.F
+++ b/phys/module_sf_gecros.F
@@ -643,7 +643,7 @@ IMPLICIT NONE
     RM = MAX(0., MIN(APCAN-1.E-5/TCP,RMUL/TCP) + RMRE)  !gC m-2 s-1
 
     ! Daily and total C and N returns from crop to soil
-    ! ji: RLVDS eingefuehrt. Standardmaesig war der Wert von RLVDS auf 0.1 hard-gecoded
+    ! ji: RLVDS eingefuehrt. Standardmaessig war der Wert von RLVDS auf 0.1 hard-gecoded
     ! CLVD: Amount of carbon in dead leaves
     ! CLVDS: Amount of carbon in dead leaves that have become litter in soil
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ASCII

SOURCE: internal

DESCRIPTION OF CHANGES:
Remove several types of characters that are outside the range of the ASCII character set: 32-127. For example:
```
REAL, PARAMETER :: TBD = 0.0      !Base temperature of phenology (°C)
------------------------------------------------------------------^
```
becomes
```
REAL, PARAMETER :: TBD = 0.0      !Base temperature of phenology (C)
```

LIST OF MODIFIED FILES:
M       module_sf_gecros.F

TESTS CONDUCTED:
 - [x] Modifications are to comments only. No tests required.