### PR TITLE
Fix half vs full 1d coeffs for HVC in small_step

### DIFF
--- a/dyn_em/module_small_step_em.F
+++ b/dyn_em/module_small_step_em.F
@@ -260,7 +260,7 @@ SUBROUTINE small_step_prep( u_1, u_2, v_1, v_2, w_1, w_2, &
     DO k=k_start, k_end
     DO i=i_start, i_end
       t_save(i,k,j) = t_2(i,k,j)
-      t_2(i,k,j) = (c1f(k)*muts(i,j)+c2f(k))*t_1(i,k,j)-(c1f(k)*mut(i,j)+c2f(k))*t_2(i,k,j)
+      t_2(i,k,j) = (c1h(k)*muts(i,j)+c2h(k))*t_1(i,k,j)-(c1h(k)*mut(i,j)+c2h(k))*t_2(i,k,j)
     ENDDO
     ENDDO
     ENDDO
@@ -409,7 +409,7 @@ SUBROUTINE small_step_finish( u_2, u_1, v_2, v_1, w_2, w_1,    &
     DO j = j_start, j_end
     DO k = kds, kde-1
     DO i = i_start, i_end
-      t_2(i,k,j) = (t_2(i,k,j) + t_save(i,k,j)*(c1f(k)*mut(i,j)+c2f(k)))/(c1f(k)*muts(i,j)+c2f(k))
+      t_2(i,k,j) = (t_2(i,k,j) + t_save(i,k,j)*(c1h(k)*mut(i,j)+c2h(k)))/(c1h(k)*muts(i,j)+c2h(k))
     ENDDO
     ENDDO
     ENDDO
@@ -418,8 +418,8 @@ SUBROUTINE small_step_finish( u_2, u_1, v_2, v_1, w_2, w_1,    &
     DO j = j_start, j_end
     DO k = kds, kde-1
     DO i = i_start, i_end
-      t_2(i,k,j) = (t_2(i,k,j) - dts*number_of_small_timesteps*(c1f(k)*mut(i,j)+c2f(k))*h_diabatic(i,k,j) &
-                    + t_save(i,k,j)*(c1f(k)*mut(i,j)+c2f(k)))/(c1f(k)*muts(i,j)+c2f(k))
+      t_2(i,k,j) = (t_2(i,k,j) - dts*number_of_small_timesteps*(c1h(k)*mut(i,j)+c2h(k))*h_diabatic(i,k,j) &
+                    + t_save(i,k,j)*(c1h(k)*mut(i,j)+c2h(k)))/(c1h(k)*muts(i,j)+c2h(k))
     ENDDO
     ENDDO
     ENDDO


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: HVC, hybrid, coefficients, half, full

SOURCE: internal, found by May Wong (NCAR)

DESCRIPTION OF CHANGES:
In the original implementation of the hybrid vertical coordinate (v3.9), the
cpp directives utilized capitalization to differentiate between the use
of full-level (c1f, for example) and half-level (c1h, for example) 1d
coeffieicent arrays. For several locations in the small_step, the use of the
"mu" array with the "t_2" field incorrectly was assigned to full levels.

In three statements where the half-level t_2 array is used, the half-level
c1h and c2h 1d arrays replace the incorrect full-level 1d arrays c1f and c2f.

ISSUE:
Fixes #604

LIST OF MODIFIED FILES: 
M	dyn_em/module_small_step_em.F

TESTS CONDUCTED: 
1. Look at diffs of fields. 
   a. theta fixed (new code) MINUS theta busted (original code) at k=26, though the difference pattern and magnitude was similar throughout the vertical levels
![screen shot 2018-09-10 at 10 57 41 am](https://user-images.githubusercontent.com/12666234/45312136-831e1800-b4e8-11e8-8809-3d964236f406.png)


2. Regression test.
 - [x] Regression test passses

RELEASE NOTE: 
This bug was introduced with the start of the hybrid vertical coordinate option. This 
same functionality of modification for v4.0 would need to go into v3.9, v3.9.1, and
v3.9.1.1. The differences are typical of a small perturbation in an initial condition:
the differences do not look unphysical.