### PR TITLE
Fix index bounds error in ARW real when using SSIB LSM

### DIFF
--- a/share/module_soil_pre.F
+++ b/share/module_soil_pre.F
@@ -849,14 +849,14 @@ print *,'WATER CHANGE = ',change_water
                                  ids , ide , jds , jde , kds , kde , &
                                  ims , ime , jms , jme , kms , kme , &
                                  its , ite , jts , jte , kts , kte )
-      ELSE IF ( ( sf_surface_physics .EQ. 8 ) .AND. ( num_soil_layers .GT. 1 ) ) THEN
+      ELSE IF ( ( sf_surface_physics .EQ. SSIBSCHEME ) .AND. ( num_soil_layers .GT. 1 ) ) THEN
          CALL init_soil_depth_8 ( zs , dzs , num_soil_layers )
-         CALL init_soil_3_real ( tsk , tmn , smois , tslb , &
-                                 st_input , sm_input , landmask , sst , &
+         CALL init_soil_2_real ( tsk , tmn , smois , sh2o , tslb , &
+                                 st_input , sm_input , sw_input , landmask , sst , &
                                  zs , dzs , &
-                                 st_levels_input , sm_levels_input , &
-                                 num_soil_layers , num_st_levels_input , num_sm_levels_input , &
-                                 num_st_levels_alloc , num_sm_levels_alloc , &
+                                 st_levels_input , sm_levels_input , sw_levels_input , &
+                                 num_soil_layers , num_st_levels_input , num_sm_levels_input , num_sw_levels_input , &
+                                 num_st_levels_alloc , num_sm_levels_alloc , num_sw_levels_alloc , &
                                  flag_sst , flag_soil_layers , flag_soil_levels , &
                                  ids , ide , jds , jde , kds , kde , &
                                  ims , ime , jms , jme , kms , kme , &
@@ -1271,11 +1271,13 @@ cycle
 
       REAL, DIMENSION(1:num_soil_layers), INTENT(OUT)  ::  zs,dzs
 
-      INTEGER                   ::      l
-
       zs(1) = 0.00
       zs(2) = 0.05
       zs(3) = 1.05
+
+      dzs(1) = 0.05
+      dzs(2) = 1.00
+      dzs(3) = 0.00
 
    END SUBROUTINE init_soil_depth_8
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: SSIB, bounds error, LSM, real

SOURCE: internal

DESCRIPTION OF CHANGES:
Using a different but already existing vertical interpolation option (the one used for both Noah and NoahMP). As with the rest of the vertical interpolation options for soil temperature and moisture in this part of the code, pass in the requested soil levels and the first guess soil temp/moisture. Get the returned the soil temp/moisture vertically interpolated to the new requested levels.

LIST OF MODIFIED FILES:
M          share/module_soil_pre.F

TESTS CONDUCTED:
1. Before this mod, the code could not pass a bounds check in real ARW.
```
&physics
sf_surface_physics    = 8
num_soil_layers       = 3 ! 4, 5, 6 also fail
/
```
With several values for the number of soil levels, most efforts resulted in the following message:
```
At line 1955 of file module_soil_pre.f90
Fortran runtime error: Index '5' of dimension 1 of array 'zhave' above upper bound of 4
```
The source code at that location:
```
1954          DO l = 1 , num_st_levels_input
1955             zhave(l+1) = st_levels_input(l) / 100.
1956          END DO
```

2. With this mod, the real program runs just fine.

3. Algebra is not entirely appropriate in a PR. However, given the requested soil depth values (ZS), the input soil temperatures from the metgrid program (ST), and their locations below ground, 7 digits of precision are in agreement between the output from real and what algorithmically should be produced.

