### PR TITLE
Mod to prevent floating point error with WETCAN calculation

### DIFF
--- a/phys/module_sf_ruclsm.F
+++ b/phys/module_sf_ruclsm.F
@@ -2592,7 +2592,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
 !--- water, and DRYCAN is the fraction of vegetated area where
 !--- transpiration may take place.
 
-          WETCAN=min(0.25,(CST/SAT)**CN)
+          WETCAN=min(0.25,max(0.,(CST/SAT))**CN)
 !          if(lai > 1.) wetcan=wetcan/lai
           DRYCAN=1.-WETCAN
 
@@ -3618,7 +3618,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
             SNWE=0.
          ENDIF
 
-          WETCAN=min(0.25,(CST/SAT)**CN)
+          WETCAN=min(0.25,max(0.,(CST/SAT))**CN)
 !          if(lai > 1.) wetcan=wetcan/lai
           DRYCAN=1.-WETCAN
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WETCAN, CN, positive_definite, morrison, RUC

SOURCE: internal

DESCRIPTION OF CHANGES: When using the Morrison microphysics scheme, along with the RUC LSM, an fatal error is produced: "Crash in surface energy budget," or sometimes a floating point error. This is reproducible with a basic (near-default) namelist set-up. Traced back to module_sf_ruclsm.F where WETCAN is assigned a value that can be non-real, depending on values of CST and SAT. Since CN is always equal to 0.5, if CST or SAT are negative, then we are taking the square root of a negative number. Corrected so that this is always positive. 

LIST OF MODIFIED FILES: 
M    module_sf_ruclsm.F

TESTS CONDUCTED: wtf passes, tested modified code to make sure the error is gone