### PR TITLE
Remove repeated factor of (1+Rv/Rd Qv) in start_em, p computation

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -773,13 +773,21 @@
     DO i=its,min(ite,ide-1)
 #if ( WRFPLUS == 1 )
        IF ( .NOT. config_flags%var4d_run ) THEN
-          qvf = 1.+rvovrd*moist(i,k,j,P_QV)
+          IF ( config_flags%use_theta_m == 0 ) THEN
+             qvf = 1.+rvovrd*moist(i,k,j,P_QV)
+          ELSE
+             qvf = 1
+          END IF
           grid%p(i,k,j)=p1000mb*( (r_d*(t0+grid%t_1(i,k,j))*qvf)/                     &
                      (p1000mb*(grid%al(i,k,j)+grid%alb(i,k,j))) )**cpovcv  &
                      -grid%pb(i,k,j)
        END IF
 #else
-       qvf = 1.+rvovrd*moist(i,k,j,P_QV)
+       IF ( config_flags%use_theta_m == 0 ) THEN
+          qvf = 1.+rvovrd*moist(i,k,j,P_QV)
+       ELSE
+          qvf = 1
+       END IF
        grid%p(i,k,j)=p1000mb*( (r_d*(t0+grid%t_1(i,k,j))*qvf)/                     &
                   (p1000mb*(grid%al(i,k,j)+grid%alb(i,k,j))) )**cpovcv  &
                   -grid%pb(i,k,j)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: use_theta_m, moist theta

SOURCE: Several users pointed out problem, solution from Wei Wang

DESCRIPTION OF CHANGES:
In the porting of the theta_m mods from being ONLY inside of the WRF model
to being part of the initialization step in the real and ideal programs,
the start_em file was modified. Part of the computation of the pressure
involves dry_theta * ( 1 + rv/Rd Qv ).

When the incoming data from the real or ideal program has the namelist
option use_theta_m==1, then the factor ( 1 + Rv/Rd Qv ) is already included
in the theta field. An IF test based on the namelist option use_theta_m
tests whether or not to assign the factor qvf as either 1 or ( 1 + Rv/Rd Qv ).


ISSUE:
Fixes #608

LIST OF MODIFIED FILES:
M	dyn_em/start_em.F

TESTS CONDUCTED:

1. Differences at 0h (since the mod is in start_em.F). Compare original (busted)
code with use_theta_m=1 to fixed code. Differences shown are: 

LEFT: t=0, use_theta_m=0 MINUS  use_theta_m=1_FIXED.

RIGHT: t=0, use_theta_m=0 MINUS  use_theta_m=1_BUSTED.

The differences are supposed to be very small, for example a few hundredths
of a Pa.
![screen shot 2018-09-10 at 9 27 04 am](https://user-images.githubusercontent.com/12666234/45308687-4b5ea280-b4df-11e8-9db7-709ee35521e0.png)

2. The error is introduced in the initialization routine in WRF. After that initial
p' error (3000 Pa), the imbalance quickly decays. However, the perturbations
are enough to change the larger scale solution, which leads to pressure
differences around 300 Pa. Shown is the differences of the p' field at 3h and 12h,
where the differences are wrfout_FIXED - wrfout_BUSTED.
![screen shot 2018-09-10 at 10 05 36 am](https://user-images.githubusercontent.com/12666234/45310519-b14d2900-b4e3-11e8-9484-d4ae96631ed5.png)

3. Regression test on cheyenne.
- [x] Reggie looks OK 

RELEASE NOTE:
This bug was introduced in v4.0. This is a critical modification because 
the option use_theta_m=1 is the default, and the results are unphysical.