### PR TITLE
Fix for GWDO option from KIAPS

### DIFF
--- a/phys/module_bl_gwdo.F
+++ b/phys/module_bl_gwdo.F
@@ -401,7 +401,7 @@ contains
      kbl(i) = max(min(kbl(i),kpblmax),kpblmin)
    enddo
 !
-! determine the level of maximum orograhpic height
+! determine the level of maximum orographic height
 !
    komax(:) = kbl(:)
 !
@@ -444,7 +444,7 @@ contains
      ol4p(4) = ol4(i,3)
      olp(i)  = ol4p(mod(nwd-1,4)+1) 
 !
-! compute orograhpic direction (horizontal orograhpic aspect ratio)
+! compute orographic direction (horizontal orographic aspect ratio)
 !
      od(i) = olp(i)/max(ol(i),olmin)
      od(i) = min(od(i),odmax)


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: Gravity-wave drag, gwd_opt=1

SOURCE: Hyun-Joo Choi (KIAPS)

DESCRIPTION OF CHANGES: 
Most of the changes are just clean-up, but some are to reduce excessive orographic stress in
unstable conditions in response to comments by Michael Toy (ESRL).
Details quoted from developer
_The main scientific modification is to reduce the excessive orographic stress in unstable conditions, which was pointed out by Dr. Toy.
For this, we removed the minimum threshold of N2 (i.e., the removal of line 511 in the original code: bnv2(i,k) = max(bnv2(i,k), bnv2min )).

In this way, the GW stresses are not calculated when the averaged N2 below the reference level is less than 0 by the coding (ldrag(i) = ldrag(i) .or. bnv2(i,1).le.0.0), where bnv2(i,1) is the averaged N2 below the reference level. 
Note that the minimum threshold of N2  is still needed in the levels above the reference level for a numerical reason (i.e., line 645 in the original code).
We also modified the reference level (max(2σ,hpbl)) into 2σ, where σ is the standard deviation of subgrid orography and hpbl is the PBL height._


LIST OF MODIFIED FILES: 
M       phys/module_bl_gwdo.F

TESTS CONDUCTED: 
WTF passed
Differences in U10 show reduced drag in mountain areas. Main difference is at surface.
<img width="1200" alt="screen shot 2018-05-22 at 10 22 03 am" src="https://user-images.githubusercontent.com/17932284/40375858-0857fc16-5daa-11e8-87cd-0a3730de5088.png">
