### PR TITLE
Add a few checks in check_nml_consistency

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -894,6 +894,7 @@
       DO i = 1, model_config_rec % max_dom
          IF ( model_config_rec%shcu_physics(i) .EQ. GRIMSSHCUSCHEME ) THEN
             IF ( (model_config_rec%bl_pbl_physics(i) .EQ. YSUSCHEME) .OR. &
+                 (model_config_rec%bl_pbl_physics(i) .EQ. SHINHONGSCHEME) .OR. &
                  (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2) .OR. &
                  (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3) ) THEN
                !NO PROBLEM
@@ -904,19 +905,19 @@
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- NOTE: bl_pbl_physics /= 1,5,6 implies shcu_physics cannot be 3, resetting'
+         wrf_err_message = '--- NOTE: bl_pbl_physics /= 1,5,6,11 implies shcu_physics cannot be 3, resetting'
          CALL wrf_message ( wrf_err_message )
       END IF
 
 !-----------------------------------------------------------------------
-! If MYNN PBL is not used, set bl_mynn_edmf = 0 so that we don't get
-! additional output
+! If MYNN PBL is not used, set bl_mynn_edmf = 0 so that shallow convection
+! options can be set and we don't get additional output
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
          IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME2 ) .AND. &
               ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME3 ) ) THEN
-            model_config_rec % bl_mynn_edmf = 0
+              model_config_rec % bl_mynn_edmf(i) = 0
          END IF
       ENDDO
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: mynn, edmf, ishallow, shcu_physics, shinhongpbl

SOURCE: internal, found by Jiyeong Jiang (NCAR and KIAPS)

DESCRIPTION OF CHANGES: 
1. There is a check to turn any shallow convection off if EDMF option is on with MYNN. When we turned the EDMF option "on" by default, it broke these checks. 
    a. This PR first checks if MYNN is used. It turns EDMF off if MYNN isn't used. 
    b. Then shallow options are checked. This prevents turning off shallow convection even when MYNN is not on.

2. Also adding SHINHONG PBL to the list of PBLs that can be used with shcu_physics = 3 (the GRIMS shallow scheme)

LIST OF MODIFIED FILES: 
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
 - [x] Compiled and tested to confirm that the check works as expected.