### PR TITLE
bounds check bug regarding  mminlu string length

### DIFF
--- a/dyn_em/module_initialize_heldsuarez.F
+++ b/dyn_em/module_initialize_heldsuarez.F
@@ -82,6 +82,7 @@ CONTAINS
    REAL :: thtmp, ptmp, temp(3), cof1, cof2
 
    INTEGER :: icm,jcm
+   CHARACTER (LEN=256) :: mminlu_temp 
 
    SELECT CASE ( model_data_order )
          CASE ( DATA_ORDER_ZXY )
@@ -225,7 +226,8 @@ CONTAINS
    !WRITE(*,*) ''
    !WRITE(*,'(A,1PG14.6,A,1PG14.6)') ' For the namelist: dx =',grid%dx,', dy =',grid%dy
 
-   CALL nl_set_mminlu(1,'    ')
+   mminlu_temp(1:10) = 'never_used'
+   CALL nl_set_mminlu(1, mminlu_temp)
    grid%iswater = 0
    grid%cen_lat = 0.
    grid%cen_lon = 0.

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -30,6 +30,7 @@ MODULE module_initialize_ideal
 #endif
 
 
+
 CONTAINS
 
 
@@ -111,7 +112,7 @@ CONTAINS
 
    LOGICAL :: moisture_init
    LOGICAL :: stretch_grid, dry_sounding
-   character (len=256) :: mminlu2
+   CHARACTER (len=256) :: mminlu_temp 
 
    REAL    :: xa1, xal1,pii,hm1  !  data for intercomparison setup from dale
 !  space for initial jet in b_wave
@@ -308,7 +309,8 @@ CONTAINS
 
    CASE(hill2d_x, quarter_ss, squall2d_x, squall2d_y, grav2d_x)
 
-    CALL nl_set_mminlu(1,'    ')
+    mminlu_temp(1:10) = 'never_used'
+    CALL nl_set_mminlu(1, mminlu_temp)
     CALL nl_set_iswater(1,0)
     CALL nl_set_cen_lat(1,40.)
     CALL nl_set_cen_lon(1,-105.)
@@ -343,7 +345,8 @@ CONTAINS
 
    CASE(b_wave)
 
-    CALL nl_set_mminlu(1,'    ')
+    mminlu_temp(1:10) = 'never_used'
+    CALL nl_set_mminlu(1, mminlu_temp)
     CALL nl_set_iswater(1,0)
     CALL nl_set_cen_lat(1,40.)
     CALL nl_set_cen_lon(1,-105.)
@@ -377,10 +380,9 @@ CONTAINS
    END DO
 
    CASE(convrad)
-    mminlu2 = ' '
-    mminlu2(1:4) = 'USGS'
-    CALL nl_set_mminlu(1, mminlu2)
-!   CALL nl_set_mminlu(1, 'USGS')
+
+    mminlu_temp(1:10) = 'never_used'
+    CALL nl_set_mminlu(1, mminlu_temp)
     CALL nl_set_iswater(1,16)
     CALL nl_set_isice(1,3)
     CALL nl_set_cen_lat(1,20.)
@@ -469,10 +471,8 @@ CONTAINS
                                    its,ite, jts,jte, kts,kte )
    CASE(seabreeze2d_x)
 
-    mminlu2 = ' '
-    mminlu2(1:4) = 'USGS'
-    CALL nl_set_mminlu(1, mminlu2)
-!   CALL nl_set_mminlu(1, 'USGS')
+    mminlu_temp(1:10) = 'never_used'
+    CALL nl_set_mminlu(1, mminlu_temp)
     CALL nl_set_iswater(1,16)
     CALL nl_set_isice(1,3)
     CALL nl_set_cen_lat(1,20.)
@@ -566,7 +566,8 @@ CONTAINS
 
    CASE (les)
 
-    CALL nl_set_mminlu(1, '    ')
+    mminlu_temp(1:10) = 'never_used'
+    CALL nl_set_mminlu(1, mminlu_temp)
     CALL nl_set_iswater(1,0)
     CALL nl_set_cen_lat(1,40.)
     CALL nl_set_cen_lon(1,-105.)

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -30,7 +30,6 @@ MODULE module_initialize_ideal
 #endif
 
 
-
 CONTAINS
 
 

--- a/dyn_em/module_wps_io_arw.F
+++ b/dyn_em/module_wps_io_arw.F
@@ -115,6 +115,7 @@ MODULE module_wps_io_arw
 
       CHARACTER (LEN=256) , PRIVATE :: a_message
 
+
 CONTAINS
 
    SUBROUTINE read_wps ( grid, filename, file_date_string, num_metgrid_levels )

--- a/dyn_em/module_wps_io_arw.F
+++ b/dyn_em/module_wps_io_arw.F
@@ -115,7 +115,6 @@ MODULE module_wps_io_arw
 
       CHARACTER (LEN=256) , PRIVATE :: a_message
 
-
 CONTAINS
 
    SUBROUTINE read_wps ( grid, filename, file_date_string, num_metgrid_levels )
@@ -131,6 +130,7 @@ CONTAINS
       CHARACTER (LEN=132)              :: VarName
       CHARACTER (LEN=150)             :: chartemp
       CHARACTER (*) , INTENT(IN) :: filename
+      CHARACTER (LEN=256)  :: mminlu_temp
 
       INTEGER :: ids,ide,jds,jde,kds,kde           &
                 ,ims,ime,jms,jme,kms,kme           &
@@ -357,17 +357,18 @@ CONTAINS
         CALL nl_set_isice (grid%id, igarb2 )
 
       IF ( igarb .eq. 16 .and. igarb2 .eq. 24 ) THEN
-      CALL nl_set_mminlu ( grid%id, 'USGS')
+      mminlu_temp(1:4) = 'USGS'
+      CALL nl_set_mminlu (grid%id, mminlu_temp)
       ENDIF
 
       IF ( igarb .eq. 17 .and. igarb2 .eq. 15 ) THEN
-! ambiguous
-      CALL nl_set_mminlu ( grid%id, 'MODIFIED_IGBP_MODIS_NOAH')
-!      CALL nl_set_mminlu ( grid%id, 'MODIS')
+      mminlu_temp(1:24) = 'MODIFIED_IGBP_MODIS_NOAH'
+      CALL nl_set_mminlu ( grid%id, mminlu_temp)
       ENDIF
 
       IF ( igarb .eq. 15 .and. igarb2 .eq. 16 ) THEN
-      CALL nl_set_mminlu ( grid%id, 'SiB')
+      mminlu_temp(1:3) = 'SiB'
+      CALL nl_set_mminlu (grid%id, mminlu_temp)
       ENDIF
 
       VarName='FLAG_SNOWH'

--- a/dyn_nmm/module_si_io_nmm.F
+++ b/dyn_nmm/module_si_io_nmm.F
@@ -133,7 +133,6 @@ MODULE module_si_io_nmm
       INTEGER, PARAMETER          :: max_fg_variables = 200
       INTEGER, PARAMETER          :: max_vertical_levels = 2000
 
-
 !   This module defines the items needed for the WRF metadata
 !   which is broken up into three levels:  
 !      Global metadata:  Those things which apply to the

--- a/dyn_nmm/module_si_io_nmm.F
+++ b/dyn_nmm/module_si_io_nmm.F
@@ -133,6 +133,7 @@ MODULE module_si_io_nmm
       INTEGER, PARAMETER          :: max_fg_variables = 200
       INTEGER, PARAMETER          :: max_vertical_levels = 2000
 
+
 !   This module defines the items needed for the WRF metadata
 !   which is broken up into three levels:  
 !      Global metadata:  Those things which apply to the
@@ -261,6 +262,7 @@ CONTAINS
 
       CHARACTER (LEN= 8) :: dummy_char
       CHARACTER (LEN=256) :: dummy_char_256
+      CHARACTER (LEN=256) :: mminlu_temp
 
       INTEGER :: ok , map_proj , ok_open
       REAL :: pt
@@ -611,7 +613,8 @@ CONTAINS
 !      write(0,*) 'global_meta%lu_source: ', global_meta%lu_source
 !      write(0,*) 'global_meta%lu_water: ', global_meta%lu_water
       IF      ( global_meta%si_version .EQ. 1 ) THEN
-         CALL nl_set_mminlu (grid%id, 'USGS' )
+         mminlu_temp(1:4) = 'USGS'
+         CALL nl_set_mminlu (grid%id, mminlu_temp)
          CALL nl_set_iswater (grid%id, 16 )
       ELSE IF ( global_meta%si_version .EQ. 2 ) THEN
          CALL nl_set_mminlu ( grid%id, global_meta%lu_source )

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -880,8 +880,9 @@ integer myproc
 !jm   CALL nl_get_mminlu( 1, mminlu_loc )
    CALL nl_get_mminlu( id, mminlu_loc )
 #if (NMM_CORE == 1 && HWRF == 1 )
-   IF ( trim(mminlu_loc) .eq. "" ) THEN
+   IF ( ( trim(mminlu_loc) .eq. "" ) .OR. (config_flags%sf_surface_physics .EQ. nolsmscheme) ) THEN
      CALL wrf_message('WARNING:   MMINLU NOT SET, USING USGS')
+module_surface_driver.F:                     ra_sw_physics, mminlu                                        &
      MMINLU_LOC = 'USGS'
    ENDIF
 #endif
@@ -1006,7 +1007,7 @@ integer myproc
    DO j=jts,jtf
    DO i=its,itf
      IF(XLAND(i,j) .LT. 1.5)THEN
-       IF(mminlu_loc .EQ. '    ') ALBBCK(i,j)=ALBLND
+       IF( (mminlu_loc .EQ. '    ') .OR. (config_flags%sf_surface_physics .EQ. nolsmscheme) ) ALBBCK(i,j)=ALBLND
        EMBCK(i,j)=0.85
        ALBEDO(i,j)=ALBBCK(i,j)
        EMISS(i,j)=EMBCK(i,j)
@@ -1017,7 +1018,7 @@ integer myproc
 #endif
        MAVAIL(i,j)=XMAVA
      ELSE
-       IF(mminlu_loc .EQ. '    ') ALBBCK(i,j)=0.08
+       IF( (mminlu_loc .EQ. '    ') .OR. (config_flags%sf_surface_physics .EQ. nolsmscheme) ) ALBBCK(i,j)=0.08
        ALBEDO(i,j)=ALBBCK(i,j)
        EMBCK(i,j)=0.98
        EMISS(i,j)=EMBCK(i,j)
@@ -1087,7 +1088,7 @@ integer myproc
 
    CALL wrf_debug ( 200 , 'module_start: phy_init: Before call to landuse_init' )
 
-   IF(mminlu_loc .ne. '    ')THEN
+   IF( (mminlu_loc .ne. '    ') .AND. (config_flags%sf_surface_physics .NE. nolsmscheme) ) THEN
 !-- initialize surface properties
 
      CALL landuse_init(lu_index, snowc, albedo, albbck, snoalb, mavail, emiss, embck, &

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -618,7 +618,7 @@
                 ( ( mminlu(1:1) .GE. "a" ) .AND. ( mminlu(1:1) .LE. "z" ) ) .OR. &
                 ( ( mminlu(1:1) .GE. "0" ) .AND. ( mminlu(1:1) .LE. "9" ) ) ) THEN
          ! no-op, the mminlu field is probably OK
-      ELSE IF ( mminlu(1:1) .EQ. " " ) THEN
+      ELSE IF ( ( mminlu(1:1) .EQ. " " ) .OR. (config_flags%sf_surface_physics .EQ. nolsmscheme) ) THEN
          mminlu = " "
       ELSE
          mminlu = " "

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -935,7 +935,7 @@ endif
       MMINLU='USGS'
     ENDIF
 
-    IF(MMINLU(1:1) .EQ. " ")THEN
+    IF( (MMINLU(1:1) .EQ. " ") .OR. (config_flags%sf_surface_physics .EQ. nolsmscheme) )THEN
        CALL wrf_put_dom_ti_char ( fid , 'MMINLU',  "    "       , ierr )
     ELSE
        CALL wrf_put_dom_ti_char ( fid , 'MMINLU',  TRIM(mminlu) , ierr )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: mminlu, bounds check, character, string, length

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
User complained that when they turned on bounds checking, they received runtime errors: 
```
Fortran runtime error: Actual string length is shorter than the declared one for dummy argument 'mminlu'
```
This call to nl_{set,get}_mminlu was treated incorrectly in a few different files - specifically some ideal initialization files. Modified the files in which the user found the issue to correct the problem.

Due to those modifications, for all files that had logic asking whether mminlu* was equal/not-equal to '  ' (i.e., nothing), it was necessary to add to this logic for when sf_surface_physics was equal/not-equal to nolsmscheme (no LSM scheme set in the namelist). Otherwise, the model assumed one was set, and executed calls, etc. that were not supposed to be used.

ISSUE: 
This issue was referenced in and fixes wrf-model/WRF#631 "Bounds checking: string length shorter than declared size in ideal initialization code"

LIST OF MODIFIED FILES: 
M    dyn_em/module_initialize_heldsuarez.F
M    dyn_em/module_initialize_ideal.F
M    dyn_em/module_wps_io_arw.F
M    dyn_nmm/module_si_io_nmm.F
M    phys/module_physics_init.F
M    share/input_wrf.F
M    share/output_wrf.F

TESTS CONDUCTED: 
1. Verified that all real and idealized cases are able to be built and run with modifications (with a configure -D compile). 