### PR TITLE
KLUDGE for apparent bug in GNU compiler: RRTMG_LWK

### DIFF
--- a/phys/module_ra_rrtmg_lwk.F
+++ b/phys/module_ra_rrtmg_lwk.F
@@ -6127,10 +6127,9 @@
 !                                  (high key - nothing; high minor-cfc11, cfc12)
 !
 !-------------------------------------------------------------------------------
-   use parrrtm_k,   only : ng6, ngs5
+   use parrrtm_k,   only : ngs5
    use rrlw_ref_k,  only : chi_mls
-   use rrlw_kg06_k, only : fracrefa, absa, ka, ka_mco2,                        &
-                         selfref, forref, cfc11adj, cfc12
+   use rrlw_kg06_k
 !
 ! Local 
 !
@@ -9002,11 +9001,8 @@
 !  old band 6:  820-980 cm-1 (low - h2o; high - nothing)
 !
 !-------------------------------------------------------------------------------
-   use parrrtm_k,   only : mg, nbndlw, ngptlw, ng6
-   use rrlw_kg06_k, only : fracrefao, kao, kao_mco2, cfc11adjo, cfc12o,        &
-                         selfrefo, forrefo,                                    &
-                         fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12,         &
-                         selfref, forref
+   use parrrtm_k,   only : mg, nbndlw, ngptlw
+   use rrlw_kg06
 !
 ! Local
 !
@@ -12813,8 +12809,7 @@
 !  etc.  The second index runs over the g-channel (1 to 16).
 !
 !-------------------------------------------------------------------------------
-   use rrlw_kg06_k, only : fracrefao, kao, kao_mco2, selfrefo, forrefo,        &
-                         cfc11adjo, cfc12o
+   use rrlw_kg06_k
 !
    implicit none
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: GNU, rrtmg_lwk

SOURCE: internal

DESCRIPTION OF CHANGES:
The GNU compiler complains about some module variables that are used by other modules (an internal compiler error). There is a redundancy in the variables, so perhaps there is a namespace conflict. The solution is to force the variable to come from a particular module and not the other.

We made this mod for RRTMG previously. Now, using virtually the identical changes from PR #325 SHA-1 500898c6a.

LIST OF MODIFIED FILES:
M	phys/module_ra_rrtmg_lwk.F

TESTS CONDUCTED:
 - [x] Code builds on Mac GNU/6.2.0 when fully optimized, -D, and -d. Without this mod, the code did not build optimized.
 - [x] reggie v04.07 OK