### PR TITLE
Bug fix in optical_prep_gocart

### DIFF
--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -3529,7 +3529,10 @@ END subroutine optical_prep_modal_soa_vbs
 ! SAM 7/18/09 - Modal parameters for OC1 (hydrophobic) OC2 (hydrophylic), BC1,BC2,
 ! and sulfate - just use dginia (meters) and sginia from module_data_sorgam.
 ! Not using accumulation mode from d'Almedia 1991 Table 7.1 and 7.2 global model
-!
+! 10/16/18 - A. Ukhov, bug fix: dust particles having radii in the range 0.1-0.46 microns
+! were not accounted in the calculation of the mass redistribution between the GOCART and 
+! MOZAIC grids.
+
 ! This subroutine computes volume-averaged refractive index and wet radius needed
 ! by the mie calculations. Aerosol number is also passed into the mie calculations
 ! in terms of other units.
@@ -3553,7 +3556,7 @@ END subroutine optical_prep_modal_soa_vbs
 ! real*8, DIMENSION (4), PARAMETER :: rb(4)=(/5.d-1,1.5d0,5.d0,1.d1/)
 ! real*8, DIMENSION (4), PARAMETER :: den_seas(4)=(/2.2d3,2.2d3,2.2d3,2.2d3/)
 ! real*8, DIMENSION (4), PARAMETER :: reff_seas(4)=(/0.30D-6,1.00D-6,3.25D-6,7.50D-6/)
-   USE module_data_gocart_dust, only:  ndust, reff_dust, den_dust
+   USE module_data_gocart_dust, only:  ndust, reff_dust, den_dust,ra_dust,rb_dust
 !  real*8, DIMENSION (5), PARAMETER :: den_dust(5)=(/2500.,2650.,2650.,2650.,2650./)
 !  real*8, DIMENSION (5), PARAMETER :: reff_dust(5)=(/0.73D-6,1.4D-6,2.4D-6,4.5D-6,8.0D-6/)
 
@@ -3716,15 +3719,17 @@ END subroutine optical_prep_modal_soa_vbs
 !      WRITE(*,*)'         ','       ',(dlo_sectm(n),n=1,nbin_o)
 !      WRITE(*,*)'         ','       ',(dhi_sectm(n),n=1,nbin_o)
         dustfrc_goc8bin=0.
-        dlogoc=0.46*2.E-6 ! Begin lower dust bin, makes upper limit diam 20 micron diameter 
+        !dlogoc=0.46*2.E-6 ! Begin lower dust bin, makes upper limit diam 20 micron diameter 
        do m =1, ndust  ! loop over dust size bins
-       dhigoc = 2.*2.*reff_dust(m)-dlogoc ! hi diameter limit (m)
+       !dhigoc = 2.*2.*reff_dust(m)-dlogoc ! hi diameter limit (m)  ! A. Ukhov
+        dlogoc = ra_dust(m)*2.E-6  ! low diameter limit (m)
+        dhigoc = rb_dust(m)*2.E-6  ! hi diameter limit (m)
         do n = 1, nbin_o
         dustfrc_goc8bin(m,n)=max(DBLE(0.),min(DBLE(dhi_sectm(n)),dhigoc)- &
                              max(dlogoc,DBLE(dlo_sectm(n))) )/(dhigoc-dlogoc)
        end do
 !      WRITE(*,*)m,dlogoc,dhigoc,(dustfrc_goc8bin(m,n),n=1,nbin_o)
-       dlogoc=dhigoc
+       !dlogoc=dhigoc
        end do
         kcall=kcall+1
 !       ISTOP=1

--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -3719,9 +3719,7 @@ END subroutine optical_prep_modal_soa_vbs
 !      WRITE(*,*)'         ','       ',(dlo_sectm(n),n=1,nbin_o)
 !      WRITE(*,*)'         ','       ',(dhi_sectm(n),n=1,nbin_o)
         dustfrc_goc8bin=0.
-        !dlogoc=0.46*2.E-6 ! Begin lower dust bin, makes upper limit diam 20 micron diameter 
        do m =1, ndust  ! loop over dust size bins
-       !dhigoc = 2.*2.*reff_dust(m)-dlogoc ! hi diameter limit (m)  ! A. Ukhov
         dlogoc = ra_dust(m)*2.E-6  ! low diameter limit (m)
         dhigoc = rb_dust(m)*2.E-6  ! hi diameter limit (m)
         do n = 1, nbin_o
@@ -3729,7 +3727,6 @@ END subroutine optical_prep_modal_soa_vbs
                              max(dlogoc,DBLE(dlo_sectm(n))) )/(dhigoc-dlogoc)
        end do
 !      WRITE(*,*)m,dlogoc,dhigoc,(dustfrc_goc8bin(m,n),n=1,nbin_o)
-       !dlogoc=dhigoc
        end do
         kcall=kcall+1
 !       ISTOP=1

--- a/phys/module_data_gocart_dust.F
+++ b/phys/module_data_gocart_dust.F
@@ -29,6 +29,11 @@ Module module_data_gocart_dust
 ! real*8, DIMENSION (ndust), PARAMETER :: lo_dust=(/0.1D-6,1.0D-6,1.8D-6,3.0D-6,6.0D-6/)
 ! real*8, DIMENSION (ndust), PARAMETER :: up_dust=(/1.0D-6,1.8D-6,3.0D-6,6.0D-6,10.0D-6/)
 
+  !GOCART bins radii ranges
+  real*8, DIMENSION (5), PARAMETER :: ra_dust(5)=(/1.d-1,1.0d0,1.8d0,3.0d0,6.0d0/)
+  real*8, DIMENSION (5), PARAMETER :: rb_dust(5)=(/1.0d0,1.8d0,3.0d0,6.0d0,10.0d0/)
+
+
 END Module module_data_gocart_dust
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: optical_prep_gocart, volume-averaged refractive index, WRF-Chem

SOURCE: Alexander Ukhov, KAUST

DESCRIPTION OF CHANGES: 
Problem: It was found that the dust particles having radii less than 0.46 microns are not accounted in the calculation of volume-averaged refractive index needed by Mie calculations. Since the finer particles have a bigger influence on AOD in comparison to the coarser particles (per unit of mass), it eventually led to the underestimation of the AOD. 

Solution: 0.46 was replaced by 0.1, where the value 0.1 corresponds to the beginning of the first GOCART bin (radii: 0.1-1.0 μm).

Left column (1-5) - GOCART dust bins.
other columns are 8 MOZAIC size bins.

dustfrc_goc8bin BEFORE CORRECTION:
![image](https://user-images.githubusercontent.com/5716976/47048874-58d50f80-d1a4-11e8-852c-ceb39c0594a0.png)

dustfrc_goc8bin AFTER CORRECTION:
![image](https://user-images.githubusercontent.com/5716976/47048860-51156b00-d1a4-11e8-8f6e-488af4812e12.png)


LIST OF MODIFIED FILES: 
M       chem/module_optical_averaging.F
M       phys/module_data_gocart_dust.F

TESTS CONDUCTED: 
Test case was run. The obtained result is expected: the AOD level has increased.
![result](https://user-images.githubusercontent.com/5716976/47048622-9edda380-d1a3-11e8-8db8-15b4f8106355.png)
