### PR TITLE
Consistency between DA and WRF after the NSAS KSAS renaming

### DIFF
--- a/Registry/Registry.EM_COMMON.tladj
+++ b/Registry/Registry.EM_COMMON.tladj
@@ -2764,7 +2764,6 @@ package   kfcupscheme    cu_physics==10              -             state:cldfrat
 package   mskfscheme   cu_physics==11              -             state:w0avg,w_up
 package   ksasscheme     cu_physics==14              -             -
 package   nsasscheme     cu_physics==96              -             -
-package   nsasoldscheme  cu_physics==96              -             -
 package   ntiedtkescheme cu_physics==16              -             -
 package   gdscheme       cu_physics==93              -             -
 package   sasscheme      cu_physics==94              -             -


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NSASOLDSCHEME==96

SOURCE: internal, found by Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Remove the package line in the TLADJ Registry that still had the NSASOLDSCHEME assignment.

LIST OF MODIFIED FILES:
M	   Registry.EM_COMMON.tladj

TESTS CONDUCTED:
 - [ ] About to run a regression test, but no DA tests are conducted.