### PR TITLE
Tuning factor 0.25 was removed from module gocart_seasalt.F

### DIFF
--- a/chem/module_gocart_seasalt.F
+++ b/chem/module_gocart_seasalt.F
@@ -258,12 +258,12 @@ SUBROUTINE source_ss(imx,jmx,lmx,nmx, dt1, tc, &
                  src = dfm*dxy(j)*w10m(i,j)**c0(2)
 !                 src = ch_ss(n,dt(1)%mn)*dfm*dxy(j)*w10m(i,j)**c0(2)
                  if(src < 0.0 ) src=0.
-                 tc(i,j,1,n) = tc(i,j,1,n) + .25*src/airmas(i,j,1)
+                 tc(i,j,1,n) = tc(i,j,1,n) + src/airmas(i,j,1)
 !                if(ipr.eq.1)write(0,*)n,dfm,c0(2),dxy(j),w10m(i,j),src,airmas(i,j,1)
               ELSE
                  src = 0.0
               END IF
-              bems(i,j,n) = bems(i,j,n) + .25*src
+              bems(i,j,n) = bems(i,j,n) + src
            END DO  ! i
         END DO ! j
      END DO ! ir


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRF-Chem, GOCART, Sea salt, emission, Tuning factor

SOURCE: Alexander Ukhov (KAUST)

DESCRIPTION OF CHANGES: 
Tuning factor 0.25 was removed from module gocart_seasalt.F. This module is responsible for sea salt emissions.  I removed this factor by analogy with a8ed3e6 commit, where the similar tuning factor was removed from dust emission procedure (see module_gocart_dust.F).

The amount of emitted sea salt is expected to increase by 4 times, when this tuning factor is removed. In combination with the bug-fix in #513 it will lead to the slight changes in total AOD over the sea surface.

LIST OF MODIFIED FILES: 
M       chem/module_gocart_seasalt.F

TESTS CONDUCTED: test run is not needed.