### PR TITLE
Fix zero-valued d02 dry potential temp pert, from horiz interpolation

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -231,7 +231,7 @@ i1       real   ph_tendf       ikj     dyn_em      1         Z
 i1       real   ph_save        ikj     dyn_em      1         Z 
 
 # Potential Temperature
-state    real   th_phy_m_t0    ikj      dyn_em      1         -     ih  "t"      "perturbation potential temperature theta-t0" "K"
+state    real   th_phy_m_t0    ikj      dyn_em      1         -     ihd "t"      "perturbation potential temperature theta-t0" "K"
 state    real   t              ikjb     dyn_em      2         -     \
        i0rhusdf=(bdy_interp:dt)   "thm"      "either 1) pert moist pot temp=(1+Rv/Rd Qv)*(theta)-T0, or 2) pert dry pot temp=theta-T0; based on use_theta_m setting" "K"
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: input_from_file, use_theta_m, max_dom, mythical 1-character change

SOURCE: Jordan Powers (NCAR)

DESCRIPTION OF CHANGES:

At the initial time of the WRF model, the perturbation dry potential
temperature field ("T" in the netcdf file) for d02 (and greater) is
identically zero when the initial conditions for the fine-domain
fields are manufactured via horizontal interpolation (in the WRF
Registry, this horizontal interpolation at the initial time is
activated through the "d" switch in the nest options).

This error is noticed when
```
 &time_control
 input_from_file                     = .true.,.false.,
 /
```
```
 &domains
 max_dom                             = 2,
 /
```
```
 &dynamics
 use_theta_m                        = 1,
 /
```

This modification is diagnostic only. This does not change the WRF
model simulation. However, if users grab the initial condition dry
potential temperature perturbation field, "T" in the netcdf file,
that value will be identically zero. Most WRF post-processors
will assume that is a uniform dry potential temperature = 300 K,
which would provide almost reasonable looking values for temperature
near the surface.

ISSUE:
Fixes #660 "v4.0, v4.01 use_theta_m with input_from_file=.f., d02 dry theta field = 0 at init"

LIST OF MODIFIED FILES: 
M           Registry/Registry.EM_COMMON

TESTS CONDUCTED:
Tests conducted by and figures provided by Jordan Powers (NCAR).

1. Without this mod, the internally horizontally interpolated domain has the wrong temperature at the initial time (in this case, approximately 10 K too warm).
![sfc_t_orig](https://user-images.githubusercontent.com/12666234/47315222-2e9aac00-d601-11e8-8e0e-7590bed3ddd1.png)

2. With this mod, the low level temperature field is correct.
![sfc_t_fixed](https://user-images.githubusercontent.com/12666234/47315239-3b1f0480-d601-11e8-840d-d8496ff862ac.png)

RELEASE NOTE:
At the initial time of the WRF model, the perturbation dry potential temperature field ("T" in the netcdf file) for d02 (and greater) is identically zero when the initial conditions for the fine-domain fields are manufactured via horizontal interpolation (in the WRF Registry, this horizontal interpolation at the initial time is activated through the "d" switch in the nest options). This modification is diagnostic only, so this fix does not change the WRF model simulation results. However, if users grab the initial condition dry potential temperature perturbation field, "T" in the netcdf file, that value will be identically zero (the field is initialized within the solver routine for all subsequent time steps). Most WRF post-processors will assume that the field is a horizontally and vertically uniform dry potential temperature = 300 K, which would provide almost reasonable looking values for temperature near the surface. After the first time step, the model results will be correct. This bug is in v4.0 and v4.0.1.