### PR TITLE
Bug fix: need to change NSAS to KSAS in these two NMM modules

### DIFF
--- a/dyn_nmm/module_PHYSICS_CALLS.F
+++ b/dyn_nmm/module_PHYSICS_CALLS.F
@@ -1659,7 +1659,7 @@
 
      &               ,MZNT=MZ0                                        &
 #endif
-     &               ,HPBL_HOLD=HPBL_HOLD                             &   !for new NSAS
+     &               ,HPBL_HOLD=HPBL_HOLD                             &   !for new KSAS
      &               ,HT=SFCZ                                         &   !KWON
      &               ,UST=USTAR,MIXHT=MIXHT,PBLH=PBLH                 &
      &               ,HFX=TWBS,QFX=QWBS,GRDFLX=GRNFLX                 &
@@ -2301,7 +2301,7 @@
      &                 ,SIGMU, SIGMU1                                   & !updraft fraction
      &                 ,AVCNVC,ACUTIM,IHE,IHW                           &
      &                 ,GRID,CONFIG_FLAGS                               &
-     &                 ,HPBL_HOLD                                       & ! for new NSAS
+     &                 ,HPBL_HOLD                                       & ! for new KSAS
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                         &
      &                 ,IMS,IME,JMS,JME,KMS,KME                         &
      &                 ,IPS,IPE,JPS,JPE,KPS,KPE                         &
@@ -2530,7 +2530,7 @@
       IF(MOD(NTSD,NCNVC)/=0.AND.                                      &
      &   CONFIG_FLAGS%CU_PHYSICS==BMJSCHEME)RETURN
       IF(MOD(NTSD,NCNVC)/=0.AND.                                      &
-     &   CONFIG_FLAGS%CU_PHYSICS==NSASSCHEME)RETURN
+     &   CONFIG_FLAGS%CU_PHYSICS==KSASSCHEME)RETURN
       IF(MOD(NTSD,NCNVC)/=0.AND.                                      &
      &   CONFIG_FLAGS%CU_PHYSICS==NSASOLDSCHEME)RETURN
       IF(MOD(NTSD,NCNVC)/=0.AND.                                      &
@@ -3029,7 +3029,7 @@
 !
           cps_select: SELECT CASE(config_flags%cu_physics)
 !
-          CASE (KFSCHEME,KFETASCHEME,GDSCHEME,SASSCHEME,SCALESASSCHEME,OSASSCHEME,NSASSCHEME,NSASOLDSCHEME,TIEDTKESCHEME)
+          CASE (KFSCHEME,KFETASCHEME,GDSCHEME,SASSCHEME,SCALESASSCHEME,OSASSCHEME,KSASSCHEME,NSASOLDSCHEME,TIEDTKESCHEME)
            IF(config_flags%mp_physics==fer_mp_hires_advect) THEN
              ! Update QI and QRIMEF:
              call QITEND_FER_HIRES_ADVECT( &

--- a/dyn_nmm/solve_nmm.F
+++ b/dyn_nmm/solve_nmm.F
@@ -1665,7 +1665,7 @@
      &            ,grid%zsig1,grid%rchno                               &
      &            ,grid%charn,grid%msang                               &
      &            ,grid%DUBLDT,grid%DVBLDT,grid%DTHBLDT,grid%DQVBLDT   &!wang added PBL tendency output
-     &            ,hpbl_hold                                           & !used by new NSAS
+     &            ,hpbl_hold                                           & !used by new KSAS
      &            ,IDS,IDF,JDS,JDF,KDS,KDE                             &
      &            ,IMS,IME,JMS,JME,KMS,KME                             &
      &            ,IPS,IPE,JPS,JPE,KPS,KPE                             &
@@ -1807,7 +1807,7 @@
       IF(MOD(grid%ntsd,GRID%NCNVC)==0.AND.                              &
      &   (CONFIG_FLAGS%CU_PHYSICS.eq.KFETASCHEME .or.                     &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.OSASSCHEME .or.                       &
-     &   CONFIG_FLAGS%CU_PHYSICS.eq.NSASSCHEME .or.                       &
+     &   CONFIG_FLAGS%CU_PHYSICS.eq.KSASSCHEME .or.                       &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.NSASOLDSCHEME .or.                    &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.SCALESASSCHEME .or.                   &
      &   CONFIG_FLAGS%CU_PHYSICS.eq.SASSCHEME))THEN                       ! 
@@ -1897,7 +1897,7 @@
      &             ,grid%sigmu, grid%sigmu1                            & !wang
      &             ,grid%avcnvc,grid%acutim,grid%ihe,grid%ihw          &
      &             ,GRID,CONFIG_FLAGS                                  &
-     &             ,hpbl_hold                                          & !used by new NSAS
+     &             ,hpbl_hold                                          & !used by new KSAS
      &             ,IDS,IDF,JDS,JDF,KDS,KDE                            &
      &             ,IMS,IME,JMS,JME,KMS,KME                            &
      &             ,IPS,IPE,JPS,JPE,KPS,KPE                            &
@@ -1923,7 +1923,7 @@
 !emc_2010_bugfix_h50
         IF(MOD(grid%ntsd, GRID%NCNVC).eq.0.and.                 &
      &    (CONFIG_FLAGS%CU_PHYSICS.eq.OSASSCHEME.or.            &
-     &     CONFIG_FLAGS%CU_PHYSICS.eq.NSASSCHEME.or.            &
+     &     CONFIG_FLAGS%CU_PHYSICS.eq.KSASSCHEME.or.            &
      &     CONFIG_FLAGS%CU_PHYSICS.eq.NSASOLDSCHEME.or.         &
      &     CONFIG_FLAGS%CU_PHYSICS.eq.SCALESASSCHEME.or.        &
      &     CONFIG_FLAGS%CU_PHYSICS.eq.SASSCHEME))THEN 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NSAS, KSAS

SOURCE: internal

DESCRIPTION OF CHANGES: 
PR# 476 omitted two changes needed for dyn_nmm directory. This causes compile failure for NMM core. This PR should correct that.

LIST OF MODIFIED FILES: 
M       dyn_nmm/module_PHYSICS_CALLS.F
M       dyn_nmm/solve_nmm.F

TESTS CONDUCTED: 
Compilation for NMM is successful.