### PR TITLE
bug fix: incorrect PSISAT sign change introduced with groundwater fixes

### DIFF
--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -1600,7 +1600,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 	      
               BEXP   =   BEXP_TABLE(ISLTYP(I,J))
               SMCMAX = SMCMAX_TABLE(ISLTYP(I,J))
-              PSISAT = -1.0*PSISAT_TABLE(ISLTYP(I,J))
+              PSISAT = PSISAT_TABLE(ISLTYP(I,J))
 
               DO NS=1, NSOIL
 	        IF ( SMOIS(I,NS,J) > SMCMAX )  SMOIS(I,NS,J) = SMCMAX


### PR DESCRIPTION
bug fix: incorrect PSISAT sign change introduced with groundwater fixes

TYPE: bug fix

KEYWORDS: Noah-MP

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

PSISAT sign change incorrectly introduced in Noah-MP subroutine noahmp_init (PR #287; commit 45d1945c). This sign change is already taken into account in the equation where it is used and should not have been added. The sign change added to subroutine groundwater_init in PR #287 is correct.

Only affects the initialization of frozen soil but can have large effect on soil temperature and moisture simulations when soil temperature is below freezing.
    
LIST OF MODIFIED FILES: 

M       phys/module_sf_noahmpdrv.F

TESTS CONDUCTED:
1. Summer and winter 24-hr case

