### PR TITLE
README.DA v4.0, fix release date

### DIFF
--- a/doc/README.DA
+++ b/doc/README.DA
@@ -25,7 +25,7 @@ This is the main directory for the WRFDA Version 4 source code release.
 V4.0 Release Notes :
 -------------------
 
-Version 4.0 was released on June 7, 2018.
+Version 4.0 was released on June 8, 2018.
 
   For more information about WRFDA, visit the WRFDA Users home page
   http://www2.mmm.ucar.edu/wrf/users/wrfda/index.html


### PR DESCRIPTION
TYPE: text only

KEYWORDS: README, DA

SOURCE: internal

DESCRIPTION OF CHANGES:
Release date is 8 June, not 7 June.

LIST OF MODIFIED FILES:
M	 doc/README.DA

TESTS CONDUCTED:
Looks like an "8" in the file.