### PR TITLE
fixed coefficients for calculation of PM10 and PM2.5. For GOCART aerosol scheme

### DIFF
--- a/chem/module_gocart_aerosols.F
+++ b/chem/module_gocart_aerosols.F
@@ -94,9 +94,9 @@ end subroutine gocart_aerosols_driver
          INTENT(IN ) ::                                   chem
    real d_2_5,s_2_5,d_10,sulfate
    integer i,j,k,ii,jj,n
-    d_2_5=0.286
-    s_2_5=0.942
-    d_10=0.87
+    d_2_5=0.380       ! ln(2.5/2)/ln(3.6/2)
+    s_2_5=0.834       ! ln(2.5/1)/ln(3/1)
+    d_10=0.737        ! ln(10/6)/ln(12/6)
 
 !
 ! sum up pm2_5 and pm10 output


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: GOCART, PM10, PM2.5, dust, sea salt, WRF-Chem

SOURCE: Alexander Ukhov (KAUST)

DESCRIPTION OF CHANGES: There is a procedure "sum_pm_gocart" in module_gocart_aerosols.F which calculates PM2.5 and PM10 concentrations. Contribution of the dust and sea salt bins into PM2.5 and PM10 is defined by the coefficients d_2_5, d_10 for the DUST2, DUST_4 dust bins and s_2_5 for the SEAS_2 sea salt bin. 
From the communication with the Kate Zhang (WRF-CHEM team) I found out that values of s_2_5, d_2_5, d_10 are incorrect. Probably because they were calculated for different bin range. Kate also proposed a way how to calculate the correct values "_assuming the dust mass are equally distributed in the log-scale of radius for the largest bin._".
 
The procedure is the following:
 d_2_5=ln(2.5/2) / ln(3.6/2) =0.380
 s_2_5=ln(2.5/1) / ln(3/1)     =0.834
 d_10 = ln(10/6) / ln(12/6)   =0.737

The impact of the changes might be different. For example, in my simulations of dust over Arabian Peninsula I see decrease of PM10 by 10-50 ug/m^3, which is closer to observations. In  non-dusty regions the effect will be less noticeable.


LIST OF MODIFIED FILES: 
M       chem/module_gocart_aerosols.F

TESTS CONDUCTED: Test is not needed.