### PR TITLE
Modify upper stretching function in auto_levels_opt

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7358,7 +7358,7 @@ end do
     print *,1,dz,zup(1),eta(1)
     isave=1
     do i=1,nlev-1
-        a=dzstretch_u+(dzstretch_s-dzstretch_u)*max((zscale-zup(i))/zscale, 0.)
+        a=dzstretch_u+(dzstretch_s-dzstretch_u)*max((dzmax*0.5-dz)/(dzmax*0.5), 0.)
         dz=a*dz
         dztest=(ztop-zup(isave))/(nlev-isave)
         if(dztest.lt.dz)exit


### PR DESCRIPTION

TYPE: enhancement

KEYWORDS: auto_levels_opt=2, dzstretch_u function

SOURCE: internal

DESCRIPTION OF CHANGES: 
Upper stretching factor completely takes over at max_dz*0.5 instead of upper troposphere. This
makes it more effective at controlling thickness below tropopause. The behavior for both stretching
factors equal remains the same. Typically dzstretch_s = 1.1-1.3, dzstretch_u=1.02-1.1.

LIST OF MODIFIED FILES: 
M       dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
Ran new real.exe to test levels.