### PR TITLE
Fix the typo of 'MOIST_TEHTA-T0'

### DIFF
--- a/var/da/da_main/da_update_firstguess.inc
+++ b/var/da/da_main/da_update_firstguess.inc
@@ -584,8 +584,8 @@ subroutine da_update_firstguess(grid, out_filename)
                              start_index,end_index1,               & !pat
                              ierr                                 )
 
-! Update moist potential temperature: now it is identical to T.
-     rmse_var='MOIST_TEHTA-T0'
+! Update moist potential temperature: for now, it is identical to T with use_theta_m=0.
+     rmse_var='MOIST_THETA-T0'
      call ext_ncd_get_var_info (dh1,trim(rmse_var),ndim1,ordering,staggering, &
           start_index,end_index1, WrfType, ierr    )
      call ext_ncd_write_field(dh1,DateStr1,TRIM(rmse_var),         &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Typo, MOIST_THETA-T0

SOURCE: internal

DESCRIPTION OF CHANGES: "MOIST_TEHTA-T0" shall be "MOIST_THETA-T0". This fix allows WRFDA regtest to obtain 'ok' result.

LIST OF MODIFIED FILES:
M   var/da/da_main/da_update_firstguess.inc

TESTS CONDUCTED: 
WRFDA regression test passed with 'ok' results.
