### PR TITLE
 The non-fatal messages inside check_a_mundo are output only when debug_level >= 1

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1840,6 +1840,13 @@
       CHARACTER (LEN=256) :: physics_suite_lowercase
       CHARACTER (LEN=32) :: formatstring
 
+      !
+      ! Initialize the debug level so that it can be used in the namelist testing.
+      ! wrf_debug_level is a global value in module_wrf_error.
+      !
+
+      wrf_debug_level = model_config_rec%debug_level
+
       max_dom = model_config_rec % max_dom
 
       !


### PR DESCRIPTION
TYPE:  no impact

KEYWORDS: NOTE, WARNING, check_a_mundo

SOURCE: internal

DESCRIPTION OF CHANGES: 
All of the NOTE and WARNING messages  inside check_a_mundo are output only when debug level is turned on (debug_level >= 1). For the blocks of code that deal with non-fatal namelist issues, the 
```
call wrf_message (string ) 
```
lines are replaced with 
```
call wrf_debug ( 1, string )
```
If a user turns on debug_level >=1, then these messages are put into the standard out file.

```
This is the rsl.out.0000 before the change:
taskid: 0 hostname: r12i5n21
Quilting with   1 groups of   0 I/O tasks.
 Ntasks in X            8 , ntasks in Y            9
--- WARNING: traj_opt is zero, but num_traj is not zero; setting num_traj to zero.
--- NOTE: sst_update is 0, setting io_form_auxinput4 = 0 and auxinput4_interval = 0 for all domains
--- NOTE: grid_fdda is 0 for domain      1, setting gfdda interval and ending time to 0 for that domain.
--- NOTE: both grid_sfdda and pxlsm_soil_nudge are 0 for domain      1, setting sgfdda interval and ending time to 0 for that domain.
--- NOTE: obs_nudge_opt is 0 for domain      1, setting obs nudging interval and ending time to 0 for that domain.
--- NOTE: bl_pbl_physics /= 4, implies mfshconv must be 0, resetting
bl_mynn_edmf > 0 requires both shcu_physics=0 & ishallow=0
Need MYNN PBL for icloud_bl = 1, resetting to 0
*************************************
No physics suite selected.
Physics options will be used directly from the namelist.
*************************************
```
```
This is the rsl.out.0000 after the change (debug_level=0)
taskid: 0 hostname: r14i3n31
Quilting with   1 groups of   0 I/O tasks.
 Ntasks in X            8 , ntasks in Y            9
*************************************
No physics suite selected.
Physics options will be used directly from the namelist.
*************************************
```

If debug_level = 1, rsl.*.0000 has the same messages as those before the code change. This is what we expect.
  
FILES MODIFIED:
M        share/module_check_a_mundo.F


TESTS CONDUCTED: 
1. No regression test is necessary. 
2. Manually compiled to make sure no syntax errors were introduced.