### PR TITLE
Example of how to add 4d arrays into ARW

### DIFF
--- a/Registry/registry.em_shared_collection
+++ b/Registry/registry.em_shared_collection
@@ -25,3 +25,4 @@ include registry.bdy_perturb
 include registry.hyb_coord
 include registry.new3d_wif
 include registry.trad_fields
+#include registry.test_4d

--- a/Registry/registry.test_4d
+++ b/Registry/registry.test_4d
@@ -5,7 +5,6 @@ state  real    -     ikjf   test4d   1   -  -  -
 
 #	Here are the multiple 3d arrays that will be part of the 4d array
 
-#ikjftb works
 state  real  sinx    ikjf   test4d   1   -  i "TESTSINX"   "Test pattern sin(x)"   "unitless"
 state  real  cosy    ikjf   test4d   1   -  i "TESTCOSY"   "Test pattern cos(y)"   "unitless"
 state  real  tanxy   ikjf   test4d   1   -  i "TESTTANXY"  "Test pattern tan(xy)"  "unitless"

--- a/Registry/registry.test_4d
+++ b/Registry/registry.test_4d
@@ -1,0 +1,20 @@
+#	Test 4d array, no boundary conditions, not time tendencies, not output, physics so no nesting, no restart
+
+#	Always start with an empty
+state  real    -     ikjf   test4d   1   -  -  -
+
+#	Here are the multiple 3d arrays that will be part of the 4d array
+
+#ikjftb works
+state  real  sinx    ikjf   test4d   1   -  i "TESTSINX"   "Test pattern sin(x)"   "unitless"
+state  real  cosy    ikjf   test4d   1   -  i "TESTCOSY"   "Test pattern cos(y)"   "unitless"
+state  real  tanxy   ikjf   test4d   1   -  i "TESTTANXY"  "Test pattern tan(xy)"  "unitless"
+
+#	Namelist option to turn arrays "on"
+
+rconfig  integer  opt_test4d  namelist,physics  1  0   irh  "opt_test4d"  "enable test4d array"      ""
+
+#	Mandatory package to associate 4d array with a namelist option
+package   wanttest4d  opt_test4d==1    -  test4d:sinx,cosy,tanxy
+
+

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4431,10 +4431,6 @@ endif
       !  Test initialization of a 4d array 
 
       IF ( config_flags%opt_test4d .EQ. WANTTEST4D ) THEN
-print *,'DAVE inside the initializations for test4d'
-print *,'p_sinx = ',P_sinx
-print *,'p_cosy = ',P_cosy
-print *,'p_tanxy= ',P_tanxy
          DO j = jts, min(jde-1,jte)
             DO k = kts, kte
                DO i = its, min(ide,ite)

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4428,6 +4428,24 @@ endif
          END DO
       END IF
 
+      !  Test initialization of a 4d array 
+
+      IF ( config_flags%opt_test4d .EQ. WANTTEST4D ) THEN
+print *,'DAVE inside the initializations for test4d'
+print *,'p_sinx = ',P_sinx
+print *,'p_cosy = ',P_cosy
+print *,'p_tanxy= ',P_tanxy
+         DO j = jts, min(jde-1,jte)
+            DO k = kts, kte
+               DO i = its, min(ide,ite)
+                  test4d(i,k,j,P_sinx) = sin(real(i-1)/real(ide-1)*2*3.14159)
+                  test4d(i,k,j,P_cosy) = cos(real(j-1)/real(jde-1)*4*3.14159)
+                  test4d(i,k,j,P_tanxy)= tan(real(i-1)/real(ide-1)*real(j-1)/real(jde-1)*0.49*3.14159)
+               END DO
+            END DO
+         END DO
+      END IF
+
 #ifdef DM_PARALLEL
 # include "HALO_EM_INIT_1.inc"
 # include "HALO_EM_INIT_2.inc"


### PR DESCRIPTION
## DO NOT COMMIT, EXAMPLE ONLY ##

TYPE: no impact

KEYWORDS: 4d arrays

SOURCE: internal

DESCRIPTION OF CHANGES:
These mods are directed towards a user who would like to have a new 4d array that has the following qualifications:
1. Not in the lateral BC file
2. No tendency arrays auto-created
3. Not required for output
4. Physics only, column oriented, no comms, no advection or diffusion
5. Initialized either in real or WPS
6. No nesting requirement with the field
7. No restart requirements

The new registry file has the following:
1. The 4d array container and the new constituent 3d arrays listed.
2. Namelist option to activate the fields
3. Package for the allocation of the new 4d arrays

At the tail end of the real program, is an example location of where the initialization code could be located (if the information is not coming in from WPS).

Commented out is the included new registry file in the EM shared collection.

LIST OF MODIFIED FILES:
M	   Registry/registry.em_shared_collection
A	   Registry/registry.test_4d
M	   dyn_em/module_initialize_real.F

TESTS CONDUCTED:
1. Code builds
2. New fields are in the WRF input file.

New 3d constituent SINX of TEST4D
<img width="1151" alt="screen shot 2018-05-16 at 11 30 13 am" src="https://user-images.githubusercontent.com/12666234/40133801-0880444c-58fe-11e8-9a1a-04ae56de0b85.png">

New 3d constituent COSY of TEST4D
<img width="1151" alt="screen shot 2018-05-16 at 11 29 58 am" src="https://user-images.githubusercontent.com/12666234/40133850-26c14eec-58fe-11e8-89e0-30d376986137.png">

New 3d constituent TANXY of TEST4D
<img width="1151" alt="screen shot 2018-05-16 at 11 29 43 am" src="https://user-images.githubusercontent.com/12666234/40133884-34cf4cb4-58fe-11e8-8bd9-d4487ded9f9c.png">


