### PR TITLE
Make damp_opt=3 for all em_real namelists (implicit Rayleigh damping)

### DIFF
--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -74,7 +74,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.4km
+++ b/test/em_real/namelist.input.4km
@@ -74,7 +74,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.chem
+++ b/test/em_real/namelist.input.chem
@@ -87,7 +87,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.diags
+++ b/test/em_real/namelist.input.diags
@@ -92,7 +92,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.fire
+++ b/test/em_real/namelist.input.fire
@@ -75,7 +75,7 @@
  w_damping                           = 0,
  diff_opt                            = 2,      2,      2,
  km_opt                              = 2,      2,      2,
- damp_opt                            = 0,
+ damp_opt                            = 3,
  base_temp                           = 290.
  zdamp                               = 5000.,
  dampcoef                            = 0.2,

--- a/test/em_real/namelist.input.ndown_1
+++ b/test/em_real/namelist.input.ndown_1
@@ -92,7 +92,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.ndown_2
+++ b/test/em_real/namelist.input.ndown_2
@@ -94,7 +94,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.ndown_3
+++ b/test/em_real/namelist.input.ndown_3
@@ -94,7 +94,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.pbl-les
+++ b/test/em_real/namelist.input.pbl-les
@@ -75,7 +75,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,

--- a/test/em_real/namelist.input.volc
+++ b/test/em_real/namelist.input.volc
@@ -81,7 +81,7 @@
  diff_6th_opt                        = 0,      0,      0,
  diff_6th_factor                     = 0.12,   0.12,   0.12,
  base_temp                           = 290.
- damp_opt                            = 0,
+ damp_opt                            = 3,
  zdamp                               = 5000.,  5000.,  5000.,
  dampcoef                            = 0.2,    0.2,    0.2
  khdif                               = 0,      0,      0,


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: damp_opt, em_real, namelist

SOURCE: internal

DESCRIPTION OF CHANGES:
The preferred default behavior for real-data cases is to have damp_opt=3 activated. From the Skamarock et al. (2008) Tech Note:
```Implicitly damping the vertical velocity within the implicit solution algorithm for the vertically propagating acoustic modes has been found to be a very effective and robust absorbing layer formulation by Klemp et al. (2008). We recommend its use in both large-scale and small-scale applications, and in idealized and real-data applications.```

LIST OF MODIFIED FILES:
M	 namelist.input
M	 namelist.input.4km
M	 namelist.input.chem
M	 namelist.input.diags
M	 namelist.input.fire
M	 namelist.input.ndown_1
M	 namelist.input.ndown_2
M	 namelist.input.ndown_3
M	 namelist.input.pbl-les
M	 namelist.input.volc

TESTS CONDUCTED:
 - [x] No testing required for changes to namelists. Several namelists in the test/em_real dir already had damp_opt=3. A number of real-data regession tests already use damp_opt=3.