### PR TITLE
Bug fix: cray, do loop index is real, module_mp_morr_two_moment_aero.F

### DIFF
--- a/phys/module_mp_morr_two_moment_aero.F
+++ b/phys/module_mp_morr_two_moment_aero.F
@@ -281,7 +281,8 @@ MODULE MODULE_MP_MORR_TWO_MOMENT_AERO
       real, private:: alog2_pamdm,alog3_pamdm,alogaten_pamdm,surften_pamdm
 
       real, private:: f1_pamdm(naer_cu),f2_pamdm(naer_cu) ! abdul-razzak functions of width
-      real, private:: third_pamdm, sat_pamdm
+      real, private:: third_pamdm
+      integer, private:: sat_pamdm
       real, private:: sq2_pamdm, arg_pamdm
       integer, parameter:: psat_pamdm=7 ! number of supersaturations to calc ccn concentration
       real, private:: super_pamdm(psat_pamdm)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cray, do loop, real

SOURCE: Alexander Davies (US Naval Academy)

DESCRIPTION OF CHANGES:
An index for a loop counter and also used for an array index was declared as
a real value. This is changed to an integer. There is no other place than the
do loop or the array index that this value was used.

LIST OF MODIFIED FILES:
M   module_mp_morr_two_moment_aero.F

TESTS CONDUCTED:
1. Code does not compile without this mod.
2. With this mod, the code compiles.