### PR TITLE
Update em_real namelists: e_vert=30 ==> e_vert=33, required after default stretching

### DIFF
--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -30,7 +30,7 @@
  max_dom                             = 1,
  e_we                                = 74,    112,   94,
  e_sn                                = 61,    97,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.diags
+++ b/test/em_real/namelist.input.diags
@@ -41,7 +41,7 @@
  max_dom                             = 2,
  e_we                                = 74,    31,    94,
  e_sn                                = 61,    31,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.jan00
+++ b/test/em_real/namelist.input.jan00
@@ -30,7 +30,7 @@
  max_dom                             = 1,
  e_we                                = 74,    112,   94,
  e_sn                                = 61,    97,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.jun01
+++ b/test/em_real/namelist.input.jun01
@@ -30,7 +30,7 @@
  max_dom                             = 1,
  e_we                                = 91,    112,   94,
  e_sn                                = 82,    97,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.ndown_1
+++ b/test/em_real/namelist.input.ndown_1
@@ -41,7 +41,7 @@
  max_dom                             = 1,
  e_we                                = 74,    31,    94,
  e_sn                                = 61,    31,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.ndown_2
+++ b/test/em_real/namelist.input.ndown_2
@@ -43,7 +43,7 @@
  max_dom                             = 2,
  e_we                                = 74,    31,    94,
  e_sn                                = 61,    31,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.ndown_3
+++ b/test/em_real/namelist.input.ndown_3
@@ -43,7 +43,7 @@
  max_dom                             = 1,
  e_we                                =        31,    94,
  e_sn                                =        31,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,

--- a/test/em_real/namelist.input.volc
+++ b/test/em_real/namelist.input.volc
@@ -30,7 +30,7 @@
  max_dom                             = 1,
  e_we                                = 74,    112,   94,
  e_sn                                = 61,    97,    91,
- e_vert                              = 30,    30,    30,
+ e_vert                              = 33,    33,    33,
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 27,
  num_metgrid_soil_levels             = 4,


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: em_real, e_vert

SOURCE: internal

DESCRIPTION OF CHANGES:
All test/em_real/namelist.input* files that had e_vert=30 now have e_vert=33. Due to the default (smoother) transition of the eta levels, more vertical levels are required to get up to the model lid while keeping the maximum thickness < 1 km.

ISSUES RESOLVED:
Fixes #557 

LIST OF MODIFIED FILES:
M	   namelist.input
M	   namelist.input.diags
M	   namelist.input.jan00
M	   namelist.input.jun01
M	   namelist.input.ndown_1
M	   namelist.input.ndown_2
M	   namelist.input.ndown_3
M	   namelist.input.volc

TESTS CONDUCTED:
1. Values automatically modified.
```
> foreach f ( `grep -E 'e_vert.*=.*30' namelist.input* | cut -d":" -f1` )
  sed -e '/e_vert/s/30/33/g' $f > .foo
  mv .foo $f
end
```

2. Diffs of the namelist.input files look OK.