### PR TITLE
mass redistribution between GOCART dust/sea salt and MOZAIC bins

### DIFF
--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -3532,6 +3532,8 @@ END subroutine optical_prep_modal_soa_vbs
 ! 10/16/18 - A. Ukhov, bug fix: dust particles having radii in the range 0.1-0.46 microns
 ! were not accounted in the calculation of the mass redistribution between the GOCART and 
 ! MOZAIC grids.
+! 10/24/18 - A. Ukhov, bug fix: mass redistribution between GOCART dust/sea salt and 
+! MOZAIC bins should be computed using interpolation over the logarithmic axis.
 
 ! This subroutine computes volume-averaged refractive index and wet radius needed
 ! by the mie calculations. Aerosol number is also passed into the mie calculations
@@ -3709,8 +3711,9 @@ END subroutine optical_prep_modal_soa_vbs
        dlogoc = ra(m)*2.E-6  ! low diameter limit (m)
        dhigoc = rb(m)*2.E-6  ! hi diameter limit (m)
         do n = 1, nbin_o
-        seasfrc_goc8bin(m,n)=max(DBLE(0.),min(DBLE(dhi_sectm(n)),dhigoc)- &
-                             max(dlogoc,DBLE(dlo_sectm(n))) )/(dhigoc-dlogoc)
+        seasfrc_goc8bin(m,n)=max(DBLE(0.),min(DBLE(log(dhi_sectm(n))),log(dhigoc))- &
+                             max(log(dlogoc),DBLE(log(dlo_sectm(n)))) )/(log(dhigoc)-log(dlogoc))
+
        end do
 !      WRITE(*,*)m,dlogoc,dhigoc,(seasfrc_goc8bin(m,n),n=1,nbin_o)
        end do
@@ -3723,8 +3726,9 @@ END subroutine optical_prep_modal_soa_vbs
         dlogoc = ra_dust(m)*2.E-6  ! low diameter limit (m)
         dhigoc = rb_dust(m)*2.E-6  ! hi diameter limit (m)
         do n = 1, nbin_o
-        dustfrc_goc8bin(m,n)=max(DBLE(0.),min(DBLE(dhi_sectm(n)),dhigoc)- &
-                             max(dlogoc,DBLE(dlo_sectm(n))) )/(dhigoc-dlogoc)
+        dustfrc_goc8bin(m,n)=max(DBLE(0.),min(DBLE(log(dhi_sectm(n))),log(dhigoc))- &
+                             max(log(dlogoc),DBLE(log(dlo_sectm(n)))) )/(log(dhigoc)-log(dlogoc))
+
        end do
 !      WRITE(*,*)m,dlogoc,dhigoc,(dustfrc_goc8bin(m,n),n=1,nbin_o)
        end do


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: optical_prep_gocart, volume-averaged refractive index, mass redistribution, AOD, WRF-Chem

SOURCE: Alexander Ukhov, KAUST

DESCRIPTION OF CHANGES: 
Problem: There is a code in _optical_prep_gocart_ procedure which calculates the contribution of the dust and sea salt bins into the MOZAIC bins. The code uses the interpolation over the linear axis but should use the interpolation over log axis. The similar bug was fixed In #536 "fixed coefficients for calculation of PM10 and PM2.5. For GOCART aerosol scheme".

Solution: use interpolation over the log axis instead of linear axis.

Effect: Interpolation over log axis changes the mass redistribution between the MOZAIC bins.
It leads to the increased contribution of the small dust and sea salt particles into the Aerosol Optical Depth (AOD). As a result of the correction, AOD is increasing.

DUST_1..5 are GOCART dust bins
MOZ0...7 are MOZAIC bins

**dustfrc_goc8bin BEFORE THE CORRECTION:**
![image](https://user-images.githubusercontent.com/5716976/47463793-f2796e00-d7ef-11e8-84e4-9fc8c043d1a2.png)


**dustfrc_goc8bin AFTER THE CORRECTION:**
![image](https://user-images.githubusercontent.com/5716976/47462862-40d93d80-d7ed-11e8-9041-1b98897efd3d.png)


LIST OF MODIFIED FILES: M       chem/module_optical_averaging.F

TESTS CONDUCTED:
The test case was run. The obtained result is expected: the AOD level has increased.

![image](https://user-images.githubusercontent.com/5716976/47462750-f5269400-d7ec-11e8-8fee-ca7f137416c5.png)
