### PR TITLE
limit Q2 change to land only

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -4035,7 +4035,9 @@ CONTAINS
        DO ij = 1 , num_tiles
          DO j=j_start(ij),j_end(ij)
          DO i=i_start(ij),i_end(ij)
+            IF (XLAND(I,J).LT.1.5) THEN
             Q2(i,j) = MIN(Q2(i,j),1.05*QV_CURR(i,1,j))
+            END IF
          ENDDO
          ENDDO
        ENDDO


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Q2, diagnostics

SOURCE: Internal

DESCRIPTION OF CHANGES: 
PR#481 sets an upper limit for Q2 to be 5% more than the lowest model level QVAPOR. This PR limits that change to be applied to land values only because the original problem is known to appear over land.

LIST OF MODIFIED FILES: 
M    phys/module_surface_driver.F


TESTS CONDUCTED: 
No test yet.