### PR TITLE
Fix bugs in initialization of Noah-MP Gecros crop model

### DIFF
--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -1735,8 +1735,11 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 ! Initialize cropcat for gecros crop model
 
 	     if(iopt_crop == 2) then
-	       cropcat    (i,j) = 1
-               if(croptype(i,1,j) > croptype(i,3,j)) cropcat(i,j) = 2 ! change to maize
+	       cropcat    (i,j) = 0
+               if(croptype(i,5,j) >= 0.5) then
+                  if(croptype(i,3,j) > 0.0)             cropcat(i,j) = 1 ! if any wheat, set to wheat
+                  if(croptype(i,1,j) > croptype(i,3,j)) cropcat(i,j) = 2 ! change to maize
+	       end if
 
                hti    = 0.01
                rdi    = 10.


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: Noah-MP, crop

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

Fix two problems with the new Noah-MP gecros crop model (opt_crop=2):

1. Model was running crop everywhere. Solution: Similar to opt_crop=1, only use when crop is >50% of grid based on input crop data

2. Model fails when running parallel due to improper indexing in initialization. Solution: move gecros crop model initialization to inside noahmp_init ij loop

LIST OF MODIFIED FILES: 

M       phys/module_sf_noahmpdrv.F

TESTS CONDUCTED:

1. 24-hour winter and summer simulations

