### PR TITLE
Update individual molar masses of Na and Cl to match the molar mass of NaCl

### DIFF
--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -1455,8 +1455,8 @@
 !jdfcz           (mass_naj/dens_na)+(mass_clj/dens_cl) +    &  
 !jdfcz           (mass_dustj/dens_dust)
         vol_ac = (mass_antha/dens_oin)+ &
-                 (mass_seas*(22.9897/58.4428)/dens_na)+ &
-                 (mass_seas*(35.4270/58.4428)/dens_cl)+ &
+                 (mass_seas*(22.9898/58.4428)/dens_na)+ &
+                 (mass_seas*(35.4530/58.4428)/dens_cl)+ &
                  (mass_soil/dens_dust)
 !
 ! Now divide mass into sections which is done by sect02:
@@ -1500,9 +1500,9 @@
                      mass_ba1j+mass_ba2j+mass_ba3j+mass_ba4j)*xmas_sectj(isize)
           mass_bc  = mass_bci*xmas_secti(isize) + mass_bcj*xmas_sectj(isize)
           mass_na  = mass_nai*xmas_secti(isize) + mass_naj*xmas_sectj(isize)+ &
-                     mass_seas*xmas_sectc(isize)*(22.9897/58.4428)
+                     mass_seas*xmas_sectc(isize)*(22.9898/58.4428)
           mass_cl  = mass_cli*xmas_secti(isize) + mass_clj*xmas_sectj(isize)+ &
-                     mass_seas*xmas_sectc(isize)*(35.4270/58.4428)
+                     mass_seas*xmas_sectc(isize)*(35.4530/58.4428)
           mass_h2o = mass_h2oi*xmas_secti(isize) + mass_h2oj*xmas_sectj(isize)
 !         mass_h2o = 0.0 ! testing purposes only
           vol_so4 = mass_so4 / dens_so4
@@ -2173,8 +2173,8 @@ if (l .ge. p1st)  mass_asoa2j= chem(i,k,j,l)*conv1a
 !jdfcz           (mass_naj/dens_na)+(mass_clj/dens_cl) +    &  
 !jdfcz           (mass_dustj/dens_dust)
         vol_ac = (mass_antha/dens_oin)+ &
-                 (mass_seas*(22.9897/58.4428)/dens_na)+ &
-                 (mass_seas*(35.4270/58.4428)/dens_cl)+ &
+                 (mass_seas*(22.9898/58.4428)/dens_na)+ &
+                 (mass_seas*(35.4530/58.4428)/dens_cl)+ &
                  (mass_soil/dens_dust)
 !
 ! Now divide mass into sections which is done by sect02:
@@ -2222,9 +2222,9 @@ if (l .ge. p1st)  mass_asoa2j= chem(i,k,j,l)*conv1a
           mass_oc  = mass_oci*xmas_secti(isize) + mass_ocj*xmas_sectj(isize)
           mass_bc  = mass_bci*xmas_secti(isize) + mass_bcj*xmas_sectj(isize)
           mass_na  = mass_nai*xmas_secti(isize) + mass_naj*xmas_sectj(isize)+ &
-                     mass_seas*xmas_sectc(isize)*(22.9897/58.4428)
+                     mass_seas*xmas_sectc(isize)*(22.9898/58.4428)
           mass_cl  = mass_cli*xmas_secti(isize) + mass_clj*xmas_sectj(isize)+ &
-                     mass_seas*xmas_sectc(isize)*(35.4270/58.4428)
+                     mass_seas*xmas_sectc(isize)*(35.4530/58.4428)
           mass_h2o = mass_h2oi*xmas_secti(isize) + mass_h2oj*xmas_sectj(isize)
 !         mass_h2o = 0.0 ! testing purposes only
           vol_so4 = mass_so4 / dens_so4
@@ -2829,8 +2829,8 @@ END subroutine optical_prep_modal_soa_vbs
 !jdfcz           (mass_naj/dens_na)+(mass_clj/dens_cl) +    &
 !jdfcz           (mass_dustj/dens_dust)
         vol_ac = (mass_antha/dens_oin)+ &
-                 (mass_seas*(22.9897/58.4428)/dens_na)+ &
-                 (mass_seas*(35.4270/58.4428)/dens_cl)+ &
+                 (mass_seas*(22.9898/58.4428)/dens_na)+ &
+                 (mass_seas*(35.4530/58.4428)/dens_cl)+ &
                  (mass_soil/dens_dust)
 
 !
@@ -2875,9 +2875,9 @@ END subroutine optical_prep_modal_soa_vbs
                      mass_ba1j+mass_ba2j+mass_ba3j+mass_ba4j)*xmas_sectj(isize)
           mass_bc  = mass_bci*xmas_secti(isize) + mass_bcj*xmas_sectj(isize)
           mass_na  = mass_nai*xmas_secti(isize) + mass_naj*xmas_sectj(isize)+ &
-                     mass_seas*xmas_sectc(isize)*(22.9897/58.4428)
+                     mass_seas*xmas_sectc(isize)*(22.9898/58.4428)
           mass_cl  = mass_cli*xmas_secti(isize) + mass_clj*xmas_sectj(isize)+ &
-                     mass_seas*xmas_sectc(isize)*(35.4270/58.4428)
+                     mass_seas*xmas_sectc(isize)*(35.4530/58.4428)
           mass_h2o = mass_h2oi*xmas_secti(isize) + mass_h2oj*xmas_sectj(isize)
 !         mass_h2o = 0.0 ! testing purposes only
           vol_so4 = mass_so4 / dens_so4
@@ -3995,8 +3995,8 @@ END subroutine optical_prep_modal_soa_vbs
        n = n+1
         mass_soil=mass_soil+dustfrc_goc8bin(n,isize)*chem(i,k,j,m)
        end do
-       mass_cl=mass_seas*conv1a*22.9897/58.4428
-       mass_na=mass_seas*conv1a*35.4270/58.4428
+       mass_cl=mass_seas*conv1a*35.4530/58.4428
+       mass_na=mass_seas*conv1a*22.9898/58.4428
        mass_soil=mass_soil*conv1a
 !         mass_h2o = 0.0 ! testing purposes only
           vol_so4 = mass_so4 / dens_so4


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: optical properties, NaCl, sea salt, mass balance, molar mass, Natrium, Sodium, Chlorine, AOD

SOURCE: Alexander Ukhov (KAUST)

DESCRIPTION OF CHANGES: Na and Cl had incorrect values of molar masses. In one of the cases their molar masses were mixed. Both of these problems lead to incorrect calculation of sea salt contribution on aerosol optical depth (AOD). Now, after molar masses are fixed, mass is conserved. The sum of the components (Na and Cl) is now equal to the molar mass of NaCl molecule. 
There are other files, where little bit different values of molar mass are used for Na, Cl and NaCl, but it is less critical.

Natrium (Sodium) 22.9898 g/mole, Chlorine 35.4530 g/mole, NaCl=58.4428 g/mole

LIST OF MODIFIED FILES: 
M       chem/module_optical_averaging.F

TESTS CONDUCTED: 
I believe, test run is not needed here.
