### PR TITLE
BF of compile script: -j n trips "unrecognized option" exit

### DIFF
--- a/compile
+++ b/compile
@@ -23,6 +23,7 @@ endif
 
 set ZAP = .foofoo
 set arglist=""
+set prev_was_j = false
 foreach a ( $argv )
   if ( "$a" == "-h" ) then
     goto hlp
@@ -72,6 +73,9 @@ foreach a ( $argv )
   else if ( "$a" == "-j" ) then
     shift argv
     setenv J "-j $argv[1]"
+    set prev_was_j = true
+  else if ( "$prev_was_j" == "true" ) then
+    set prev_was_j = false
   else
     echo "This option is not recognized: $a"
     exit ( 1 )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile, -j

SOURCE: Found by Stacy Walters (ACOM), internal

DESCRIPTION OF CHANGES:
The csh for loop used a "shift" to find the argument after the "-j" command line flag. That "shift" command does not actually modify the for loop processing, and the (in the example of "-j 6"), the "6" is seen as an unrecognized argument. If the "-j" argument is found a flag is set to skip over the next argument.

LIST OF MODIFIED FILES:
M   compile

TESTS CONDUCTED:
```
./compile -j 6 em_real
```
 - [x] With this mod, the compile script works.
 - [x] Without this mod, the compile script stops immediately 