### PR TITLE
Add a flag that turns on/off soil moisture adjustment

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2178,7 +2178,7 @@ rconfig   integer mosaic_cat              namelist,physics	1             3      
 rconfig   integer mosaic_cat_soil         derived         	1            12       rh     "mosaic_cat_soil"          "should be the number of soil layers times the mosaic_cat"      ""  
 rconfig   integer mosaic_lu               namelist,physics      1             0       irh    "mosaic_lu"             ""      ""
 rconfig   integer mosaic_soil             namelist,physics      1             0       irh    "mosaic_soil"           ""      ""
-rconfig   integer flag_sm_adj             namelist,physics      1             1       irh    "flag_sm_adj" "1-adjustment, 0-no soil moisture adjustment in RUC soil moisture initialization from Noah LSM"      ""
+rconfig   integer flag_sm_adj             namelist,physics      1             0       irh    "flag_sm_adj" "1-adjustment, 0-no soil moisture adjustment in RUC soil moisture initialization from Noah LSM"      ""
 rconfig   integer maxiens                 namelist,physics	1             1       irh    "maxiens"                    ""      ""
 rconfig   integer maxens                  namelist,physics	1             3       irh    "maxens"                    ""      ""
 rconfig   integer maxens2                 namelist,physics	1             3       irh    "maxens2"                    ""      ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2178,6 +2178,7 @@ rconfig   integer mosaic_cat              namelist,physics	1             3      
 rconfig   integer mosaic_cat_soil         derived         	1            12       rh     "mosaic_cat_soil"          "should be the number of soil layers times the mosaic_cat"      ""  
 rconfig   integer mosaic_lu               namelist,physics      1             0       irh    "mosaic_lu"             ""      ""
 rconfig   integer mosaic_soil             namelist,physics      1             0       irh    "mosaic_soil"           ""      ""
+rconfig   integer flag_sm_adj             namelist,physics      1             1       irh    "flag_sm_adj" "1-adjustment, 0-no soil moisture adjustment in RUC soil moisture initialization from Noah LSM"      ""
 rconfig   integer maxiens                 namelist,physics	1             1       irh    "maxiens"                    ""      ""
 rconfig   integer maxens                  namelist,physics	1             3       irh    "maxens"                    ""      ""
 rconfig   integer maxens2                 namelist,physics	1             3       irh    "maxens2"                    ""      ""

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2891,8 +2891,9 @@ integer::oops1,oops2
                                   grid%landmask , grid%sst , grid%ht, grid%toposoil, &
                                   st_input , sm_input , sw_input , &
                                   st_levels_input , sm_levels_input , sw_levels_input , &
-                                  grid%zs , grid%dzs , grid%tslb , grid%smois , grid%sh2o , &
-                                  flag_sst , flag_tavgsfc, flag_soilhgt,&
+                                  grid%zs , grid%dzs , model_config_rec%flag_sm_adj , &
+                                  grid%tslb , grid%smois , grid%sh2o , &
+                                  flag_sst , flag_tavgsfc, flag_soilhgt, &
                                   flag_soil_layers, flag_soil_levels, &
                                   ids , ide , jds , jde , kds , kde , &
                                   ims , ime , jms , jme , kms , kme , &

--- a/share/module_soil_pre.F
+++ b/share/module_soil_pre.F
@@ -594,7 +594,7 @@ print *,'WATER CHANGE = ',change_water
                                 landmask , sst , ht, toposoil, &
                                 st_input , sm_input , sw_input , &
                                 st_levels_input , sm_levels_input , sw_levels_input , &
-                                zs , dzs , tslb , smois , sh2o , &
+                                zs , dzs , flag_sm_adj, tslb , smois , sh2o , &
                                 flag_sst , flag_tavgsfc, flag_soilhgt, &
                                 flag_soil_layers, flag_soil_levels, &
                                 ids , ide , jds , jde , kds , kde , &
@@ -613,7 +613,7 @@ print *,'WATER CHANGE = ',change_water
                               num_st_levels_input , num_sm_levels_input , num_sw_levels_input , &
                               num_st_levels_alloc , num_sm_levels_alloc , num_sw_levels_alloc
 
-      INTEGER , INTENT(IN) :: flag_sst, flag_tavgsfc
+      INTEGER , INTENT(IN) :: flag_sst, flag_tavgsfc, flag_sm_adj
       INTEGER , INTENT(IN) :: flag_soil_layers, flag_soil_levels, flag_soilhgt
 
       REAL , DIMENSION(ims:ime,jms:jme) , INTENT(IN) :: landmask , sst
@@ -816,7 +816,7 @@ print *,'WATER CHANGE = ',change_water
          CALL init_soil_depth_3 ( zs , dzs , num_soil_layers )
          CALL init_soil_3_real ( tsk , tmn , smois , tslb , &
                                  st_input , sm_input , landmask , sst , &
-                                 zs , dzs , &
+                                 zs , dzs , flag_sm_adj,    &
                                  st_levels_input , sm_levels_input , &
                                  num_soil_layers , num_st_levels_input , num_sm_levels_input , &
                                  num_st_levels_alloc , num_sm_levels_alloc , &
@@ -1811,20 +1811,20 @@ cycle
 
    END SUBROUTINE init_soil_2_ideal
 
-   SUBROUTINE init_soil_3_real ( tsk , tmn , smois , tslb , &
+   SUBROUTINE init_soil_3_real ( tsk , tmn , smois , tslb ,           &
                                  st_input , sm_input , landmask, sst, &
-                                 zs , dzs , &
-                                 st_levels_input , sm_levels_input , &
-                                 num_soil_layers , num_st_levels_input , num_sm_levels_input ,  &
+                                 zs , dzs , flag_sm_adj,              &
+                                 st_levels_input , sm_levels_input ,  &
+                                 num_soil_layers , num_st_levels_input , num_sm_levels_input , &
                                  num_st_levels_alloc , num_sm_levels_alloc , &
                                  flag_sst , flag_soil_layers , flag_soil_levels , &
-                                 ids , ide , jds , jde , kds , kde , &
-                                 ims , ime , jms , jme , kms , kme , &
+                                 ids , ide , jds , jde , kds , kde ,  &
+                                 ims , ime , jms , jme , kms , kme ,  &
                                  its , ite , jts , jte , kts , kte )
 
       IMPLICIT NONE
 
-      INTEGER , INTENT(IN) :: num_soil_layers , &
+      INTEGER , INTENT(IN) :: num_soil_layers , flag_sm_adj,      &
                               num_st_levels_input , num_sm_levels_input , &
                               num_st_levels_alloc , num_sm_levels_alloc , &
                               ids , ide , jds , jde , kds , kde , &
@@ -2057,6 +2057,10 @@ cycle
 
       END IF
 
+   IF(flag_sm_adj == 1) then
+       write(message, FMT='(A)') ' Soil moisture adjustment from Noah to RUC is ON'
+       CALL wrf_message ( message )
+!-- perform soil moisture adjustmen when flag_sm_adj == 1
       if( flag_soil_levels .ne. 1) then
            write(message, FMT='(A)') ' from Noah to RUC - compute RUC bucket'
            CALL wrf_message ( message )
@@ -2114,6 +2118,7 @@ cycle
       END DO
 
       endif ! flag_soil_levels
+   ENDIF ! flag_sm_adj
 
       !  Over water, put in reasonable values for soil temperature and moisture.  These won't be
       !  used, but they will make a more continuous plot.


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: soil moisture, initialization, RUC LSM

SOURCE: Tanya Smirnova (GSD/ESRL/NOAA)

DESCRIPTION OF CHANGES: 
Issue: This enhancement was motivated by the WRF user's request who initializes RUC soil moisture from the ECMWF soil moisture. The soil moisture adjustment code uses specific Noah's vertical structure, and therefore does not work for ECMWF initialization. Plus, the user cycles soil moisture and does not need any adjustment.

Solution: Flag_sm_adj is added to turn on/off soil moisture adjustment when RUC LSM. The default value is 1 = do soil moisture adjustment.

LIST OF MODIFIED FILES:
M       Registry/Registry.EM_COMMON
M       dyn_em/module_initialize_real.F
M       share/module_soil_pre.F

TESTS CONDUCTED: 
Tested in RAP model at GSD/ESRL

