### PR TITLE
bugfix: fix potential divide by zero in stomatal resistance diagnostic

### DIFF
--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -979,7 +979,7 @@ CONTAINS
              RB                            = MAX(RB, 0.0)
 ! New Calculation of total Canopy/Stomatal Conductance Based on Bonan et al. (2011) 
 ! -- Inverse of Canopy Resistance (below)
-             IF(RSSUN .le. 0.0 .and. RSSHA .le. 0.0) THEN
+             IF(RSSUN .le. 0.0 .or. RSSHA .le. 0.0 .or. LAISUN .eq. 0.0 .or. LAISHA .eq. 0.0) THEN
                 RS    (I,J)                = 0.0
              ELSE
                 RS    (I,J)                = ((1.0/(RSSUN+RB)*LAISUN) + ((1.0/(RSSHA+RB))*LAISHA))


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah-MP

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

Bug fix introduced in #399 where divide by zero can occur if LAI is zero. Added check in IF statement. This calculation is only for diagnostics so shouldn't change answers, except to prevent model crash.

Mods to release-v4.0.1, not develop. Replaces PR #633 

LIST OF MODIFIED FILES:

M phys/module_sf_noahmpdrv.F

TESTS CONDUCTED:

Summer and winter 24-hr case