### PR TITLE
Correct a few wrong namelist options in namelist.input.fire

### DIFF
--- a/test/em_real/namelist.input.fire
+++ b/test/em_real/namelist.input.fire
@@ -118,12 +118,12 @@
 !
 ! ignition
  fire_num_ignitions = 3,        ! integer, only the first fire_num_ignition used, up to 5 allowed
- fire_ignition_start_long1=-107.293664, ! start points of ignition lines, longitude 
+ fire_ignition_start_lon1=-107.293664, ! start points of ignition lines, longitude 
  fire_ignition_start_lat1 =  39.698696, ! start points of ignition lines,latitude 
- fire_ignition_end_long1 = -107.293664, ! end points of ignition lines
+ fire_ignition_end_lon1 = -107.293664, ! end points of ignition lines
  fire_ignition_end_lat1 =    39.710990, ! end points of ignition lines
  fire_ignition_radius1 =    18, ! all within this radius (m) will ignite, > fire mesh step
- fire_ignition_time1  =      2, ! sec for ignition from the start
+ fire_ignition_start_time1  =      2, ! sec for ignition from the start
  fire_ignition_start_long2=-107.287954, ! start points of ignition lines, 
  fire_ignition_start_lat2 =  39.698696, ! start points of ignition lines, 
  fire_ignition_end_long2 = -107.287954,! end points of ignition lines, 


### PR DESCRIPTION
TYPE:  Text only

KEYWORDS: WRF-FIRE, namelist

SOURCE: internal

DESCRIPTION OF CHANGES: In the sample namelist.input.fire that comes with the released WRF.tar file, the syntax for some variables is different than the ones in the registry.fire. 

A few namelist options were spelled incorrectly in the sample namelist.input.fire. This PR corrects the spelling. I compared the namelist options with those in registry.fire to make sure they are correctly spelled in the sample namelist.

LIST OF MODIFIED FILES: 
M test/em_real/namelist.input.fire

TESTS CONDUCTED: Regression test is not necessary