### PR TITLE
Fix bugs in Noah-MP introduced to accommodate more crop models

### DIFF
--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -8788,9 +8788,9 @@ END SUBROUTINE CO2FLUX_CROP
       TDIFF = TC - parameters%GDDTBASE
     END IF
 
-    GDD     = (GDD + TDIFF) * IPA * IHA
+    GDD     = (GDD + TDIFF * DT / 86400.0) * IPA * IHA
 
-    GDDDAY  = GDD / (86400.0 / DT)
+    GDDDAY  = GDD
 
    ! Decide corn growth stage, based on Hybrid-Maize 
    !   PGS = 1 : Before planting


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah-MP, crop

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

When adding new crop option to Noah-MP, a new namelist option (opt_crop) was added. Incomplete testing introduced a few bugs into the original crop options, namely
1. uninitialized flags (crop_active and dveg_active) caused strange behavior when original crop is activated
2. leaf area index was getting reset internally in subroutine phenology and then correctly output from subroutine carbon_crop so output seemed correct but internally calculated absorbed radiation was incorrect/inconsistent
3. units of growing degree days changed to [C] from [C*dt], which previously would get large in long simulations, and now makes the variable more understandable.

LIST OF MODIFIED FILES: 

M       phys/module_sf_noahmplsm.F

TESTS CONDUCTED:
1. Simulations with default options (dveg=4) and standard dynamic vegetation (dveg=5) unchanged
2. When the original crop option (opt_crop=1) is activated, results are as expected
