### PR TITLE
Remove MPI build option from single column model (SCM)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,16 @@ configcheck:
 	 echo "------------------------------------------------------------------------------" ; \
          exit 2 ; \
 	fi
+	@if [ "$(A1DCASE)" -a "$(DMPARALLEL)" ] ; then \
+	 echo "------------------------------------------------------------------------------" ; \
+	 echo "WRF CONFIGURATION ERROR                                                       " ; \
+	 echo "The $(A1DCASE) case requires a build for only single domain.                  " ; \
+	 echo "The $(A1DCASE) case cannot be used on distributed memory parallel systems.    " ; \
+	 echo "Only 3D WRF cases will run with the options that you selected.                " ; \
+	 echo "Please choose a different case, or rerun configure and choose a different set of options."  ; \
+	 echo "------------------------------------------------------------------------------" ; \
+         exit 21 ; \
+	fi
  
 
 framework_only : configcheck

--- a/compile
+++ b/compile
@@ -101,6 +101,8 @@ if ( "$arglist" == "" ) then
 else
   unsetenv A2DCASE
   setenv A2DCASE `echo $arglist | grep 2d`
+  unsetenv A1DCASE
+  setenv A1DCASE `echo $arglist | grep scm`
 
   if ( ! (   $?WRF_EM_CORE  || $?WRF_NMM_CORE \
           ||  $?WRF_COAMPS_CORE || $?WRF_EXP_CORE \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: single column model, SCM, MPI

SOURCE: found by @sodoesaburningbus

DESCRIPTION OF CHANGES:
The logic is already in place to correctly detect and stop MPI builds when
running a 2d case. Use the same logic for the 1d case of the SCM.
Instead of searching for the string "2d", search for the string "scm".

ISSUE:
Fixes #622 "WRF SCM 3x3 stencil too small for MPI runs"

LIST OF MODIFIED FILES:
M   Makefile
M   compile

TESTS CONDUCTED:

1. Without this mod, the code successfully builds an MPI version of WRF. At run-time, this fails.
2. With this mod, the user is stopped at the build step:
```
------------------------------------------------------------------------------
WRF CONFIGURATION ERROR
The em_scm_xy case requires a build for only single domain.
The em_scm_xy case cannot be used on distributed memory parallel systems.
Only 3D WRF cases will run with the options that you selected.
Please choose a different case, or rerun configure and choose a different set of options.
------------------------------------------------------------------------------
```