### PR TITLE
RA variable in surface driver needs IF PRESENT test

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3209,11 +3209,13 @@ CONTAINS
 
 ! added RA population for WRF/Noah-CMAQ RS Consistency
 ! following Garland et al. (1977) and Nemitz et al., 2009
+         IF ( PRESENT(RA) ) THEN
          DO j=j_start(ij),j_end(ij)
          DO i=i_start(ij),i_end(ij)
             RA(I,J) = WSPD(I,J)/UST(I,J)**2.0
          ENDDO
          ENDDO
+         END IF
 !------------------------------------------------------------------
 
        ELSE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RA, aerodynamic resistance

SOURCE: internal

DESCRIPTION OF CHANGES:
For NMM builds, since RA is not in the Registry.NMM, an IF PRESENT test is added around the RA diagnostic calculation.

LIST OF MODIFIED FILES:
M	   phys/module_surface_driver.F

TESTS CONDUCTED:
 - [x] Without IF PRESENT mods, NMM fails bound checks. With mods, NMM short tests are OK.
 - [x] Reggie v04.07 OK