### PR TITLE
Bug fix in Noah LSM - divide by zero

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -977,7 +977,7 @@ CONTAINS
 #endif
 
           IF (rdlai2d) THEN
-             if(lai(i,j).eq.0.0) lai(i,j) = 0.01 
+             IF (SHDFAC > 0.0 .AND. XLAI <= 0.0) XLAI = 0.0
              xlai = lai(i,j)
           endif
 
@@ -3306,7 +3306,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 #endif
       
                 IF (rdlai2d) THEN
-                   if(lai(i,j).eq.0.0) lai(i,j) = 0.01 
+                   IF (SHDFAC > 0.0 .AND. XLAI <= 0.0) XLAI = 0.01
                    xlai = lai(i,j)
                 endif
       

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -977,7 +977,7 @@ CONTAINS
 #endif
 
           IF (rdlai2d) THEN
-             IF (SHDFAC > 0.0 .AND. XLAI <= 0.0) XLAI = 0.0
+             IF (SHDFAC(I,J) > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
              xlai = lai(i,j)
           endif
 
@@ -3306,7 +3306,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 #endif
       
                 IF (rdlai2d) THEN
-                   IF (SHDFAC > 0.0 .AND. XLAI <= 0.0) XLAI = 0.01
+                   IF (SHDFAC(I,J) > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
                    xlai = lai(i,j)
                 endif
       

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -977,7 +977,7 @@ CONTAINS
 #endif
 
           IF (rdlai2d) THEN
-             IF (SHDFAC(I,J) > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
+             IF (SHDFAC > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
              xlai = lai(i,j)
           endif
 
@@ -3306,7 +3306,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 #endif
       
                 IF (rdlai2d) THEN
-                   IF (SHDFAC(I,J) > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
+                   IF (SHDFAC > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
                    xlai = lai(i,j)
                 endif
       

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -977,6 +977,7 @@ CONTAINS
 #endif
 
           IF (rdlai2d) THEN
+             if(lai(i,j).eq.0.0) lai(i,j) = 0.01 
              xlai = lai(i,j)
           endif
 

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -3306,6 +3306,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 #endif
       
                 IF (rdlai2d) THEN
+                   if(lai(i,j).eq.0.0) lai(i,j) = 0.01 
                    xlai = lai(i,j)
                 endif
       


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NOAH LSM, divided by zero

SOURCE: internal

DESCRIPTION OF CHANGES: when the leaf area index is derived from static input data (rdlai2d=true), the value could be zero at certain areas. This leads to extremely large, unrealistic HFX and the model eventually crashed.  

LIST OF MODIFIED FILES: 
M       phys/module_sf_noahdrv.F

TESTS CONDUCTED: 
One case has been tested. The case crashed immediately without the fix. The same case can be done successfully  with the fix. 

Reggie passed. 