### PR TITLE
o3rad is not input to WRF from the real program, fix Registry files

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1063,7 +1063,7 @@ state    real   acfrcv           ij     misc        1         -      -
 state integer   ncfrcv           ij     misc        1         -      -
 
 # new rad variables
-state    real   o3rad           ikj     misc        1         -      irh       "o3rad"    "RADIATION 3D OZONE" "ppmv"
+state    real   o3rad           ikj     misc        1         -      rh        "o3rad"    "RADIATION 3D OZONE" "ppmv"
 
 # incoming optical depth derived from aerosol data
 state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -

--- a/Registry/Registry.EM_COMMON.tladj
+++ b/Registry/Registry.EM_COMMON.tladj
@@ -1063,7 +1063,7 @@ state    real   acfrcv           ij     misc        1         -      -
 state integer   ncfrcv           ij     misc        1         -      -
 
 # new rad variables
-state    real   o3rad           ikj     misc        1         -      irh       "o3rad"    "RADIATION 3D OZONE" "ppmv"
+state    real   o3rad           ikj     misc        1         -      rh        "o3rad"    "RADIATION 3D OZONE" "ppmv"
 
 # incoming optical depth derived from aerosol data
 state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1566,7 +1566,7 @@ state  real   mth12    i{ls}jf ozmixm      1    -   -     "OZMIXMTH12"  "Month 1
 state  real   pin       {ls}     misc      1    -   -      "PIN"             "PRESSURE LEVEL OF OZONE MIXING RATIO"  "millibar"
 
 # new rad variables
-state    real   o3rad           ikj     misc        1         -      irh      "o3rad"    "RADIATION 3D OZONE" "ppmv"
+state    real   o3rad           ikj     misc        1         -      rh       "o3rad"    "RADIATION 3D OZONE" "ppmv"
 
 ifdef HWRF=1
 rconfig   integer ntrack                 namelist,physics      max_domains  10       irh    "ntrack" "nest movement timestep (multiples of nphs)"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: o3rad, input, registry

SOURCE: internal

DESCRIPTION OF CHANGES:
In the ARW, NMM, and TLADJ registry files, in the I/O column, remove the "i" attribute. The o3rad variable is not provided by any of the WRF preprocessor programs.

LIST OF MODIFIED FILES:
M	   Registry.EM_COMMON
M	   Registry.EM_COMMON.tladj
M	   Registry.NMM

TESTS CONDUCTED:
1. It is an unused variable on input. I'll compile ARW to be sure.