### PR TITLE
Fix in DA to make the code consistent with formulation for sfc wind correction

### DIFF
--- a/var/da/da_tools/da_mo_correction.inc
+++ b/var/da/da_tools/da_mo_correction.inc
@@ -176,7 +176,7 @@ function da_mo_correction (ho, po, to, qo, &
       if (hll > 1.5) then
          if (zint < 0.2) then
             correc = 1.000 + 0.320 * zint ** 0.200
-         else if (zint < 0.0) then
+         else if (zint >= 0.2) then
             correc = 1.169 + 0.315 * zint
          end if
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, sfc wind correction

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
The current if-elseif coding in the code is not consistent with the intended formulation
as in figure 2 of Stauffer et al. 1991, MWR,
0<z0<0.2 : u40/u10=1.000+0.320*z0**0.2
z0>=0.2 : u40/u10=1.169+0.315*z0

Notes:
1. the sfc wind correction is applied only when
(1) sfc_assi_options=1.
(2) The obs height is below the model lowest half level height and the height difference is larger than 10 meters.
(3) Bulk Richardson number<0.0 and h/L>1.5.
2. My personal comment is that the concept of the empirical correction derived 25+ years ago
(when the lowest model level was 40 meters) is not applicable to current models that have
much higher vertical resolutions near surface. The proposed fix corrects a coding error
(per a top-down request) but the impact  is not too meaningful and is expected to be small.

LIST OF MODIFIED FILES:
M       var/da/da_tools/da_mo_correction.inc

TESTS CONDUCTED: none

RELEASE NOTE:
Not worth mentioning this fix for release.