### PR TITLE
4DVAR fix for cloud variables

### DIFF
--- a/Registry/Registry.EM_COMMON.var
+++ b/Registry/Registry.EM_COMMON.var
@@ -186,6 +186,8 @@ state   real    qr             ijkftb   moist       1         -     \
    i0rhusdf=(bdy_interp:dt)  "QRAIN"            "Rain water mixing ratio"       "kg kg-1"
 state   real    qi             ijkftb   moist       1         -     \
    i0rhusdf=(bdy_interp:dt)  "QICE"             "Ice mixing ratio"              "kg kg-1"
+state   real    qi2            ijkftb   moist       1         -     \
+   i0rhusdf=(bdy_interp:dt)  "QICE2"            "Ice mixing ratio cat 2"        "kg kg-1"
 state   real    qs             ijkftb   moist       1         -     \
    i0rhusdf=(bdy_interp:dt)  "QSNOW"            "Snow mixing ratio"             "kg kg-1"
 state   real    qg             ijkftb   moist       1         -     \

--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -61,15 +61,11 @@ state   real    a_qs           ijkft   a_moist     1         -     rh   "A_QSNOW
 state   real    g_qs           ijkft   g_moist     1         -     rh   "G_QSNOW"            "Snow mixing ratio"             "kg kg-1"
 state   real    a_qg           ijkft   a_moist     1         -     rh   "A_QGRAUP"           "Graupel mixing ratio"          "kg kg-1"
 state   real    g_qg           ijkft   g_moist     1         -     rh   "G_QGRAUP"           "Graupel mixing ratio"          "kg kg-1"
-#state   real    a_qh           ijkft   a_moist     1         -     rh   "A_QHAIL"            "Hail mixing ratio"             "kg kg-1"
-#state   real    g_qh           ijkft   g_moist     1         -     rh   "G_QHAIL"            "Hail mixing ratio"             "kg kg-1"
+state   real    a_qh           ijkft   a_moist     1         -     rh   "A_QHAIL"            "Hail mixing ratio"             "kg kg-1"
+state   real    g_qh           ijkft   g_moist     1         -     rh   "G_QHAIL"            "Hail mixing ratio"             "kg kg-1"
+state   real    a_qi2          ijkft   a_moist     1         -     rh   "A_QICE2"            "Ice mixing ratio cat 2"        "kg kg-1"
+state   real    g_qi2          ijkft   g_moist     1         -     rh   "G_QICE2"            "Ice mixing ratio cat 2"        "kg kg-1"
 # Other Misc State Variables                                            
-state   real    g_h_diabatic   ijk     misc         1         -      rdu      "g_h_diabatic"          "MICROPHYSICS LATENT HEATING"         "K s-1"      
-state   real    a_h_diabatic   ijk     misc         1         -      rdu      "a_h_diabatic"          "MICROPHYSICS LATENT HEATING"         "K s-1"      
-state   real    g_qv_diabatic  ijk     misc         1         -      rdu      "g_qv_diabatic"         "MICROPHYSICS QV TENDENCY"            "g g-1 s-1"
-state   real    a_qv_diabatic  ijk     misc         1         -      rdu      "a_qv_diabatic"         "MICROPHYSICS QV TENDENCY"            "g g-1 s-1"
-state   real    g_qc_diabatic  ijk     misc         1         -      rdu      "g_qc_diabatic"         "MICROPHYSICS QC TENDENCY"            "g g-1 s-1"
-state   real    a_qc_diabatic  ijk     misc         1         -      rdu      "a_qc_diabatic"         "MICROPHYSICS QC TENDENCY"            "g g-1 s-1"
 state    real  G_RAINC          ij      misc        1         -      rhdu     "G_RAINC"               "ACCUMULATED TOTAL CUMULUS PRECIPITATION"                 "mm"      
 state    real  A_RAINC          ij      misc        1         -      rhdu     "A_RAINC"               "ACCUMULATED TOTAL CUMULUS PRECIPITATION"                 "mm"      
 state    real  G_RAINNC         ij      misc        1         -      rhdu     "G_RAINNC"              "ACCUMULATED TOTAL GRID SCALE PRECIPITATION"              "mm"      
@@ -501,8 +497,6 @@ rconfig   logical var4d_run                 namelist,perturbation  1  .true.  - 
 rconfig   integer  mp_physics_ad            namelist,physics   max_domains   99   -      "mp_physics_ad"            ""      ""
 # NAMELIST DERIVED
 rconfig   integer mp_physics_4dvar        derived                  max_domains   -1       -        "mp_physics_4dvar"     ""      "-1 = no 4dvar and so no need to allocate a_ and g_ moist and scalar variables, >0 = running 4dvar, so allocate a_ and g_ moist and scalar variables appropriate for selected microphysics package"
-rconfig   integer mp_physics_da           derived                  max_domains    1       -        "mp_physics_da"        ""      "1 when mp_physics>0 for allocating moist variables"
-rconfig   integer mp_physics_da_4dvar     derived                  max_domains   -1       -        "mp_physics_da_4dvar"  ""      "1 when mp_physics>0 for allocating g_/a_moist variables"
 #
 #---------------------------------------------------------------------------------------------------------------------------------------
 # Package Declarations
@@ -517,15 +511,70 @@ package   dyn_em_ad    dyn_opt==302                 -             -
 package   dyn_em_tst   dyn_opt==402                 -             -
 package   dyn_em_var   dyn_opt==502                 -             -
 
-package   mp_phys_zero     mp_physics_da==0         -             moist:qv
-package   mp_phys_set      mp_physics_da==1         -             moist:qv,qc,qr,qi,qs,qg
+package   nomoist_ad   mp_physics_ad==98            -             -
+package   warmrain_ad  mp_physics_ad==99            -             -
 
-package   nomoist_4dvar    mp_physics_da_4dvar==-1  -             -
-package   passiveqv_4dvar  mp_physics_da_4dvar==0   -             g_moist:g_qv;a_moist:a_qv
-package   warmrain_4dvar   mp_physics_da_4dvar==1   -             g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
+#do "grep package Registry/Registry.EM_COMMON | grep mp_physics==", then remove non-moist lists
+package   passiveqv       mp_physics==0                -             moist:qv
+package   kesslerscheme   mp_physics==1                -             moist:qv,qc,qr
+package   linscheme       mp_physics==2                -             moist:qv,qc,qr,qi,qs,qg
+package   wsm3scheme      mp_physics==3                -             moist:qv,qc,qr
+package   wsm5scheme      mp_physics==4                -             moist:qv,qc,qr,qi,qs
+package   fer_mp_hires    mp_physics==5                -             moist:qv,qc,qr,qi
+package   fer_mp_hires_advect  mp_physics==15          -             moist:qv,qc,qr,qi
+package   wsm6scheme      mp_physics==6                -             moist:qv,qc,qr,qi,qs,qg
+package   gsfcgcescheme   mp_physics==7                -             moist:qv,qc,qr,qi,qs,qg
+package   thompson        mp_physics==8                -             moist:qv,qc,qr,qi,qs,qg
+package   milbrandt2mom   mp_physics==9                -             moist:qv,qc,qr,qi,qs,qg,qh
+package   morr_two_moment mp_physics==10               -             moist:qv,qc,qr,qi,qs,qg
+package   cammgmpscheme   mp_physics==11               -             moist:qv,qc,qi,qr,qs
+package   sbu_ylinscheme  mp_physics==13               -             moist:qv,qc,qr,qi,qs
+package   wdm5scheme      mp_physics==14               -             moist:qv,qc,qr,qi,qs
+package   wdm6scheme      mp_physics==16               -             moist:qv,qc,qr,qi,qs,qg
+package   nssl_2mom       mp_physics==17               -             moist:qv,qc,qr,qi,qs,qg,qh
+package   nssl_2momccn    mp_physics==18               -             moist:qv,qc,qr,qi,qs,qg,qh
+package   nssl_1mom       mp_physics==19               -             moist:qv,qc,qr,qi,qs,qg,qh
+package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc,qr,qi,qs,qg
+package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg
+package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg
+package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi
+package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi
+package   p3_2category    mp_physics==52               -             moist:qv,qc,qr,qi,qi2
+package   morr_tm_aero    mp_physics==40               -             moist:qv,qc,qr,qi,qs,qg
+package   etampnew        mp_physics==95               -             moist:qv,qc,qr,qs
+package   lscondscheme    mp_physics==98               -             moist:qv
+package   mkesslerscheme  mp_physics==99               -             moist:qv,qc,qr
+#
+package   passiveqv_4dvar        mp_physics_4dvar==0      -          g_moist:g_qv;a_moist:a_qv
+package   kessler_4dvar          mp_physics_4dvar==1      -          g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
+package   lins_4dvar             mp_physics_4dvar==2      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr
+package   wsm3_4dvar             mp_physics_4dvar==3      -          g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
+package   wsm5_4dvar             mp_physics_4dvar==4      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs
+package   fer_mp_hi_4dvar        mp_physics_4dvar==5      -          g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
+package   fer_mp_hi_advect_4dvar mp_physics_4dvar==15     -          g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
+package   wsm6_4dvar             mp_physics_4dvar==6      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   gsfcgce_4dvar          mp_physics_4dvar==7      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   thompson_4dvar         mp_physics_4dvar==8      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   milbrandt2mom_4dvar    mp_physics_4dvar==9      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh
+package   morr_two_mom_4dvar     mp_physics_4dvar==10     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   cammgmp_4dvar          mp_physics_4dvar==11     -          g_moist:g_qv,g_qc,g_qi,g_qr,g_qs;a_moist:a_qv,a_qc,a_qi,a_qr,a_qs
+package   sbu_ylin_4dvar         mp_physics_4dvar==13     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs
+package   wdm5_4dvar             mp_physics_4dvar==14     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs
+package   wdm6_4dvar             mp_physics_4dvar==16     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   nssl_2mom_4dvar        mp_physics_4dvar==17     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh
+package   nssl_2momccn_4dvar     mp_physics_4dvar==18     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh
+package   nssl_1mom_4dvar        mp_physics_4dvar==19     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg,g_qh;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg,a_qh
+package   nssl_1momlfo_4dvar     mp_physics_4dvar==21     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   nssl_2momg_4dvar       mp_physics_4dvar==22     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   thompsonaero_4dvar     mp_physics_4dvar==28     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   p3_1category_4dvar     mp_physics_4dvar==50     -          g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
+package   p3_1category_nc_4dvar  mp_physics_4dvar==51     -          g_moist:g_qv,g_qc,g_qr,g_qi;a_moist:a_qv,a_qc,a_qr,a_qi
+package   p3_2category_4dvar     mp_physics_4dvar==52     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qi2;a_moist:a_qv,a_qc,a_qr,a_qi,a_qi2
+package   morr_tm_aero_4dvar     mp_physics_4dvar==40     -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr,a_qi,a_qs,a_qg
+package   etampnew_4dvar         mp_physics_4dvar==95     -          g_moist:g_qv,g_qc,g_qr,g_qs;a_moist:a_qv,a_qc,a_qr,a_qs
+package   lscond_4dvar           mp_physics_4dvar==98     -          g_moist:g_qv;a_moist:a_qv
+package   mkessler_4dvar         mp_physics_4dvar==99     -          g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
 
-package   lscondscheme    mp_physics==98               -             moist:qv;g_moist:g_qv;a_moist:a_qv
-package   mkesslerscheme  mp_physics==99               -             moist:qv,qc,qr;g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
 package   surfdragscheme  bl_pbl_physics==98           -             -
 package   ducuscheme      cu_physics==98               -             -
 
@@ -870,7 +919,7 @@ rconfig   integer var4d_used              derived               1             0 
 package   no_adj_sens    adj_sens_used==0            -             -
 package   do_adj_sens    adj_sens_used==1            -             state:a_u,a_v,a_t,a_mu,a_ph,g_u,g_v,g_t,g_mu,g_ph;a_moist:a_qv;g_moist:g_qv
 package   no_var4d       var4d_used==0               -             -
-package   do_var4d       var4d_used==1               -             state:a_u,a_v,a_w,a_ph,a_t,a_mu,a_p,a_z,g_u,g_v,g_w,g_ph,g_t,g_mu,g_p,g_z,a_h_diabatic,g_h_diabatic,a_rainc,g_rainc,a_rainnc,g_rainnc,a_raincv,g_raincv,a_rainncv,g_rainncv
+package   do_var4d       var4d_used==1               -             state:a_u,a_v,a_w,a_ph,a_t,a_mu,a_p,g_u,g_v,g_w,g_ph,g_t,g_mu,g_p,a_rainc,g_rainc,a_rainnc,g_rainnc,a_raincv,g_raincv,a_rainncv,g_rainncv
 
 rconfig   integer cv_w_used               derived               1             0       -     "cv_w_used"       "turn on if use_cv_w=true"
 rconfig   integer ens_used                derived               1             0       -     "ens_used"        "turn on if ensdim_alpha>0"
@@ -886,7 +935,7 @@ package   cloud_cv_1      cloud_cv_options==1         -             state:xa%qt,
 package   cloud_cv_2      cloud_cv_options==2         -             state:xa%qrn,xa%qcw,xa%qci,xa%qsn,xa%qgr,vp%v6,vp%v7,vp%v8,vp%v9,vp%v10,vv%v6,vv%v7,vv%v8,vv%v9,vv%v10
 package   cloud_cv_3      cloud_cv_options==3         -             state:xa%qrn,xa%qcw,xa%qci,xa%qsn,xa%qgr,vp%v6,vp%v7,vp%v8,vp%v9,vp%v10,vv%v6,vv%v7,vv%v8,vv%v9,vv%v10
 package   not_var4d       var4d_cloudcv==-1           -             -
-package   no_var4d_ccv    var4d_cloudcv==0            -             state:vp6%v1,vp6%v2,vp6%v3,vp6%v4,vp6%v5,vv6%v1,vv6%v2,vv6%v3,vv6%v4,vv6%v5,xa%qrn,xa%qcw
+package   no_var4d_ccv    var4d_cloudcv==0            -             state:vp6%v1,vp6%v2,vp6%v3,vp6%v4,vp6%v5,vv6%v1,vv6%v2,vv6%v3,vv6%v4,vv6%v5
 package   var4d_ccv_1     var4d_cloudcv==1            -             state:vp6%v1,vp6%v2,vp6%v3,vp6%v4,vp6%v5,vv6%v1,vv6%v2,vv6%v3,vv6%v4,vv6%v5,x6a%qt,x6a%qrn,x6a%qcw
 package   var4d_ccv_2     var4d_cloudcv==2            -             state:vp6%v1,vp6%v2,vp6%v3,vp6%v4,vp6%v5,vv6%v1,vv6%v2,vv6%v3,vv6%v4,vv6%v5,vp6%v6,vp6%v7,vp6%v8,vp6%v9,vp6%v10,vv6%v6,vv6%v7,vv6%v8,vv6%v9,vv6%v10,x6a%qrn,x6a%qcw,x6a%qci,x6a%qsn,x6a%qgr
 package   var4d_ccv_3     var4d_cloudcv==3            -             state:vp6%v1,vp6%v2,vp6%v3,vp6%v4,vp6%v5,vv6%v1,vv6%v2,vv6%v3,vv6%v4,vv6%v5,vp6%v6,vp6%v7,vp6%v8,vp6%v9,vp6%v10,vv6%v6,vv6%v7,vv6%v8,vv6%v9,vv6%v10,x6a%qrn,x6a%qcw,x6a%qci,x6a%qsn,x6a%qgr

--- a/var/da/da_main/da_update_firstguess.inc
+++ b/var/da/da_main/da_update_firstguess.inc
@@ -28,7 +28,8 @@ subroutine da_update_firstguess(grid, out_filename)
   use da_control,    only : use_radarobs, use_rad, crtm_cloud, &
                             use_radar_rhv, use_radar_rqv    
   use module_state_description, only : p_qv, p_qc, p_qr, p_qi, &
-                                       p_qs, p_qg
+                                       p_qs, p_qg, &
+                                       f_qc, f_qr, f_qi, f_qs, f_qg
 
   implicit none
 
@@ -854,7 +855,7 @@ subroutine da_update_firstguess(grid, out_filename)
 
 !-------------Update QCLOUD, QRAIN, QICE, QSNOW & QGROUP 
 if ( cloud_cv_options >= 1 ) then ! update qcw and qrn
-   if (size(grid%moist,dim=4) >= 4) then         ! update QCLOUD & QRAIN
+   if ( f_qc ) then
 !
 !  update QCLOUD
 !
@@ -904,7 +905,9 @@ if ( cloud_cv_options >= 1 ) then ! update qcw and qrn
 #ifdef DM_PARALLEL
       deallocate(globbuf) 
 #endif
+   end if ! f_qc
 
+   if ( f_qr ) then
 !
 !  update QRAIN
 !
@@ -955,11 +958,11 @@ if ( cloud_cv_options >= 1 ) then ! update qcw and qrn
       deallocate(globbuf) 
 #endif
 
-   end if    ! end of update QCLOUD & QRAIN
+   end if ! f_qr
 end if ! cloud_cv_options >= 1
 
 if ( cloud_cv_options >= 2 ) then ! update qci, qsn, qgr
-   if (size(grid%moist,dim=4) >= 6) then     ! update QICE & QSNOW
+   if ( f_qi ) then
 !
 !  update QICE
 !
@@ -1010,6 +1013,9 @@ if ( cloud_cv_options >= 2 ) then ! update qci, qsn, qgr
       deallocate(globbuf) 
 #endif
 
+   end if ! f_qi
+
+   if ( f_qs ) then
 !
 !  update QSNOW
 !
@@ -1060,9 +1066,9 @@ if ( cloud_cv_options >= 2 ) then ! update qci, qsn, qgr
       deallocate(globbuf) 
 #endif
 
-   end if    ! end of update QICE & QSNOW 
+   end if ! f_qs
 
-   if (size(grid%moist,dim=4) >= 7) then      ! update QGRAUP
+   if ( f_qg ) then
 !
 !  update QGRAUP
 !
@@ -1113,7 +1119,7 @@ if ( cloud_cv_options >= 2 ) then ! update qci, qsn, qgr
       deallocate(globbuf) 
 #endif
 
-   end if     ! end of update QGRAUP
+   end if ! f_qg
 end if ! cloud_cv_options >= 2
 !-------------End of update QCLOUD, QRAIN, QICE, QSNOW & QGROUP
 

--- a/var/da/da_main/da_wrfvar_init2.inc
+++ b/var/da/da_main/da_wrfvar_init2.inc
@@ -76,30 +76,14 @@ subroutine da_wrfvar_init2
       call da_message(message(1:1))
    endif
 
-   !mp_physics_da can be 0/1, used for allocating moist variables
-   !allocate all moist variables (excluding qh) used in DA when mp_physics is on
-   do i = 1, model_config_rec%max_dom
-      if ( mp_physics(i) > 0 ) then
-         model_config_rec%mp_physics_da(i) = 1
-      else if ( mp_physics(i) == 0 ) then
-         model_config_rec%mp_physics_da(i) = 0
-      else if ( mp_physics(i) == -1 ) then
-         !for DA, if physics_suite is set and mp_physics is not set, mp_physics will be -1
-         !in this case, also allocate all moist variables
-         model_config_rec%mp_physics_da(i) = 1
-      end if
-   end do
+   if (max_dom > 1 .and. ( .not. anal_type_hybrid_dual_res) ) then
+      call da_error(__FILE__,__LINE__, (/'WRFDA does not handle nests (max_domain > 1)'/))
+   end if
 
    if ( var4d ) then
       model_config_rec%var4d_used = 1
-      !mp_physics_da_4dvar can be 0/1, used for allocating a_moist and g_moist variables
-      do i = 1, model_config_rec%max_dom
-         if ( mp_physics(i) > 0 ) then
-            model_config_rec%mp_physics_da_4dvar(i) = 1
-         else
-            model_config_rec%mp_physics_da_4dvar(i) = 0
-         end if
-      end do
+      !mp_physics_4dvar is used for allocating a_moist and g_moist variables
+      model_config_rec%mp_physics_4dvar = model_config_rec%mp_physics
    end if
 
    if ( adj_sens ) then
@@ -142,12 +126,6 @@ subroutine da_wrfvar_init2
    call set_wrf_debug_level (debug_level)
 
    nullify(null_domain)
-
-
-!  if (max_dom > 1 ) then 
-   if (max_dom > 1 .and. ( .not. anal_type_hybrid_dual_res) ) then
-      call da_error(__FILE__,__LINE__, (/'WRFDA does not handle nests (max_domain > 1)'/))
-   end if
 
    !<DESCRIPTION>
    ! The top-most domain in the simulation is then allocated and configured

--- a/var/da/da_transfer_model/da_transfer_model.f90
+++ b/var/da/da_transfer_model/da_transfer_model.f90
@@ -14,7 +14,7 @@ module da_transfer_model
       p_g_qv, p_g_qr, p_g_qi, p_g_qs, p_g_qg, p_g_qc, &
       p_a_qv, p_a_qr, p_a_qi, p_a_qs, p_a_qg, p_a_qc, num_g_moist, num_a_moist, &
       f_qc, f_qr, f_qi, f_qs, f_qg, f_g_qc, f_g_qr, f_g_qi, f_g_qs, f_g_qg, &
-      f_a_qc, f_a_qr, f_a_qi, f_a_qs, f_a_qg
+      f_a_qc, f_a_qr, f_a_qi, f_a_qs, f_a_qg, warmrain_ad
    use module_dm, only : wrf_dm_sum_real, wrf_dm_sum_reals
 #ifdef DM_PARALLEL
    use module_dm, only : local_communicator, &
@@ -42,7 +42,8 @@ module da_transfer_model
       t_kelvin, num_fgat_time, num_pseudo, iso_temp, interval_seconds, trajectory_io, &
       ids,ide,jds,jde,kds,kde, ims,ime,jms,jme,kms,kme, num_fft_factors, &
       its,ite,jts,jte,kts,kte, ips,ipe,jps,jpe,kps,kpe, qlimit, &
-      update_sfcdiags, use_wrf_sfcinfo, use_radar_rqv, cloudbase_calc_opt, use_gpsephobs
+      update_sfcdiags, use_wrf_sfcinfo, use_radar_rqv, cloudbase_calc_opt, use_gpsephobs, &
+      cloud_cv_options
    use da_control, only: base_pres_strat, base_lapse_strat
    use da_control, only: c1f, c2f, c1h, c2h, c3f, c3h, c4f, c4h
    use da_define_structures, only : xbx_type, be_type

--- a/var/da/da_transfer_model/da_transfer_wrftltoxa.inc
+++ b/var/da/da_transfer_model/da_transfer_wrftltoxa.inc
@@ -169,21 +169,26 @@ subroutine da_transfer_wrftltoxa(grid, config_flags, filnam, timestr)
    end do
 
    if ( var4d ) then
-      if ( f_g_qc ) then
-         grid%xa%qcw(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qc)
+      if ( config_flags%mp_physics_ad == warmrain_ad ) then
+         if ( f_g_qc .and. cloud_cv_options >= 1 ) then
+            grid%xa%qcw(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qc)
+         end if
+         if ( f_g_qr .and. cloud_cv_options >= 1 ) then
+            grid%xa%qrn(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qr)
+         end if
       end if
-      if ( f_g_qr ) then
-         grid%xa%qrn(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qr)
-      end if
-      if ( f_g_qi ) then
-         grid%xa%qci(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qi)
-      end if
-      if ( f_g_qs ) then
-         grid%xa%qsn(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qs)
-      end if
-      if ( f_g_qg ) then
-         grid%xa%qgr(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qg)
-      end if
+      !placeholder
+      !if ( config_flags%mp_physics_ad == icecld_ad ) then
+      !   if ( f_g_qi .and. cloud_cv_options >= 2 ) then
+      !      grid%xa%qci(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qi)
+      !   end if
+      !   if ( f_g_qs .and. cloud_cv_options >= 2 ) then
+      !      grid%xa%qsn(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qs)
+      !   end if
+      !   if ( f_g_qg .and. cloud_cv_options >= 2 ) then
+      !      grid%xa%qgr(is:ie,js:je,ks:ke)=grid%g_moist(is:ie,js:je,ks:ke,p_g_qg)
+      !   end if
+      !end if
    end if
 
 #ifdef DM_PARALLEL

--- a/var/da/da_transfer_model/da_transfer_wrftltoxa_adj.inc
+++ b/var/da/da_transfer_model/da_transfer_wrftltoxa_adj.inc
@@ -64,21 +64,26 @@ subroutine da_transfer_wrftltoxa_adj(grid, config_flags, filnam, timestr)
    grid%xa%w(is:ie,js:je,ks:ke+1) = 0.0
 
    if ( var4d ) then
-      if ( f_g_qc ) then
-         grid%g_moist(is:ie,js:je,ks:ke,p_g_qc)=grid%xa%qcw(is:ie,js:je,ks:ke)
+      if ( config_flags%mp_physics_ad == warmrain_ad ) then
+         if ( f_g_qc .and. cloud_cv_options >= 1 ) then
+            grid%g_moist(is:ie,js:je,ks:ke,p_g_qc)=grid%xa%qcw(is:ie,js:je,ks:ke)
+         end if
+         if ( f_g_qr .and. cloud_cv_options >= 1 ) then
+            grid%g_moist(is:ie,js:je,ks:ke,p_g_qr)=grid%xa%qrn(is:ie,js:je,ks:ke)
+         end if
       end if
-      if ( f_g_qr ) then
-         grid%g_moist(is:ie,js:je,ks:ke,p_g_qr)=grid%xa%qrn(is:ie,js:je,ks:ke)
-      end if
-      if ( f_g_qi ) then
-         grid%g_moist(is:ie,js:je,ks:ke,p_g_qi)=grid%xa%qci(is:ie,js:je,ks:ke)
-      end if
-      if ( f_g_qs ) then
-         grid%g_moist(is:ie,js:je,ks:ke,p_g_qs)=grid%xa%qsn(is:ie,js:je,ks:ke)
-      end if
-      if ( f_g_qg ) then
-         grid%g_moist(is:ie,js:je,ks:ke,p_g_qg)=grid%xa%qgr(is:ie,js:je,ks:ke)
-      end if
+      !placeholder
+      !if ( config_flags%mp_physics_ad == icecld_ad ) then
+      !   if ( f_g_qi .and. cloud_cv_options >= 2 ) then
+      !      grid%g_moist(is:ie,js:je,ks:ke,p_g_qi)=grid%xa%qci(is:ie,js:je,ks:ke)
+      !   end if
+      !   if ( f_g_qs .and. cloud_cv_options >= 2 ) then
+      !      grid%g_moist(is:ie,js:je,ks:ke,p_g_qs)=grid%xa%qsn(is:ie,js:je,ks:ke)
+      !   end if
+      !   if ( f_g_qg .and. cloud_cv_options >= 2 ) then
+      !      grid%g_moist(is:ie,js:je,ks:ke,p_g_qg)=grid%xa%qgr(is:ie,js:je,ks:ke)
+      !   end if
+      !end if
    end if
 
    !----------------------------------------------------------------------------

--- a/var/da/da_transfer_model/da_transfer_xatowrftl.inc
+++ b/var/da/da_transfer_model/da_transfer_xatowrftl.inc
@@ -258,20 +258,25 @@ subroutine da_transfer_xatowrftl(grid, config_flags, filnam, timestr)
       end do
    end do
 
-   if ( f_g_qc ) then
-      grid%g_moist(is:ie,js:je,ks:ke,p_g_qc) = grid%xa%qcw(is:ie,js:je,ks:ke)
-   end if
-   if ( f_g_qr ) then
-      grid%g_moist(is:ie,js:je,ks:ke,p_g_qr) = grid%xa%qrn(is:ie,js:je,ks:ke)
-   end if
-   if ( f_g_qi ) then
-      grid%g_moist(is:ie,js:je,ks:ke,p_g_qi) = grid%xa%qci(is:ie,js:je,ks:ke)
-   end if
-   if ( f_g_qs ) then
-      grid%g_moist(is:ie,js:je,ks:ke,p_g_qs) = grid%xa%qsn(is:ie,js:je,ks:ke)
-   end if
-   if ( f_g_qg ) then
-      grid%g_moist(is:ie,js:je,ks:ke,p_g_qg) = grid%xa%qgr(is:ie,js:je,ks:ke)
+   if ( config_flags%mp_physics_ad == warmrain_ad ) then
+      if ( f_g_qc .and. cloud_cv_options >= 1 ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qc) = grid%xa%qcw(is:ie,js:je,ks:ke)
+      end if
+      if ( f_g_qr .and. cloud_cv_options >= 1 ) then
+         grid%g_moist(is:ie,js:je,ks:ke,p_g_qr) = grid%xa%qrn(is:ie,js:je,ks:ke)
+      end if
+      !placeholder
+      !if ( config_flags%mp_physics_ad == icecld_ad ) then
+      !   if ( f_g_qi .and. cloud_cv_options >= 2 ) then
+      !      grid%g_moist(is:ie,js:je,ks:ke,p_g_qi) = grid%xa%qci(is:ie,js:je,ks:ke)
+      !   end if
+      !   if ( f_g_qs .and. cloud_cv_options >= 2 ) then
+      !      grid%g_moist(is:ie,js:je,ks:ke,p_g_qs) = grid%xa%qsn(is:ie,js:je,ks:ke)
+      !   end if
+      !   if ( f_g_qg .and. cloud_cv_options >= 2 ) then
+      !      grid%g_moist(is:ie,js:je,ks:ke,p_g_qg) = grid%xa%qgr(is:ie,js:je,ks:ke)
+      !   end if
+      !end if
    end if
 
    call da_transfer_wrftl_lbc_t0 ( grid )

--- a/var/da/da_transfer_model/da_transfer_xatowrftl_adj.inc
+++ b/var/da/da_transfer_model/da_transfer_xatowrftl_adj.inc
@@ -296,20 +296,25 @@ subroutine da_transfer_xatowrftl_adj(grid, config_flags, filnam)
       end do
    end do
 
-   if ( f_a_qc ) then
-      grid%xa%qcw(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qc)
-   end if
-   if ( f_a_qr ) then
-      grid%xa%qrn(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qr)
-   end if
-   if ( f_a_qi ) then
-      grid%xa%qci(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qi)
-   end if
-   if ( f_a_qs ) then
-      grid%xa%qsn(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qs)
-   end if
-   if ( f_a_qg ) then
-      grid%xa%qgr(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qg)
+   if ( config_flags%mp_physics_ad == warmrain_ad ) then
+      if ( f_a_qc .and. cloud_cv_options >= 1 ) then
+         grid%xa%qcw(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qc)
+      end if
+      if ( f_a_qr .and. cloud_cv_options >= 1 ) then
+         grid%xa%qrn(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qr)
+      end if
+      !placeholder
+      !if ( config_flags%mp_physics_ad == icecld_ad ) then
+      !   if ( f_a_qi .and. cloud_cv_options >= 2 ) then
+      !      grid%xa%qci(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qi)
+      !   end if
+      !   if ( f_a_qs .and. cloud_cv_options >= 2 ) then
+      !      grid%xa%qsn(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qs)
+      !   end if
+      !   if ( f_a_qg .and. cloud_cv_options >= 2 ) then
+      !      grid%xa%qgr(its:ite,jts:jte,kts:kte)=grid%a_moist(its:ite,jts:jte,kts:kte,p_a_qg)
+      !   end if
+      !end if
    end if
 
    grid%a_moist = 0.0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, moist

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
This is an important follow-up bug fix to commit 81ca2ff.

CWB reported a case of 4DVAR analysis that failed to perform the subsequent WRF forecast.
It was identified that there were unreasonable 4DVAR QICE and QGRAUP increments
when only surface observations are assimilated with cloud_cv_options=3 and mp_physics=99.
That motivated the revisiting of the handling of moist variables.

The main fix is to put back the package of moist variables for individual mp_physics options.
The reason is that WRFPLUS 'assumes' num_moist=num_g_moist=num_a_moist for
packing/unpacking NL/TL/ADJ trajectories. Inconsistent number counts lead to incorrect memory (data) access.
Before this fix (after previous commit 81ca2ff), num_moist may be different from num_g_moist and num_a_moist with certain mp_physics options.

Other minor changes:
Clean up some unused packaged variables.
Improve the if-check conditions for updating cloud analyses and increments.

LIST OF MODIFIED FILES:
M       Registry/Registry.EM_COMMON.var
M       Registry/registry.var
M       var/da/da_main/da_update_firstguess.inc
M       var/da/da_main/da_wrfvar_init2.inc
M       var/da/da_transfer_model/da_transfer_model.f90
M       var/da/da_transfer_model/da_transfer_wrftltoxa.inc
M       var/da/da_transfer_model/da_transfer_wrftltoxa_adj.inc
M       var/da/da_transfer_model/da_transfer_xatowrftl.inc
M       var/da/da_transfer_model/da_transfer_xatowrftl_adj.inc

TESTS CONDUCTED:
1. a ZTD 4DVAR case, a rainfall 4DVAR case, and a radar 3DVAR case to play with on Mac.
No ice-phase 4DVAR increments after the fix.
2. V3.9.1-based DA regtests, no impact on 3DVAR results.
3. Depending on the mp_physics settings, 4DVAR results may change after the fix.