### PR TITLE
Fix 4dvar compilation after the force_use_old_data commit.

### DIFF
--- a/var/build/da_name_space.pl
+++ b/var/build/da_name_space.pl
@@ -193,4 +193,5 @@ wrf_get_dm_quilt_comm
 wrf_dm_nestexchange_init
 set_tiles
 wrf_get_dom_ti_integer
+is_this_data_ok_to_use
 ###########################################################################################


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, compile

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Following commit c3b4d7b, PR #512, a new subroutine name needs to be added
in da_name_space.pl to avoid name conflict for 4DVAR build with the error message:

> duplicate symbol _is_this_data_ok_to_use_ in:
>     /Volumes/sysdisk1/hclin/sugar2/hclin/git_code/myWRFV4/wrfplus/main/libwrflib.a(input_wrf.o)
>     ./libwrfvar.a(input_wrf.o)
> ld: 1 duplicate symbol for architecture x86_64
> collect2: error: ld returned 1 exit status

LIST OF MODIFIED FILES:
M       var/build/da_name_space.pl

TESTS CONDUCTED:
1. 4DVAR builds after the fix.