### PR TITLE
README.namelist modifications (since V3.9.1.1)

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1233,7 +1233,7 @@ Options for use with the Noah-MP Land Surface Model:
  io_form_sgfdda                      = 2        ; sfc analysis data io format (2 = netCDF)
  guv_sfc (max_dom)                   = 0.0003   ; nudging coefficient for sfc u and v (sec-1)
  gt_sfc (max_dom)                    = 0.0003   ; nudging coefficient for sfc temp (sec-1)
- gq_sfc (max_dom)                    = 0.0003   ; nudging coefficient for sfc qvapor (sec-1)
+ gq_sfc (max_dom)                    = 0.00001  ; nudging coefficient for sfc qvapor (sec-1)
  rinblw (max_dom)                    = 0.       ; radius of influence used to determine the confidence (or weights) for
                                                   the analysis, which is based on the distance between the grid point to the nearest
                                                   obs. The analysis without nearby observation is used at a reduced weight.


### PR DESCRIPTION
TYPE: text only

KEYWORDS: README.namelist, V4.0, namelist, registry

SOURCE: internal

DESCRIPTION OF CHANGES: 
1. Included namelist variables that have been added to the registry files since V3.9.1.1 (or possibly before) to README.namelist in preparation for the V4.0 release. 
2. Removed the section regarding how to build the hybrid vertical coordinate for V3.9. There will be a separate README file associated with the HVC.
3. Per developers request, changed default coefficient value of gq_sfc from 0.0003 to 0.00001

LIST OF MODIFIED FILES: 
M     run/README.namelist

TESTS CONDUCTED: no tests necessary - text only.
