### PR TITLE
Revert to the code in 3.8.1 for dealing with climatological ozone

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1063,7 +1063,7 @@ state    real   acfrcv           ij     misc        1         -      -
 state integer   ncfrcv           ij     misc        1         -      -
 
 # new rad variables
-state    real   o3rad           ikj     misc        1         -      r         "o3rad"    "RADIATION 3D OZONE" "ppmv"
+state    real   o3rad           ikj     misc        1         -      rdf=(p2c)      "o3rad"    "RADIATION 3D OZONE" "ppmv"
 
 # incoming optical depth derived from aerosol data
 state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1888,7 +1888,11 @@ integer myproc
 !   Read in CAM ozone data, and interpolate data to model grid
 !   Interpolation is done on domain 1 only
 
+#if (EM_CORE==1) 
+   IF ( config_flags%o3input .EQ. 2 .AND. id .EQ. 1 ) THEN
+#else
    IF ( config_flags%o3input .EQ. 2 ) THEN
+#endif
       CALL oznini(ozmixm,pin,levsiz,n_ozmixm,XLAT,                &
                      ids, ide, jds, jde, kds, kde,                  &
                      ims, ime, jms, jme, kms, kme,                  &

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1357,7 +1357,11 @@ CONTAINS
 
 !     Interpolating climatological ozone and aerosol to model time and levels
 !     Adapted from camrad code
+#if (EM_CORE==1)
+     IF ( o3input .EQ. 2 .AND. id .EQ. 1 ) THEN
+#else
      IF ( o3input .EQ. 2 ) THEN
+#endif
 !       ! Find the current month (adapted from Cavallo)
 !       CALL cam_time_interp( ozmixm, pin, levsiz, date_str, &
 !                             ids , ide , jds , jde , kds , kde , &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ozone input, moving nest

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
PR#468 together with two changes made for 3.9 in registry and radiation driver broke moving nest which uses climatological ozone in RRTMG. The changes made to 3.9 was aimed at addressing a restart issue.

Solution:
Revert code. Original problems (purpose for the original modification) no longer exist.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       phys/module_physics_init.F
M       phys/module_radiation_driver.F

TESTS CONDUCTED: 
 - [x] Reg test passed
 - [x] Tests specific to this change
1. Now with the code reverting to pre 3.9, the restart issue is no longer there. 
2. With this change, moving nest with climatological ozone works. 
3. Normal nests also work with ozone. 
4. Restart behaves as well.
 - [x] spot check restart with V4 code all works