### PR TITLE
Change the number of "28" to 'thompsonaero' in solve_em.F

### DIFF
--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -3548,7 +3548,7 @@ BENCH_START(moist_physics_prep_tim)
                                    its, ite, jts, jte,               &
                                    k_start    , k_end               )
 
-       IF (config_flags%dust_emis.eq.1 .AND. config_flags%mp_physics.eq.28)  then
+       IF (config_flags%dust_emis.eq.1 .AND. config_flags%mp_physics.eq.thompsonaero)  then
          CALL wrf_debug ( 200 , ' call bulk_dust_emis' )
          CALL bulk_dust_emis (grid%itimestep,dtm,config_flags%num_soil_layers  &
                ,grid%u_phy,grid%v_phy,grid%rho,grid%alt                        &


### PR DESCRIPTION

TYPE: no impact

KEYWORDS:  dust emission and Thompson scheme  

SOURCE:  internal (Dave Gill)

DESCRIPTION OF CHANGES: when  surface dust emissions scheme is  linked to the ice-friend aerosol variable of Thompson  microphysics, in solve_em.F, the line is changed from
```
       IF (config_flags%dust_emis.eq.1 .AND. config_flags%mp_physics.eq.28)  then
```
to
```
       IF (config_flags%dust_emis.eq.1 .AND. config_flags%mp_physics.eq.thompsonaero)  then
```
LIST OF MODIFIED FILES:
M       dyn_em/solve_em.F

TESTS CONDUCTED: regression test is not done
