### PR TITLE
Fix improper DA qc flag when synop q ob is missing for q_error_options=2

### DIFF
--- a/var/da/da_synop/da_get_innov_vector_synop.inc
+++ b/var/da/da_synop/da_get_innov_vector_synop.inc
@@ -188,9 +188,14 @@ subroutine da_get_innov_vector_synop( it,num_qcstat_conv, grid, ob, iv)
       if ( it == 1 .and. q_error_options == 2 ) then
          allocate (model_qs(iv%info(synop)%n1:iv%info(synop)%n2))
          do n=iv%info(synop)%n1,iv%info(synop)%n2
-            call da_tp_to_qs(model_t(1,n), model_p(1,n), es, model_qs(n))
-            rh_error = iv%synop(n)%q%error !q error is rh at this stage
-            iv%synop(n)%q%error = model_qs(n)*rh_error*0.01
+           if ( abs(ob%synop(n)%q-missing_r) > 1.0 ) then
+               call da_tp_to_qs(model_t(1,n), model_p(1,n), es, model_qs(n))
+               rh_error = iv%synop(n)%q%error !q error is rh at this stage
+               iv%synop(n)%q%error = model_qs(n)*rh_error*0.01
+           else
+               iv%synop(n)%q%error = missing_r
+               iv%synop(n)%q%qc    = missing_data
+           end if
          end do
          deallocate (model_qs)
       end if


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, gts_omb_oma, synop, q_error_options=2, qc flag

SOURCE: Problem reported by Central Weather Bureau, Taiwan

DESCRIPTION OF CHANGES:

Add checks for missing Q obs to set proper Q qc flags.

LIST OF MODIFIED FILES:
M       var/da/da_synop/da_get_innov_vector_synop.inc

TESTS CONDUCTED:
CWB confirmed the changes fixed the problems.