### PR TITLE
Fix for cloud/w BE rescaling for not-first outerloops

### DIFF
--- a/var/da/da_minimisation/da_get_var_diagnostics.inc
+++ b/var/da/da_minimisation/da_get_var_diagnostics.inc
@@ -222,11 +222,21 @@ subroutine da_get_var_diagnostics(it, iv, j)
          write(unit=stdout,fmt='(a,f15.5)') '   Final J / total num_obs     = ', j % total / &
                                                           real(num_stats_tot)
       if (cv_options /= 3) then
-        write(unit=stdout,fmt='(a,(5f15.5))') '   Jb factor used(1)           = ', var_scaling1(it)
-        write(unit=stdout,fmt='(a,(5f15.5))') '   Jb factor used(2)           = ', var_scaling2(it)
-        write(unit=stdout,fmt='(a,(5f15.5))') '   Jb factor used(3)           = ', var_scaling3(it)
-        write(unit=stdout,fmt='(a,(5f15.5))') '   Jb factor used(4)           = ', var_scaling4(it)
-        write(unit=stdout,fmt='(a,(5f15.5))') '   Jb factor used(5)           = ', var_scaling5(it)
+        write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(1)         = ', var_scaling1(it)
+        write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(2)         = ', var_scaling2(it)
+        write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(3)         = ', var_scaling3(it)
+        write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(4)         = ', var_scaling4(it)
+        write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(5)         = ', var_scaling5(it)
+        if ( cloud_cv_options >= 2 ) then
+           write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(6)         = ', var_scaling6(it)
+           write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(7)         = ', var_scaling7(it)
+           write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(8)         = ', var_scaling8(it)
+           write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(9)         = ', var_scaling9(it)
+           write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(10)        = ', var_scaling10(it)
+        end if
+        if ( use_cv_w ) then
+           write(unit=stdout,fmt='(a,(5f15.5))') '   var_scaling used(11)        = ', var_scaling11(it)
+        end if
       endif
 
       write(unit=stdout,fmt='(a, f15.5)') '   Jb factor used              = ', jb_factor

--- a/var/da/da_minimisation/da_minimisation.f90
+++ b/var/da/da_minimisation/da_minimisation.f90
@@ -54,7 +54,9 @@ module da_minimisation
       use_satcv, sensitivity_option, print_detail_outerloop, adj_sens, filename_len, &
       ims, ime, jms, jme, kms, kme, ips, ipe, jps, jpe, kps, kpe, fgat_rain_flags, var4d_bin_rain, freeze_varbc, &
       use_wpec, wpec_factor, use_4denvar, anal_type_hybrid_dual_res, alphacv_method, alphacv_method_xa, &
-      write_detail_grad_fn, pseudo_uvtpq, lanczos_ep_filename, use_divc, divc_factor
+      write_detail_grad_fn, pseudo_uvtpq, lanczos_ep_filename, use_divc, divc_factor, &
+      cloud_cv_options, use_cv_w, var_scaling6, var_scaling7, var_scaling8, var_scaling9, &
+      var_scaling10, var_scaling11
    use da_define_structures, only : iv_type, y_type,  j_type, be_type, &
       xbx_type, jo_type, da_allocate_y,da_zero_x,da_zero_y,da_deallocate_y, &
       da_zero_vp_type, qhat_type

--- a/var/da/da_setup_structures/da_scale_background_errors.inc
+++ b/var/da/da_setup_structures/da_scale_background_errors.inc
@@ -12,6 +12,9 @@ subroutine da_scale_background_errors ( be, it )
    integer  :: i, ix, jy, kz, v1_mz, v2_mz, v3_mz, v4_mz, v5_mz
    real     :: ds
 
+   real*8, allocatable, dimension(:) :: rf_len6, rf_len7, rf_len8, &
+                                        rf_len9, rf_len10, rf_len11
+
    if ( jb_factor <= 0.0 ) return
 !
 ! Rewind the unit:
@@ -105,6 +108,40 @@ subroutine da_scale_background_errors ( be, it )
     deallocate ( rf_len4 )
     deallocate ( v5_val )
     deallocate ( rf_len5 )
-!
+
+    if ( cloud_cv_options >= 2 ) then
+       allocate ( rf_len6(1:kz) )
+       allocate ( rf_len7(1:kz) )
+       allocate ( rf_len8(1:kz) )
+       allocate ( rf_len9(1:kz) )
+       allocate ( rf_len10(1:kz) )
+       read (be_rf_unit) be%v6%val, be%v7%val, be%v8%val, &
+                         be%v9%val, be%v10%val
+       read (be_rf_unit) rf_len6, rf_len7, rf_len8, rf_len9, rf_len10
+       call da_rescale_background_errors( var_scaling6(it), len_scaling6(it), &
+                                          ds, rf_len6, be % v6 )
+       call da_rescale_background_errors( var_scaling7(it), len_scaling7(it), &
+                                          ds, rf_len7, be % v7 )
+       call da_rescale_background_errors( var_scaling8(it), len_scaling8(it), &
+                                          ds, rf_len8, be % v8 )
+       call da_rescale_background_errors( var_scaling9(it), len_scaling9(it), &
+                                          ds, rf_len9, be % v9 )
+       call da_rescale_background_errors( var_scaling10(it), len_scaling10(it), &
+                                          ds, rf_len10, be % v10)
+       deallocate ( rf_len6 )
+       deallocate ( rf_len7 )
+       deallocate ( rf_len8 )
+       deallocate ( rf_len9 )
+       deallocate ( rf_len10 )
+    end if
+    if ( use_cv_w ) then
+       allocate ( rf_len11(1:kz) )
+       read (be_rf_unit) be%v11%val
+       read (be_rf_unit) rf_len11
+       call da_rescale_background_errors( var_scaling11(it), len_scaling11(it), &
+                                          ds, rf_len11, be % v11)
+       deallocate ( rf_len11 )
+    end if
+
 end subroutine da_scale_background_errors
 

--- a/var/da/da_setup_structures/da_setup_be_regional.inc
+++ b/var/da/da_setup_structures/da_setup_be_regional.inc
@@ -1450,6 +1450,7 @@ subroutine da_setup_be_regional(xb, be, grid)
 
       if (max_ext_its > 1 .and. jb_factor > 0.0) then
 
+        if ( rootproc ) then
           write(unit=message(1),fmt='(A,I4)') '>>> Save the variances and scale-lengths in outer-loop', it
           call da_message(message(1:1))
           write(be_rf_unit)  kz, jy, ix, be % v1 % mz, be % v2 % mz, be% v3 % mz, &
@@ -1458,7 +1459,17 @@ subroutine da_setup_be_regional(xb, be, grid)
                                      be % v4 % val, be % v5 % val, &
              be1_rf_lengthscale, be2_rf_lengthscale, be3_rf_lengthscale, &
              be4_rf_lengthscale, be5_rf_lengthscale
-     
+          if ( cloud_cv_options >= 2 ) then
+             write(be_rf_unit) be%v6%val, be%v7%val, be%v8%val, be%v9%val, be%v10%val
+             write(be_rf_unit) be6_rf_lengthscale, be7_rf_lengthscale, be8_rf_lengthscale, &
+                               be9_rf_lengthscale, be10_rf_lengthscale
+          end if
+          if ( use_cv_w ) then
+             write(be_rf_unit) be%v11%val
+             write(be_rf_unit) be11_rf_lengthscale
+          end if
+        end if ! rootproc
+
           if (print_detail_be ) then
              write(be_print_unit,'("it=",i2,2x,"kz=",i3,2x,"jy=",i4,2x,"ix=",i4,2x,"ds=",e12.5)') &
                                                it, kz, jy, ix, xb % ds


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, cloud control variable, outerloop

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
1. Add cloud and w control variables that were not included in the original BE rescaling code.
2. Only root processor writes out the intermediate file for BE rescaling.
3. Change the log message from Jb factor used() to var_scaling used().

LIST OF MODIFIED FILES:
M       var/da/da_minimisation/da_get_var_diagnostics.inc
M       var/da/da_minimisation/da_minimisation.f90
M       var/da/da_setup_structures/da_scale_background_errors.inc
M       var/da/da_setup_structures/da_setup_be_regional.inc

TESTS CONDUCTED:
1. Results remain the same when var_scaling[6..11] do not vary with outerloops.
2. WRFDA regtests with intel 17.0.1 on cheyenne passed.

RELEASE NOTE:
Bug fix for max_ext_its>=2 and cloud BE scaling factors (i.e. var_scaling6..11 and len_scaling6..11) vary with outerloops.