### PR TITLE
NSSL mp_physics final mods for V4.0

### DIFF
--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -1603,20 +1603,9 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
 
 
 
-#if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )
-#define MPI
-      USE module_dm, ONLY : &
-         local_communicator, mytask
-! keep a spacing line here to keep Apple cpp from adding a space in front of the endif
-#endif
 
       implicit none
 
-#if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) ) || defined(MPI)
-      INCLUDE 'mpif.h'
-#else
-      integer :: mytask = 0
-#endif
 
  !Subroutine arguments:
 
@@ -1730,14 +1719,6 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
       
       logical :: f_cnatmp
 
-#ifdef MPI
-
-#if defined(MPI) 
-      integer, parameter :: ntot = 50
-      double precision  mpitotindp(ntot), mpitotoutdp(ntot)
-      INTEGER :: mpi_error_code = 1
-#endif
-#endif
 
 
 ! -------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix, enhancement, text only

KEYWORDS: nssl, mp_physics, ice_crystal, fall_speed, supersaturation, droplet, accretion

SOURCE: Ted Mansell, National Severe Storms Laboratory

DESCRIPTION OF CHANGES: 
**Bug fix**
Fixed a couple rates in case a user changes the droplet shape parameter (cnu) from default value of 0.0 to a non-zero value.

**Enhancements**
-Added a new default ice crystal fall speed formula (icefallopt = 3), which has faster speeds for small ice particles. The main effect is on anvil clouds to help them settle a bit faster. The old behavior can be recovered with icefallopt=1
- Added an option to change ice crystal and snow fall speeds by an arbitrary factor, but default factors are 1.0 (no impact with default settings)
- Added a calculation of reflectivity-weighted snow fall speed instead of using mass-weighted (for size-sorting limiter)
- Added a check for large supersaturation w.r.t. liquid at ice-only temperatures and nucleate/condense if needed.
- Added option to limit accretion of droplets smaller than "exwmindiam" by setting a "reserve value" that is excluded from accretion so that a minimum value of mass and number remains. (Default is no limit, i.e., exwmindiam = 0.0 )
- Added two options for rime density on graupel/hail (irimdenopt). Default is original Heymsfield and Pflaum formula. Extra options are for Cober and List (1993) and Macklin 
- Added a rime density calculation for rain accreted by graupel instead of always assuming high density.
- Added a calculation of a separate rate for number of rain drops produced by snow melting rather than using the snow number loss rate.
- Separated rain-ice freezing from flag ifrzg, and is now controlled by ifiacrg (no impact -- for sensitivity study only)
- Snow aggregation coefficient set back to 1.0 (increases aggregation rate)
- Made consistent use of dtpinv to replace divisions by dtp (no impact)

**Text change**
- Removed unmatched quotes from comments to avoid warnings from certain flavors of cpp.

LIST OF MODIFIED FILES: 
M    module_mp_nssl_2mom.F

TESTS CONDUCTED: Tested with a basic namelist case - March 2016 snowstorm over Colorado, with the 3 2-moment NSSL microphysics options (17, 18, 22) to verify that this didn't dramatically change anything. WTF passes.