### PR TITLE
Include "total fields" diags to main Chem registry file

### DIFF
--- a/Registry/Registry.EM_CHEM
+++ b/Registry/Registry.EM_CHEM
@@ -23,6 +23,7 @@ include registry.bdy_perturb
 include registry.new3d_gca
 include registry.hyb_coord
 include registry.new3d_wif
+include registry.trad_fields
 
 state   real   landmask            ij    misc          1     -     i012rh0d=(interp_fcnm_imask)u=(copy_fcnm)   "LANDMASK"      "LAND MASK (1 FOR LAND, 0 FOR WATER)"  ""
 state   real   lakemask            ij    misc          1     -     i012rh0d=(interp_fcnm_imask)u=(copy_fcnm)   "LAKEMASK"      "LAKE MASK (1 FOR LAND, 0 FOR WATER)"  ""


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Chem, total fields, nwp2

SOURCE: internal, noticed by PNNL, fixed by Wei Wang

DESCRIPTION OF CHANGES:
While caught up in the spirit of placing the Registry entries for each new feature in its own separate file, one needs to also remember to "registry include" that new registry file in both Registry.EM and Registry.EM_CHEM.

LIST OF MODIFIED FILES:
M	   Registry/Registry.EM_CHEM

TESTS CONDUCTED:
 - [x] WRF Chem builds with mod
 - [x] WRF Chem DOES NOT build without mod