### PR TITLE
Make wrfplus.exe the only executable when compiling for wrfplus.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,12 +133,8 @@ wrfplus : configcheck
 	$(MAKE) MODULE_DIRS="$(ALL_MODULES)" physics_plus
 	$(MAKE) MODULE_DIRS="$(ALL_MODULES)" em_core
 	$(MAKE) MODULE_DIRS="$(ALL_MODULES)" wrftlmadj
-	( cd main ; $(MAKE) RLFLAGS="$(RLFLAGS)" MODULE_DIRS="$(ALL_MODULES)" SOLVER=em em_wrf )
-	( cd main ; $(MAKE) RLFLAGS="$(RLFLAGS)" MODULE_DIRS="$(ALL_MODULES)" SOLVER=em IDEAL_CASE=real em_real )
+	( cd main ; $(MAKE) RLFLAGS="$(RLFLAGS)" MODULE_DIRS="$(ALL_MODULES)" SOLVER=em em_wrfplus )
 	( cd run ; /bin/rm -f *.exe ; ln -s ../main/*.exe . )
-	if [ $(ESMF_COUPLING) -eq 1 ] ; then \
-	  ( cd main ; $(MAKE) RLFLAGS="$(RLFLAGS)" MODULE_DIRS="$(ALL_MODULES)" SOLVER=em em_wrf_SST_ESMF ) ; \
-	fi
 	@echo "build started:   $(START_OF_COMPILE)"
 	@echo "build completed:" `date`
 

--- a/compile
+++ b/compile
@@ -68,7 +68,7 @@ foreach a ( $argv )
     set arglist = ( $arglist $a )
   else if ( "$a" == "wrfplus" ) then
     set arglist = ( $arglist $a )
-    set ZAP = ( main/wrf.exe main/real.exe main/ndown.exe main/tc.exe )
+    set ZAP = ( main/wrfplus.exe )
     setenv WRF_EM_CORE   1
     setenv WRF_PLUS_CORE 1
     echo not sure what to do, but this seems to be legit so far

--- a/main/Makefile
+++ b/main/Makefile
@@ -16,6 +16,10 @@ $(SOLVER)_wrf : wrf.o ../main/module_wrf_top.o
 	$(RANLIB) $(RLFLAGS) $(LIBWRFLIB)
 	$(LD) -o wrf.exe $(LDFLAGS) wrf.o ../main/module_wrf_top.o $(LIBWRFLIB) $(LIB) 
 
+$(SOLVER)_wrfplus : wrf.o ../main/module_wrf_top.o
+	$(RANLIB) $(RLFLAGS) $(LIBWRFLIB)
+	$(LD) -o wrfplus.exe $(LDFLAGS) wrf.o ../main/module_wrf_top.o $(LIBWRFLIB) $(LIB)
+
 $(SOLVER)_wrf_SST_ESMF : wrf_ESMFMod.o wrf_SST_ESMF.o ../main/module_wrf_top.o
 	$(RANLIB) $(RLFLAGS) $(LIBWRFLIB)
 	$(LD) -o wrf_SST_ESMF.exe $(LDFLAGS) wrf_SST_ESMF.o wrf_ESMFMod.o ../main/module_wrf_top.o $(LIBWRFLIB) $(LIB)


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFPLUS, exe

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
The only tested executable after compiling for wrfplus is the main wrf.exe.
This PR proposes to
1. remove compilation for other executable
2. make the executable wrfplus.exe instead of wrf.exe, because the executable
should not be used for regular WRF runs.

LIST OF MODIFIED FILES:
M       Makefile
M       compile
M       main/Makefile

TESTS CONDUCTED:
main/wrfplus.exe is generated.