### PR TITLE
WPS removed SLOPECAT field, so also remove it from real and WRF, for both ARW and NMM

### DIFF
--- a/Registry/Registry.CONVERT
+++ b/Registry/Registry.CONVERT
@@ -446,7 +446,6 @@ state   real   slp_azi             ij    misc          1     -     rdu     "SLP_
 state   real   shdmax              ij    misc          1     -     -   "SHDMAX"        "ANNUAL MAX VEG FRACTION" ""
 state   real   shdmin              ij    misc          1     -     -   "SHDMIN"        "ANNUAL MIN VEG FRACTION" ""
 state   real   snoalb              ij    misc          1     -     -   "SNOALB"        "ANNUAL MAX SNOW ALBEDO IN FRACTION" ""
-state   real   slopecat            ij    misc          1     -     i12     "SLOPECAT"      "SLOPE CATEGORY"  ""
 state   real   toposoil            ij    misc          1     -     i12     "SOILHGT"       "ELEVATION OF LSM DATA"  "m"
 state   real   landusef            iuj   misc          1     Z     i12     "LANDUSEF"      "LANDUSE FRACTION BY CATEGORY"  ""
 state   real   soilctop            isj   misc          1     Z     i12     "SOILCTOP"      "SOIL CAT FRACTION (TOP)"  ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -658,7 +658,6 @@ state   real   slp_azi             ij    misc          1     -     rdu     "SLP_
 state   real   shdmax              ij    misc          1     -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SHDMAX"        "ANNUAL MAX VEG FRACTION" ""
 state   real   shdmin              ij    misc          1     -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SHDMIN"        "ANNUAL MIN VEG FRACTION" ""
 state   real   snoalb              ij    misc          1     -     i012rh  "SNOALB"        "ANNUAL MAX SNOW ALBEDO IN FRACTION" ""
-state   real   slopecat            ij    misc          1     -     i12     "SLOPECAT"      "SLOPE CATEGORY"  ""
 state   real   toposoil            ij    misc          1     -     i12     "SOILHGT"       "ELEVATION OF LSM DATA"  "m"
 state   real   landusef            iuj   misc          1     Z     i012rdu   "LANDUSEF"      "LANDUSE FRACTION BY CATEGORY"  ""
 state   real   soilctop            isj   misc          1     Z     i012rdu   "SOILCTOP"      "SOIL CAT FRACTION (TOP)"  ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -798,7 +798,6 @@ state   real   toposlpy            ij    misc          1     -     i1      "TOPO
 state   real   greenmax            ij    misc          1     -     i1      "GREENMAX"      "description"  "units"
 state   real   greenmin            ij    misc          1     -     i1      "GREENMIN"      "description"  "units"
 state   real   albedomx            ij    misc          1     -     i1      "ALBEDOMX"      "description"  "units"
-state   real   slopecat            ij    misc          1     -     i1      "SLOPECAT"      "description"  "units"
 state   real   toposoil            ij    misc          1     -     i1d=(DownNear)      "TOPOSOIL"      "description"  "units"
 state   real   landusef            iuj   misc          1     Z     -      ""      "description"  "units"
 state   real   soilctop            isj   misc          1     Z     -      ""      "description"  "units"

--- a/dyn_em/module_wps_io_arw.F
+++ b/dyn_em/module_wps_io_arw.F
@@ -874,17 +874,6 @@ CONTAINS
         ENDDO
 
 
-    varName='SLOPECAT'
-    CALL retrieve_index(index,VarName,varname_all,nrecs,iret)
-    CALL mpi_file_read_at(iunit,file_offset(index+1),     &
-                             dumdata,hor_size,mpi_real4,             &
-                             mpi_status_ignore, ierr)
-        DO J=JTS,min(JTE,JDE-1)
-         DO I=ITS,min(ITE,IDE-1)
-           grid%slopecat(I,J)=dumdata(I,J,1)
-         ENDDO
-        ENDDO
-
     varName='SNOALB'
     CALL retrieve_index(index,VarName,varname_all,nrecs,iret)
     CALL mpi_file_read_at(iunit,file_offset(index+1),     &

--- a/dyn_nmm/module_si_io_nmm.F
+++ b/dyn_nmm/module_si_io_nmm.F
@@ -1650,10 +1650,6 @@ print *,'------------------> skipping ', var_info%name(1:8)
                        grid%t_gc(its:imax, jts:jmax, kts:num_metgrid_levels),&
                          ierr)
 
-      call io_int_fetch_data(iunit, r, 'SLOPECAT', &
-                         grid%slopecat(its:imax, jts:jmax), &
-                         ierr)
-
       call io_int_fetch_data(iunit, r, 'SNOALB', &
                          grid%snoalb(its:imax, jts:jmax), &
                          ierr)

--- a/run/grib2map.tbl
+++ b/run/grib2map.tbl
@@ -354,7 +354,6 @@
   2 | 0 |196| TOPOSTDV  | Standard Deviation of topography         |  3 |  0 |
   2 | 0 |197| TOPOSLPX  | Sub-gridscale mean topographic slope     |  6 |  0 |
   2 | 0 |198| TOPOSLPY  | Sub-gridscale mean topographic slope     |  6 |  0 |
-  2 | 0 |199| SLOPECAT  | Topographical Categorical Slope          |  1 |  0 |
   2 | 0 |200| LANDUSEF  | Land use categorical fraction on mass gr |  3 |  0 |
   2 | 0 |201| SOILCTOP  | Top layer soil type as a categ. fraction |  3 |  0 |
   2 | 0 |202| SOILCBOT  | Bot layer soil type as a categ. fraction |  3 |  0 |

--- a/run/gribmap.txt
+++ b/run/gribmap.txt
@@ -214,7 +214,6 @@
 212:TOPOSTDV:Standard Deviation of Topography:TOPOSTDV:3
 213:TOPOSLPX:Sub-gridscale mean topographic slope in x-direction:SLPX,TOPOSLPX:6
 214:TOPOSLPY:Sub-gridscale mean topographic slope in y-direction:SLPY,TOPOSLPY:6
-215:SLOPECAT:Topographical Categorical Slope:SLOPECAT:1
 216:LANDUSEF:Land use categorical fraction on mass grid:LANDUSEF:3
 217:SOILCTOP:Top layer soil type as a categorical fraction:SOILCTOP:3
 218:SOILCBOT:Top layer soil type as a categorical fraction:SOILCBOT:3


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: SLOPECAT

SOURCE: internal, suggested and hidden files found by Michael Duda (NCAR)

DESCRIPTION OF CHANGES:
The WPS code was modified to remove an unused field, SLOPECAT. The real code and the WRF model are also modified:
1. SLOPECAT removed from all registry files
2. SLOPECAT removed from hardcoded binary I/O
3. SLOPECAT removed from grib tables

LIST OF MODIFIED FILES:
M	   Registry/Registry.CONVERT
M	   Registry/Registry.EM_COMMON
M	   /Registry.NMM
M	   /module_wps_io_arw.F
M	   /module_si_io_nmm.F
M	   /grib2map.tbl
M	   /gribmap.txt

TESTS CONDUCTED:
1. Code builds.
2. Hard to test the absence of something that was never used. "Absence of evidence is not evidence of absence."