### PR TITLE
Change index 2 to p_qv

### DIFF
--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -731,11 +731,11 @@ BENCH_END(update_phy_ten_tim)
       IF (grid%sppt_on==1) then
           !$OMP PARALLEL DO   &
           !$OMP PRIVATE ( ij )
-          ! JB comment:  P_QV is in moist_tend(ims,kms,jms,2)
           DO ij = 1 , grid%num_tiles
                  call perturb_physics_tend(grid%gridpt_stddev_sppt,          &
                         grid%stddev_cutoff_sppt,grid%rstoch,                 &
-                        ru_tendf,rv_tendf,t_tendf,moist_tend(ims,kms,jms,2), &
+                        ru_tendf,rv_tendf,t_tendf,                           &
+                        moist_tend(ims,kms,jms,p_qv),                        &
                         ids, ide, jds, jde, kds, kde,                        &
                         ims, ime, jms, jme, kms, kme,                        &
                         grid%i_start(ij), grid%i_end(ij),                    &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: stochastic perturbation, moist tendency

SOURCE: internal (Dave Gill) 

DESCRIPTION OF CHANGES: in the code "module_first_rk_step_part2.F" for stochastic perturbation, the moist tendency term should be "moist_tend(ims,kms,jms,p_qv)" instead of "moist_tend(ims,kms,jms,2)". 

LIST OF MODIFIED FILES: 
M       dyn_em/module_first_rk_step_part2.F

TESTS CONDUCTED: regression test is not done yet. 
