### PR TITLE
Fix DA compilation when RTTOV-v11 is built with HDF5-enabled

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -510,7 +510,7 @@ while ( <CONFIGURE_DEFAULTS> )
 	 }
 
     if ( $sw_hdf5_path ) 
-      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5_fortran -lhdf5 -lm -lz: ;
+      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
         $_ =~ s:CONFIGURE_HDF5_FLAG:-DHDF5: ;
          }
     else

--- a/compile
+++ b/compile
@@ -371,10 +371,19 @@ else
        endif
        if ( -e ${RTTOV}/lib/librttov11.1.0_main.a ) then
           setenv RTTOV_LIB "-L${RTTOV}/lib -lrttov11.1.0_coef_io -lrttov11.1.0_emis_atlas -lrttov11.1.0_main"
+          if ( -e ${RTTOV}/lib/librttov11.1.0_hdf.a ) then
+             setenv RTTOV_LIB "${RTTOV_LIB} -lrttov11.1.0_hdf"
+          endif
        else if ( -e ${RTTOV}/lib/librttov11.2.0_main.a ) then
           setenv RTTOV_LIB "-L${RTTOV}/lib -lrttov11.2.0_coef_io -lrttov11.2.0_emis_atlas -lrttov11.2.0_main"
+          if ( -e ${RTTOV}/lib/librttov11.2.0_hdf.a ) then
+             setenv RTTOV_LIB "${RTTOV_LIB} -lrttov11.2.0_hdf"
+          endif
        else if ( -e ${RTTOV}/lib/librttov11_main.a ) then
           setenv RTTOV_LIB "-L${RTTOV}/lib -lrttov11_coef_io -lrttov11_emis_atlas -lrttov11_main"
+          if ( -e ${RTTOV}/lib/librttov11_hdf.a ) then
+             setenv RTTOV_LIB "${RTTOV_LIB} -lrttov11_hdf"
+          endif
        else
           echo "Can not find a compatible RTTOV library! Please ensure that your RTTOV build was successful,"
           echo "your 'RTTOV' environment variable is set correctly, and you are using a supported version of RTTOV."


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, compile, RTTOV-v11, HDF5

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
1. Add two more libs (hdf5hl_fortran and hdf5_hl) to CONFIGURE_HDF5_LIB_PATH
2. Add one more lib (rttov11_hdf) to RTTOV_LIB when RTTOV-v11 is built with HDF5-enabled.
**Note that this fix is specific to WRFDA with RTTOV-v11 and
should NOT be merged to the develop branch that has different RTTOV-v12 implementation.**

LIST OF MODIFIED FILES:
M       arch/Config.pl
M       compile

TESTS CONDUCTED:
1. DA compiles after the fix.
2. Without the fix, users have to manually edit configure.wrf to add missing libs to LIB_EXTERNAL in order to compile.