### PR TITLE
More understandable message to user about using old input data with v4

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -172,7 +172,12 @@
        ELSE
           CALL wrf_debug( 0 , 'File name that is causing troubles = ' // TRIM(fname) )
           CALL wrf_debug( 0 , TRIM(fname) )
-          WRITE(wrf_err_message,*)'Whoa there pard, there are troubles with this data. It might be too old.'
+          CALL wrf_debug( 0 , TRIM(wrf_err_message) )
+          WRITE(wrf_err_message,*)'You can try 1) ensure that the input file was created with WRF v4 pre-processors, or '
+          CALL wrf_debug( 0 , TRIM(wrf_err_message) )
+          WRITE(wrf_err_message,*)'2) use force_use_old_data=T in the time_control record of the namelist.input file'
+          CALL wrf_debug( 0 , TRIM(wrf_err_message) )
+          WRITE(wrf_err_message,*)'---- ERROR: The input file appears to be from a pre-v4 version of WRF initialization routines'
           CALL wrf_error_fatal( wrf_err_message )
        END IF
     END IF


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: input, v4

SOURCE: internal

DESCRIPTION OF CHANGES:
Replace existing message with one that indicates the problem is with old data. Give the user a couple of options:
1. use new data
2. try the force_use_old_data=T switch

ISSUES RESOLVED:
Fixes #559 

LIST OF MODIFIED FILES:
M	   share/input_wrf.F

TESTS CONDUCTED:
1. Using v4 data with v4 source code, A-OK
```
   Input data is acceptable to use: wrfinput_d01
d01 2000-01-24_12:00:00  Input data is acceptable to use: wrfbdy_d01
Timing for processing lateral boundary for domain        1:    0.00676 elapsed seconds
Timing for main: time 2000-01-24_12:03:00 on domain   1:    4.62356 elapsed seconds
d01 2000-01-24_12:03:00 wrf: SUCCESS COMPLETE WRF
```

2. Using v3.8.1 data with v4 source code, controlled exit.
```
   This input data is not V4:  OUTPUT FROM REAL_EM V3.8.1 PREPROCESSOR
  File name that is causing troubles = wrfinput_d01
  wrfinput_d01
   This input data is not V4:  OUTPUT FROM REAL_EM V3.8.1 PREPROCESSOR
   You can try 1) ensure that the input file was created with WRF v4 pre-processors, or
   2) use force_use_old_data=T in the time_control record of the namelist.input file
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     324
 ---- ERROR: The input file appears to be from a pre-v4 version of WRF initialization routines
-------------------------------------------
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     324
 ---- ERROR: The input file appears to be from a pre-v4 version of WRF initialization routines
-------------------------------------------
```

3. Using v3.8.1 data with force_use_old_data + trying HVC and moist theta, controlled exit
```
   This input data is not V4:  OUTPUT FROM REAL_EM V3.8.1 PREPROCESSOR
   Input data is acceptable to use: wrfinput_d01
  ---- ERROR: Cannot have old input data when requesting use_theta_m=1
NOTE:       1 namelist vs input data inconsistencies found.
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1241
NOTE:  Please check and reset these options
-------------------------------------------
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1241
NOTE:  Please check and reset these options
-------------------------------------------
```

4. Using v3.8.1 with force_use_old_data, A-OK
```
   This input data is not V4:  OUTPUT FROM REAL_EM V3.8.1 PREPROCESSOR
   Input data is acceptable to use: wrfinput_d01
  ---- WARNING : Maybe old non-HVC input, setting default 1d array values for TF
  ---- WARNING : Older v3 input data detected
d01 2000-01-24_12:00:00  This input data is not V4:  OUTPUT FROM REAL_EM V3.8.1 PREPROCESSOR
d01 2000-01-24_12:00:00  Input data is acceptable to use: wrfbdy_d01
Timing for main: time 2000-01-24_12:03:00 on domain   1:    4.59791 elapsed seconds
d01 2000-01-24_12:03:00 wrf: SUCCESS COMPLETE WRF
```