### PR TITLE
Moist theta is now default in ARW Registry, remove from moist theta option from em_real LES nml file

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2468,7 +2468,7 @@ rconfig   real    diff_6th_factor         namelist,dynamics     max_domains    0
 rconfig   integer diff_6th_opt            namelist,dynamics     max_domains    0      irh   "diff_6th_opt" "switch for 6th-order numerical diffusion"
 rconfig   integer diff_6th_slopeopt       namelist,dynamics     max_domains    0      irh   "diff_6th_slopeopt" "switch for 6th-order numerical diffusion - terrain-slope tapering"
 rconfig   real    diff_6th_thresh         namelist,dynamics     max_domains    0.10    ih    "diff_6th_thresh" "slope threshold (m/m) that turns off 6th order diff is steep terrain"
-rconfig   integer use_theta_m             namelist,dynamics	1              0       rh    "use_theta_m" "theta_m = theta (1 + 1.61 Qv); 0-no, 1=yes"     ""
+rconfig   integer use_theta_m             namelist,dynamics	1              1       rh    "use_theta_m" "theta_m = theta (1 + 1.61 Qv); 0-no, 1=yes"     ""
 rconfig   integer use_q_diabatic          namelist,dynamics     1              0       rh    "use_q_diabatic" "account for q diabatic terms in advection "     ""
 rconfig   real    c_s                     namelist,dynamics     max_domains    0.25    h    "c_s"         "Smagorinsky coeff"      ""
 rconfig   real    c_k                     namelist,dynamics     max_domains    0.15    h    "c_k"         "TKE coeff"      ""

--- a/test/em_real/namelist.input.pbl-les
+++ b/test/em_real/namelist.input.pbl-les
@@ -69,7 +69,6 @@
 
  &dynamics
  hybrid_opt                          = 2, 
- use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 4,      3,      3,


### PR DESCRIPTION
TYPE: new default behavior

KEYWORDS: use_theta_m, Registry, namelist

SOURCE: internal

DESCRIPTION OF CHANGES:
1. The LES namelist in the test/em_real directory has the use_theta_m switch removed. This is not a switch that we want most users adjusting. This is now consistent with the remainder of the test/em_real namelist files (no easy access to use_theta_m).
2. The main Registry file for ARW has the default behavior that the moist theta option is activated. This will mean that the DA group, which shares the Registry file, will need to explicitly turn use_theta_m OFF in their WRF namelist files.

LIST OF MODIFIED FILES: 
M	   Registry/Registry.EM_COMMON
M	   test/em_real/namelist.input.pbl-les

TESTS CONDUCTED:
Numerous tests with moist theta have been conducted, including zillions of regression tests.