### PR TITLE
Forgot a "-1" in a DO index

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4405,7 +4405,7 @@ endif
 
       DO j = jts, min(jde-1,jte)
          DO k = kts, kte
-            DO i = its, min(ide,ite)
+            DO i = its, min(ide-1,ite)
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
                grid%th_phy_m_t0(i,k,j) = grid%t_2(i,k,j)
             END DO


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: oops, index

SOURCE: internal

DESCRIPTION OF CHANGES:
Loop index should be
```
 DO i = its , MIN(ide-1,ite)
```
I forgot the "-1" part.

LIST OF MODIFIED FILES:
M	module_initialize_real.F

TESTS CONDUCTED:
1. Code behaved fine with the bug.