### PR TITLE
add check_a_mundo test so that LSM mosaic is not used with urban options 2 or 3

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -188,6 +188,7 @@
             wrf_err_message = '--- ERROR: mosaic option cannot work with urban options 2 and 3 '
             CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- ERROR: Fix sf_surface_mosaic and sf_urban_physics in namelist.input.'
+            CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- ERROR: Either: use Noah LSM without the mosaic option, OR change the urban option to 1 '
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1


### PR DESCRIPTION
TYPE:  no impact

KEYWORDS: check_a_mundo, mosaic and urban physics

SOURCE: internal

DESCRIPTION OF CHANGES: 
Modify module_check_a_mundo.F to make sure when using Noah LSM with urban options 2 or 3, mosaic option must be turned off.  If mosaic option is turned on, urban option should be 1.  

Test with intentionally wrong settings yields the following message:
```
 Ntasks in X            1 , ntasks in Y            1
*************************************
No physics suite selected.
Physics options will be used directly from the namelist.
*************************************
--- ERROR: mosaic option cannot work with urban options 2 and 3
--- ERROR: Either: use Noah LSM without the mosaic option, OR change the urban option to 1
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1694
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1694
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```

LIST OF MODIFIED FILES:
M       share/module_check_a_mundo.F

TESTS CONDUCTED:  no regression test is necessary;