### PR TITLE
add opt_run = 5 for noah_mp namelist

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1149,6 +1149,7 @@ Options for use with the Noah-MP Land Surface Model:
                                                 ;    2 = TOPMODEL with equilibrium water table
                                                 ;    3 = original surface and subsurface runoff (free drainage) - default
                                                 ;    4 = BATS surface and subsurface runoff (free drainage)
+                                                ;    5 = Miguez-Macho & Fan groundwater scheme 
  opt_frz                            = 1,        ; Noah-MP Supercooled Liquid Water option
                                                 ;    1 = No iteration; 2 = Koren's iteration
  opt_inf                            = 1,        ; Noah-MP Soil Permeability option


### PR DESCRIPTION

TYPE: text only

KEYWORDS: README.namelist, opt_run=5

SOURCE: internal

DESCRIPTION OF CHANGES: 
opt_run = 5 was missing from the noah_mp namelist in the README.namelist

LIST OF MODIFIED FILES: 
M       run/README.namelist

TESTS CONDUCTED: 
None. Text only.