### PR TITLE
Build status message after compile of em_fire, now consistent with all other ARW builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,25 @@ em_fire : wrf
 		/bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; fi ; \
 		/bin/rm -f namelist.input ; cp ../test/em_fire/namelist.input . )
 	( cd run ; /bin/rm -f input_sounding ; ln -s ../test/em_fire/input_sounding . )
+	@echo " "
+	@echo "=========================================================================="
 	@echo "build started:   $(START_OF_COMPILE)"
 	@echo "build completed:" `date`
+	@if test -e main/wrf.exe -a -e main/ideal.exe ; then \
+		echo " " ; \
+		echo "--->                  Executables successfully built                  <---" ; \
+		echo " " ; \
+		ls -l main/*.exe ; \
+		echo " " ; \
+		echo "==========================================================================" ; \
+		echo " " ; \
+	else \
+		echo " " ; \
+		echo "---> Problems building executables, look for errors in the build log  <---" ; \
+		echo " " ; \
+		echo "==========================================================================" ; \
+		echo " " ; \
+	fi
 
 em_quarter_ss : wrf
 	@/bin/rm -f ideal.exe > /dev/null 2>&1


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: em_fire, Makefile

SOURCE: internal

DESCRIPTION OF CHANGES:
The ARW builds all have a nice message at the end of the build. If the build worked, you get a message concerning how long the build required and a listing of the generated executables. If the build was not successful, there is a message that problems were encountered. While testing the separated ideal initialization modules (tropical cyclone, held suarez, fire, scm), it was noticed that the em_fire build did not produce the nice message (a convenient "grep"), so that lack-of-message is now rectified.

LIST OF MODIFIED FILES:
M	   Makefile

TESTS CONDUCTED:
1. A couple of dozen builds with em_fire during some recent development demonstrate that this new code is OK.
```
 
==========================================================================
build started:   Wed May 30 19:16:03 MDT 2018
build completed: Wed May 30 19:21:54 MDT 2018
 
--->                  Executables successfully built                  <---
 
-rwxr-xr-x  1 gill  1500  81071248 May 30 19:21 main/ideal.exe
-rwxr-xr-x  1 gill  1500  95343752 May 30 19:21 main/wrf.exe
 
==========================================================================
```
If I purposefully introduce a compiler error ...
```
==========================================================================
build started:   Wed May 30 19:35:00 MDT 2018
build completed: Wed May 30 19:35:15 MDT 2018
 
---> Problems building executables, look for errors in the build log  <---
 
==========================================================================
```
2. Without the mods, there is no final message after a build about the status of the executables.
```
build started:   Wed May 30 19:33:06 MDT 2018
build completed: Wed May 30 19:33:20 MDT 2018
```