### PR TITLE
Remove (logically incorrect) debugging prints in RUC LSM

### DIFF
--- a/phys/module_sf_ruclsm.F
+++ b/phys/module_sf_ruclsm.F
@@ -417,9 +417,6 @@ CONTAINS
              enddo
            enddo
          enddo 
-  if(ktau.eq.10 .and. ktau.eq.20 .and. ktau.eq.30) then
-   print *,'ktau, min/max rstoch',ktau,minval(rstoch(:,1,:)),maxval(rstoch(:,1,:))
-  endif
        endif  
 #endif
 !---- table TBQ is for resolution of balance equation in VILKA


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: RUC LSM, debug prints

SOURCE: internal, found by Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Remove debug print statements in RUC LSM. The way they were set up, they were never active anyways. Since they print statements were never activated (basically the IF condition was always FALSE), that is why the print statements were not easily found and removed.

LIST OF MODIFIED FILES:
M	   module_sf_ruclsm.F

TESTS CONDUCTED:
1. Just deleted lines, so no test.