### PR TITLE
Add the "io" target back for compile

### DIFF
--- a/compile
+++ b/compile
@@ -64,6 +64,8 @@ foreach a ( $argv )
   else if   ( `echo $a | cut -c 1-3` == "em_" ) then
     set arglist = ( $arglist $a )
     set ZAP = ( main/wrf.exe main/ideal.exe )
+  else if   ( "$a" ==  "io" ) then
+    set arglist = ( $arglist $a )
   else if ( "$a" == "wrfplus" ) then
     set arglist = ( $arglist $a )
     set ZAP = ( main/wrf.exe main/real.exe main/ndown.exe main/tc.exe )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile, io, target, Makefile

SOURCE: Suggested by Mike Kavulich (RAL), internal

DESCRIPTION OF CHANGES: 
With the commit cleaning up the arguments to the compile command 4a518b417b, only positively recognized options are permitted. The original compile script allowed values that we have assumed that were explicitly codified in the compile script. An example of this is "io" as in 
```
> ./compile io
```
An additional if test has been added to the top of the compile script to accommodate this target.

LIST OF MODIFIED FILES: 
M        compile

TESTS CONDUCTED: 
 - [x] "compile io" works. After
```
> ./compile io
```
completes, then WPS may be be successfully built:
```
WPS_V4> ./compile >&! foo
WPS_V4> ls -ls *.exe
8 lrwxr-xr-x  1 gill  1500  23 Apr  6 16:44 geogrid.exe -> geogrid/src/geogrid.exe
8 lrwxr-xr-x  1 gill  1500  23 Apr  6 16:45 metgrid.exe -> metgrid/src/metgrid.exe
8 lrwxr-xr-x  1 gill  1500  21 Apr  6 16:45 ungrib.exe -> ungrib/src/ungrib.exe
```
