### PR TITLE
bugfix: add limit to Noah-MP leaf aerodynamic resistance

### DIFF
--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -4284,6 +4284,7 @@ ENDIF   ! CROPTYPE == 0
 
        TMPRB  = CWPC*50. / (1. - EXP(-CWPC/2.))
        RB     = TMPRB * SQRT(parameters%DLEAF/UC)
+       RB     = MAX(RB,100.0)
 !       RB = 200
 
   END SUBROUTINE RAGRB


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah-MP

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

Change in Noah-MP subroutine RAGRB to limit leaf aerodynamic resistance (RB). Currently there is no lower limit. This can result is very large canopy exchange coefficients and subsequent canopy fluxes. Can result in model blow-up with high wind speed.

Mods to release-v4.0.1, not develop. Replaces PR #634 

LIST OF MODIFIED FILES:

M phys/module_sf_noahmplsm.F

TESTS CONDUCTED:

Summer and winter 24-hr case