### PR TITLE
change write message to debug print

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -2562,7 +2562,6 @@ ENDIF
                   CONTINUE
                ELSE
                   CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
-                  call wrf_message(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2597,7 +2596,6 @@ ENDIF
                   CONTINUE
                ELSE
                   CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
-                  call wrf_message(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2632,7 +2630,6 @@ ENDIF
                   CONTINUE
                ELSE
                   CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
-                  call wrf_message(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2667,7 +2664,6 @@ ENDIF
                   CONTINUE
                ELSE
                   CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
-                  call wrf_message(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: print, debug print

SOURCE: internal

DESCRIPTION OF CHANGES: 
When a urban option is used, the routine urban_var_init is called. If urban data, HGT_URB2D isn't provided, the code prints out 'USING DEFAULT URBAN MORPHOLOGY' for each grid point that is urban. This is not necessary. This PR changes to CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY'). This change has no impact to results.

LIST OF MODIFIED FILES: 
M     phys/module_sf_urban.F

TESTS CONDUCTED: 
A run is made to verify that the large block of prints disappears.