### PR TITLE
TEMPORARY bug fix for build after splitting sea level pressure from module_diag_afwa.F

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -766,7 +766,13 @@ module_diagnostics_driver.o: \
 		../share/module_model_constants.o
 
 module_diag_functions.o:
-		
+	$(RM) $@
+	sed -e "s/^\!.*'.*//" -e "s/^ *\!.*'.*//" $*.F > $*.G
+	$(CPP) -I$(WRF_SRC_ROOT_DIR)/inc $(CPPFLAGS) $(OMPCPP) $*.G  > $*.bb
+	$(SED_FTN) $*.bb | $(CPP) $(TRADFLAG) > $*.f90
+	$(RM) $*.G $*.bb
+	$(FC) -o $@ -c $(FCFLAGS) $(OMP) $(MODULE_DIRS) $(PROMOTION) $(FCSUFFIX) $*.f90
+
 module_diag_misc.o: \
 		../frame/module_dm.o
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: temporary, build

SOURCE: internal

DESCRIPTION OF CHANGES:

The better working solution, though not tested as well, is to have the main/depend.common have this structure:
```
a.o: b.o
b.o: c.o
```
instead of the current:
```
c.o:
<tab>explicit rules to build c.o
a.o: c.o
b.o: c.o
```
There should never be any need to have explicit rules in the dependency file.

LIST OF MODIFIED FILES:
M	main/depend.common

TESTS CONDUCTED: 
In the main/depend.common, a working method to build the code reproducibly is to insert the build rules in the depend.common file. I tested this with all combinations of the following 1 through 3 on cheyenne. I ran on cheyenne manually and through the full regression test. I ran manually the GNU compiler with -j =1,2 processors, and with all three levels of optimization:
1. compiler: Intel, GNU, PGI
2. parallel make: -j = 1, 2, 4, 6, 8
3. optimized, -d, -D
4. manually built and through the entire regression test
5. cheyenne and local Mac
For most of the above I ran multiple instances.