### PR TITLE
Analysis FDDA should use dry theta from the real program

### DIFF
--- a/main/real_em.F
+++ b/main/real_em.F
@@ -872,7 +872,7 @@ real::t1,t2
                DO i = ips , ipe
                   grid%fdda3d(i,k,j,p_u_ndg_old) = grid%u_2(i,k,j)
                   grid%fdda3d(i,k,j,p_v_ndg_old) = grid%v_2(i,k,j)
-                  grid%fdda3d(i,k,j,p_t_ndg_old) = grid%t_2(i,k,j)
+                  grid%fdda3d(i,k,j,p_t_ndg_old) = grid%th_phy_m_t0(i,k,j)
                   grid%fdda3d(i,k,j,p_q_ndg_old) = grid%moist(i,k,j,P_QV)
                   grid%fdda3d(i,k,j,p_ph_ndg_old) = grid%ph_2(i,k,j)
                END DO
@@ -1026,7 +1026,7 @@ real::t1,t2
                DO i = ips , ipe
                   grid%fdda3d(i,k,j,p_u_ndg_new) = grid%u_2(i,k,j)
                   grid%fdda3d(i,k,j,p_v_ndg_new) = grid%v_2(i,k,j)
-                  grid%fdda3d(i,k,j,p_t_ndg_new) = grid%t_2(i,k,j)
+                  grid%fdda3d(i,k,j,p_t_ndg_new) = grid%th_phy_m_t0(i,k,j)
                   grid%fdda3d(i,k,j,p_q_ndg_new) = grid%moist(i,k,j,P_QV)
                   grid%fdda3d(i,k,j,p_ph_ndg_new) = grid%ph_2(i,k,j)
                END DO


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FDDA, analysis, grid, dry theta

SOURCE: internal, the direction proposed by Wei Wang and Jimy Dudhia

DESCRIPTION OF CHANGES:
The analysis FDDA files contain two time levels of the 3d potential temperature variable: T_NDG_OLD and T_NDG_NEW. Inside of the real program, instead of using the t_2 variable (which, depending on the setting of the use_theta_m namelist switch could be either dry or moist), we fill the the potential temperature portion of the 4d FDDA fields with th_phy_m_t0. This field (th_phy_m_t0) is always dry. Since the analysis FDDA processing is called from within first_rk_step_part1 (physics), we always want the dry potential temperature and the resulting dry potential temperature tendencies.

LIST OF MODIFIED FILES:
M	main/real_em.F

TESTS CONDUCTED:
1. With fix, the FDDA files should be bit-wise identical with either use_theta_m = 0 or 1.
```
> diffwrf use_theta_m=0/wrffdda_d02 use_theta_m=1/wrffdda_d02 
 Just plot  F
Diffing use_theta_m=0/wrffdda_d02 use_theta_m=1/wrffdda_d02
 Next Time 2000-01-24_12:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-24_18:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-25_00:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-25_06:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
```
```
> diffwrf use_theta_m=0/wrffdda_d01 use_theta_m=1/wrffdda_d01
 Just plot  F
Diffing use_theta_m=0/wrffdda_d01 use_theta_m=1/wrffdda_d01
 Next Time 2000-01-24_12:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-24_18:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-25_00:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-25_06:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
```
2. The diffs of the dry potential temperature field seem relatively small, after 12 h of a nested Jan 2000 run, looking at d01 near the surface during an analysis nudging test.
<img width="1131" alt="screen shot 2018-05-04 at 6 01 45 am" src="https://user-images.githubusercontent.com/12666234/39626841-dc472450-4f60-11e8-849d-17282301daf3.png">

3. Without the mods, the potential temperature differences when using analysis FDDA when use_theta_m = 0 compared to 1 are large. Left plot are the diffs (use_theta_m = 0 vs 1) without these mods, and the right plot shows the diffs (again, use_theta_m = 0 vs 1) with mods. The larger diffs on the left indicate that the analysis FDDA is not working correctly without the mods.
<img width="1135" alt="screen shot 2018-05-04 at 6 15 48 am" src="https://user-images.githubusercontent.com/12666234/39627383-e9b1af3c-4f62-11e8-84d8-0b181bd35e6a.png">

