### PR TITLE
compile target "wrf" is now available again

### DIFF
--- a/compile
+++ b/compile
@@ -72,6 +72,9 @@ foreach a ( $argv )
     setenv WRF_EM_CORE   1
     setenv WRF_PLUS_CORE 1
     echo not sure what to do, but this seems to be legit so far
+  else if   ( "$a" ==  "wrf" ) then
+    set arglist = ( $arglist $a )
+    set ZAP = ( main/wrf.exe )
   else if ( "$a" == "-j" ) then
     shift argv
     setenv J "-j $argv[1]"


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: compile, wrf

SOURCE: internal

DESCRIPTION OF CHANGES:
Add in the target "wrf" in the top if test in the compile script. The test is placed after the "wrfplus" target. The only executable to be built is wrf.exe, so that is the only executable that is removed.

LIST OF MODIFIED FILES:
M    compile

TESTS CONDUCTED:
 - [x] Without the mod, the build target is not recognized.
 - [x] With the mod, the wrf.exe (and only wrf.exe) executable is rebuilt.