### PR TITLE
Remove redundant include of mpif.h in module_dm.F

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -1298,7 +1298,6 @@ CONTAINS
    REAL FUNCTION wrf_dm_max_int ( inval )
       IMPLICIT NONE
 #ifndef STUBMPI
-      INCLUDE 'mpif.h'
       INTEGER, intent(in) :: inval
       INTEGER :: ierr, retval
       CALL mpi_allreduce ( inval, retval , 1, MPI_INTEGER, MPI_MAX, local_communicator, ierr )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Fujitsu rsl mpif.h module_dm.F duplicate

SOURCE: Chengguang Li (Fujitsu, Taiwan)

DESCRIPTION OF CHANGES:
The same fix as commit 6106eb0 to apply to a new include of mpif.h introduced in commit 8cb2192.
The module module_dm.F has mpif.h INCLUDED at the top of the module above the
CONTAINS statement. Remove the replicated instance inside subroutine wrf_dm_max_int.

LIST OF MODIFIED FILES:
M       external/RSL_LITE/module_dm.F

TESTS CONDUCTED:
(1) compile em_real still compiles on Mac after the change.
(2) Can someone help pick this for the reg test?