### PR TITLE
Fix unbalanced quote for SWDDNIC registry entry

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1441,7 +1441,7 @@ state    real  diffuse_frac     ij      misc        1         -      rd       "D
 state   real    swddir       ij     misc         1         -     rd     "SWDDIR"     "Shortwave surface downward direct irradiance" "W m-2" ""
 state   real    swddirc      ij     misc         1         -     rd     "SWDDIRC"    "Clear-sky Shortwave surface downward direct irradiance" "W m-2" ""
 state   real    swddni       ij     misc         1         -     rd     "SWDDNI"     "Shortwave surface downward direct normal irradiance" "W m-2" ""
-state   real    swddnic      ij     misc         1         -     rd     "SWDDNIC"    "Clear-sky Shortwave surface downward direct normal irradiance" "W m-2" "
+state   real    swddnic      ij     misc         1         -     rd     "SWDDNIC"    "Clear-sky Shortwave surface downward direct normal irradiance" "W m-2" ""
 state   real    swddif       ij     misc         1         -     rd     "SWDDIF"     "Shortwave surface downward diffuse irradiance" "W m-2" ""
 state   real    Gx           ij     misc         1         -     rd     "Gx" "" ""
 state   real    Bx           ij     misc         1         -     rd     "Bx" "" ""


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: registry

SOURCE: Michael Kavulich

DESCRIPTION OF CHANGES: A missing quote in the registry results in a warning message at compile time:
`Registry error: unbalanced quotes in line:`
`state   real    swddnic      ij     misc         1         -     rd     "SWDDNIC"    "Clear-sky Shortwave surface downward direct normal irradiance" "W m-2" "`

Though there does not appear to be any ill effects due to this missing quote, it should be fixed nonetheless. Properly adding the second quote eliminates the error message.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON

TESTS CONDUCTED: Compiled with this fix on Cheyenne (with Intel 17.0.1) and local Linux machine (with GNU 4.9.2), the error message no longer appears and the code compiles successfully. Did not run WTF.
