### PR TITLE
Add location where use_theta_m test should have been included

### DIFF
--- a/dyn_em/depend.dyn_em
+++ b/dyn_em/depend.dyn_em
@@ -300,6 +300,7 @@ module_first_rk_step_part2.o : \
                 module_bc_em.o         \
                 module_stoch.o         \
 		module_sfs_driver.o \
+		module_big_step_utilities_em.o \
 		../frame/module_domain.o \
 		../frame/module_state_description.o \
 		../frame/module_driver_constants.o \

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -7,8 +7,8 @@ MODULE module_first_rk_step_part2
 
 CONTAINS
 
-  SUBROUTINE first_rk_step_part2 (   grid , config_flags              &
-                             , moist , moist_tend               &
+  SUBROUTINE first_rk_step_part2 (   grid , config_flags        &
+                             , moist , moist_old , moist_tend   &
                              , chem  , chem_tend                &
                              , tracer, tracer_tend              &
                              , scalar , scalar_tend             &
@@ -37,6 +37,7 @@ CONTAINS
     USE module_model_constants
     USE module_domain, ONLY : domain
     USE module_configure, ONLY : grid_config_rec_type, model_config_rec
+    USE module_big_step_utilities_em, ONLY : conv_t_tendf_to_moist
 #ifdef DM_PARALLEL
     USE module_dm, ONLY : local_communicator, mytask, ntasks, ntasks_x, ntasks_y, local_communicator_periodic, &
                           wrf_dm_maxval, wrf_err_message, local_communicator_x, local_communicator_y
@@ -79,6 +80,7 @@ CONTAINS
     REAL, INTENT(IN)                           :: curr_secs
 
     REAL    ,DIMENSION(ims:ime,kms:kme,jms:jme,num_moist),INTENT(INOUT)   :: moist
+    REAL    ,DIMENSION(ims:ime,kms:kme,jms:jme,num_moist),INTENT(IN)      :: moist_old
     REAL    ,DIMENSION(ims:ime,kms:kme,jms:jme,num_moist),INTENT(INOUT)   :: moist_tend
     REAL    ,DIMENSION(ims:ime,kms:kme,jms:jme,num_chem),INTENT(INOUT)   :: chem
     REAL    ,DIMENSION(ims:ime,kms:kme,jms:jme,num_chem),INTENT(INOUT)   :: chem_tend
@@ -809,6 +811,85 @@ BENCH_END(tke_rhs_tim)
 
        ENDIF
 
+       IF ( grid%obs_nudge_opt .EQ. 1 .AND. grid%xtime <= grid%fdda_end ) THEN
+# ifdef DM_PARALLEL
+#       include "HALO_OBS_NUDGE.inc"
+#endif
+!***********************************************************************
+! This section for obs nudging
+         !$OMP PARALLEL DO   &
+         !$OMP PRIVATE ( ij )
+
+         DO ij = 1 , grid%num_tiles
+
+           CALL fddaobs_driver (grid%grid_id, model_config_rec%grid_id, &
+                   model_config_rec%parent_id, config_flags%restart,    &
+                   config_flags,                                        &
+                   grid%obs_nudge_opt,                                  &
+                   grid%obs_ipf_errob,                                  &
+                   grid%obs_ipf_nudob,                                  &
+                   grid%fdda_start,                                     &
+                   grid%fdda_end,                                       &
+                   grid%obs_nudge_wind,                                 &
+                   grid%obs_nudge_temp,                                 &
+                   grid%obs_nudge_mois,                                 &
+                   grid%obs_nudge_pstr,                                 &
+                   grid%obs_coef_wind,                                  &
+                   grid%obs_coef_temp,                                  &
+                   grid%obs_coef_mois,                                  &
+                   grid%obs_coef_pstr,                                  &             
+                   grid%obs_rinxy,                                      &
+                   grid%obs_rinsig,                                     &
+                   grid%obs_npfi,                                       &
+                   grid%obs_ionf,                                       &
+                   grid%obs_prt_max,                                    &
+                   grid%obs_prt_freq,                                   &
+                   grid%obs_idynin,                                     &
+                   grid%obs_dtramp,                                     &
+                   grid%parent_grid_ratio,                              &
+                   grid%max_dom, grid%itimestep,                        &
+                   grid%xtime,                                          &
+                   grid%dt, grid%gmt, grid%julday, grid%fdob,           &
+                   grid%max_obs,                                        &
+                   model_config_rec%nobs_ndg_vars,                      &
+                   model_config_rec%nobs_err_flds,                      &
+                   grid%fdob%nstat, grid%fdob%varobs, grid%fdob%errf,   &
+                   grid%dx, grid%KPBL,grid%HT,                          &
+                   grid%mut, grid%muu, grid%muv, grid%c1h, grid%c2h,    &
+                   grid%msftx, grid%msfty, grid%msfux, grid%msfuy, grid%msfvx, grid%msfvy, &
+                   p_phy, t_tendf, t0,                                  &
+                   grid%u_2, grid%v_2, grid%th_phy_m_t0,                &
+                   moist(ims,kms,jms,P_QV),                             &
+                   grid%pb, grid%p_top, grid%p, grid%phb, grid%ph_2,    &
+                   grid%uratx, grid%vratx, grid%tratx,                  &
+                   ru_tendf, rv_tendf,                                  &
+                   moist_tend(ims,kms,jms,P_QV), grid%obs_savwt,        &
+                   grid%regime, grid%pblh, grid%z_at_w, grid%z,         &
+                   ids,ide, jds,jde, kds,kde,                           &
+                   ims,ime, jms,jme, kms,kme,                           &
+                   grid%i_start(ij), min(grid%i_end(ij),ide-1),         &
+                   grid%j_start(ij), min(grid%j_end(ij),jde-1),         &
+                   k_start    , min(k_end,kde-1)                     )
+ 
+         ENDDO
+         !$OMP END PARALLEL DO
+       ENDIF  ! obs_nudge_opt .eq. 1
+
+       IF ( config_flags%use_theta_m .EQ. 1 ) THEN
+         !$OMP PARALLEL DO   &
+         !$OMP PRIVATE ( ij )
+         DO ij = 1 , grid%num_tiles
+           CALL conv_t_tendf_to_moist ( grid%t_1 , moist_old(ims,kms,jms,P_qv) ,  &
+                                        t_tendf  , moist_tend(ims,kms,jms,P_qv) , &
+                                        ids, ide, jds, jde, kds, kde ,            &
+                                        ims, ime, jms, jme, kms, kme ,            &
+                                        grid%i_start(ij), grid%i_end(ij),         &
+                                        grid%j_start(ij), grid%j_end(ij),         &
+                                        k_start    , k_end                        )
+         END DO 
+         !$OMP END PARALLEL DO
+       END IF ! use moist theta
+
 ! calculate vertical diffusion first and then horizontal
 ! (keep this order)
 
@@ -883,69 +964,6 @@ BENCH_START(hor_diff_tim)
 BENCH_END(hor_diff_tim)
        ENDIF
 
-       IF ( grid%obs_nudge_opt .EQ. 1 .AND. grid%xtime <= grid%fdda_end ) THEN
-# ifdef DM_PARALLEL
-#       include "HALO_OBS_NUDGE.inc"
-#endif
-!***********************************************************************
-! This section for obs nudging
-         !$OMP PARALLEL DO   &
-         !$OMP PRIVATE ( ij )
-
-         DO ij = 1 , grid%num_tiles
-
-           CALL fddaobs_driver (grid%grid_id, model_config_rec%grid_id, &
-                   model_config_rec%parent_id, config_flags%restart,    &
-                   config_flags,                                        &
-                   grid%obs_nudge_opt,                                  &
-                   grid%obs_ipf_errob,                                  &
-                   grid%obs_ipf_nudob,                                  &
-                   grid%fdda_start,                                     &
-                   grid%fdda_end,                                       &
-                   grid%obs_nudge_wind,                                 &
-                   grid%obs_nudge_temp,                                 &
-                   grid%obs_nudge_mois,                                 &
-                   grid%obs_nudge_pstr,                                 &
-                   grid%obs_coef_wind,                                  &
-                   grid%obs_coef_temp,                                  &
-                   grid%obs_coef_mois,                                  &
-                   grid%obs_coef_pstr,                                  &             
-                   grid%obs_rinxy,                                      &
-                   grid%obs_rinsig,                                     &
-                   grid%obs_npfi,                                       &
-                   grid%obs_ionf,                                       &
-                   grid%obs_prt_max,                                    &
-                   grid%obs_prt_freq,                                   &
-                   grid%obs_idynin,                                     &
-                   grid%obs_dtramp,                                     &
-                   grid%parent_grid_ratio,                              &
-                   grid%max_dom, grid%itimestep,                        &
-                   grid%xtime,                                          &
-                   grid%dt, grid%gmt, grid%julday, grid%fdob,           &
-                   grid%max_obs,                                        &
-                   model_config_rec%nobs_ndg_vars,                      &
-                   model_config_rec%nobs_err_flds,                      &
-                   grid%fdob%nstat, grid%fdob%varobs, grid%fdob%errf,   &
-                   grid%dx, grid%KPBL,grid%HT,                          &
-                   grid%mut, grid%muu, grid%muv, grid%c1h, grid%c2h,    &
-                   grid%msftx, grid%msfty, grid%msfux, grid%msfuy, grid%msfvx, grid%msfvy, &
-                   p_phy, t_tendf, t0,                                  &
-                   grid%u_2, grid%v_2, grid%th_phy_m_t0,                &
-                   moist(ims,kms,jms,P_QV),                             &
-                   grid%pb, grid%p_top, grid%p, grid%phb, grid%ph_2,    &
-                   grid%uratx, grid%vratx, grid%tratx,                  &
-                   ru_tendf, rv_tendf,                                  &
-                   moist_tend(ims,kms,jms,P_QV), grid%obs_savwt,        &
-                   grid%regime, grid%pblh, grid%z_at_w, grid%z,         &
-                   ids,ide, jds,jde, kds,kde,                           &
-                   ims,ime, jms,jme, kms,kme,                           &
-                   grid%i_start(ij), min(grid%i_end(ij),ide-1),         &
-                   grid%j_start(ij), min(grid%j_end(ij),jde-1),         &
-                   k_start    , min(k_end,kde-1)                     )
- 
-         ENDDO
-         !$OMP END PARALLEL DO
-       ENDIF  ! obs_nudge_opt .eq. 1
 ! 
 !***********************************************************************
 

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -762,7 +762,7 @@ BENCH_START(calc_p_rho_tim)
 #endif
 
        CALL first_rk_step_part2 (    grid, config_flags         &
-                             , moist , moist_tend               &
+                             , moist , moist_old , moist_tend   &
                              , chem  , chem_tend                &
                              , tracer, tracer_tend              &
                              , scalar , scalar_tend             &
@@ -788,12 +788,6 @@ BENCH_START(calc_p_rho_tim)
                              , ipsy, ipey, jpsy, jpey, kpsy, kpey    &
                              , k_start , k_end                  &
                             )
-
-        CALL conv_t_tendf_to_moist ( grid%t_1 , moist_old(ims,kms,jms,P_qv) ,  &
-                                     t_tendf  , moist_tend(ims,kms,jms,P_qv) , &
-                                     ids, ide, jds, jde, kds, kde ,            &
-                                     ims, ime, jms, jme, kms, kme ,            &
-                                     ips, ipe, jps, jpe, kps, kpe              )
 
      END IF rk_step_is_one
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: use_theta_m, t_tendf

SOURCE: internal, lots of help from Wei Wang and Jimy Dudhia, problem originally identified by Ming Chen

DESCRIPTION OF CHANGES:
1. conv_t_tendf_moist needs to have a use_theta_m option to determine whether or not to assume the t_tendf field stays dry or is converted to a moist field.
2. The rk_step_part2 routine now explicitly includes the conv_t_tendf_moist routine (removed from solve_em).
3. The rk_step_part2 routine has the obs nudging (dry theta tendency moved above the computation of the moist theta tendency).
4. The first_rk_step_part2 now depends on big_step, so a "USE" statement is added, and a line to the dependency file is introduced

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M   dyn_em/depend.dyn_em
M   dyn_em/module_first_rk_step_part2.F
M   dyn_em/solve_em.F

TESTS CONDUCTED:
1. Nest Jan 2000 case shows consistent precip for 3.9.1.1 (with and without use_theta_m), and the same pattern is evident after this mod.
![screen shot 2018-05-03 at 4 19 29 pm](https://user-images.githubusercontent.com/12666234/39607143-9cc39166-4ef6-11e8-93eb-0a61e6d3f8b1.png)


2. Without this mod, the use_theta_m=0 option had a precip bias.
![screen shot 2018-05-03 at 4 21 05 pm](https://user-images.githubusercontent.com/12666234/39607159-ac39527a-4ef6-11e8-8415-98c790a328bc.png)


3. Reggie v04.07 OK.