### PR TITLE
Bug fix: Cray compiler, character string, module_cu_mskf.F

### DIFF
--- a/phys/module_cu_mskf.F
+++ b/phys/module_cu_mskf.F
@@ -5062,8 +5062,8 @@ updraft:    DO NK=K,KL-1
                Itest = 0
                 if(Itest.eq.1) then
 
-               write(121,*),'k,nk, kq,jk,su,quuE3,muu,duu,cmel,zfu,pru,tee, &
-               qeeE3,zmqliqE4,zmqiceE4,rprd,wump,euu,ncmp,nimp,sprd,frz'
+               write(121,*) 'k,nk, kq,jk,su,quuE3,muu,duu,cmel,zfu,pru,tee,&
+              &qeeE3,zmqliqE4,zmqiceE4,rprd,wump,euu,ncmp,nimp,sprd,frz'
                do kq=K,NK
                JK = KTE-KQ+1
                write (121,2021) k,nk,kq,jk,su(1,jk),quu(1,jk)*1000,muu(1,jk),duu(1,jk),cmel(1,jk)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: write syntax, character string continuation

SOURCE: Alexander Davies (US Naval Academy)

DESCRIPTION OF CHANGES:
1. Remove comma after write statement.
2. Clean up continuation of string across more than one line.

LIST OF MODIFIED FILES:
M	phys/module_cu_mskf.F

TESTS CONDUCTED:
1. Without mods, code does not compile on Cray with ftn.
2. With mods, code compiles and runs.