### PR TITLE
BF: chemical reaction rate change: e-11 -> e-31

### DIFF
--- a/chem/KPP/mechanisms/mozart/mozart.def
+++ b/chem/KPP/mechanisms/mozart/mozart.def
@@ -109,6 +109,10 @@ REAL(KIND=dp) FUNCTION usr17a( rh, temp )
 END FUNCTION usr17a
 
 REAL(KIND=dp) FUNCTION usr23( temp, c_m )
+!------------------------------------------------------------------
+!   This reaction rate constant has been updated to be
+!   consistent with CAM-Chem (2018-10-19)
+!------------------------------------------------------------------
 
     REAL(KIND=dp), INTENT(IN) :: temp
     REAL(KIND=dp), INTENT(IN) :: c_m
@@ -116,7 +120,7 @@ REAL(KIND=dp) FUNCTION usr23( temp, c_m )
     REAL(KIND=dp) :: fc, k0
     REAL(KIND=dp) :: wrk
 
-    fc    = 3.e-11_dp * (300._dp/temp) ** 3.3_dp
+    fc    = 3.e-31_dp * (300._dp/temp) ** 3.3_dp
     wrk   = fc * c_m
     k0    = wrk / (1._dp + wrk/1.5e-12_dp)
     usr23 = k0 * .6_dp ** (1._dp/(1._dp + (log10( wrk/1.5e-12_dp ))**2._dp))

--- a/chem/KPP/mechanisms/mozart_mosaic_4bin/mozart_mosaic_4bin.def
+++ b/chem/KPP/mechanisms/mozart_mosaic_4bin/mozart_mosaic_4bin.def
@@ -109,6 +109,10 @@ REAL(KIND=dp) FUNCTION usr17a( rh, temp )
 END FUNCTION usr17a
 
 REAL(KIND=dp) FUNCTION usr23( temp, c_m )
+!------------------------------------------------------------------
+!   This reaction rate constant has been updated to be
+!   consistent with CAM-Chem (2018-10-19)
+!------------------------------------------------------------------
 
     REAL(KIND=dp), INTENT(IN) :: temp
     REAL(KIND=dp), INTENT(IN) :: c_m
@@ -116,7 +120,7 @@ REAL(KIND=dp) FUNCTION usr23( temp, c_m )
     REAL(KIND=dp) :: fc, k0
     REAL(KIND=dp) :: wrk
 
-    fc    = 3.e-11_dp * (300._dp/temp) ** 3.3_dp
+    fc    = 3.e-31_dp * (300._dp/temp) ** 3.3_dp
     wrk   = fc * c_m
     k0    = wrk / (1._dp + wrk/1.5e-12_dp)
     usr23 = k0 * .6_dp ** (1._dp/(1._dp + (log10( wrk/1.5e-12_dp ))**2._dp))

--- a/chem/KPP/mechanisms/mozart_mosaic_4bin_aq/mozart_mosaic_4bin_aq.def
+++ b/chem/KPP/mechanisms/mozart_mosaic_4bin_aq/mozart_mosaic_4bin_aq.def
@@ -109,6 +109,10 @@ REAL(KIND=dp) FUNCTION usr17a( rh, temp )
 END FUNCTION usr17a
 
 REAL(KIND=dp) FUNCTION usr23( temp, c_m )
+!------------------------------------------------------------------
+!   This reaction rate constant has been updated to be
+!   consistent with CAM-Chem (2018-10-19)
+!------------------------------------------------------------------
 
     REAL(KIND=dp), INTENT(IN) :: temp
     REAL(KIND=dp), INTENT(IN) :: c_m
@@ -116,7 +120,7 @@ REAL(KIND=dp) FUNCTION usr23( temp, c_m )
     REAL(KIND=dp) :: fc, k0
     REAL(KIND=dp) :: wrk
 
-    fc    = 3.e-11_dp * (300._dp/temp) ** 3.3_dp
+    fc    = 3.e-31_dp * (300._dp/temp) ** 3.3_dp
     wrk   = fc * c_m
     k0    = wrk / (1._dp + wrk/1.5e-12_dp)
     usr23 = k0 * .6_dp ** (1._dp/(1._dp + (log10( wrk/1.5e-12_dp ))**2._dp))

--- a/chem/KPP/mechanisms/mozcart/mozcart.def
+++ b/chem/KPP/mechanisms/mozcart/mozcart.def
@@ -109,6 +109,10 @@ REAL(KIND=dp) FUNCTION usr17a( rh, temp )
 END FUNCTION usr17a
 
 REAL(KIND=dp) FUNCTION usr23( temp, c_m )
+!------------------------------------------------------------------
+!   This reaction rate constant has been updated to be
+!   consistent with CAM-Chem (2018-10-19)
+!------------------------------------------------------------------
 
     REAL(KIND=dp), INTENT(IN) :: temp
     REAL(KIND=dp), INTENT(IN) :: c_m
@@ -116,7 +120,7 @@ REAL(KIND=dp) FUNCTION usr23( temp, c_m )
     REAL(KIND=dp) :: fc, k0
     REAL(KIND=dp) :: wrk
 
-    fc    = 3.e-11_dp * (300._dp/temp) ** 3.3_dp
+    fc    = 3.e-31_dp * (300._dp/temp) ** 3.3_dp
     wrk   = fc * c_m
     k0    = wrk / (1._dp + wrk/1.5e-12_dp)
     usr23 = k0 * .6_dp ** (1._dp/(1._dp + (log10( wrk/1.5e-12_dp ))**2._dp))

--- a/chem/KPP/mechanisms/t1_mozcart/t1_mozcart.def
+++ b/chem/KPP/mechanisms/t1_mozcart/t1_mozcart.def
@@ -459,6 +459,10 @@ END FUNCTION usr_N2O5_M
 REAL(KIND=dp) FUNCTION usr_SO2_OH( temp, c_m )
 ! for cesm-consistent reaction labels, equivalent to usr23
 ! SO2 + OH -> SO4
+!------------------------------------------------------------------
+!   This reaction rate constant has been updated to be
+!   consistent with CAM-Chem (2018-10-19)
+!------------------------------------------------------------------
 
     REAL(KIND=dp), INTENT(IN) :: temp
     REAL(KIND=dp), INTENT(IN) :: c_m
@@ -466,7 +470,7 @@ REAL(KIND=dp) FUNCTION usr_SO2_OH( temp, c_m )
     REAL(KIND=dp) :: fc, k0
     REAL(KIND=dp) :: wrk
 
-    fc    = 3.e-11_dp * (300._dp/temp) ** 3.3_dp
+    fc    = 3.e-31_dp * (300._dp/temp) ** 3.3_dp
     wrk   = fc * c_m
     k0    = wrk / (1._dp + wrk/1.5e-12_dp)
     usr_SO2_OH = k0 * .6_dp ** (1._dp/(1._dp + &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: chemical reaction rate constant

SOURCE: internal

DESCRIPTION OF CHANGES:

Correct the reaction rate constant for reaction:

SO2 + OH -> SO4         (tag usr23)

The prior code had the expression:

    fc    = 3.e-11_dp * (300._dp/temp) ** 3.3_dp

which has been corrected to:

    fc    = 3.e-31_dp * (300._dp/temp) ** 3.3_dp

Although the coefficient change from 3.e-11 to 3.e-31 is large
this change is only part of a complex expression for the rate
constant and leads to much smaller and expected changes in
the chemical species SO4 and OH. (See pdf at end of this listing)

This change applies only to the following chem_opt options:

MOZART_KPP,MOZCART_KPP,T1_MOZCART_KPP,MOZART_MOSAIC_4BIN_KPP,MOZART_MOSAIC_4BIN_AQ_KPP

LIST OF MODIFIED FILES:

M       chem/KPP/mechanisms/mozart/mozart.def
M       chem/KPP/mechanisms/mozart_mosaic_4bin/mozart_mosaic_4bin.def
M       chem/KPP/mechanisms/mozart_mosaic_4bin_aq/mozart_mosaic_4bin_aq.def
M       chem/KPP/mechanisms/mozcart/mozcart.def
M       chem/KPP/mechanisms/t1_mozcart/t1_mozcart.def

TESTS CONDUCTED:

Gabi Pfister has compared simulations with the old and new rate constant.
Differences are consistent with the modification and are within an expected
range.

[usr23_changes.pdf](https://github.com/wrf-model/WRF/files/2503503/usr23_changes.pdf)
