### PR TITLE
Unify Registry includes for atmos model and chemistry

### DIFF
--- a/Registry/Registry.EM
+++ b/Registry/Registry.EM
@@ -1,6 +1,7 @@
 #  Registry file, EM
 
 #INCLUDES
+include registry.dimspec
 include registry.em_shared_collection
 
 # added to output 5 for ESMF

--- a/Registry/Registry.EM_CHEM
+++ b/Registry/Registry.EM_CHEM
@@ -1,6 +1,7 @@
 # Registry file, EM_CHEM
 
 #INCLUDES
+include registry.dimspec
 include registry.chem
 include registry.new3d_gca
 include registry.em_shared_collection

--- a/Registry/registry.em_shared_collection
+++ b/Registry/registry.em_shared_collection
@@ -5,26 +5,23 @@
 #		Registry.EM
 #		Registry.EM_CHEM
 
-# Dimension specifications MUST GO FIRST
-include registry.dimspec
-
-include registry.afwa
+include Registry.EM_COMMON
+include registry.io_boilerplate
+include registry.fire
 include registry.avgflx
-include registry.bdy_perturb
+include registry.stoch
+include registry.les
 include registry.cam
 include registry.clm
-include registry.diags
-include registry.elec
-include Registry.EM_COMMON
-include registry.fire
-include registry.hyb_coord
-include registry.io_boilerplate
 include registry.lake
-include registry.les
-include registry.new3d_wif
-include registry.noahmp
-include registry.rasm_diag
-include registry.sbm
 include registry.ssib
-include registry.stoch
+include registry.noahmp
+include registry.sbm
+include registry.diags
+include registry.afwa
+include registry.rasm_diag
+include registry.elec
+include registry.bdy_perturb
+include registry.hyb_coord
+include registry.new3d_wif
 include registry.trad_fields


### PR DESCRIPTION
#TYPE: enhancement

KEYWORDS: Registry, shared_collection

SOURCE: internal

DESCRIPTION OF CHANGES:
The PR for #454 edde918 pointed out the need to always remember to include new registry files in multiple top-level locations. That "also need to remember this" concept is problematic for maintaining code, and in this case, entirely unnecessary. The better solution is to identify the commonality, refactor some code, and collect that common/shared bit into a new single file. This new single file is then used by two of the top level Registry files (for atmos: Registry.EM, and for chemistry: Registry.EM_CHEM).

LIST OF MODIFIED FILES:
M	   Registry/Registry.EM
M	   Registry/Registry.EM_CHEM
A	   Registry/registry.em_shared_collection

TESTS CONDUCTED:
1. The intersection of the included files was constructed via tools from the OLD versions of the EM and EM_CHEM Registry files:
```
> grep ^include Registry.EM | sort > EM
> grep ^include Registry.EM_CHEM | sort > CHEM
```
<img width="535" alt="screen shot 2018-04-23 at 2 34 51 pm" src="https://user-images.githubusercontent.com/12666234/39151932-e655b980-4703-11e8-95e4-e1a077549af4.png">

Other than the upper-case/lower-case alpha-numerical ordering on Linux vs Mac, the above list is identical to the proposed new shared collection.

<img width="277" alt="screen shot 2018-04-23 at 2 39 52 pm" src="https://user-images.githubusercontent.com/12666234/39152089-6462c61a-4704-11e8-8055-852e9298fd65.png">

2. The results using these test are supposed to be bit-for-bit (before the mods vs after the mods). However, just getting one regression test to finish is hard enough ...
 - [x] Reggie 04.07 OK