### PR TITLE
WSM6 change of refl_10cm to "optional" to work with mpas

### DIFF
--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -136,8 +136,8 @@ CONTAINS
                                                           re_ice, &
                                                          re_snow
 !+---+-----------------------------------------------------------------+
-  REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT) ::     &  ! GT
-                                                       refl_10cm
+  REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL,           &   ! GT
+        INTENT(INOUT) ::                               refl_10cm
 !+---+-----------------------------------------------------------------+
 
   REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,                 &

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -1,5 +1,4 @@
 #if ( (defined(wrfmodel) ) && ( RWORDSIZE == 4 ) ) || ( ( defined(mpas) ) && defined(SINGLE_PRECISION) )
-!kkw test
 #  define VREC vsrec
 #  define VSQRT vssqrt
 #else

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -1,4 +1,5 @@
 #if ( (defined(wrfmodel) ) && ( RWORDSIZE == 4 ) ) || ( ( defined(mpas) ) && defined(SINGLE_PRECISION) )
+!kkw test
 #  define VREC vsrec
 #  define VSQRT vssqrt
 #else


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: wsm6, mp_physics, wrf, mpas, unification

SOURCE: internal

DESCRIPTION OF CHANGES: Added 'optional' to the variable refl_10cm inside subroutine wsm6, so that it would work with MPAS.

LIST OF MODIFIED FILES: 
M    phys/module_mp_wsm6.F

TESTS CONDUCTED: code compiles and gives bit-for-bit results before and after modifications.