### PR TITLE
Integrated MPAS and WRF code for module_sf_noahlsm.F

### DIFF
--- a/phys/module_sf_noahlsm.F
+++ b/phys/module_sf_noahlsm.F
@@ -3262,13 +3262,9 @@ CONTAINS
 ! ABOVE FREEZING BLOCK
 ! ----------------------------------------------------------------------
       ELSE
-#if defined(mpas)
-         T1 - TFREEZ * SNCOVR ** SNOEXP + T12 * (1.0- SNCOVR ** SNOEXP)
-#else
 !     From V3.9 original code (commented) replaced to allow complete melting of small snow amounts
 !        T1 = TFREEZ * SNCOVR ** SNOEXP + T12 * (1.0- SNCOVR ** SNOEXP)
          T1 = TFREEZ * max(0.01,SNCOVR ** SNOEXP) + T12 * (1.0- max(0.01,SNCOVR ** SNOEXP))
-#endif
          BETA = 1.0
 
 ! ----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: module_sf_noahlsm.F, MPAS, wrf, integration, physics, shared

SOURCE: Internal

DESCRIPTION OF CHANGES: Took the MPAS-specific code from MPAS HWT top-of-repo (27Feb2018) and added them into the WRF top-of-repo (26April2018) for module_sf_noahlsm.F.
There are a few mpas if-defs, and still several differences between the files due to intents (IN/OUT/INOUT) that differ between the 2 models. This needs to be looked-into deeper in the future.

LIST OF MODIFIED FILES:
M phys/module_sf_noahlsm.F

TESTS CONDUCTED: Conducted a test, using a fairly basic test case (2 domains, March 2016 snow event over Colorado). The "soon-to-be" TROPICAL physics suite (wsm6, New Tiedtke, RRTMG, YSU, Noah and old MM5, gwd_opt) was used. Verified that the results, after 6 hours, for both domains, were bit-for-bit with unmodified code. WTF pending.