### PR TITLE
Fix MYJ for use with LES

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2067,10 +2067,10 @@ CONTAINS
                ustm(i,j) = ust(i,j)
             END DO
          END DO
+#endif
        ELSE
          CALL wrf_error_fatal('Lacking arguments for MYJSFC in surface driver')
        ENDIF
-#endif
 
       CASE (QNSESFCSCHEME)
        IF(PRESENT(SCM_FORCE_FLUX))THEN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MYJ SFC with LES

SOURCE: internal (problem from user)

DESCRIPTION OF CHANGES: 
LES requires array USTM which is u* for momentum. In SFCLAY this is different from UST because it excludes the convective velocity, and this is what is needed for LES. After MYJSFC we simply copy UST into USTM because it is used for momentum with the convective velocity effect. USTM not available in NMM so ifdef'd out.

LIST OF MODIFIED FILES:
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
WTF with gnu passed all.
User confirmed it works with LES.
