### PR TITLE
Limit diagnostic Q2 (2-meter mixing ratio)

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3994,8 +3994,10 @@ CONTAINS
        !$OMP END PARALLEL DO
      ENDIF
 
-! Limit Q2 diagnostic to 5 per cent higher than lowest level value
-!     and set to that value in that case
+! Limit Q2 diagnostic to no more than 5 per cent higher than lowest level value
+!     This prevents unrealistic values when QFX is not mostly surface flux 
+!          because calculation is based on surface flux only
+!     Problems occurred in transition periods and weak winds and vegetation source
        !$OMP PARALLEL DO   &
        !$OMP PRIVATE ( ij, i, j, k )
        DO ij = 1 , num_tiles


### PR DESCRIPTION

TYPE: enhancement
KEYWORDS: Q2 diagnostic, all options

SOURCE: internal

DESCRIPTION OF CHANGES: 
Up until this fix, Q2 may show unrealistically high values especially in weak winds at morning and evening transition hours resulting in a spike in time series of Q2 that does not show in the lowest level QVAPOR. This is fixed by limiting Q2 not to exceed the lowest level QVAPOR by more than 5%.
<img width="2509" alt="screen shot 2017-07-06 at 5 13 37 pm" src="https://user-images.githubusercontent.com/17932284/39540496-09b419fa-4e00-11e8-92c3-5776cdf9a275.png">
The problem arises from the too simple assumption that the latent heat flux is all due to the surface moisture flux, but evapotranspiration can dominate around the transition times. Assigning the total flux to the surface leads to an unrealistically large effective value at 2 m.

The fix affects all surface options because it is applied at the end of the surface driver, and all use the same kind of Q2 calculation. 5% was chosen to allow for the 2m temperature being slightly warmer than the lowest level and maintaining a similar RH.

LIST OF MODIFIED FILES: 
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
WTF (intel-only script).
Real-time WRF forecasts have been using this for a few months.
