### PR TITLE
add new namelist options to global attributes

### DIFF
--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -792,9 +792,9 @@ endif
         CALL wrf_put_dom_ti_integer   ( fid, 'OPT_STC',     config_flags%opt_stc     , 1 , ierr )
         CALL wrf_put_dom_ti_integer   ( fid, 'OPT_GLA',     config_flags%opt_gla     , 1 , ierr )
         CALL wrf_put_dom_ti_integer   ( fid, 'OPT_RSF',     config_flags%opt_rsf     , 1 , ierr )
-        CALL wrf_put_dom_ti_integer   ( fid, 'OPT_SOIL',    config_flags%opt_rsf     , 1 , ierr )
-        CALL wrf_put_dom_ti_integer   ( fid, 'OPT_PEDO',    config_flags%opt_rsf     , 1 , ierr )
-        CALL wrf_put_dom_ti_integer   ( fid, 'OPT_CROP',    config_flags%opt_rsf     , 1 , ierr )
+        CALL wrf_put_dom_ti_integer   ( fid, 'OPT_SOIL',    config_flags%opt_soil    , 1 , ierr )
+        CALL wrf_put_dom_ti_integer   ( fid, 'OPT_PEDO',    config_flags%opt_pedo    , 1 , ierr )
+        CALL wrf_put_dom_ti_integer   ( fid, 'OPT_CROP',    config_flags%opt_crop    , 1 , ierr )
       ENDIF
 
       CALL wrf_put_dom_ti_integer   ( fid, 'DFI_OPT',          config_flags%dfi_opt      , 1 , ierr )


### PR DESCRIPTION
TYPE:  no impact

KEYWORDS: namelist, wrfout

SOURCE: internal

DESCRIPTION OF CHANGES: 
For each of the "important" namelist variables that has been added to the namelist with the rconfig keyword in the Registry.EM_COMMON, a single line to output time independent data has been added in output_wrf to include that information in the global attributes of the WRF system files.

Generic namelist values added:
AERCU_OPT
AERCU_FCT

EM_CORE==1 namelist values added:
IDEAL_CASE
DIFF_6TH_SLOPEOPT
AUTO_LEVELS_OPT
DIFF_6TH_THRESH
DZBOT
DZSTRETCH_S
DZSTRETCH_U

NoahMP namelist values added:
OPT_STC
OPT_GLA
OPT_RSF
OPT_SOIL
OPT_PEDO
OPT_CROP

LIST OF MODIFIED FILES:
M       share/output_wrf.F

TESTS CONDUCTED:
1. Here is a sample of a few of the new the global attributes (starting after DX):
```
// global attributes:
                :TITLE = " OUTPUT FROM WRF V4.0FR#3 MODEL" ;
                :START_DATE = "2015-06-04_00:00:00" ;
                :SIMULATION_START_DATE = "2015-06-04_00:00:00" ;
                :WEST-EAST_GRID_DIMENSION = 401 ;
                :SOUTH-NORTH_GRID_DIMENSION = 261 ;
                :BOTTOM-TOP_GRID_DIMENSION = 40 ;
                :DX = 15000.f ;
                :DY = 15000.f ;
                :AERCU_OPT = 0 ;
                :AERCU_FCT = 1.f ;
                :IDEAL_CASE = 0 ;
                :DIFF_6TH_SLOPEOPT = 0 ;
                :AUTO_LEVELS_OPT = 2 ;
                :DIFF_6TH_THRESH = 0.1f ;
                :DZBOT = 50.f ;
                :DZSTRETCH_S = 1.3f ;
                :DZSTRETCH_U = 1.1f ;
                .....
                ......             
```

2. No regression test is necessary. The code was manually compiled and a test case was run.