### PR TITLE
Add CODEOWNERS file to .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,15 +34,15 @@
 #	Dynamics
 
 /dyn_em/				@wrf-model/arw_dev_team	
-/dyn_nmm/				@wrf-model/nmm_dev_team	
+/dyn_nmm/				@wrf-model/hwrf_dev_team	
 
 #	Registry
 
 /Registry/				@wrf-model/infrastructure
 
-/Registry/Registry.NMM			@wrf-model/nmm_dev_team
-/Registry/registry.tracker		@wrf-model/nmm_dev_team
-/Registry/registry.tornado		@wrf-model/nmm_dev_team
+/Registry/Registry.NMM			@wrf-model/hwrf_dev_team
+/Registry/registry.tracker		@wrf-model/hwrf_dev_team
+/Registry/registry.tornado		@wrf-model/hwrf_dev_team
 
 /Registry/Registry.EM_CHEM		@wrf-model/chem
 /Registry/registry.chem			@wrf-model/chem
@@ -56,12 +56,12 @@
 #	Test directories
 
 /test/em_*				@wrf-model/arw_dev_team
-/test/nmm_*				@wrf-model/nmm_dev_team
+/test/nmm_*				@wrf-model/hwrf_dev_team
 /test/em_fire				@wrf-model/fire
 
 #	Executable directory
 
-/main/					@wrf-model/arw_dev_team @wrf-model/nmm_dev_team @wrf-model/infrastructure
+/main/					@wrf-model/arw_dev_team @wrf-model/hwrf_dev_team @wrf-model/infrastructure
 
 #	Externals directory structure
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,7 @@
 
 /test/em_*				@wrf-model/arw_dev
 /test/nmm_*				@wrf-model/hwrf_dev
-/test/em_fire				@wrf-model/fire
+/test/em_fire/				@wrf-model/fire
 
 #	Executable directory
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,6 @@
 /phys/module_ra_rrtmg_lw.F		@wrf-model/shared_physics
 /phys/module_ra_rrtmg_sw.F		@wrf-model/shared_physics
 /phys/module_bl_ysu.F 			@wrf-model/shared_physics
-/phys/module_mp_wsm6.F			@wrf-model/shared_physics
 /phys/module_sf_sfclay.F		@wrf-model/shared_physics
 /phys/module_sf_noah_seaice.F		@wrf-model/shared_physics
 /phys/module_sf_noah_seaice_drv.F	@wrf-model/shared_physics

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,68 @@
+#	This file sets up default notification for reviews based on who "owns" code.
+
+#	Default
+
+*					@wrf-model/global_owner
+
+#	Next, generic top-level run dir and build files
+
+/run/					@wrf-model/infrastructure
+/configure				@wrf-model/infrastructure
+/compile				@wrf-model/infrastructure
+/clean					@wrf-model/infrastructure
+/Makefile				@wrf-model/infrastructure
+
+#	Architecture directories
+
+/arch/					@wrf-model/infrastructure
+/tools/					@wrf-model/infrastructure
+
+#	Chemistry
+/chem/					@wrf-model/chem
+
+#	Physics
+
+/phys/					@wrf-model/physics
+
+/phys/module_mp_thompson.F		@gthompsnWRF @wrf-model/physics
+
+#	Data Assimilation
+
+/wrftladj/				@wrf-model/da
+/var/					@wrf-model/da
+
+#	Dynamics
+
+/dyn_em/				@wrf-model/arw_dev_team	
+/dyn_nmm/				@wrf-model/nmm_dev_team	
+
+#	Registry
+
+/Registry/				@wrf-model/infrastructure
+
+/Registry/Registry.NMM			@wrf-model/nmm_dev_team
+/Registry/registry.tracker		@wrf-model/nmm_dev_team
+/Registry/registry.tornado		@wrf-model/nmm_dev_team
+
+/Registry/Registry.EM_CHEM		@wrf-model/chem
+/Registry/registry.chem			@wrf-model/chem
+
+/Registry/registry.var 			@wrf-model/da
+/Registry/registry.var_chem		@wrf-model/da
+/Registry/registry.wrfplus		@wrf-model/da
+/Registry/Registry.wrfvar		@wrf-model/da
+/Registry/Registry.tladj		@wrf-model/da
+
+#	Test directories
+
+/test/em_*				@wrf-model/arw_dev_team
+/test/nmm_*				@wrf-model/nmm_dev_team
+/test/em_fire				@wrf-model/fire
+
+#	Executable directory
+
+/main/					@wrf-model/arw_dev_team @wrf-model/nmm_dev_team @wrf-model/infrastructure
+
+#	Externals directory structure
+
+/external/ 				@wrf-model/infrastructure

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,21 @@
 
 /phys/module_mp_thompson.F		@gthompsnWRF @wrf-model/physics
 
+#	Shared Physics Between MPAS and WRF
+
+/phys/module_mp_wsm6.F			@wrf-model/shared_physics
+/phys/module_cu_ntiedtke.F		@wrf-model/shared_physics
+/phys/module_ra_rrtmg_lw.F		@wrf-model/shared_physics
+/phys/module_ra_rrtmg_sw.F		@wrf-model/shared_physics
+/phys/module_bl_ysu.F 			@wrf-model/shared_physics
+/phys/module_mp_wsm6.F			@wrf-model/shared_physics
+/phys/module_sf_sfclay.F		@wrf-model/shared_physics
+/phys/module_sf_noah_seaice.F		@wrf-model/shared_physics
+/phys/module_sf_noah_seaice_drv.F	@wrf-model/shared_physics
+/phys/module_sf_noahdrv.F		@wrf-model/shared_physics
+/phys/module_sf_noahlsm.F		@wrf-model/shared_physics
+/phys/module_sf_noahlsm_glacial_only.F	@wrf-model/shared_physics
+
 #	Data Assimilation
 
 /wrftladj/				@wrf-model/da
@@ -33,16 +48,16 @@
 
 #	Dynamics
 
-/dyn_em/				@wrf-model/arw_dev_team	
-/dyn_nmm/				@wrf-model/hwrf_dev_team	
+/dyn_em/				@wrf-model/arw_dev
+/dyn_nmm/				@wrf-model/hwrf_dev
 
 #	Registry
 
 /Registry/				@wrf-model/infrastructure
 
-/Registry/Registry.NMM			@wrf-model/hwrf_dev_team
-/Registry/registry.tracker		@wrf-model/hwrf_dev_team
-/Registry/registry.tornado		@wrf-model/hwrf_dev_team
+/Registry/Registry.NMM			@wrf-model/hwrf_dev
+/Registry/registry.tracker		@wrf-model/hwrf_dev
+/Registry/registry.tornado		@wrf-model/hwrf_dev
 
 /Registry/Registry.EM_CHEM		@wrf-model/chem
 /Registry/registry.chem			@wrf-model/chem
@@ -55,13 +70,13 @@
 
 #	Test directories
 
-/test/em_*				@wrf-model/arw_dev_team
-/test/nmm_*				@wrf-model/hwrf_dev_team
+/test/em_*				@wrf-model/arw_dev
+/test/nmm_*				@wrf-model/hwrf_dev
 /test/em_fire				@wrf-model/fire
 
 #	Executable directory
 
-/main/					@wrf-model/arw_dev_team @wrf-model/hwrf_dev_team @wrf-model/infrastructure
+/main/					@wrf-model/arw_dev @wrf-model/hwrf_dev @wrf-model/infrastructure
 
 #	Externals directory structure
 


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: CODEOWNERS

SOURCE: internal

DESCRIPTION OF CHANGES:
This is the start of a list for shared and individual responsibility
for files and directories. When a PR is issued that modifies one of
the known files or files within a known directory (and required
reviews are enabled on that branch), then an automatic request for
review is issued to the code owners.

CODEOWNERS file is linked to the GitHub via the following teams:
   * physics
   * shared_physics
   * da
   * chem
   * hwrf_dev
   * arw_dev
   * infrastructure
   * global_owner
   * fire

Replaces PR #437 "Add CODEOWNERS file to .github directory". The fork and branch were deleted, so amending was not easy. 

More info:
```
https://help.github.com/articles/about-codeowners/
```

LIST OF MODIFIED FILES:
M	     .github/CODEOWNERS

TESTS CONDUCTED:
 - [x] Successfully forced a "code owner" to review before merge was permitted.