### PR TITLE
Add -I netcdf/include path in makefile for the WRFDA code that includes netcdf.inc

### DIFF
--- a/var/build/da.make
+++ b/var/build/da.make
@@ -387,10 +387,10 @@ da_radiance.o :
         fi
 	if $(FGREP) '!$$OMP' $*.f ; then \
           if [ -n "$(OMP)" ] ; then echo COMPILING $*.f90 WITH OMP ; fi ; \
-	  $(FC) -c $(FCFLAGS) $(OMP) $(PROMOTION) $(CRTM_SRC) $(RTTOV_SRC) $(HDF5_INC) $*.f ; \
+	  $(FC) -c $(FCFLAGS) $(OMP) $(PROMOTION) $(CRTM_SRC) $(RTTOV_SRC) $(HDF5_INC) -I$(NETCDF)/include $*.f ; \
         else \
 	if [ -n "$(OMP)" ] ; then echo COMPILING $*.f90 WITHOUT OMP ; fi ; \
-	  $(FC) -c $(FCFLAGS) $(PROMOTION) $(CRTM_SRC) $(RTTOV_SRC) $(HDF5_INC) $*.f ; \
+	  $(FC) -c $(FCFLAGS) $(PROMOTION) $(CRTM_SRC) $(RTTOV_SRC) $(HDF5_INC) -I$(NETCDF)/include $*.f ; \
         fi
 
 da_radiance1.o \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, netcdf include, radiance

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

On systems that do not wrap netcdf paths in the compiler command,
the compilation failed (after commit c47ec6b) with the error:
da_radiance.f:83: Error: Can't open included file 'netcdf.inc'

The solution is to add explicit include path to da.make for da_radiance.o.

LIST OF MODIFIED FILES:
M       var/build/da.make

TESTS CONDUCTED:
3DVAR code compiles on MMM Mac after the change.