### PR TITLE
Clean up redundant code in module_sf_sfclay.F

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -24,8 +24,9 @@ CONTAINS
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
-                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux &
-                    ,dxCell                                        &
+                     ustm,ck,cka,cd,cda,                           &
+                     isftcflx,iz0tlnd,scm_force_flux,              &
+                     dxCell                                        &
                          )
 !-------------------------------------------------------------------
       IMPLICIT NONE
@@ -241,14 +242,11 @@ CONTAINS
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
-#if defined(mpas) 
                 ,isftcflx,iz0tlnd,scm_force_flux,                  &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j),dxCell(ims,j)                 &
-#elif ( EM_CORE == 1)
-                ,isftcflx,iz0tlnd,scm_force_flux,                  &
-                USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j)                               & 
+                CD(ims,j),CDA(ims,j)                               &
+#if defined(mpas)
+                ,dxCell(ims,j)                                     &
 #endif
                                                                    )
       ENDDO


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: mm5, sfclay, physics, redundant

SOURCE: internal

DESCRIPTION OF CHANGES: Within an 'if defined()" statement, there was some redundant code. Just cleaned it up.

LIST OF MODIFIED FILES: 
M    phys/module_sf_sfclay.F

TESTS CONDUCTED: verified that code builds in WRF and MPAS. 