### PR TITLE
RRTMG tests need to include RRTMG_FAST and RRTMK

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1658,7 +1658,6 @@
            ( model_config_rec % ra_sw_physics(1) .EQ. RRTMG_SWSCHEME )  .OR. &
            ( model_config_rec % ra_lw_physics(1) .EQ. RRTMK_LWSCHEME )  .OR. &
            ( model_config_rec % ra_lw_physics(1) .EQ. RRTMK_SWSCHEME )  .OR. &
-           ( model_config_rec % ra_sw_physics(1) .EQ. RRTMG_SWSCHEME )  .OR. &
            ( model_config_rec % ra_lw_physics(1) .EQ. RRTMG_LWSCHEME_FAST )  .OR. &
            ( model_config_rec % ra_sw_physics(1) .EQ. RRTMG_SWSCHEME_FAST )  ) THEN
          wrf_err_message = '--- NOTE: RRTMG radiation is used, namelist ' // &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RRTMG, RRTMG_FAST, RRTMK, check_a_mundo

SOURCE: internal

DESCRIPTION OF CHANGES:
A couple of places inside of check_a_mundo test to see if the user selected RRTMG. The Fortran IF tests should include a determination if we are using _any_ of the family that we now have of RRTMG schemes.

LIST OF MODIFIED FILES:
M	share/module_check_a_mundo.F

TESTS CONDUCTED:
 - [x] Compiles OK.