### PR TITLE
ARW new feature consistency check between real and wrf: HVC and moist theta

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -48,12 +48,13 @@
     Type(WRFU_Time) time, currtime, currentTime
     CHARACTER*19  new_date
     CHARACTER*24  base_date
-    CHARACTER*256  fname
+    CHARACTER*256  fname, version_name
     CHARACTER*80  dname, memord, sim_type
     LOGICAL dryrun
     INTEGER idt
     INTEGER itmp
     INTEGER filestate, ierr3
+    INTEGER hybrid_opt, use_theta_m
     INTEGER :: ide_compare , jde_compare , kde_compare
     CHARACTER (len=19) simulation_start_date , first_date_input , first_date_nml
     INTEGER first_date_start_year   , &
@@ -174,6 +175,42 @@
           WRITE(wrf_err_message,*)'Whoa there pard, there are troubles with this data. It might be too old.'
           CALL wrf_error_fatal( wrf_err_message )
        END IF
+    END IF
+#endif
+
+#if ( NMM_CORE != 1 )
+    ! Verify feature consistency between model input and model nml settings
+
+    IF ( .NOT. dryrun ) THEN
+
+      IF ( switch .EQ. input_only ) THEN
+        CALL wrf_get_dom_ti_char ( fid , 'TITLE' , version_name, ierr )
+
+        IF ( INDEX(TRIM(version_name),' V4.') .NE. 0 ) THEN
+          CALL wrf_get_dom_ti_integer( fid , 'HYBRID_OPT',  hybrid_opt,  1, icnt, ierr )
+          CALL wrf_get_dom_ti_integer( fid , 'USE_THETA_M', use_theta_m, 1, icnt, ierr )
+
+          IF ( hybrid_opt .NE. config_flags%hybrid_opt ) THEN
+            WRITE(wrf_err_message,*) '---- ERROR: Input file hybrid_opt = ',hybrid_opt
+            CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+            WRITE(wrf_err_message,*) '---- ERROR: Namelist hybrid_opt   = ',config_flags%hybrid_opt
+            CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+            CALL wrf_debug ( 0, "---- ERROR: hybrid_opt values must be consistent" )
+            count_fatal_error = count_fatal_error + 1
+          END IF
+
+          IF ( use_theta_m .NE. config_flags%use_theta_m ) THEN
+            WRITE(wrf_err_message,*) '---- ERROR: Input file use_theta_m = ',use_theta_m
+            CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+            WRITE(wrf_err_message,*) '---- ERROR: Namelist use_theta_m   = ',config_flags%use_theta_m
+            CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+            CALL wrf_debug ( 0, "---- ERROR: use_theta_m values must be consistent" )
+            count_fatal_error = count_fatal_error + 1
+          END IF
+
+        END IF
+
+      END IF
     END IF
 #endif
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: consistency, namelist, hybrid, theta_m

SOURCE: internal

DESCRIPTION OF CHANGES:
In the first routine where the metadata and the namelist values exist so as to allow value comparison, check whether the new features of v4.0 (use_theta_m and hybrid_opt) are set the same between the real program and the WRF model. If an inconsistency exists, flag the discrepancy for a graceful exit. Only tested for non NMM builds.

This mod fixes the existing bug that allows inconsistent IC/BC data to be used by the model. The moist theta issue causes bad results in areas of higher moisture, but the WRF model will usually run to completion. The HVC inconsistency is typically more serious, causing the model to stop after 10-100 time steps. Neither would be easy to figure out what actually happened.

LIST OF MODIFIED FILES:
M	   share/input_wrf.F

TESTS CONDUCTED:
1. Real program has options turned off, WRF has them turned on:
```
   Input data is acceptable to use: wrfinput_d01
   ---- ERROR: Input file hybrid_opt =            0
   ---- ERROR: Namelist hybrid_opt   =            2
  ---- ERROR: hybrid_opt values must be consistent
   ---- ERROR: Input file use_theta_m =            0
   ---- ERROR: Namelist use_theta_m   =            1
  ---- ERROR: use_theta_m values must be consistent
NOTE:       2 namelist vs input data inconsistencies found.
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1207
NOTE:  Please check and reset these options
-------------------------------------------
```

2. Real program has options turned on, WRF has them turned off:
```
   Input data is acceptable to use: wrfinput_d01
   ---- ERROR: Input file hybrid_opt =            2
   ---- ERROR: Namelist hybrid_opt   =            0
  ---- ERROR: hybrid_opt values must be consistent
   ---- ERROR: Input file use_theta_m =            1
   ---- ERROR: Namelist use_theta_m   =            0
  ---- ERROR: use_theta_m values must be consistent
NOTE:       2 namelist vs input data inconsistencies found.
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1207
NOTE:  Please check and reset these options
-------------------------------------------
```