### PR TITLE
Idealized vegfra bug - changed from fraction to percentage

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2424,7 +2424,7 @@ rconfig   real    scm_force_dx            namelist,scm  1       4000.       rh  
 rconfig   integer num_force_layers        namelist,scm  1       8           rh   "num_force_layers"     "Number of SCM forcing layers" ""
 rconfig   integer scm_lu_index            namelist,scm  1       2           rh   "scm_lu_index"         "SCM landuse index" ""
 rconfig   integer scm_isltyp              namelist,scm  1       4           rh   "scm_isltyp"           "SCM soil category" ""
-rconfig   real    scm_vegfra              namelist,scm  1       0.5         rh   "scm_vegfra"           "SCM vegetation fraction" ""
+rconfig   real    scm_vegfra              namelist,scm  1       50.         rh   "scm_vegfra"           "SCM vegetation fraction" ""
 rconfig   real    scm_canwat              namelist,scm  1       0.0         rh   "scm_canwat"           "SCM canopy water" "kg m-2"
 rconfig   real    scm_lat                 namelist,scm  1        36.605     rh   "scm_lat"              "SCM latitude" "degrees"
 rconfig   real    scm_lon                 namelist,scm  1       -97.485     rh   "scm_lon"              "SCM longitude" "degrees"

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -439,7 +439,7 @@ CONTAINS
         DO j = jts , MIN(jde-1,jte)
            DO i = its , MIN(ide-1,ite)
               IF (grid%xland(i,j) .lt. 1.5) THEN
-                 grid%vegfra(i,j) = 0.5
+                 grid%vegfra(i,j) = 50.
                  grid%canwat(i,j) = 0.
                  grid%ivgtyp(i,j) = 18
                  grid%isltyp(i,j) = 8
@@ -534,7 +534,7 @@ CONTAINS
         DO j = jts , MIN(jde-1,jte)
            DO i = its , MIN(ide-1,ite)
               IF (grid%xland(i,j) .lt. 1.5) THEN
-                 grid%vegfra(i,j) = 0.5
+                 grid%vegfra(i,j) = 50.
                  grid%canwat(i,j) = 0.
                  grid%ivgtyp(i,j) = 18
                  grid%isltyp(i,j) = 8

--- a/test/em_scm_xy/namelist.input
+++ b/test/em_scm_xy/namelist.input
@@ -50,7 +50,7 @@
  num_force_layers                    = 8
  scm_lu_index                        = 2
  scm_isltyp                          = 4
- scm_vegfra                          = 0.5
+ scm_vegfra                          = 50. 
  scm_lat                             = 37.600
  scm_lon                             = -96.700
  scm_th_adv                          = .false.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: scm_vegfra, vegfra, seabreeze, convrad, scm, percentage, fraction

SOURCE: internal

DESCRIPTION OF CHANGES: Idealized cases were initializing vegfra as a fraction (default setting of 0.5). Modified this to change to a percentage (default 50.) to be consistent with Noah driver. This setting was only used for convrad, seabreeze and scm cases. Since convrad is all water points, it should never matter, but modified the code for consistency. Seabreeze will only be affected if one turns on the Noah LSM. Convrad and seabreeze are controlled in module_initialize_ideal and scm is controlled by the namelist/registry. 

LIST OF MODIFIED FILES: 
M     Registry/Registry.EM_COMMON
M     dyn_em/module_initialize_ideal.F
M     test/em_scm_xy/namelist.input

TESTS CONDUCTED: 
Ran before/after tests to determine that variables Q2 and latent heat flux were more realistic after the modification (see attached files for Q2 comparison).
![q2_after](https://user-images.githubusercontent.com/21043917/47229884-1539fb80-d386-11e8-9662-98aad5421798.png)
![q2_before](https://user-images.githubusercontent.com/21043917/47229885-1539fb80-d386-11e8-8887-a03edaacb40c.png)

RELEASE NOTE: The default value for vegfra in idealized cases was modified from a fraction to a percentage, consistent with the Noah LSM driver.