### PR TITLE
MYNN PBL shcu combo bug

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -52,7 +52,7 @@
 
       LOGICAL :: exists, vnest
       LOGICAL , EXTERNAL :: wrf_dm_on_monitor
-      INTEGER :: i, j, oops, d1_value
+      INTEGER :: i, j, oops, d1_value, EDMFMAX, SCHUMAX
       LOGICAL :: km_opt_already_done , diff_opt_already_done
       INTEGER :: count_opt
       LOGICAL :: lon_extent_is_global , lat_extent_is_global
@@ -994,18 +994,18 @@
 !-----------------------------------------------------------------------
 
       oops = 0
-      DO i = 1, model_config_rec % max_dom
-         IF ( model_config_rec%bl_mynn_edmf(i) .EQ. MYNN_STEM_EDMF .OR. &
-              model_config_rec%bl_mynn_edmf(i) .EQ. MYNN_TEMF_EDMF) THEN
-               model_config_rec%shcu_physics(i) = 0  ! maxdom
-               model_config_rec%ishallow = 0         ! not maxdom
-               oops = oops + 1
+      EDMFMAX = MAXVAL(model_config_rec%bl_mynn_edmf(1:model_config_rec%max_dom))
+      SCHUMAX = MAXVAL(model_config_rec%shcu_physics(1:model_config_rec%max_dom))
+         IF ( ( ( EDMFMAX .GT. 0 ) .AND. ( SCHUMAX .GT. 0 ) ) .OR. &
+              ( ( EDMFMAX .GT. 0 ) .AND. ( model_config_rec%ishallow .GT. 0 ) ) ) THEN
+            wrf_err_message = '--- ERROR: bl_mynn_edmf > 0 requires both shcu_physics=0 & ishallow=0' 
+            CALL wrf_message(wrf_err_message)
+            wrf_err_message = 'when using MYNN PBL, by default bl_mynn_edmf is turned on'
+            CALL wrf_message(wrf_err_message)
+            wrf_err_message = 'Modify namelist.input so that shcu_physics nor ishallow is used when bl_mynn_edmf is turned on'
+            CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+            count_fatal_error = count_fatal_error + 1
          END IF
-      ENDDO      ! Loop over domains
-      IF ( oops .GT. 0 ) THEN
-         wrf_err_message = 'bl_mynn_edmf > 0 requires both shcu_physics=0 & ishallow=0'
-         CALL wrf_debug ( 1, wrf_err_message )
-      END IF
 
 !-----------------------------------------------------------------------
 !  We need to know if any of the cumulus schemes are active. This


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: mynn, bug, shcu, ishallow, bl_mynn_edmf, check_a_mundo, fatal

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem: 
The MYNN PBL has the EDMF (bl_mynn_edmf=1) option turned on by default. In check_a_mundo when the bl_mynn_edmf=1, (even if the user specifically asks for the shallow cumulus option to be activated (sh_cu=1)), the shallow cumulus scheme is simply turned off. 

Solution:
The check_a_mundo test is modified to give a fatal error when bl_mynn_edmf=1 AND  sh_cu=1 so that a user will not overlook this message in the log file.

ISSUE: 
This addresses the issue referenced in wrf-model/WRF#617 "MYNN PBL can't be used with SHCU"
closes:#617

LIST OF MODIFIED FILES:
M     share/module_check_a_mundo.F

TESTS CONDUCTED: Verified that code builds with modification. Verified that when using the MYNN PBL, and turning on ishallow, shcu_physics, or both, the real.exe or wrf.exe program stops with the intended fatal error message.

RELEASE NOTE: A check was implemented to stop the real or wrf program if bl_mynn_edmf (which is set to 1 by default in the MYNN scheme) is being used in combination with either the ishallow or shcu_physics options turned on. A message informs the user that bl_mynn_edmf cannot be used with the other 2 options and the namelist must be modified.