### PR TITLE
Fixed qc, qr, qi, qs, qg updates to WRF moist variables

### DIFF
--- a/var/da/da_transfer_model/da_transfer_xatowrf.inc
+++ b/var/da/da_transfer_model/da_transfer_xatowrf.inc
@@ -442,17 +442,17 @@ subroutine da_transfer_xatowrf(grid, config_flags)
                grid%moist(i,j,k,P_QV) = grid%moist(i,j,k,P_QV)+q_cgrid(i,j,k)
             end if
 
-            if (size(grid%moist,dim=4) >= 4) then
+            if (size(grid%moist,dim=4) >= 4 .and. cloud_cv_options >= 1) then
                grid%moist(i,j,k,p_qc) = max(grid%moist(i,j,k,p_qc) + grid%xa%qcw(i,j,k), 0.0)
                grid%moist(i,j,k,p_qr) = max(grid%moist(i,j,k,p_qr) + grid%xa%qrn(i,j,k), 0.0)
             end if
 
-            if (size(grid%moist,dim=4) >= 6) then
+            if (size(grid%moist,dim=4) >= 6 .and. cloud_cv_options >= 2) then
                grid%moist(i,j,k,p_qi) = max(grid%moist(i,j,k,p_qi) + grid%xa%qci(i,j,k), 0.0)
                grid%moist(i,j,k,p_qs) = max(grid%moist(i,j,k,p_qs) + grid%xa%qsn(i,j,k), 0.0)
             end if
 
-            if (size(grid%moist,dim=4) >= 7) then
+            if (size(grid%moist,dim=4) >= 7 .and. cloud_cv_options >= 2) then
                grid%moist(i,j,k,p_qg) = max(grid%moist(i,j,k,p_qg) + grid%xa%qgr(i,j,k), 0.0)
             end if
          end do


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: moist, analysis update

SOURCE: Internal (JJG)

DESCRIPTION OF CHANGES: 
xatowrf now requires cloud_cv_options that match packaging defined in registry.var
for xa%qrn, xa%qcw, xa%qci, xa%qsn, and xa%qgr.

This bugfix is connected to PR #283 from  11 AUG 2017 (https://github.com/wrf-model/WRF/commit/c7405bb3544a3eecd070263865de7d4834d9ee14#diff-fe8b020143d32583d82b945e2bd66f50)

The array bounds error this avoids occurs when mp_physics ~= [0, 98] and cloud_cv_options==0.

LIST OF MODIFIED FILES: 
M       var/da/da_transfer_model/da_transfer_xatowrf.inc

TESTS CONDUCTED: 
The following error at the end of rsl.error.0000 is avoided with this fix when "debug" build is used for WRFDA:

>``forrtl: severe (408): fort: (2): Subscript #1 of the array QCW has value 2 which is greater than the upper bound of 1``
>
>``Image              PC                Routine            Line        Source
da_wrfvar.exe      00000000060CF996  Unknown               Unknown  Unknown
da_wrfvar.exe      00000000017EDB3B  da_transfer_model        2224  da_transfer_model.f
da_wrfvar.exe      00000000018A4263  da_transfer_model        3399  da_transfer_model.f
da_wrfvar.exe      00000000004C5D92  da_wrfvar_top_mp_        3675  da_wrfvar_top.f
da_wrfvar.exe      00000000004B0699  da_wrfvar_top_mp_        2779  da_wrfvar_top.f
da_wrfvar.exe      00000000004B0559  da_wrfvar_top_mp_        2749  da_wrfvar_top.f
da_wrfvar.exe      0000000000459863  MAIN__                     34  da_wrfvar_main.f
da_wrfvar.exe      0000000000405C1E  Unknown               Unknown  Unknown
libc-2.19.so       00002AAAAB7E5B25  __libc_start_main     Unknown  Unknown
da_wrfvar.exe      0000000000405B29  Unknown               Unknown  Unknown``


The WRFDA Regression test was not run.  The changes are minor and fix the known bug.
