### PR TITLE
Modifying to include moist value for potential temp in ideal initializations

### DIFF
--- a/dyn_em/module_initialize_fire.F
+++ b/dyn_em/module_initialize_fire.F
@@ -944,6 +944,19 @@ ENDIF
    ENDDO
  ENDIF
 
+ !  Turn dry potential temperature into moist potential temperature
+      !  at the very end of this routine
+      !  This field will be in the model IC and and used to construct the 
+      !  BC file.
+
+      DO J  = jts, min(jde-1,jte)
+         DO K = kts, kte-1
+            DO I = its, min(ide-1,ite)
+               grid%t_2(i,k,j) = ( grid%t_2(i,k,j) + T0 ) * (1. + (R_v/R_d) * moist(i,k,j,p_qv)) - T0
+            END DO
+         END DO
+      END DO
+
  END SUBROUTINE init_domain_rk
 
    SUBROUTINE init_module_initialize

--- a/dyn_em/module_initialize_heldsuarez.F
+++ b/dyn_em/module_initialize_heldsuarez.F
@@ -474,6 +474,19 @@ CONTAINS
    END DO
    END DO
 
+   !  Turn dry potential temperature into moist potential temperature
+      !  at the very end of this routine
+      !  This field will be in the model IC and and used to construct the 
+      !  BC file.
+
+      DO J  = jts, min(jde-1,jte)
+         DO K = kts, kte-1
+            DO I = its, min(ide-1,ite)
+               grid%t_2(i,k,j) = ( grid%t_2(i,k,j) + T0 ) * (1. + (R_v/R_d) * moist(i,k,j,p_qv)) - T0
+            END DO
+         END DO
+      END DO
+
    RETURN
 
  END SUBROUTINE init_domain_rk

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -1691,6 +1691,19 @@ CONTAINS
 
   END SELECT tracers
 
+  !  Turn dry potential temperature into moist potential temperature
+      !  at the very end of this routine
+      !  This field will be in the model IC and and used to construct the 
+      !  BC file.
+
+      DO J  = jts, min(jde-1,jte)
+         DO K = kts, kte-1
+            DO I = its, min(ide-1,ite)
+               grid%t_2(i,k,j) = ( grid%t_2(i,k,j) + T0 ) * (1. + (R_v/R_d) * moist(i,k,j,p_qv)) - T0
+            END DO
+         END DO
+      END DO
+
   RETURN
 
  END SUBROUTINE init_domain_rk

--- a/dyn_em/module_initialize_scm_xy.F
+++ b/dyn_em/module_initialize_scm_xy.F
@@ -604,6 +604,19 @@ CONTAINS
     grid%z_base(k) = 0.5*(grid%phb(1,k,1)+grid%phb(1,k+1,1)+grid%ph_1(1,k,1)+grid%ph_1(1,k+1,1))/g
   ENDDO
 
+ !  Turn dry potential temperature into moist potential temperature
+      !  at the very end of this routine
+      !  This field will be in the model IC and and used to construct the 
+      !  BC file.
+
+      DO J  = jts, min(jde-1,jte)
+         DO K = kts, kte-1
+            DO I = its, min(ide-1,ite)
+               grid%t_2(i,k,j) = ( grid%t_2(i,k,j) + T0 ) * (1. + (R_v/R_d) * moist(i,k,j,p_qv)) - T0
+            END DO
+         END DO
+      END DO
+ 
   RETURN
 
  END SUBROUTINE init_domain_rk

--- a/dyn_em/module_initialize_tropical_cyclone.F
+++ b/dyn_em/module_initialize_tropical_cyclone.F
@@ -1053,6 +1053,19 @@ CONTAINS
   ENDDO
   ENDDO
 
+  !  Turn dry potential temperature into moist potential temperature
+      !  at the very end of this routine
+      !  This field will be in the model IC and and used to construct the 
+      !  BC file.
+
+      DO J  = jts, min(jde-1,jte)
+         DO K = kts, kte-1
+            DO I = its, min(ide-1,ite)
+               grid%t_2(i,k,j) = ( grid%t_2(i,k,j) + T0 ) * (1. + (R_v/R_d) * moist(i,k,j,p_qv)) - T0
+            END DO
+         END DO
+      END DO
+
   RETURN
 
  END SUBROUTINE init_domain_rk


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: idealized, initialization, theta_m, potential_temp, dry, moist, perturbation

SOURCE: Internal

DESCRIPTION OF CHANGES: 
The WRF model now assumes that the variables grid%t_2 and grid%t_1 are moist perturbation potential temperature in the RK looping and within the sound step routines. The WRF real and ideal pre-processors now pass in moist (not dry) potential temperature. The moist value for potential temperature is placed at the very end of the init_domain_rk routine, as the moist value for potential temperature is not used within the vertical interpolation, diagnostics, or integrations. For cases with no moisture, the Qvapor field is zero, so the moist and dry potential temperature is identical. 

LIST OF MODIFIED FILES: 
M   dyn_em/module_initialize_fire.F
M   dyn_em/module_initialize_heldsuarez.F
M   dyn_em/module_initialize_ideal.F
M   dyn_em/module_initialize_scm_xy.F
M   dyn_em/module_initialize_tropical_cyclone.F

TESTS CONDUCTED: All ideal cases compile serially, pending WTF.