### PR TITLE
Fix recent classic vs compressed NC build error

### DIFF
--- a/configure
+++ b/configure
@@ -202,18 +202,35 @@ else
   exit 6
 fi
 
-# testing for netcdf4 IO features
-if [ -n "$NETCDF4" ] ; then
-  if [ $NETCDF4 -eq 1 ] ; then
-    make nc4_test > tools/nc4_test.log 2>&1
-    retval=-1
-    if  [ -f tools/nc4_test.exe ] ; then
-      retval=0
-      rm -f tools/nc4_test.log
+# If the user asked for classic netcdf, acquiesce to the request.
+
+if [ "`uname`" = "Linux" ] ; then
+  ans="`whereis nf-config`"
+elif [ "`uname`" = "Darwin" ] ; then
+  ans="`which nf-config`"
+else
+  ans=""
+# echo "Add in your architecture's uname and the command to find executables in the path"
+# exit 1
+fi
+if [ "$ans" = "nf-config:" -o "$ans" = "" ] ; then
+    export NETCDF_classic=1
+    unset NETCDF4
+else
+  if [ -n "$NETCDF_classic" ] ; then
+    if [ $NETCDF_classic -eq 1 ] ; then
+      unset  NETCDF4
+    else
+      unset  NETCDF_classic
+      export NETCDF4=1
     fi
-    if [ $retval -ne 0 ] ; then
+  else
+    if [ "`nf-config --has-nc4`" = "yes" ] ; then
+      unset  NETCDF_classic
+      export NETCDF4=1
+    else
       export NETCDF_classic=1
-      unset NETCDF4
+      unset  NETCDF4
     fi
   fi
 fi


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: netcdf, classic, compression, HDF5, build

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The effort to put in an automatic detection of the compression capabilities for netcdf caused a chicken and egg issue. The flags for netcdf with compression are set in the Config.pl script for the configure.wrf file. However, that configure.wrf file is used to first build a test program to determine if we can use those flags that are already in that file. Conundrum.

Towards the very top of the configure script, a test was introduced to check on availability of netcdf with compression capability. Unfortunately, the configure.wrf file did not yet exist, so the Makefile line `include configure.wrf` returned a `no rule to make configure.wrf`, and the resulting test for netcdf with compression ALWAYS failed. That made the default IO format netcdf classic. However, it was noticed that once a configure.wrf file existed, THEN a second `./configure` would allow the netcdf compression option to be successfully used.

Solution:
Since netcdf4, the nf-config command has existed. We use this command directly to inquire whether this netcdf library was built with compression enabled. We get the required answer without the need of a build (with out the pre-need of the flags within configure.wrf before that file exists).

Do I get netcdf classic or netcdf with compression?
1. If a user specifically requests classic (setenv NETCDF_classic 1), then the user gets classic netcdf, with no compression.
2. Otherwise the user gets netcdf compression if it is available.

Unexpected issue:
On a Linux machine, the "whereis" command inside of /bin/sh can be used to find an executable in the user's path. On Darwin, it is the "which" command. The executable that we want is "nf-config". If neither of these architectures is available, then the code assumes netcdf classic (with no compression).

LIST OF MODIFIED FILES:
M	  configure

ISSUE:
Fixes #582

TESTS CONDUCTED:
 - [x] I did test builds on Linux and Darwin.
 - [x] On Darwin, we have access to netcdf/3.6.3 and netcdf/4.5.0
1. With NC3, regardless of env variables, the WRF code built with classic
2. With NC4, `setenv NETCDF_classic 1` generated classic netcdf
3. With NC4, a clean environment generated netcdf with compression

 - [x] On cheyenne Linux, we only have NC4 available
1. With `setenv NETCDF_classic 1` generated classic netcdf
2. With a clean environment generated netcdf with compression

RELEASE NOTE:
Since this bug was introduced within the last month or so, no need to announce a "fix". However, the WRF code now (correctly) is able to automatically output with compressed netcdf, if the user's version of netcdf supports compression.