### PR TITLE
Remove unnecessary WRFPLUS check

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -772,11 +772,7 @@ SUBROUTINE calc_ww_cp ( u, v, mup, mub, c1h, c2h, ww,    &
 !                                     +rdx*(ru(i+1,k-1,j)-ru(i,k-1,j))  &
 !                                     +rdy*(rv(i,k-1,j+1)-rv(i,k-1,j)) )
 
-#if ( WRFPLUS != 1 )
            ww(i,k,j)=ww(i,k-1,j) - dnw(k-1)*c1h(k-1)*dmdt(i) - divv(i,k-1)
-#else
-           ww(i,k,j)=ww(i,k-1,j) - dnw(k-1)*dmdt(i) - divv(i,k-1)
-#endif
 
         ENDDO
         ENDDO


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: WRFPLUS, c1h

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
As noted in commit 2299083 of WRFPLUSV3 branch,
#if ( WRFPLUS != 1 ) was added in dyn_em/module_big_step_utilities_em.F
to avoid undefined c1h, c2h, c1f, and c2f when the input file
is from pre-V3.9 that does not have those HVC variables.
This should be revisited after WRF model implements proper
initializations for those variables.
After commit 0d5bf35e, the WRFPLUS check is no longer needed.

LIST OF MODIFIED FILES:
M       dyn_em/module_big_step_utilities_em.F

TESTS CONDUCTED: none
