### PR TITLE
Fix a few 'typos' for 4DVAR JcDF

### DIFF
--- a/Registry/registry.wrfplus
+++ b/Registry/registry.wrfplus
@@ -626,7 +626,7 @@ package   dyn_em_tl     dyn_opt==202                 -             -
 package   dyn_em_ad     dyn_opt==302                 -             -
 
 package   jcdfi_off     jcdfi_diag==0                  -             -
-package   jcdfi_on      jcdfi_diag==1                  -             state:jcdfi_u,dfi_v,jcdfi_t,jcdfi_p
+package   jcdfi_on      jcdfi_diag==1                  -             state:jcdfi_u,jcdfi_v,jcdfi_t,jcdfi_p
 
 package   lscondscheme   mp_physics==98              -             moist:qv
 package   mkesslerscheme mp_physics==99              -             moist:qv,qc,qr

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1722,9 +1722,9 @@
 #if (EM_CORE == 1 && WRFPLUS == 1 )
       IF ( ( model_config_rec%jcdfi_use ).AND. &
            ( model_config_rec%jcdfi_diag .NE. 1 ) ) THEN
-         wrf_err_message = '--- ERROR: If jcdfi_use = 1, then jcdfi_io must also = 1 for that domain '
+         wrf_err_message = '--- ERROR: If jcdfi_use = 1, then jcdfi_diag must also = 1 '
          CALL wrf_message ( wrf_err_message )
-         wrf_err_message = '--- Change jcdfi_io in namelist.input '
+         wrf_err_message = '--- Change jcdfi_diag in namelist.input '
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
       END IF


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, jcdfi

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
1. When jcdfi_diag==1, one of the packaged variable names should be jcdfi_v, not dfi_v.
This fix does not affect results.

2. Correct the error message in check-a-mundo when jcdfi_use=1 and jcdfi_diag=0.
The message before the fix:
--- ERROR: If jcdfi_use = 1, then jcdfi_io must also = 1 for that domain
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1541
--- Change jcdfi_io in namelist.input
-------------------------------------------
(1) jcdfi_io should be jcdfi_diag. There is no jcdfi_io anywhere else in the code.
(2) 'for that domain' should be removed because jcdfi_diag is a single value.

LIST OF MODIFIED FILES:
M       Registry/registry.wrfplus
M       share/module_check_a_mundo.F

TESTS CONDUCTED:
1. a 4dvar surface DA case
2. DA regtest 4dvar_small and radar_4dvar_cv7 cases that have jcdfi_use=true produced
identical results.