### PR TITLE
Remove ifdef REVERT, from the ancient ages past

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -5482,10 +5482,6 @@ END SUBROUTINE phy_prep_part2
        DO j = j_start, j_end
        DO k = k_start, k_end
        DO i = i_start, i_end
-#ifdef REVERT
-intentional compiler error, t_new is moist, h_diabatic is dry
-         t_new(i,k,j) = t_new(i,k,j)-h_diabatic(i,k,j)*dt
-#endif
            th_phy(i,k,j) = (t_new(i,k,j) + t0) / (1. + (R_v/R_d) * qv(i,k,j))
        ENDDO
        ENDDO
@@ -5494,9 +5490,6 @@ intentional compiler error, t_new is moist, h_diabatic is dry
        DO j = j_start, j_end
        DO k = k_start, k_end
        DO i = i_start, i_end
-#ifdef REVERT
-         t_new(i,k,j) = t_new(i,k,j)-h_diabatic(i,k,j)*dt
-#endif
          th_phy(i,k,j) =  t_new(i,k,j) + t0
        ENDDO
        ENDDO

--- a/dyn_em/module_small_step_em.F
+++ b/dyn_em/module_small_step_em.F
@@ -405,15 +405,6 @@ SUBROUTINE small_step_finish( u_2, u_1, v_2, v_1, w_2, w_1,    &
   ENDDO
   ENDDO
 
-#ifdef REVERT
-  DO j = j_start, j_end
-  DO k = kds, kde-1
-  DO i = i_start, i_end
-    t_2(i,k,j) = (t_2(i,k,j) + t_save(i,k,j)*(c1f(k)*mut(i,j)+c2f(k)))/(c1f(k)*muts(i,j)+c2f(k))
-  ENDDO
-  ENDDO
-  ENDDO
-#else
   IF ( rk_step < rk_order ) THEN
     DO j = j_start, j_end
     DO k = kds, kde-1
@@ -433,7 +424,6 @@ SUBROUTINE small_step_finish( u_2, u_1, v_2, v_1, w_2, w_1,    &
     ENDDO
     ENDDO
   ENDIF
-#endif
 
   DO j = j_start, j_end
   DO i = i_start, i_end


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: ifdef, REVERT

SOURCE: internal

DESCRIPTION OF CHANGES:
There were three REVERT cpp ifdefs in the source. Whatever reverting was possibly going to go on has not happened in the last 13 years or so. No one remembers why it was even in there.
```
db92ff9ac (John Michalakes 2005-05-12 19:28:53 +0000 5472) #ifdef REVERT
db92ff9ac (John Michalakes 2005-05-12 19:28:53 +0000 5473)        t_new(i,k,j) = t_new(i,k,j)-h_diabatic(i,k,j)*dt
db92ff9ac (John Michalakes 2005-05-12 19:28:53 +0000 5474) #endif
```


1. Remove the ifdefs and all the code that was within the affirmative sections.
```
#ifdef REVERT
blah, this will be gone
#endif
```

2. Remove the ifdefs and all the code that was within the affirmative sections, leaving the else part alone
```
#ifdef REVERT
blah, this will be gone
#else
cogent and informative source code that is deemed worthy to hang around
#endif
```

LIST OF MODIFIED FILES:
M	   dyn_em/module_big_step_utilities_em.F
M	   dyn_em/module_small_step_em.F

TESTS CONDUCTED:
 - [x] Compiles A-OK.
 - [x] Bit-for-bit identical, 12-h Jan 2000 nested case (before vs after removal of ifdefs)