### PR TITLE
Fix for o3input=2 option: interpolate data to model grid for all domains

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1879,11 +1879,7 @@ integer myproc
 !   Read in CAM ozone data, and interpolate data to model grid
 !   Interpolation is done on domain 1 only
 
-#if (EM_CORE==1) 
-   IF ( config_flags%o3input .EQ. 2 .AND. id .EQ. 1 ) THEN
-#else
    IF ( config_flags%o3input .EQ. 2 ) THEN
-#endif
       CALL oznini(ozmixm,pin,levsiz,n_ozmixm,XLAT,                &
                      ids, ide, jds, jde, kds, kde,                  &
                      ims, ime, jms, jme, kms, kme,                  &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ozone, nest

SOURCE: internal

DESCRIPTION OF CHANGES: 
When trying to fix a restart problem for V3.9 release, it was decided that the CAM ozone data will be processed for all domains. But that fix missed a line in physics_init, which caused all nested domains having NO ozone input. This data is only used in RRTMG options. And the error is in all 3.9* versions.

LIST OF MODIFIED FILES: 
M       phys/module_physics_init.F

TESTS CONDUCTED: 
- reg test v04.07 passes
- test done on a case to make sure now that ozone data is in the nest. 