### PR TITLE
Fix AFWA diag dependency

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -765,14 +765,6 @@ module_diagnostics_driver.o: \
 		../frame/module_driver_constants.o 	\
 		../share/module_model_constants.o
 
-module_diag_functions.o:
-	$(RM) $@
-	sed -e "s/^\!.*'.*//" -e "s/^ *\!.*'.*//" $*.F > $*.G
-	$(CPP) -I$(WRF_SRC_ROOT_DIR)/inc $(CPPFLAGS) $(OMPCPP) $*.G  > $*.bb
-	$(SED_FTN) $*.bb | $(CPP) $(TRADFLAG) > $*.f90
-	$(RM) $*.G $*.bb
-	$(FC) -o $@ -c $(FCFLAGS) $(OMP) $(MODULE_DIRS) $(PROMOTION) $(FCSUFFIX) $*.f90
-
 module_diag_misc.o: \
 		../frame/module_dm.o
 
@@ -787,7 +779,7 @@ module_diag_zld.o: \
 		../share/module_model_constants.o
 
 module_diag_afwa.o: \
-		module_diag_functions.o			\
+		module_diag_trad_fields.o		\
 		../frame/module_domain.o 		\
 		../frame/module_dm.o 			\
 		../frame/module_state_description.o 	\


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: AFWA, diagnostic, diag, build, dependency

SOURCE: internal

DESCRIPTION OF CHANGES:
The problem (that the existing code fixed) was a race condition in the build for the AFWA diagnostics. The existing code fixed that problem, but introduced the requirement of including explicit rules in the dependency file. So, this PR is the permanent fix to the previous tentative fix.

The original build dependency looked like this:
```
c.o :
<tab>explicit rules
<tab>lots of explicit rules
<tab>even more explicit rules

a.o : c.o (among others)
b.o : c.o (among others)
```
The better way to have this dependency is:
```
a.o : b.o (among others)
b.o : c.o (among others)
```
This removes the need for having explicit build rules in a file that should only have dependencies.

LIST OF MODIFIED FILES:
M	   main/depend.common

TESTS CONDUCTED:
1. Code repeatedly builds without troubles.