### PR TITLE
Fix to assign proper radar rv/rf errors to avoid excessive check_max_iv prints

### DIFF
--- a/var/da/da_obs_io/da_read_obs_radar.inc
+++ b/var/da/da_obs_io/da_read_obs_radar.inc
@@ -179,11 +179,13 @@ subroutine da_read_obs_radar (iv, filename, grid)
                              platform % each (i) % rf % qc,          &
                              platform % each (i) % rf % error
 
-            if (platform % each (i) % rv % error == 0.0) then
+            if (platform % each (i) % rv % error == 0.0 .or. &
+                abs(platform % each (i) % rv % error - missing_r) < 1.0) then
                  platform % each (i) % rv % error  = 1.0
             end if
 
-            if (platform % each (i) % rf % error == 0.0) then
+            if (platform % each (i) % rf % error == 0.0 .or. &
+                abs(platform % each (i) % rf % error - missing_r) < 1.0) then
                  platform % each (i) % rf % error  = 1.0
             end if
 

--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -310,6 +310,10 @@ END IF
                            .and. (iv % radar(n) % rf(k) % qc >= obs_qc_pointer)
 
             if (use_radar_rv) then
+               !set qc to missing_data for rv of -999.99 (radar_non_precip_rf)
+               if ( abs(ob%radar(n)%rv(k) - radar_non_precip_rf) < 0.1 ) then
+                   iv % radar(n) % rv(k) % qc = missing_data
+               end if
                if (abs(iv % radar(n) % rv(k) % qc - missing_data) > 1) then
                   if (abs(ob % radar(n) % rv(k) - missing_r) > 1.0 .AND. &
                        iv % radar(n) % rv(k) % qc >= obs_qc_pointer) then


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, radar rf/rv, obs error

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

1. Missing rv are set incorrectly as no-rain rf in NCAR-processed radar data.
The fix is to set qc to missing_data for -999.99 rv in var/da/da_radar/da_get_innov_vector_radar.inc
2. Missing rv/rf has error of missing_r in CWB-processed radar data.
The fix is to set a default error value in var/da/da_obs_io/da_read_obs_radar.inc.

NCAR-processed radar data sample
```
FM-128 RADAR   2017-06-02_03:06:00        22.961       117.830      38.0       1
         5158.0    -999.990   0       0.500      -999.990   0       0.000     -8888.880

```
CWB-processed radar data sample 1
```
FM-128 RADAR   2017-07-06_06:00:00        19.570       117.335       0.0       1
        12000.0 -888888.000 -88 -888888.000      -999.990   0       0.000
```

CWB-processed radar data sample 2
```
FM-128 RADAR   2017-07-06_06:02:00        24.134       122.223      63.0       1
          946.0       1.300   0       2.000   -888888.000 -88 -888888.000
```

LIST OF MODIFIED FILES:
M       var/da/da_obs_io/da_read_obs_radar.inc
M       var/da/da_radar/da_get_innov_vector_radar.inc

TESTS CONDUCTED:
1. After the fix, radar rf and rv errors are assigned proper values in the code when the info is not provided in the input ob.radar.
2. WRFDA regtests with intel-17.0.1 on cheyenne passed.

RELEASE NOTE:
Bug fix for ob.radar that contains rv=-999.99, rv_err=-888888.0, rf_err=-888888.0.