### PR TITLE
Remove unnecessary message about suite usage

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1907,10 +1907,14 @@
       ! If physics suite is 'none', we can return early
       !
       IF ( trim(physics_suite_lowercase) == 'none' ) THEN
-         CALL wrf_message ('*************************************')
-         CALL wrf_message ('No physics suite selected.')
-         CALL wrf_message ('Physics options will be used directly from the namelist.')
-         CALL wrf_message ('*************************************')
+         wrf_err_message = '*************************************'
+         call wrf_debug ( 1, wrf_err_message )
+         wrf_err_message = 'No physics suite selected.'
+         call wrf_debug ( 1, wrf_err_message )
+         wrf_err_message = 'Physics options will be used directly from the namelist.'
+         call wrf_debug ( 1, wrf_err_message )
+         wrf_err_message = '*************************************'
+         call wrf_debug ( 1, wrf_err_message )
          RETURN
       END IF
 


### PR DESCRIPTION
TYPE:  no impact

KEYWORDS: check_a_mundo

SOURCE: internal

DESCRIPTION OF CHANGES: 
Modify module_check_a_mundo.F to remove an unnecessary message related to the namelist settings for the physical parameterization settings. At init, there is no need to have the model report whether the settings for physics are from a suite definition or are explicitly selected.

Before the change, we have the message 
```
Ntasks in X            1 , ntasks in Y            1
*************************************
No physics suite selected.
Physics options will be used directly from the namelist.
WRF V4.0FR#3 MODEL
*************************************
```
After the change, we have
```
 Ntasks in X            1 , ntasks in Y            1
WRF V4.0FR#3 MODEL
 *************************************
```
LIST OF MODIFIED FILES:
M       share/module_check_a_mundo.F

TESTS CONDUCTED:  
1. The code compiles and runs with the correct output.
2. No regression test is necessary
                                      