### PR TITLE
lightning_start_seconds changed from integer to real WRF Chem registry file

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -3755,7 +3755,7 @@ rconfig   logical CAM_MP_MAM_cpled         namelist,chem        1            .tr
 # Lightning
 rconfig   integer     lightning_opt       namelist,chem        max_domains        0       rh      "lightning_opt"     ""      ""
 rconfig   integer     lightning_time_step namelist,chem        max_domains        0       rh     "lightning_time_step"  ""      ""
-rconfig   integer     lightning_start_seconds namelist,chem    max_domains        0       rh     "lightning_start_seconds"    ""      ""
+rconfig   real        lightning_start_seconds namelist,chem    max_domains        0       rh     "lightning_start_seconds"    ""      ""
 rconfig   real        temp_upper          namelist,chem        max_domains      -45.      rh     "temp_upper"         ""      ""
 rconfig   real        temp_lower          namelist,chem        max_domains      -15.      rh     "temp_lower"         ""      ""
 rconfig   real        N_IC                namelist,chem        max_domains        0.      rh     "N_IC"               ""    ""


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: lightning, real

SOURCE: internal

DESCRIPTION OF CHANGES:
1. The files Registry.EM_COMMON and Registry.EM_COMMON_tladj have lightning_start_seconds defined as a real:
```
Registry.EM_COMMON
rconfig  real       lightning_start_seconds  namelist,physics   max_domains    0.     -    "lightning_start_seconds"   ""   "s"
Registry.EM_COMMON.tladj
rconfig  real       lightning_start_seconds  namelist,physics   max_domains    0.     -    "lightning_start_seconds"   ""   "s"
```

2. The WRF Chem registry file registry.chem has lightning_start_physics defined as an integer:
```
registry.chem
rconfig   integer     lightning_start_seconds namelist,chem    max_domains        0       rh     "lightning_start_seconds"    ""      ""
```

3. The module_lightning_driver.F defines the input lightning_start_seconds twice (in separate routines) as a real:
```
etotheipi.local:/Users/gill/Desktop/WRFV3>grep lightning_start_seconds phys/*.F
phys/module_lightning_driver.F:
REAL,     INTENT(IN)        :: lightning_dt, lightning_start_seconds
REAL,    INTENT(IN   )    ::       lightning_dt, lightning_start_seconds, flashrate_factor
```
The definition of the namelist value in registy.chem is changed from integer to a real.

LIST OF MODIFIED FILES:
M	Registry/registry.chem

TESTS CONDUCTED:
1. WRF Chem code compiles with mod, and not without.
2. Reg test v04.07 works with mod.