### PR TITLE
Fix NDOWN to work with use_theta_m=1

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4678,8 +4678,13 @@ endif
             qvf1 = qvf1*qvf2
             grid%p(i,kk,j) = - 0.5*((grid%c1f(k)*grid%Mu_2(i,j))+qvf1*(grid%c1f(k)*grid%Mub(i,j)+grid%c2f(k)))/grid%rdnw(kk)/qvf2
             qvf = 1. + rvovrd*moist(i,kk,j,P_QV)
-            grid%alt(i,kk,j) = (r_d/p1000mb)*(grid%t_2(i,kk,j)+t0)*qvf* &
-                                 (((grid%p(i,kk,j)+grid%pb(i,kk,j))/p1000mb)**cvpm)
+            IF ( config_flags%use_theta_m .EQ. 1 ) THEN
+               grid%alt(i,kk,j) = (r_d/p1000mb)*(grid%t_2(i,kk,j)+t0)* &
+                                  (((grid%p(i,kk,j)+grid%pb(i,kk,j))/p1000mb)**cvpm)
+            ELSE 
+               grid%alt(i,kk,j) = (r_d/p1000mb)*(grid%t_2(i,kk,j)+t0)*qvf* &
+                                  (((grid%p(i,kk,j)+grid%pb(i,kk,j))/p1000mb)**cvpm)
+            END IF
             grid%al(i,kk,j) = grid%alt(i,kk,j) - grid%alb(i,kk,j)
             grid%p_hyd(i,kk,j) = grid%p(i,kk,j) + grid%pb(i,kk,j)
             !  Now, integrate down the column to compute the pressure perturbation, and diagnose the two
@@ -4691,8 +4696,13 @@ endif
                qvf1 = qvf1*qvf2
                grid%p(i,kk,j) = grid%p(i,kk+1,j) - ((grid%c1f(k)*grid%Mu_2(i,j)) + qvf1*(grid%c1f(k)*grid%Mub(i,j)+grid%c2f(k)))/qvf2/grid%rdn(kk+1)
                qvf = 1. + rvovrd*moist(i,kk,j,P_QV)
-               grid%alt(i,kk,j) = (r_d/p1000mb)*(grid%t_2(i,kk,j)+t0)*qvf* &
-                           (((grid%p(i,kk,j)+grid%pb(i,kk,j))/p1000mb)**cvpm)
+               IF ( config_flags%use_theta_m .EQ. 1 ) THEN
+                  grid%alt(i,kk,j) = (r_d/p1000mb)*(grid%t_2(i,kk,j)+t0)* &
+                                     (((grid%p(i,kk,j)+grid%pb(i,kk,j))/p1000mb)**cvpm)
+               ELSE
+                  grid%alt(i,kk,j) = (r_d/p1000mb)*(grid%t_2(i,kk,j)+t0)*qvf* &
+                                     (((grid%p(i,kk,j)+grid%pb(i,kk,j))/p1000mb)**cvpm)
+               END IF
                grid%al(i,kk,j) = grid%alt(i,kk,j) - grid%alb(i,kk,j)
                grid%p_hyd(i,kk,j) = grid%p(i,kk,j) + grid%pb(i,kk,j)
             END DO


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: use_theta_m, ndown

SOURCE: internal

DESCRIPTION OF CHANGES:
In the NDOWN processing, the computation of the total inverse density has a factor of qvf, where qvf = 1 + Rv/Rd * Qv. This factor is used to turn dry potential temperature into moist potential temperature. 

If the user has selected the use_theta_m=1 switch in the dynamics namelist record, then the grid%t_2 field is ALREADY scaled by this qvf factor. When running NDOWN, this double counting of moisture artificially increases the total inverse density, resulting in an incorrect perturbation inverse density, which breaks the hydrostatic integration.

The problem shows as OK results at the lateral boundaries, and increasingly (in time) worse results in the interior of the nested domain.

The fix is to include an IF test inside of the calculation.
```
IF ( use_theta_m == 1 ) then
   computation without using QVF
ELSE
   original computation that still uses QVF scaling of theta
END IF
```

LIST OF MODIFIED FILES:
M	   module_initialize_real.F

TESTS CONDUCTED:
 - [x] Regression tests will not catch this.
 - [x] Three NDOWN tests were conducted. Long story short, the differences with the fixed code (with and without moist theta) should be small, and the differences broken vs corrected should be big.

1. Test 1 - CONTROL, use_theta_m=0
2. Test 2 - BROKEN, use_theta_m=1 with original code
3. Test 3 - FIXED, use_theta_m=1 with new code

BROKEN-CONTROL figs on LEFT, FIXED-CONTROL figs on RIGHT. The following figures show the impact of the broken code vs the fixed code.

MU, using scaling from BROKEN-CONTROL
![screen shot 2018-05-11 at 12 19 21 pm](https://user-images.githubusercontent.com/12666234/39941090-b0453f78-5518-11e8-8bd1-aa5e669bd021.png)

MU, using scaling from FIXED-CONTROL (notice total range of diffs is 40x smaller)
![screen shot 2018-05-11 at 12 20 17 pm](https://user-images.githubusercontent.com/12666234/39941142-dd1abb72-5518-11e8-80fe-1dbefc4120b3.png)

T2, using scaling form BROKEN-CONTROL (typical signature of reasonable results near boundaries and increasingly bad results (in time) in the interior)
![screen shot 2018-05-11 at 12 21 18 pm](https://user-images.githubusercontent.com/12666234/39941155-ec4219b0-5518-11e8-9cc0-559f6a1d8414.png)

Q2, using scaling from BROKEN-CONTROL
![screen shot 2018-05-11 at 12 22 02 pm](https://user-images.githubusercontent.com/12666234/39941204-05c16b34-5519-11e8-95eb-5d503c2a2436.png)

RAINNC, using scaling from BROKEN-CONTROL
![screen shot 2018-05-11 at 12 22 54 pm](https://user-images.githubusercontent.com/12666234/39941214-1169729c-5519-11e8-897b-87607463c0a6.png)


========

With this modified version of the WRF code, the 12-h NDOWN comparison of the d02 output for a few fields near the surface (the surface is where most of the moisture impact is, the upper levels will be impacted by the hyb coordinate). Four tests were conducted:
1. Test 1 : hybrid_opt = 0, use_theta_m = 0
2. Test 2 : hybrid_opt = 0, use_theta_m = 1
3. Test 3 : hybrid_opt = 2, use_theta_m = 0
4. Test 4 : hybrid_opt = 2, use_theta_m = 1

The following figures are pulled from the above tests. Each figure has the same min/max color scale LEFT, MIDDLE, RIGHT. 
LEFT = Test 4 - Test 1
MIDDLE = Test 2 - Test 1
RIGHT = Test3 - Test 1
These figures show the impact of the various new settings available in WRF v4.0. The differences show the impacts on the results with code that is "fixed". The differences shown below are legitimate. 

MU
![screen shot 2018-05-11 at 2 47 40 pm](https://user-images.githubusercontent.com/12666234/39946429-5c732a96-552b-11e8-8d3b-4e4d0a66ad3a.png)

Q2
![screen shot 2018-05-11 at 2 49 09 pm](https://user-images.githubusercontent.com/12666234/39946440-66dd9476-552b-11e8-8406-0d9920976f19.png)

RAINNC
![screen shot 2018-05-11 at 2 50 43 pm](https://user-images.githubusercontent.com/12666234/39946448-6fa90892-552b-11e8-9c49-18742d7fd9f7.png)

T2
![screen shot 2018-05-11 at 2 52 31 pm](https://user-images.githubusercontent.com/12666234/39946463-7beac488-552b-11e8-91b8-a8326b52ad3a.png)


