### PR TITLE
Update the crtm_coeffs_2.2.3 path per cheyenne file system restructuring

### DIFF
--- a/var/run/crtm_coeffs
+++ b/var/run/crtm_coeffs
@@ -1,1 +1,1 @@
-/glade/p/work/wrfhelp/WRFDA_files/crtm_coeffs_2.2.3
+/glade/work/wrfhelp/WRFDA_files/crtm_coeffs_2.2.3


### PR DESCRIPTION
TYPE: no impact (except for WRFDA regtests)

KEYWORDS: WRFDA, crtm_coeffs

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Make var/run/crtm_coeffs point to the updated /glade/work path for release-v4.0.1.

LIST OF MODIFIED FILES:
M       var/run/crtm_coeffs

TESTS CONDUCTED:
1. WRFDA regtests run with the updated path.