### PR TITLE
Add hybrid_opt explicitly to all ARW namelists

### DIFF
--- a/test/em_b_wave/namelist.input
+++ b/test/em_b_wave/namelist.input
@@ -68,6 +68,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 1,      1,      1,

--- a/test/em_b_wave/namelist.input.backwards
+++ b/test/em_b_wave/namelist.input.backwards
@@ -68,6 +68,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 1,      1,      1,

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -70,6 +70,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_esmf_exp/namelist.input.jan00.ESMFSST
+++ b/test/em_esmf_exp/namelist.input.jan00.ESMFSST
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_esmf_exp/namelist.input.jan00.NETCDFSST
+++ b/test/em_esmf_exp/namelist.input.jan00.NETCDFSST
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_fire/namelist.input_hill_simple
+++ b/test/em_fire/namelist.input_hill_simple
@@ -73,6 +73,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_fire/namelist.input_two_fires
+++ b/test/em_fire/namelist.input_two_fires
@@ -74,6 +74,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_grav2d_x/namelist.input
+++ b/test/em_grav2d_x/namelist.input
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_grav2d_x/namelist.input.100m
+++ b/test/em_grav2d_x/namelist.input.100m
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_grav2d_x/namelist.input.200m
+++ b/test/em_grav2d_x/namelist.input.200m
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_grav2d_x/namelist.input.400m
+++ b/test/em_grav2d_x/namelist.input.400m
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_heldsuarez/namelist.input
+++ b/test/em_heldsuarez/namelist.input
@@ -68,6 +68,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 1,      1,      1,

--- a/test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
+++ b/test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
+++ b/test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_hill2d_x/extras/namelist.input-HILL
+++ b/test/em_hill2d_x/extras/namelist.input-HILL
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_hill2d_x/extras/namelist.input-HILL-51
+++ b/test/em_hill2d_x/extras/namelist.input-HILL-51
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_hill2d_x/extras/namelist.input-HILL-schar
+++ b/test/em_hill2d_x/extras/namelist.input-HILL-schar
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  diff_opt                            = 0,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_hill2d_x/namelist.input
+++ b/test/em_hill2d_x/namelist.input
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 1,      1,      1,

--- a/test/em_les/namelist.input
+++ b/test/em_les/namelist.input
@@ -70,6 +70,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_les/namelist.input.SGP
+++ b/test/em_les/namelist.input.SGP
@@ -80,6 +80,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 0,
  km_opt                              = 0,

--- a/test/em_les/namelist.input_shalconv
+++ b/test/em_les/namelist.input_shalconv
@@ -71,6 +71,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_quarter_ss/namelist.input
+++ b/test/em_quarter_ss/namelist.input
@@ -68,6 +68,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_quarter_ss/namelist.input_2to1
+++ b/test/em_quarter_ss/namelist.input_2to1
@@ -69,6 +69,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_quarter_ss/namelist.input_3to1
+++ b/test/em_quarter_ss/namelist.input_3to1
@@ -69,6 +69,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_quarter_ss/namelist.input_4to1
+++ b/test/em_quarter_ss/namelist.input_4to1
@@ -69,6 +69,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_quarter_ss/namelist.input_5to1
+++ b/test/em_quarter_ss/namelist.input_5to1
@@ -69,6 +69,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -66,6 +66,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.4km
+++ b/test/em_real/namelist.input.4km
@@ -73,6 +73,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.chem
+++ b/test/em_real/namelist.input.chem
@@ -86,6 +86,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 1,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.diags
+++ b/test/em_real/namelist.input.diags
@@ -91,6 +91,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.fire
+++ b/test/em_real/namelist.input.fire
@@ -76,6 +76,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  rk_ord                              = 3,
  w_damping                           = 0,
  diff_opt                            = 2,      2,      2,

--- a/test/em_real/namelist.input.global
+++ b/test/em_real/namelist.input.global
@@ -72,6 +72,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  diff_opt                            = 0,      0,      0,
  km_opt                              = 0,      0,      0,
  damp_opt                            = 3,

--- a/test/em_real/namelist.input.jan00
+++ b/test/em_real/namelist.input.jan00
@@ -73,6 +73,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.jun01
+++ b/test/em_real/namelist.input.jun01
@@ -73,6 +73,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.ndown_1
+++ b/test/em_real/namelist.input.ndown_1
@@ -91,6 +91,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.ndown_2
+++ b/test/em_real/namelist.input.ndown_2
@@ -93,6 +93,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.ndown_3
+++ b/test/em_real/namelist.input.ndown_3
@@ -93,6 +93,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_real/namelist.input.volc
+++ b/test/em_real/namelist.input.volc
@@ -80,6 +80,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 2, 
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_scm_xy/namelist.input
+++ b/test/em_scm_xy/namelist.input
@@ -75,6 +75,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_seabreeze2d_x/namelist.input
+++ b/test/em_seabreeze2d_x/namelist.input
@@ -69,6 +69,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_seabreeze2d_x/namelist.input.windfarm
+++ b/test/em_seabreeze2d_x/namelist.input.windfarm
@@ -72,6 +72,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/test/em_squall2d_x/namelist.input
+++ b/test/em_squall2d_x/namelist.input
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_squall2d_y/namelist.input
+++ b/test/em_squall2d_y/namelist.input
@@ -60,6 +60,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,

--- a/test/em_tropical_cyclone/namelist.input
+++ b/test/em_tropical_cyclone/namelist.input
@@ -61,6 +61,7 @@
  /
 
  &dynamics
+ hybrid_opt                          = 0, 
  rk_ord                              = 3,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 4,      4,      4,


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: hybrid_opt, namelist

SOURCE: internal

DESCRIPTION OF CHANGES:
For each namelist.input* file that is NOT in the nmm_* directory structure, add a single line in the &dynamics namelist record. 
1. If the namelist file is under test/em_real or test/em_hill2d_x, then the hybrid option is activated.
```
&dynamics
 hybrid_opt = 2
```
2. If the namelist file is under any other test/em_* directory, then the hybrid option is de-activated.
```
&dynamics
 hybrid_opt = 0
```
3. If the namelist.input file already had an explicit entry for hybrid_opt (such as all of the test/em_hill2d_x namelist files in the extras directory), no modifications were made.

LIST OF MODIFIED FILES:
M      em_b_wave/namelist.input
M      em_b_wave/namelist.input.backwards
M      em_convrad/namelist.input
M      em_esmf_exp/namelist.input.jan00.ESMFSST
M      em_esmf_exp/namelist.input.jan00.NETCDFSST
M      em_fire/namelist.input_hill_simple
M      em_fire/namelist.input_two_fires
M      em_grav2d_x/namelist.input
M      em_grav2d_x/namelist.input.100m
M      em_grav2d_x/namelist.input.200m
M      em_grav2d_x/namelist.input.400m
M      em_heldsuarez/namelist.input
M      em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
M      em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
M      em_hill2d_x/extras/namelist.input-HILL
M      em_hill2d_x/extras/namelist.input-HILL-51
M      em_hill2d_x/extras/namelist.input-HILL-schar
M      em_hill2d_x/namelist.input
M      em_les/namelist.input
M      em_les/namelist.input.SGP
M      em_les/namelist.input_shalconv
M      em_quarter_ss/namelist.input
M      em_quarter_ss/namelist.input_2to1
M      em_quarter_ss/namelist.input_3to1
M      em_quarter_ss/namelist.input_4to1
M      em_quarter_ss/namelist.input_5to1
M      em_real/namelist.input
M      em_real/namelist.input.4km
M      em_real/namelist.input.chem
M      em_real/namelist.input.diags
M      em_real/namelist.input.fire
M      em_real/namelist.input.global
M      em_real/namelist.input.jan00
M      em_real/namelist.input.jun01
M      em_real/namelist.input.ndown_1
M      em_real/namelist.input.ndown_2
M      em_real/namelist.input.ndown_3
M      em_real/namelist.input.volc
M      em_scm_xy/namelist.input
M      em_seabreeze2d_x/namelist.input
M      em_seabreeze2d_x/namelist.input.windfarm
M      em_squall2d_x/namelist.input
M      em_squall2d_y/namelist.input
M      em_tropical_cyclone/namelist.input

TESTS CONDUCTED:
 - [x] No regression tests since these files not used there.