### PR TITLE
bug in G3 cu_physics - random seed array bounds errors

### DIFF
--- a/phys/module_cu_g3.F
+++ b/phys/module_cu_g3.F
@@ -3138,8 +3138,8 @@ CONTAINS
        allocate(seed(1:seed_size))           ! Allocate according to returned size
 
        seed=0
-       seed(2)=j
-       seed(3)=ktau
+       if(seed_size .ge. 2) seed(2)=j
+       if(seed_size .ge. 3) seed(3)=ktau
        nens=0
        irandom=1
        if(high_resolution.eq.1)irandom=0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: grell, G3, cu_physics, random seed, array, bounds, bug, module_cu_g3, cup_forcing_ens_3d

SOURCE: bug found by and fix suggested by Jeremy Silver (U Melbourne)

DESCRIPTION OF CHANGES: 
A user reported that when configuring with a particular set of debug flags, they were getting array bound exceedance errors in subroutine cup_forcing_ens_3d inside module_cu_g3.F. They offered a seemingly legitimate fix that helped them get past it.

ISSUE: This PR fixes issue referenced in wrf-model/WRF#623 "Array bounds issue in cu_g3 random number seed"
closes:#623

LIST OF MODIFIED FILES: 
M     phys/module_cu_g3.F

TESTS CONDUCTED: Verified that the code compiles after the modification.

RELEASE NOTE: A minor modification was made to the Grell 3 scheme to prevent random seed array bounds errors in the cup_forcing_ens_3d subroutine.