### PR TITLE
Fix unnecessary stop and print in obsproc for duplicate surface obs

### DIFF
--- a/var/obsproc/src/module_qc.F90
+++ b/var/obsproc/src/module_qc.F90
@@ -692,7 +692,6 @@ SUBROUTINE vert_cons_check ( obs , counter , print_vert, iunit, failed )
    REAL                                   :: p1 , p2 , h1 , h2
    LOGICAL                                :: found
    LOGICAL                                :: failed
-   LOGICAL                                :: fatal, listing
    INTEGER                                :: iunit
 
 !  INCLUDE 'error.inc'
@@ -738,15 +737,14 @@ SUBROUTINE vert_cons_check ( obs , counter , print_vert, iunit, failed )
           IF ((      eps_equal (h1 , h2 , 0.1 )) .AND. &
               (.NOT. eps_equal (p1 , p2 , 0.1 ))) THEN
 
+             if ( print_vert ) then
                WRITE (message, FMT = '(" Duplicate surface found at ",A8,A8)') &
                TRIM  (obs%location%id),  TRIM (obs%location%name)
-               fatal = .true.
-               listing = .false.
+               WRITE (iunit, '(A)') TRIM (message)
+             end if
 
 ! To discard the OBS:                
                obs%info % discard = .TRUE.
-
-               CALL error_handler (proc_name, message, "",fatal)
 
                current%meas%pressure%data     = missing_r
                current%meas%height%data       = missing_r


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, obsproc, duplicate surface, fatal not

SOURCE: Siou-Ying Jiang (Central Weather Bureau, Taiwan)

DESCRIPTION OF CHANGES:

Commit 6a9cbed made the fatal actually fatal in subroutine error_handler.
CWB encountered a case in their operational runs that duplicate surface
obs are found but it should not be fatal.
They proposed to pass in .false. to the error_handler call.
I decided to remove the confusing and unnecessary error_handler call
because the condition is not worth a "WARNING: ERROR in" message either.

LIST OF MODIFIED FILES:
M       var/obsproc/src/module_qc.F90

TESTS CONDUCTED:
none