### PR TITLE
Bug fix in RUC LSM with MYJ PBL. Bug fix in RUC LSM for seasonal variation of LAI with .rdlai2d=.false.

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -485,6 +485,7 @@ BENCH_START(surf_driver_tim)
      &        ,SFCRUNOFF=grid%sfcrunoff,ACRUNOFF=grid%ACRUNOFF                           &
      &        ,opt_thcnd=config_flags%opt_thcnd                                          &
      &        ,SF_SFCLAY_PHYSICS=config_flags%sf_sfclay_physics                        &
+     &        ,BL_PBL_PHYSICS=config_flags%bl_pbl_physics                              &
      &        ,SF_SURFACE_PHYSICS=config_flags%sf_surface_physics  ,SH2O=grid%sh2o          &
      &        ,SHDMAX=grid%shdmax      ,SHDMIN=grid%shdmin      ,SMOIS=grid%smois        &
      &        ,SMSTAV=grid%smstav      ,SMSTOT=grid%smstot      ,SNOALB=grid%snoalb      &

--- a/dyn_nmm/module_PHYSICS_CALLS.F
+++ b/dyn_nmm/module_PHYSICS_CALLS.F
@@ -1474,6 +1474,7 @@
      &          ,FM=FM,FHH=FH,ZOL=ZOL                                   &
      &          ,PSFC=PSFC_OUT,EMISS=EPSR,EMBCK=EMBCK                   &
      &          ,SF_SFCLAY_PHYSICS=CONFIG_FLAGS%SF_SFCLAY_PHYSICS       &
+     &          ,BL_PBL_PHYSICS=config_flags%bl_pbl_physics             &
      &          ,SF_SURFACE_PHYSICS=CONFIG_FLAGS%SF_SURFACE_PHYSICS     &
      &          ,RA_LW_PHYSICS=CONFIG_FLAGS%RA_LW_PHYSICS               &
      &          ,RA_SW_PHYSICS=CONFIG_FLAGS%RA_SW_PHYSICS               &

--- a/phys/module_sf_ruclsm.F
+++ b/phys/module_sf_ruclsm.F
@@ -73,7 +73,7 @@ CONTAINS
                    SFCRUNOFF,UDRUNOFF,ACRUNOFF,SFCEXC,           &
                    SFCEVP,GRDFLX,SNOWFALLAC,ACSNOW,SNOM,         &
                    SMFR3D,KEEPFR3DFLAG,                          &
-                   myj,shdmin,shdmax,rdlai2d,                    &
+                   myjpbl,shdmin,shdmax,rdlai2d,                 &
                    ids,ide, jds,jde, kds,kde,                    &
                    ims,ime, jms,jme, kms,kme,                    &
                    its,ite, jts,jte, kts,kte                     )
@@ -160,7 +160,7 @@ CONTAINS
    INTEGER,     PARAMETER            ::     nvegclas=24+3
 
    REAL,       INTENT(IN   )    ::     DT
-   LOGICAL,    INTENT(IN   )    ::     myj,frpcpn
+   LOGICAL,    INTENT(IN   )    ::     myjpbl,frpcpn
    INTEGER,    INTENT(IN   )    ::     spp_lsm
    INTEGER,    INTENT(IN   )    ::     NLCAT, NSCAT, mosaic_lu, mosaic_soil
    INTEGER,    INTENT(IN   )    ::     ktau, nsl, isice, iswater, &
@@ -193,6 +193,7 @@ CONTAINS
                                                            XICE, &
                                                           XLAND, &
 !                                                         ALBBCK, &
+!                                                         VEGFRA, &
                                                            TBOT
 
 !beka
@@ -201,7 +202,7 @@ CONTAINS
 
 
 #if (EM_CORE==1)
-   REAL,       DIMENSION( ims:ime , jms:jme ),                   &
+   REAL,       OPTIONAL, DIMENSION( ims:ime , jms:jme ),         &
                INTENT(IN   )    ::                   GRAUPELNCV, &
                                                         SNOWNCV, &
                                                         RAINNCV
@@ -381,6 +382,7 @@ CONTAINS
                                                            TKMS, &
                                                         snowrat, &
                                                        grauprat, &
+                                                       graupamt, &
                                                          icerat, &
                                                           curat, &
                                                        INFILTRP
@@ -602,14 +604,18 @@ CONTAINS
 !--- 1*e-3 is to convert from mm/s to m/s
          PRCPMS   = (prcpncliq + prcpculiq)/DT*1.e-3
          NEWSNMS  = (prcpncfr + prcpcufr)/DT*1.e-3
-!         PRCPMS    = (RAINBL(i,j)/DT*1.e-3)*(1-FRZFRAC(I,J))
-!         NEWSNMS  = (RAINBL(i,j)/DT*1.e-3)*FRZFRAC(I,J)
+
+         IF ( PRESENT( graupelncv ) ) THEN
+             graupamt = graupelncv(i,j)
+         ELSE
+             graupamt = 0.
+         ENDIF
 
          if((prcpncfr + prcpcufr) > 0.) then
 ! -- calculate snow, graupel and ice fractions in falling frozen precip
          snowrat=min(1.,max(0.,snowncv(i,j)/(prcpncfr + prcpcufr)))
-         grauprat=min(1.,max(0.,graupelncv(i,j)/(prcpncfr + prcpcufr)))
-         icerat=min(1.,max(0.,(prcpncfr-snowncv(i,j)-graupelncv(i,j)) &
+         grauprat=min(1.,max(0.,graupamt/(prcpncfr + prcpcufr)))
+         icerat=min(1.,max(0.,(prcpncfr-snowncv(i,j)-graupamt) &
                /(prcpncfr + prcpcufr)))
          curat=min(1.,max(0.,(prcpcufr/(prcpncfr + prcpcufr))))
          endif
@@ -640,15 +646,10 @@ CONTAINS
 !    module_diagnostics
           precipfr(i,j) = NEWSNMS * DT *1.e3
 
-        if   (myj)   then
-         QKMS=CHS(i,j)
-         TKMS=CHS(i,j)
-        else
 !--- convert exchange coeff QKMS to [m/s]
          QKMS=FLQC(I,J)/RHO/MAVAIL(I,J)
 !         TKMS=FLHC(I,J)/RHO/CP
          TKMS=FLHC(I,J)/RHO/(CP*(1.+0.84*QVATM))  ! mynnsfc uses CPM
-        endif
 !--- convert incoming snow and canwat from mm to m
          SNWE=SNOW(I,J)*1.E-3
          SNHEI=SNOWH(I,J)
@@ -730,7 +731,7 @@ CONTAINS
     ENDIF
 !--- initializing soil and surface properties
      CALL SOILVEGIN  ( mosaic_lu, mosaic_soil,soilfrac,nscat,shdmin(i,j),shdmax(i,j),&
-                       NLCAT,ILAND,ISOIL,iswater,MYJ,IFOREST,lufrac,VEGFRA(I,J),     &
+                       NLCAT,ILAND,ISOIL,iswater,IFOREST,lufrac,VEGFRA(I,J),         &
                        EMISSL(I,J),PC(I,J),ZNT(I,J),LAI(I,J),RDLAI2D,                &
                        QWRTZ,RHOCS,BCLH,DQM,KSAT,PSIS,QMIN,REF,WILT,i,j )
     IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
@@ -882,6 +883,7 @@ CONTAINS
 !              soilm1d (k) = min(max(0.,soilmois(i,k,j)),dqm)
               tso1d   (k) = tso(i,k,j)
               soiliqw (k) = min(max(0.,sh2o(i,k,j)-qmin),soilm1d(k))
+              soilice (k) =(soilm1d (k) - soiliqw (k))/0.9 
            ENDDO 
 
            do k=1,nzs
@@ -937,7 +939,7 @@ CONTAINS
                 QKMS,TKMS,PC(I,J),LMAVAIL(I,J),                  &
                 canwatr,vegfra(I,J),alb(I,J),znt(I,J),           &
                 snoalb(i,j),albbck(i,j),lai(i,j),                &   !new
-                myj,seaice(i,j),isice,                           &
+                myjpbl,seaice(i,j),isice,                        &
 !--- soil fixed fields
                 QWRTZ,                                           &
                 rhocs,dqm,qmin,ref,                              &
@@ -1060,17 +1062,12 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
         patmb=P8w(i,1,j)*1.e-2
         Q2SAT=QSN(TABS,TBQ)/PATMB
         QSFC(I,J) = QVG(I,J)/(1.+QVG(I,J))
-! for MYJ surface and PBL scheme
-!      if (myj) then
-! MYJSFC expects QSFC as actual specific humidity at the surface
-        IF((QVATM.GE.Q2SAT*0.95).AND.QVATM.LT.qvg(I,J))THEN
+! for MYJ PBL scheme
+        IF((myjpbl).AND.(QVATM.GE.Q2SAT*0.95).AND.QVATM.LT.qvg(I,J))THEN
           CHKLOWQ(I,J)=0.
         ELSE
           CHKLOWQ(I,J)=1.
         ENDIF
-!      else
-!          CHKLOWQ(I,J)=1.
-!      endif
 
     IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
       if(CHKLOWQ(I,J).eq.0.) then
@@ -1637,12 +1634,6 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
              KEEP_SNOW_ALBEDO = 1.
              snow_mosaic=0.  ! ???
       ENDIF
-
-!7Mar18 -  turn off snow mosaic for T<271K to prevent from too warm
-!  temperature and loss of low-level clouds in HRRR (case 2 Feb. 2018, 15z)
-     IF (TABS < 271.) then
-             snow_mosaic=0. 
-     ENDIF
 
     IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
       print *,'SNHEI_CRIT,SNOWFRAC,SNHEI_CRIT_newsn,SNOWFRACnewsn', &
@@ -2758,6 +2749,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
     ENDIF
      endif ! myj
           QFX= XLV*EETA
+          EETA= - RHO*DEW
         ELSE
 ! ---  evaporation
           EDIR1 =-soilres*(1.-vegfrac)*QKMS*RAS*                      &
@@ -2800,6 +2792,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
     ENDIF
      endif ! myj
           QFX= XLV * EETA
+          EETA = (EDIR1 + EC1 + ETT1)*1.E3
         ENDIF
     IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
      print *,'potential temp HFT ',HFT
@@ -2849,7 +2842,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
             xlv,CP,rovcp,cw,stbolt,tabs,                        &
 !--- output variables
             tso,dew,soilt,qvg,qsg,qcg,                          &
-            eeta,qfx,hfx,s,evapl,prcpl,fltot                          &
+            eeta,qfx,hfx,s,evapl,prcpl,fltot                    &
                                                                 )
 
 !*****************************************************************
@@ -3056,6 +3049,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
     ENDIF
      endif ! myj
           QFX= XLS*EETA
+          EETA= - RHO*DEW
         ELSE
 ! ---  evaporation
      if(myj) then
@@ -3073,6 +3067,7 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
     ENDIF
      endif ! myj
           QFX= XLS * EETA
+          EETA = Q1*1.E3
         ENDIF
           EVAPL=EETA
 
@@ -3536,54 +3531,9 @@ print * ,'Soil moisture is below wilting in mixed grassland/cropland category at
         UMVEG=1.-vegfrac
         EPOT = -FQ*(QVATM-QSG) 
 
-!     IF(vegfrac.EQ.0.) then
-!           cst=0.
-!           drip=0.
-!      ELSE
-!       IF(EPOT.GE.0.) THEN
-!!         DD1=CST+ NEWSNOW*RHOnewSN*1.E-3  &
-!!              -DELT*RAS*EPOT*(CST/SAT)**CN
-!    IF ( 1==2 ) THEN
-!       print *,'DD1=',dd1,cst,sat
-!    ENDIF
-!        ELSE
-
-!! Sublimation
-!         DEW = - EPOT
-!!         DD1=CST+(NEWSNOW*RHOnewSN*1.E-3+delt*DEW*RAS)
-!    IF ( 1==2 ) THEN
-!       print *,'Sublimation DD1=',dd1,cst,sat
-!    ENDIF
-!       ENDIF
-
-!          DD1=CST+NEWSNOW*RHOnewSN*1.E-3
-
-!!        IF(DD1.LT.0.) DD1=0.
-!      IF (vegfrac.GT.0.) THEN
-!          CST=DD1
-!        IF(CST.GT.SAT) THEN
-!          CST=SAT
-!          DRIP=DD1-SAT
-!        ENDIF
-!      ENDIF
-
-
-!--- With vegetation part of NEWSNOW can be intercepted by canopy until
-!--- the saturation is reached. After the canopy saturation is reached
-!--- DRIP in the solid form will be added to SNOW cover.
-
-!   SNWE=SNWE-vegfrac*NEWSNOW*RHOnewSN*1.E-3                      &
-!   SNWE=SNHEI*RHOSN*1.e-3-vegfrac*NEWSNOW*RHOnewSN*1.E-3                      &
-!                  + DRIP                                         
-
     IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
       print *,'SNWE after subtracting intercepted snow - snwe=',snwe,vegfrac,cst
     ENDIF
-
-!       ENDIF  ! vegfrac=0.
- 
-!        DRIP=0.
-!        SNHEI=SNWE*1.e3/RHOSN
           SNWEPR=SNWE
 
 !  check if all snow can evaporate during DT
@@ -3780,6 +3730,7 @@ print *, 'TSO before calling SNOWTEMP: ', tso
     ENDIF
      endif ! myj
           QFX= XLVm*EETA
+          EETA= - RHO*DEW
         ELSE
 ! ---  evaporation
         EDIR1 = Q1*UMVEG *BETA
@@ -3814,6 +3765,7 @@ print *, 'TSO before calling SNOWTEMP: ', tso
     ENDIF
      endif ! myj
         QFX= XLVm * EETA
+        EETA = (EDIR1 + EC1 + ETT1)*1.E3
        ENDIF
         S=SNFLX
 !        sublim=eeta
@@ -4512,6 +4464,7 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
           EETA= - RHO*DEW
       endif ! myj
           QFX= XLVm*EETA
+          EETA= - RHO*DEW
           sublim = EETA
         ELSE
 ! ---  evaporation
@@ -4524,6 +4477,7 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
           EETA = Q1*BETA*1.E3
       endif ! myj
           QFX= XLVm * EETA
+          EETA = Q1*BETA*1.E3
           sublim = EETA
         ENDIF
 
@@ -4866,23 +4820,6 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
   200   CONTINUE
     IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
         print *,'200 QVG,QSG,QCG,TSO(1)',QVG,QSG,QCG,TSO(1)
-    ENDIF
-
-  if(qvatm > QSG .and. iter==0) then
-!condensation regime
-    IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
-     print *,'turn off canopy evaporation and transpiration'
-     print *,' QVATM,QVG,QSG,TS1',QVATM,QVG,QSG,TS1
-    ENDIF
-      can=0.
-      umveg=1.
-      iter=1
-      goto 2111
-  endif
-    IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
-     if(iter == 1) then
-      print *,'QVATM,QVG,QSG,QCG,TS1',QVATM,QVG,QSG,QCG,TS1
-     endif
     ENDIF
 
 !--- SOILT - skin temperature
@@ -5385,23 +5322,6 @@ print *, 'SNOWTEMP: SNHEI,SNTH,SOILT1: ',SNHEI,SNTH,SOILT1,soilt
      print *,'No Saturation QVG,QSG,QCG,TSO(1)',QVG,QSG,QCG,TSO(1)
     ENDIF
   200   CONTINUE
-
-  if(qvatm > QSG .and. iter==0) then
-!condensation regime
-    IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
-     print *,'SNOW turn off canopy evaporation and transpiration'
-     print *,' QVATM,QVG,QSG,TS1',QVATM,QVG,QSG,TS1
-    ENDIF
-      can=0.
-      umveg=1.
-      iter=1
-      goto 2211
-  endif
-    IF ( wrf_at_debug_level(LSMRUC_DBG_LVL) ) THEN
-     if(iter==1) then
-       print *,'SNOW - QVATM,QVG,QSG,QCG,TS1',QVATM,QVG,QSG,QCG,TS1
-     endif
-    ENDIF
 
 !--- SOILT - skin temperature
         SOILT=TS1
@@ -6566,7 +6486,7 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
 
      SUBROUTINE SOILVEGIN  ( mosaic_lu,mosaic_soil,soilfrac,nscat,   &
                      shdmin, shdmax,                                 &
-                     NLCAT,IVGTYP,ISLTYP,iswater,MYJ,                &
+                     NLCAT,IVGTYP,ISLTYP,iswater,                    &
                      IFOREST,lufrac,vegfrac,EMISS,PC,ZNT,LAI,RDLAI2D,&
                      QWRTZ,RHOCS,BCLH,DQM,KSAT,PSIS,QMIN,REF,WILT,I,J)
 
@@ -6801,7 +6721,6 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
                                                          ISLTYP
    INTEGER,    INTENT(IN   )    ::     mosaic_lu, mosaic_soil
 
-   LOGICAL,    INTENT(IN   )    ::     myj
    REAL,       INTENT(IN )      ::   SHDMAX
    REAL,       INTENT(IN )      ::   SHDMIN
    REAL,       INTENT(IN )      ::   VEGFRAC
@@ -6836,8 +6755,8 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
 !   INTEGER, DIMENSION( 1:50 )   ::   if1
    INTEGER   ::   kstart, kfin, lstart, lfin
    INTEGER   ::   k
-   REAL      ::   area,  deltalai, factor, znt1, lb
-   REAL,     DIMENSION( 1:NLCAT ) :: ZNTtoday, LAItoday
+   REAL      ::   area,  factor, znt1, lb
+   REAL,     DIMENSION( 1:NLCAT ) :: ZNTtoday, LAItoday, deltalai
 
 !***********************************************************************
 !        DATA ZS1/0.0,0.05,0.20,0.40,1.6,3.0/   ! o -  levels in soil
@@ -6858,43 +6777,40 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
       endif
     ENDIF
 
-        deltalai = 0.
+        deltalai(:) = 0.
 
 ! 11oct2012 - seasonal correction on ZNT for crops and LAI for all veg. types
 ! factor = 1 with minimum greenness -->  vegfrac = shdmin (cold season)
-!      if((vegfrac - shdmin) .le. 0.) then
-!        factor = 1.
-!      else
-!        factor = 1. - max(0.,min(1.,((vegfrac - shdmin)/(shdmax-shdmin))))
-!      endif
-
-! 11oct2012 - seasonal correction on ZNT for crops and LAI for all veg. types
-! factor = 1 with minimum greenness -->  vegfrac = shdmin (cold season)
+! factor = 0 with maximum greenness -->  vegfrac = shdmax
 ! SHDMAX, SHDMIN and VEGFRAC are in % here.
       if((shdmax - shdmin) .lt. 1) then
-        factor = 1.
+        factor = 1. ! min greenness
       else
         factor = 1. - max(0.,min(1.,(vegfrac - shdmin)/max(1.,(shdmax-shdmin))))
       endif
 
+! 18sept18 - LAITBL and Z0TBL are the max values
       do k = 1,nlcat
-       if(IFORTBL(k) == 1) deltalai=0.2
-       if(IFORTBL(k) == 2 .or. IFORTBL(k) == 7) deltalai=0.5
-       if(IFORTBL(k) == 3) deltalai=0.45
-       if(IFORTBL(k) == 4) deltalai=0.75
-       if(IFORTBL(k) == 5) deltalai=0.86
+       if(IFORTBL(k) == 1) deltalai(k)=min(0.2,0.8*LAITBL(K))
+       if(IFORTBL(k) == 2 .or. IFORTBL(k) == 7) deltalai(k)=min(0.5,0.8*LAITBL(K))
+       if(IFORTBL(k) == 3) deltalai(k)=min(0.45,0.8*LAITBL(K))
+       if(IFORTBL(k) == 4) deltalai(k)=min(0.75,0.8*LAITBL(K))
+       if(IFORTBL(k) == 5) deltalai(k)=min(0.86,0.8*LAITBL(K))
 
        if(k.ne.iswater) then
-        LAItoday(k) = LAITBL(K) * (1. - deltalai * factor)
+!-- 20aug18 - change in LAItoday based on the greenness fraction for the current day
+        LAItoday(k) = LAITBL(K) - deltalai(k) * factor
+
          if(IFORTBL(k) == 7) then
-!crops
-           ZNTtoday(k) = Z0TBL(K) * (1. - 0.66 * factor)
+!-- seasonal change of roughness length for crops 
+           ZNTtoday(k) = Z0TBL(K) - 0.125 * factor
          else
            ZNTtoday(k) = Z0TBL(K)
          endif
        else
         LAItoday(k) = LAITBL(K)
-        ZNTtoday(k) = Z0TBL(K)
+!        ZNTtoday(k) = Z0TBL(K)
+        ZNTtoday(k) = ZNT ! do not overwrite z0 over water with the table value
        endif
       enddo
 
@@ -7016,6 +6932,7 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
 
 ! dominant category approach
         else
+      if(isltyp.ne.14) then
           RHOCS  = HC(ISLTYP)*1.E6
           BCLH   = BB(ISLTYP)
           DQM    = MAXSMC(ISLTYP)-                               &
@@ -7026,6 +6943,7 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
           REF    = REFSMC(ISLTYP)
           WILT   = WLTSMC(ISLTYP)
           QWRTZ  = QTZ(ISLTYP)
+      endif
         endif
 
 ! parameters from the look-up tables
@@ -7172,8 +7090,7 @@ print *,'INFMAX,INFMAX1,HYDRO(1)*SOILIQW(1),-TOTLIQ', &
     ELSE
        if(isltyp(i,j).ne.14 ) then
 !-- land
-!           mavail(i,j) = max(0.00001,min(1.,(smois(i,1,j)-qmin)/dqm))
-           mavail(i,j) = max(0.00001,min(1.,smois(i,1,j)/(ref-qmin)))
+           mavail(i,j) = max(0.00001,min(1.,(smois(i,1,j)-qmin)/(ref-qmin)))
          DO L=1,NZS
 !-- for land points initialize soil ice
          tln=log(TSLB(i,l,j)/273.15)

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -48,6 +48,7 @@ CONTAINS
      &          ,flqc,flhc,psfc,sst,sst_input,sstsk,dtw,sst_update,sst_skin     &
      &          ,scm_force_skintemp,scm_force_flux,t2,emiss           &
      &          ,sf_sfclay_physics,sf_surface_physics,ra_lw_physics   & 
+     &          ,bl_pbl_physics                                       &
      &          ,mosaic_lu,mosaic_soil                                &
      &          ,landusef,soilctop,soilcbot,ra,rs,nlcat,nscat,vegf_px & ! PX-LSM
      &          ,snowncv, anal_interval, lai, imperv, canfra          & ! PX-LSM
@@ -286,6 +287,8 @@ CONTAINS
                                        ,SFCLAYREVSCHEME           &
                                        ,MYJSFCSCHEME              &
                                        ,QNSESFCSCHEME             &
+                                       ,MYJPBLSCHEME              &
+                                       ,QNSEPBLSCHEME             &
                                        ,GFSSFCSCHEME              &
                                        ,PXSFCSCHEME               &
                                        ,NOAHMPSCHEME              &
@@ -577,7 +580,7 @@ CONTAINS
 
    INTEGER, INTENT(IN) :: sf_sfclay_physics, sf_surface_physics,      &
                           sf_urban_physics,ra_lw_physics,sst_update,  &
-                          ra_sw_physics                    
+                          ra_sw_physics, bl_pbl_physics
    INTEGER, INTENT(IN),OPTIONAL :: sst_skin, tmn_update,              &
                                    scm_force_skintemp, scm_force_flux 
 
@@ -1151,7 +1154,7 @@ CONTAINS
 !
    INTEGER :: i,J,K,NK,jj,ij
    INTEGER :: gfdl_ntsflg
-   LOGICAL :: radiation, myj, frpcpn, isisfc
+   LOGICAL :: radiation, myj, myjpbl, frpcpn, isisfc
    LOGICAL, INTENT(in), OPTIONAL :: rdlai2d
    LOGICAL, INTENT(in), OPTIONAL :: usemonalb
    REAL    :: total_depth,mid_point_depth
@@ -1731,6 +1734,10 @@ CONTAINS
   frpcpn = .false.
   myj    = ((sf_sfclay_physics .EQ. MYJSFCSCHEME) .OR. &
             (sf_sfclay_physics .EQ. QNSESFCSCHEME) )
+
+  myjpbl = ((bl_pbl_physics .EQ. MYJPBLSCHEME) .OR. &
+            (bl_pbl_physics .EQ. QNSEPBLSCHEME) )
+
   isisfc = ( FRACTIONAL_SEAICE .EQ. 1  .AND. (          &
             (sf_sfclay_physics .EQ. SFCLAYSCHEME ) .OR. &
             (sf_sfclay_physics .EQ. SFCLAYREVSCHEME ) .OR. &
@@ -3322,7 +3329,7 @@ CONTAINS
                 sfcrunoff,udrunoff,acrunoff,sfcexc,             &
                 sfcevp,grdflx,snowfallac,acsnow,acsnom,         &
                 smfr3d,keepfr3dflag,                            &
-                myj,shdmin,shdmax,rdlai2d,                      &
+                myjpbl,shdmin,shdmax,rdlai2d,                   &
                 ids,ide, jds,jde, kds,kde,                      &
                 ims,ime, jms,jme, kms,kme,                      &
                 i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte    )

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -308,6 +308,8 @@ CONTAINS
                                        ,SFCLAYREVSCHEME           &
                                        ,MYJSFCSCHEME              &
                                        ,QNSESFCSCHEME             &
+                                       ,MYJPBLSCHEME              &
+                                       ,QNSEPBLSCHEME             &
                                        ,GFSSFCSCHEME              &
                                        ,PXSFCSCHEME               &
                                        ,NOAHMPSCHEME              &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MYJ PBL with RUC LSM, Leaf Area Index

SOURCE: Tanya Smirnova, NOAA/ESRL/GSD

DESCRIPTION OF CHANGES: 

1. The MYJ and QNSE PBLs use surface water vapor mixing ratio as low boundary condition for moisture and compute it from the latent heat flux, while other PBL schemes use directly latent heat flux as low boundary condition. Therefore, there is a special computation of latent heat flux inside RUC LSM to get correct surface Qv. In original code the check in the surface driver is made on the option of surface layer scheme, and not PBL scheme. Therefore, if MYJ PBL is not used together with MYJ surface layer scheme, there will be inaccuracy in low boundary condition for moisture.

2. The second bug is in the computation of LAI for particular day when LAI parameter is read in from the VEGPARM.TBL. The bug makes the value of LAI smaller than it should be. The situation when .rdlai2d.=T is not affected by the bug.

3. Removed several commented out pieces of code inside RUC LSM.

LIST OF MODIFIED FILES: 
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_sf_ruclsm.F
M       phys/module_surface_driver.F
M       dyn_nmm/module_PHYSICS_CALLS.F

TESTS CONDUCTED: 
Test cases and retrospective runs  are performed at GSD in RAP and HRRR.

RELEASE NOTE: Optional, as appropriate. Delete if not used. Included only once for new features requiring several merge cycles. Changes to default behavior are also note worthy.
