### PR TITLE
Add RA calculation for CMAQ app

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2516,6 +2516,14 @@ CONTAINS
          if(HYDRO_dt .ge. 0) HYDRO_dt = dtbl
 #endif
 
+! added RA population for WRF/Noah-CMAQ RS Consistency
+! following Garland et al. (1977) and Nemitz et al., 2009
+         DO j=j_start(ij),j_end(ij)
+         DO i=i_start(ij),i_end(ij)
+            RA(I,J) = WSPD(I,J)/UST(I,J)**2.0
+         ENDDO
+         ENDDO
+
          CALL wrf_debug(100,'in NOAH DRV')
                 
          IF (sf_surface_mosaic == 1) THEN
@@ -3197,6 +3205,13 @@ CONTAINS
            ENDDO                                                  !urban
          ENDIF
 
+! added RA population for WRF/Noah-CMAQ RS Consistency
+! following Garland et al. (1977) and Nemitz et al., 2009
+         DO j=j_start(ij),j_end(ij)
+         DO i=i_start(ij),i_end(ij)
+            RA(I,J) = WSPD(I,J)/UST(I,J)**2.0
+         ENDDO
+         ENDDO
 !------------------------------------------------------------------
 
        ELSE


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: RA, diagnostics

SOURCE: Patrick Campbell, EPA

DESCRIPTION OF CHANGES: 
This PR adds an explicit calculation of aerodynamic resistance, RA, (computed from WSPD and UST) in the module_surface_driver.F for the Noah, Noah-Mosaic, and Noah-MP. This would be more consistent with the addition of the stomatal resistance, RS, recently added for Noah for CMAQ purposes (commit f80778cb).  This a diagnostics only. No new array is needed, as RA already exists for the PX LSM option.

LIST OF MODIFIED FILES: 
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
Need to regtest.