### PR TITLE
fix cloud fraction check in Chem, now based on cu_diag==1

### DIFF
--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -1339,7 +1339,7 @@ CALL kpp_mechanism_driver (chem,                                                
       CASE (RADM2SORG,RADM2SORG_KPP,RACMSORG_KPP,RACM_SOA_VBS_KPP,RACM_SOA_VBS_HET_KPP)
          CALL wrf_debug(15,'gocart so2-so4 conversion')
          CALL  so2so4(0,chem,p_so2,p_sulf,p_h2o2,p_QC,T_PHY,MOIST,           &
-              grid%qc_cu, grid%gd_cldfr,                                    &
+              grid%qc_cu, grid%gd_cldfr, config_flags%cu_diag,                   &
               NUM_CHEM,NUM_MOIST,                                                &
               ids,ide, jds,jde, kds,kde,                                         &
               ims,ime, jms,jme, kms,kme,                                         &
@@ -1352,7 +1352,7 @@ CALL kpp_mechanism_driver (chem,                                                
       CASE (RADM2SORG,RADM2SORG_KPP,RACMSORG_KPP,RACM_SOA_VBS_KPP,RACM_SOA_VBS_HET_KPP)
          CALL wrf_debug(15,'gocart so2-so4 conversion')
          CALL  so2so4(1,chem,p_so2,p_sulf,p_h2o2,p_QC,T_PHY,MOIST,           &
-              grid%qc_cu, grid%gd_cldfr,                                    &
+              grid%qc_cu, grid%gd_cldfr, config_flags%cu_diag,                 &
               NUM_CHEM,NUM_MOIST,                                                &
               ids,ide, jds,jde, kds,kde,                                         &
               ims,ime, jms,jme, kms,kme,                                         &
@@ -1374,7 +1374,7 @@ CALL kpp_mechanism_driver (chem,                                                
       CASE (RADM2SORG)
          CALL wrf_debug(15,'gocart so2-so4 conversion')
          CALL  so2so4(0,chem,p_so2,p_sulf,p_h2o2,p_QC,T_PHY,MOIST,           &
-              grid%qc_cu, grid%gd_cldfr,                                    &
+              grid%qc_cu, grid%gd_cldfr, config_flags%cu_diag,                 &
               NUM_CHEM,NUM_MOIST,                                                &
               ids,ide, jds,jde, kds,kde,                                         &
               ims,ime, jms,jme, kms,kme,                                         &
@@ -1387,7 +1387,7 @@ CALL kpp_mechanism_driver (chem,                                                
       CASE (RADM2SORG)
          CALL wrf_debug(15,'gocart so2-so4 conversion')
          CALL  so2so4(1,chem,p_so2,p_sulf,p_h2o2,p_QC,T_PHY,MOIST,           &
-              grid%qc_cu, grid%gd_cldfr,                                    &
+              grid%qc_cu, grid%gd_cldfr, config_flags%cu_diag,                   &
               NUM_CHEM,NUM_MOIST,                                                &
               ids,ide, jds,jde, kds,kde,                                         &
               ims,ime, jms,jme, kms,kme,                                         &
@@ -1658,7 +1658,7 @@ end if !Chemistry time step check
         if(config_flags%chem_opt == CHEM_VOLC)then
           CALL wrf_debug(15,'gocart so2-so4 conversion')
           CALL  so2so4(0,chem,p_so2,p_sulf,p_h2o2,p_QC,T_PHY,MOIST,         &
-         grid%qc_cu, grid%gd_cldfr,                                    &
+         grid%qc_cu, grid%gd_cldfr, config_flags%cu_diag,                   &
          NUM_CHEM,NUM_MOIST,                                                &
          ids,ide, jds,jde, kds,kde,                                         &
          ims,ime, jms,jme, kms,kme,                                         &

--- a/chem/module_gocart_so2so4.F
+++ b/chem/module_gocart_so2so4.F
@@ -3,16 +3,16 @@ MODULE module_gocart_so2so4
 CONTAINS
 
   subroutine so2so4(ils,chem,p_so2,p_sulf,p_h2o2,p_QC,T_PHY,MOIST,gd,          &
-          gd_cldfr,NUM_CHEM,NUM_MOIST,                                              &
-         ids,ide, jds,jde, kds,kde,                                        &
-         ims,ime, jms,jme, kms,kme,                                        &
-         its,ite, jts,jte, kts,kte                                         )
+                    gd_cldfr,gd_on, NUM_CHEM,NUM_MOIST,                        &
+                    ids,ide, jds,jde, kds,kde,                                 &
+                    ims,ime, jms,jme, kms,kme,                                 &
+                    its,ite, jts,jte, kts,kte                                  )
    INTEGER,      INTENT(IN   ) :: ils,num_chem,num_moist,                      &
-                          p_so2,p_sulf,p_h2o2,p_QC,                        &
+                                  p_so2,p_sulf,p_h2o2,p_QC,gd_on,          &
                                   ids,ide, jds,jde, kds,kde,               &
                                   ims,ime, jms,jme, kms,kme,               &
                                   its,ite, jts,jte, kts,kte
-    REAL, DIMENSION( ims:ime, kms:kme, jms:jme, num_moist ),                &
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme, num_moist ),                &
          INTENT(IN ) ::                                   moist
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme, num_chem ),                 &
          INTENT(INOUT ) ::                                   chem
@@ -27,21 +27,16 @@ CONTAINS
           do j=jts,jte
           do k=kts,kte
           do i=its,ite
-          cldf=0.
-!         if(p_qc.gt.1)then
-!            if(moist(i,k,j,p_qc).gt.0 )cldf=1.
-!         endif
-          if(ils.eq.0 .and. present(gd_cldfr) ) then
-            cldf=gd_cldfr(i,k,j)
-          elseif(p_qc.gt.1 )then
+             cldf=0.
+             if(ils.eq.0 .and. gd_on==1 ) then
+                cldf=gd_cldfr(i,k,j)
+             elseif(p_qc.gt.1 )then
                if(moist(i,k,j,p_qc).gt.0 )cldf=1.
-          endif
-          tc2=chem(i,k,j,p_so2)
-          IF (cldf > 0.0 .AND. tc2 > 0.0 .AND. t_phy(i,k,j) > 258.0) THEN
-             tc3=chem(i,k,j,p_sulf)
-             h2o2=chem(i,k,j,p_h2o2)
-!            write(0,*)'1,so2,sulf,h2o2 = ',tc2,tc3,h2o2
-          
+             endif
+             tc2=chem(i,k,j,p_so2)
+             IF (cldf > 0.0 .AND. tc2 > 0.0 .AND. t_phy(i,k,j) > 258.0) THEN
+                 tc3=chem(i,k,j,p_sulf)
+                 h2o2=chem(i,k,j,p_h2o2)
 
 ! ****************************************************************************
 ! *  Update SO2 concentration after cloud chemistry.                         *


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cu_diag, gd_cldfr, chem

SOURCE: Ravan Ahmadov(NOAA/CIRES)

DESCRIPTION OF CHANGES:
The original code had “if(ils.eq.0 .and. present(gd_cldfr) ) then”. Even if cu_diag is turned off, the “gd_cldfr” will be always “present”.

In the original code it is assumed that if cu_physics is the Grell based scheme, then 
```
cldf=gd_cldfr(i,k,j)
```
However due to the "present" statement, if the cu scheme is different or not used at all then one ends up using _uninitialized_ gd_cldfr array for cldf. This assignment causes the program to crash (as gd_cldfr is packaged) or produce meaningless results.

In the modified version, this condition checks if cu_diag==1.

LIST OF MODIFIED FILES:
M chem/chem_driver.F
M chem/module_gocart_so2so4.F

TESTS CONDUCTED:
The code compiles with KPP.
Testing WTF_v04.08 on Cheyenne.