### PR TITLE
Correct loop bounds to remove addressing error for diagnostic variables.

### DIFF
--- a/chem/module_ftuv_driver.F
+++ b/chem/module_ftuv_driver.F
@@ -143,6 +143,7 @@
                               ph_hyac,                                 &
                               ph_cl2,ph_hocl,ph_fmcl,                  &
                               ivgtyp,                                  &
+                              ntuv_lev, ntuv_bin, ntuv_pht,            &
                               ph_radfld, ph_adjcoe, ph_prate,          &
                               wc_x, zref_x,                            &
                               tauaer1, tauaer2, tauaer3, tauaer4,      &    !rajesh
@@ -169,6 +170,7 @@
                                 ids,ide, jds,jde, kds,kde,       &
                                 ims,ime, jms,jme, kms,kme,       &
                                 its,ite, jts,jte, kts,kte
+      integer, intent(in   ) :: ntuv_lev, ntuv_bin, ntuv_pht
       integer, intent(in)    :: ivgtyp(ims:ime,jms:jme)                         
 
       real,     intent(in  ) :: dtstep, gmt
@@ -217,15 +219,15 @@
                              ph_n2o5,ph_mvk,ph_glyald,ph_hyac,         &
                              ph_cl2,ph_hocl,ph_fmcl
 
-      real, dimension( ims:ime, nref, jms:jme, nw-1 ),                 &
+      real, dimension( ims:ime, ntuv_lev, jms:jme, ntuv_bin ),         &
             intent(out  ) :: ph_radfld
-      real, dimension( ims:ime, nref, jms:jme, tuv_jmax ),             &
+      real, dimension( ims:ime, ntuv_lev, jms:jme, ntuv_pht ),         &
             intent(out  ) :: ph_adjcoe
-      real, dimension( ims:ime, nref, jms:jme, tuv_jmax ),             &
+      real, dimension( ims:ime, ntuv_lev, jms:jme, ntuv_pht ),         &
             intent(out  ) :: ph_prate
-      real, dimension(nw-1),             &
+      real, dimension(ntuv_bin),             &
             intent(out  ) :: wc_x
-      real, dimension(nref),             &
+      real, dimension(ntuv_lev),             &
             intent(out  ) :: zref_x
 
 !----------------------------------------------------
@@ -568,21 +570,21 @@ level_loop : &
           ph_n2o5(i,k,j)  = max( 0._dp,prate(k,pid_n2o5)*m2s )
         enddo
 
-        do m = 1,nw-1
-          do k = 1,nz
+        do m = 1,min(nw-1,ntuv_bin)
+          do k = 1,min(nz,ntuv_lev)
             ph_radfld(i,k,j,m) = radfld(k,m)
           end do
         end do
 
-        do m = 1,tuv_jmax
-          do k = 1,nz
+        do m = 1,min(ntuv_pht,tuv_jmax)
+          do k = 1,min(nz,ntuv_lev)
             ph_adjcoe(i,k,j,m) = adjcoe(k,m)
             ph_prate (i,k,j,m) = prate0(k,m)
           end do
         end do
 
-        wc_x(1:nw-1) = wc(1:nw-1)
-        zref_x(1:nref) = zref(1:nref)
+        wc_x(1:min(ntuv_bin,nw-1)) = wc(1:min(ntuv_bin,nw-1))
+        zref_x(1:min(nz,ntuv_lev)) = zref(1:min(nz,ntuv_lev))
 
         if( chm_is_mozart ) then
           do k = kts, kte

--- a/chem/photolysis_driver.F
+++ b/chem/photolysis_driver.F
@@ -209,6 +209,7 @@
                               ph_n2o5,ph_mvk,ph_glyald,ph_hyac,        &
                               ph_cl2,ph_hocl,ph_fmcl,                  &
                               ivgtyp,                                  &
+                              nref0, nw0, tuv_jmax0,                   &
                               ph_radfld, ph_adjcoe, ph_prate,          &
                               wc,zref,                                 &
                               tauaer1, tauaer2, tauaer3, tauaer4,      &    !rajesh


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FTUV, diagnostic variables

SOURCE: internal

DESCRIPTION OF CHANGES:

The diagnostic variables radfld, adjcoe, and phrate can be accessed
with indices that exceed their dimensions in the executable code
leading to an addressing exception.  The upper bounds for loops
setting the diagnostic variables have been changed to enforce
proper array addressing.

LIST OF MODIFIED FILES:

M   chem/photolysis_driver.F
M   chem/module_ftuv_driver.F

TESTS CONDUCTED:

The change has been validated with a brief run.  Since the change
only affects diagnostic variables in a few source files in the chem
directory a reg test has not been conducted.  A debugging session
on a workstation demonstrated that the unmodified code caused a
array access bounds error while the modified code executed without
indident.