### PR TITLE
Detect pre-v4.0 IC for WRF if attempting to set use_theta_m=1

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -48,7 +48,7 @@
     Type(WRFU_Time) time, currtime, currentTime
     CHARACTER*19  new_date
     CHARACTER*24  base_date
-    CHARACTER*256  fname
+    CHARACTER*256  fname, version_name
     CHARACTER*80  dname, memord, sim_type
     LOGICAL dryrun
     INTEGER idt
@@ -1010,6 +1010,35 @@
           CALL wrf_debug( 0 , wrf_err_message )
         END IF
        END IF
+
+       !  In pre v4.0 data, the moist potential temperature was entirely handled in the model. In 
+       !  v4.0 and later, the pre-processors handle the moist potential temperature field directly.
+
+       !                      Input from old data
+       !     
+       !                        WRF NML Setting
+       !                        ---------------
+       !                  use_theta_m=1 | use_theta_m=0
+       !                  ---------------------------
+       !                  |             |           | 
+       !         thetam=1 |   NO        |     OK    |
+       ! Input            |             |           | 
+       ! NML     ------------------------------------
+       ! Setting          |             |           |
+       !         thetam=0 |   NO        |     OK    |
+       !                  |             |           |
+       !                  ---------------------------
+
+       !  Old input data cannot be used when the namelist has use_theta_m=1
+
+       CALL wrf_get_dom_ti_char ( fid , 'TITLE' , version_name , ierr )
+       IF ( ( switch .EQ. input_only ) .AND. &
+            ( INDEX(TRIM(version_name),' V4.' ) .EQ. 0 ) .AND. &
+            ( config_flags%use_theta_m .EQ. 1 ) ) THEN
+          CALL wrf_debug ( 0, "---- ERROR: Cannot have old input data when requesting use_theta_m=1" )
+          count_fatal_error = count_fatal_error + 1
+       END IF
+     
 #endif
 
     ENDIF check_if_dryrun


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: use_theta_m, old IC/BC

SOURCE: internal

DESCRIPTION OF CHANGES:
In input_wrf, check three conditions:
1. this is a standard wrfinput stream
2. the metadata indicates this is pre v4.0
3. the namelist has use_theta_m=1

If all three are true, then the program gracefully exits.

This mod is required to be in input_wrf (not check_a_mundo) since the metadata needs to be used (TITLE to determine if the IC file is pre-v4.0), and metadata is not available in WRF by the time check_a_mundo is called.

This mod is contained within an EM_CORE==1 ifdef.

LIST OF MODIFIED FILES:
M	   share/input_wrf.F

TESTS CONDUCTED:
Testing is conducted to mimic the IF test inside of input_wrf.

|   | WRF use_theta_m=1 | WRF use_theta_m=0 |
| --- |  ---  | --- |
| **IC use_theta_m=1** | FAIL | OK |
| **IC use_theta_m=0** | FAIL | OK |

Four tests were conducted using a 12-h Jan 2000 nested case. The two input IC/BC files sets were both generated from v3.8.1. One set of IC/BC files set use_theta_m=0, and the other had use_theta_m=1 in the namelist.input file. These two data sets were each used with v4.0 WRF. A script ran all four tests (two input files, each run with v4.0 WRF with two namelist settings for use_theta_m), editing namelists and swapping IC/BC files as appropriate.
```
WRF use_theta_m = 1, ICBC use_theta_m = 0
     Looks like v4.0 WRF use_theta_m = 1, v381 ICBC use_theta_m = 0 FAILED

WRF use_theta_m = 1, ICBC use_theta_m = 1
     Looks like v4.0 WRF use_theta_m = 1, v381 ICBC use_theta_m = 1 FAILED

WRF use_theta_m = 0, ICBC use_theta_m = 0
     Looks like v4.0 WRF use_theta_m = 0, v381 ICBC use_theta_m = 0 PASSED

WRF use_theta_m = 0, ICBC use_theta_m = 1
     Looks like v4.0 WRF use_theta_m = 0, v381 ICBC use_theta_m = 1 PASSED
```

This behavior is expected, as regardless of the setting of use_theta_m in the v3.8.1 data, the IC/BC files are not impacted. With v4.0, the initialization routines provide both dry and moist theta. If the v4.0 WRF model tries to use moist theta, v4.0 data is required. Since the IC/BC files are not impacted, the simulations of v4.0 WRF (dry, use_theta_m=0) with the two different IC/BC files should be (and are) identical.

For the two cases that gracefully fail, here is the output error message:
```
  ---- ERROR: Cannot have old input data when requesting use_theta_m=1
NOTE:       1 namelist vs input data inconsistencies found.
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1201
NOTE:  Please check and reset these options
-------------------------------------------
```

For the two cases that work, shown is the 12-h RAINC.

v4.0 WRF with use_theta_=0, v3.8.1 IC/BC with use_theta_m=0
<img width="1045" alt="screen shot 2018-05-22 at 10 31 37 am" src="https://user-images.githubusercontent.com/12666234/40376458-a0edb79e-5dab-11e8-9415-222ebb2cd9b9.png">

v4.0 WRF with use_theta_=0, v3.8.1 IC/BC with use_theta_m=1
<img width="1047" alt="screen shot 2018-05-22 at 10 32 20 am" src="https://user-images.githubusercontent.com/12666234/40376471-a94b1468-5dab-11e8-83b7-2749ae13ef01.png">

