### PR TITLE
In EM and TLADJ Registry, remove erod and o3rad from default history stream

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -172,7 +172,7 @@ state    real   umaxw          ij       dyn_em      1        X     i1  "UMAXW"  
 state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"      "U-component of the tropopause wind" "m s-1"
 state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
-state    real   erod           ij.      misc        1        -     i012rh "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
+state    real   erod           ij.      misc        1        -     i012r  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
 
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               
@@ -1063,7 +1063,7 @@ state    real   acfrcv           ij     misc        1         -      -
 state integer   ncfrcv           ij     misc        1         -      -
 
 # new rad variables
-state    real   o3rad           ikj     misc        1         -      rh        "o3rad"    "RADIATION 3D OZONE" "ppmv"
+state    real   o3rad           ikj     misc        1         -      r         "o3rad"    "RADIATION 3D OZONE" "ppmv"
 
 # incoming optical depth derived from aerosol data
 state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -

--- a/Registry/Registry.EM_COMMON.tladj
+++ b/Registry/Registry.EM_COMMON.tladj
@@ -172,7 +172,7 @@ state    real   umaxw          ij       dyn_em      1        X     i1  "UMAXW"  
 state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"      "U-component of the tropopause wind" "m s-1"
 state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
-state    real   erod           ij.      misc        1        -     i012rh "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
+state    real   erod           ij.      misc        1        -     i012r  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
 
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               
@@ -1063,7 +1063,7 @@ state    real   acfrcv           ij     misc        1         -      -
 state integer   ncfrcv           ij     misc        1         -      -
 
 # new rad variables
-state    real   o3rad           ikj     misc        1         -      rh        "o3rad"    "RADIATION 3D OZONE" "ppmv"
+state    real   o3rad           ikj     misc        1         -      r         "o3rad"    "RADIATION 3D OZONE" "ppmv"
 
 # incoming optical depth derived from aerosol data
 state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: Registry, o3rad, erod, history

SOURCE: internal

DESCRIPTION OF CHANGES:
In both the common Registry file for both EM and TLADJ, remove the "h" qualifier in the I/O portion of the state definition. This removes these two 3d arrays from the default history stream. Most of the time, the erod array is a 3d array of zeros. The o3rad is packaged correctly, but most folks don't need ozone in their diagnostic output.

LIST OF MODIFIED FILES:
M	   Registry/Registry.EM_COMMON
M	   Registry/Registry.EM_COMMON.tladj

TESTS CONDUCTED:
1. Code compiles.
2. Expected arrays are not present. Below is a sorted list of 3d arrays in the original WRF output and the new WRF output. The o3rad array is missing in the new file (what we wanted).
<img width="374" alt="screen shot 2018-05-17 at 3 19 34 pm" src="https://user-images.githubusercontent.com/12666234/40204457-d43c9e9a-59e5-11e8-9531-549122bb7ab4.png">
