### PR TITLE
Update the commit message with optional "RELEASE NOTE" and "ISSUE" section

### DIFF
--- a/tools/commit_form.txt
+++ b/tools/commit_form.txt
@@ -8,6 +8,11 @@ SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev c
 
 DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
 
+ISSUE: For use when this PR closes an issue. For issue number 123
+```
+Fixes #123
+
+
 LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
 
 TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!


### PR DESCRIPTION
TYPE: text only

KEYWORDS: commit template, RELEASE NOTE, ISSUE

SOURCE: internal

DESCRIPTION OF CHANGES:
Add in two new sections to the WRF commit template.
1. RELEASE NOTE. This is optional, and for the benefit of those trying to go through the commit log to determine what to mention in the release notes.
2. ISSUE. This is optional. If a specific issue has been raised and a PR fixes that issues then a simple syntax closes the associated issue. For example if a PR closes issue  number 579
```
ISSUE:
Fixes #579
```

ISSUE:
Fixes #579
Fixes #581

LIST OF MODIFIED FILES:
M	 tools/commit_form.txt

TESTS CONDUCTED:
 - [x] No tests required