### PR TITLE
cleaned up mm5_sfclay scheme - removed unnecessary lines and if-defs

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -24,8 +24,8 @@ CONTAINS
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
-                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux &
-                    ,dxCell                                        &
+                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux, &
+                     dxCell                                        &
                          )
 !-------------------------------------------------------------------
       IMPLICIT NONE
@@ -240,16 +240,11 @@ CONTAINS
                 P1000mb,                                           &
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
-                its,ite, jts,jte, kts,kte                          &
-#if defined(mpas) 
-                ,isftcflx,iz0tlnd,scm_force_flux,                  &
+                its,ite, jts,jte, kts,kte,                         &
+                isftcflx,iz0tlnd,scm_force_flux,                   &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j),dxCell(ims,j)                 &
-#elif ( EM_CORE == 1)
-                ,isftcflx,iz0tlnd,scm_force_flux,                  &
-                USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j)                               & 
-#endif
+                CD(ims,j),CDA(ims,j),                              &
+                dxCell(ims,j)                                      &
                                                                    )
       ENDDO
 


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: mm5_sfclay, physics, mpas, wrf

SOURCE: Internal

DESCRIPTION OF CHANGES: removed an unnecessary "if defined(mpas)...elif defined(wrfmodel)" section that was unnecessary. The only different variable was dxCell, which is optional, and uses "if present(dxCell)," so no if-defs necessary around it.

LIST OF MODIFIED FILES: 
M       phys/module_sf_sfclay.F

TESTS CONDUCTED: Verified that modified code builds in top of repository WRF code, as well as released version of MPAS (V6.1)

