### PR TITLE
Remove num_soil_layers from all test/em_*/namelist.input* files - no longer required

### DIFF
--- a/test/em_b_wave/namelist.input
+++ b/test/em_b_wave/namelist.input
@@ -60,7 +60,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_b_wave/namelist.input.backwards
+++ b/test/em_b_wave/namelist.input.backwards
@@ -60,7 +60,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -60,7 +60,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
  /

--- a/test/em_esmf_exp/namelist.input.jan00.ESMFSST
+++ b/test/em_esmf_exp/namelist.input.jan00.ESMFSST
@@ -75,7 +75,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 1,
- num_soil_layers                     = 4,
  sf_urban_physics                    = 0,
  maxiens                             = 1,
  maxens                              = 3,

--- a/test/em_esmf_exp/namelist.input.jan00.NETCDFSST
+++ b/test/em_esmf_exp/namelist.input.jan00.NETCDFSST
@@ -75,7 +75,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 1,
- num_soil_layers                     = 4,
  sf_urban_physics                    = 0,
  maxiens                             = 1,
  maxens                              = 3,

--- a/test/em_fire/namelist.input_hill_simple
+++ b/test/em_fire/namelist.input_hill_simple
@@ -64,7 +64,6 @@
  isfflx                              = 1,
  ifsnow                              = 0,
  icloud                              = 0,
- num_soil_layers                     = 5,
  mp_zero_out                         = 0,
  /
 

--- a/test/em_fire/namelist.input_two_fires
+++ b/test/em_fire/namelist.input_two_fires
@@ -65,7 +65,6 @@
  isfflx                              = 1,
  ifsnow                              = 0,
  icloud                              = 0,
- num_soil_layers                     = 5,
  mp_zero_out                         = 0,
  /
 

--- a/test/em_grav2d_x/namelist.input
+++ b/test/em_grav2d_x/namelist.input
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_grav2d_x/namelist.input.100m
+++ b/test/em_grav2d_x/namelist.input.100m
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_grav2d_x/namelist.input.200m
+++ b/test/em_grav2d_x/namelist.input.200m
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_grav2d_x/namelist.input.400m
+++ b/test/em_grav2d_x/namelist.input.400m
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_heldsuarez/namelist.input
+++ b/test/em_heldsuarez/namelist.input
@@ -60,7 +60,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
+++ b/test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
@@ -53,7 +53,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
+++ b/test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
@@ -53,7 +53,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_hill2d_x/extras/namelist.input-HILL
+++ b/test/em_hill2d_x/extras/namelist.input-HILL
@@ -53,7 +53,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_hill2d_x/extras/namelist.input-HILL-51
+++ b/test/em_hill2d_x/extras/namelist.input-HILL-51
@@ -53,7 +53,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_hill2d_x/extras/namelist.input-HILL-schar
+++ b/test/em_hill2d_x/extras/namelist.input-HILL-schar
@@ -53,7 +53,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_hill2d_x/namelist.input
+++ b/test/em_hill2d_x/namelist.input
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_les/namelist.input
+++ b/test/em_les/namelist.input
@@ -62,7 +62,6 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 0,     0,     0,
  isfflx                              = 2,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_les/namelist.input.SGP
+++ b/test/em_les/namelist.input.SGP
@@ -71,7 +71,6 @@
  isfflx                              = 1,
  ifsnow                              = 0,
  icloud                              = 1,
- num_soil_layers                     = 5,
  mp_zero_out                         = 0,
  /
 

--- a/test/em_les/namelist.input_shalconv
+++ b/test/em_les/namelist.input_shalconv
@@ -63,7 +63,6 @@
  cudt                                = 0,     0,     0,
  isfflx                              = 1,
  ideal_xland                         = 2,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_quarter_ss/namelist.input
+++ b/test/em_quarter_ss/namelist.input
@@ -60,7 +60,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_quarter_ss/namelist.input_2to1
+++ b/test/em_quarter_ss/namelist.input_2to1
@@ -61,7 +61,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_quarter_ss/namelist.input_3to1
+++ b/test/em_quarter_ss/namelist.input_3to1
@@ -61,7 +61,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_quarter_ss/namelist.input_4to1
+++ b/test/em_quarter_ss/namelist.input_4to1
@@ -61,7 +61,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_quarter_ss/namelist.input_5to1
+++ b/test/em_quarter_ss/namelist.input_5to1
@@ -61,7 +61,6 @@
  bldt                                = 0,     0,     0,
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -59,7 +59,6 @@
  bldt                                = 0,     0,     0,
  cudt                                = 5,     5,     5,
  icloud                              = 1,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  /

--- a/test/em_real/namelist.input.4km
+++ b/test/em_real/namelist.input.4km
@@ -59,7 +59,6 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 0,     0,     0,
  icloud                              = 1,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  /

--- a/test/em_real/namelist.input.chem
+++ b/test/em_real/namelist.input.chem
@@ -66,7 +66,6 @@
  ifsnow                              = 1,
  icloud                              = 1,
  surface_input_source                = 3,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  maxiens                             = 1,

--- a/test/em_real/namelist.input.diags
+++ b/test/em_real/namelist.input.diags
@@ -72,7 +72,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 3,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  maxiens                             = 1,

--- a/test/em_real/namelist.input.fire
+++ b/test/em_real/namelist.input.fire
@@ -61,7 +61,6 @@
  cu_physics                          = 1,
  cudt                                = 5,
  surface_input_source                = 3,
- num_soil_layers                     = 5,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,
  /

--- a/test/em_real/namelist.input.global
+++ b/test/em_real/namelist.input.global
@@ -59,7 +59,6 @@
  cu_physics                          = 16,   16,     0,
  cudt                                = 0,     0,     0,
  icloud                              = 1,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  /
 

--- a/test/em_real/namelist.input.jan00
+++ b/test/em_real/namelist.input.jan00
@@ -59,7 +59,6 @@
  cudt                                = 5,     5,     5,
  icloud                              = 1,
  cu_rad_feedback                     = .true.,.true.,.false.,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  /

--- a/test/em_real/namelist.input.jun01
+++ b/test/em_real/namelist.input.jun01
@@ -59,7 +59,6 @@
  cudt                                = 5,     5,     5,
  icloud                              = 1,
  cu_rad_feedback                     = .true.,.false.,.f.,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  /

--- a/test/em_real/namelist.input.ndown_1
+++ b/test/em_real/namelist.input.ndown_1
@@ -72,7 +72,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 3,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  maxiens                             = 1,

--- a/test/em_real/namelist.input.ndown_2
+++ b/test/em_real/namelist.input.ndown_2
@@ -74,7 +74,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 3,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  maxiens                             = 1,

--- a/test/em_real/namelist.input.ndown_3
+++ b/test/em_real/namelist.input.ndown_3
@@ -74,7 +74,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 3,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  maxiens                             = 1,

--- a/test/em_real/namelist.input.pbl-les
+++ b/test/em_real/namelist.input.pbl-les
@@ -63,7 +63,6 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 0,     0,     0,
  icloud                              = 1,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  /

--- a/test/em_real/namelist.input.volc
+++ b/test/em_real/namelist.input.volc
@@ -61,7 +61,6 @@
  ifsnow                              = 0,
  icloud                              = 1,
  surface_input_source                = 3,
- num_soil_layers                     = 4,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  maxiens                             = 1,

--- a/test/em_scm_xy/namelist.input
+++ b/test/em_scm_xy/namelist.input
@@ -70,7 +70,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 4,
  /
 
  &dynamics

--- a/test/em_seabreeze2d_x/namelist.input
+++ b/test/em_seabreeze2d_x/namelist.input
@@ -61,7 +61,6 @@
  tracer_pblmix                       = 1
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_seabreeze2d_x/namelist.input.windfarm
+++ b/test/em_seabreeze2d_x/namelist.input.windfarm
@@ -62,7 +62,6 @@
  tracer_pblmix                       = 1
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  windfarm_opt                        = 1,
  windfarm_ij                         = 1,
  /

--- a/test/em_squall2d_x/namelist.input
+++ b/test/em_squall2d_x/namelist.input
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_squall2d_y/namelist.input
+++ b/test/em_squall2d_y/namelist.input
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  /
 
  &fdda

--- a/test/em_tropical_cyclone/namelist.input
+++ b/test/em_tropical_cyclone/namelist.input
@@ -52,7 +52,6 @@
  bldt                                = 0,
  cu_physics                          = 0,
  cudt                                = 0,
- num_soil_layers                     = 5,
  isftcflx                            = 1,
  /
 


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: namelist.input, num_soil_layers

SOURCE: internal

DESCRIPTION OF CHANGES:
Remove the num_soil_layers entry in all em_* namelist.input* files. This is redundant information. The sf_surface_physics provides sufficient information to determine the num_soil_layers in ALMOST all cases.

Since the RUC LSM scheme allows either 6 or 9 levels, the user may specify which is preferred. If there is no entry for num_soil_layers, for the RUC scheme, the code defaults to num_soil_layers=6.

LIST OF MODIFIED FILES:
M	   test/em_b_wave/namelist.input
M	   test/em_b_wave/namelist.input.backwards
M	   test/em_convrad/namelist.input
M	   test/em_esmf_exp/namelist.input.jan00.ESMFSST
M	   test/em_esmf_exp/namelist.input.jan00.NETCDFSST
M	   test/em_fire/namelist.input_hill_simple
M	   test/em_fire/namelist.input_two_fires
M	   test/em_grav2d_x/namelist.input
M	   test/em_grav2d_x/namelist.input.100m
M	   test/em_grav2d_x/namelist.input.200m
M	   test/em_grav2d_x/namelist.input.400m
M	   test/em_heldsuarez/namelist.input
M	   test/em_hill2d_x/extras/namelist.input-100m_hill-10mps-N^2=0.0001-30km_deep-20km_damping-dampcoef=0.1-etac=0.2
M	   test/em_hill2d_x/extras/namelist.input-700m_hill-15mps-n^2=0.0001-25km_deep-15km_damping-dampcoef=0.08-etac=0.2
M	   test/em_hill2d_x/extras/namelist.input-HILL
M	   test/em_hill2d_x/extras/namelist.input-HILL-51
M	   test/em_hill2d_x/extras/namelist.input-HILL-schar
M	   test/em_hill2d_x/namelist.input
M	   test/em_les/namelist.input
M	   test/em_les/namelist.input.SGP
M	   test/em_les/namelist.input_shalconv
M	   test/em_quarter_ss/namelist.input
M	   test/em_quarter_ss/namelist.input_2to1
M	   test/em_quarter_ss/namelist.input_3to1
M	   test/em_quarter_ss/namelist.input_4to1
M	   test/em_quarter_ss/namelist.input_5to1
M	   test/em_real/namelist.input
M	   test/em_real/namelist.input.4km
M	   test/em_real/namelist.input.chem
M	   test/em_real/namelist.input.diags
M	   test/em_real/namelist.input.fire
M	   test/em_real/namelist.input.global
M	   test/em_real/namelist.input.jan00
M	   test/em_real/namelist.input.jun01
M	   test/em_real/namelist.input.ndown_1
M	   test/em_real/namelist.input.ndown_2
M	   test/em_real/namelist.input.ndown_3
M	   test/em_real/namelist.input.pbl-les
M	   test/em_real/namelist.input.volc
M	   test/em_scm_xy/namelist.input
M	   test/em_seabreeze2d_x/namelist.input
M	   test/em_seabreeze2d_x/namelist.input.windfarm
M	   test/em_squall2d_x/namelist.input
M	   test/em_squall2d_y/namelist.input
M	   test/em_tropical_cyclone/namelist.input

TESTS CONDUCTED: 
1. No changes to source code.
