### PR TITLE
Modify lower stretching coefficient to reduce the total number of eta levels

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2059,7 +2059,7 @@ rconfig   real      eta_levels      namelist,domains    max_eta        -1.
 rconfig   integer   auto_levels_opt namelist,domains    1               2      -     "auto_levels_opt" "automatic levels, 1=old, 2=new"
 rconfig   real      max_dz          namelist,domains    1               1000.  -     "max_dz"   "maximum thickness limit for eta calc" "m"
 rconfig   real      dzbot           namelist,domains    1               50.    -     "dzbot"    "surface dz thickness for eta calc" "m"
-rconfig   real      dzstretch_s     namelist,domains    1               1.1    -     "dzstretch_s"  "surface dz stretching factor for eta calc"    ""
+rconfig   real      dzstretch_s     namelist,domains    1               1.3    -     "dzstretch_s"  "surface dz stretching factor for eta calc"    ""
 rconfig   real      dzstretch_u     namelist,domains    1               1.1    -     "dzstretch_u"  "upper dz stretching factor for eta calc"    ""
 rconfig   integer   ocean_levels    namelist,domains    1               30     irh   "ocean level"        ""      ""
 rconfig   real      ocean_z         namelist,domains    max_ocean      -1      -     "vertical profile of layer depths for ocean" "m"


### PR DESCRIPTION

TYPE: enhancement

KEYWORDS: auto_levels_opt, dzstretch_s, real

SOURCE: internal

DESCRIPTION OF CHANGES: 
The current default value for lower stretching coefficient will yield too many required vertical levels. Changing the coefficient from 1.1 to 1.3 allows the required number of vertical levels to reduce to 33 from 44 with model top at 50 mb, with comparable values to old specification.

LIST OF MODIFIED FILES:
M Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
Test conducted to verify these options do produce 33 vertical levels.