### PR TITLE
Fix DA formatted print of random_seed array when put_rand_seed=false

### DIFF
--- a/var/da/da_define_structures/da_random_seed.inc
+++ b/var/da/da_define_structures/da_random_seed.inc
@@ -28,6 +28,8 @@ subroutine da_random_seed
 #endif
 
    call random_seed(size=seed_size)              ! Get size of seed array.
+   write(unit=message(1),fmt='(a,i6)') 'Size of the random_seed array is ', seed_size
+   call da_message(message(1:1))
    allocate(seed_array(1:seed_size))
    seed_array(1:seed_size) = 1
 
@@ -77,7 +79,7 @@ subroutine da_random_seed
    else                                 ! Random seed set "randomly"
       call random_seed
       call random_seed(get=seed_array(1:seed_size))
-      write(unit=message(1),fmt='(a,10i16)') 'Random number seed array = ', seed_array
+      write(unit=message(1),fmt='(a,100i16)') 'Random number seed array = ', seed_array
       call da_message(message(1:1))
    end if
    

--- a/var/da/da_define_structures/da_random_seed.inc
+++ b/var/da/da_define_structures/da_random_seed.inc
@@ -14,6 +14,7 @@ subroutine da_random_seed
    integer, allocatable :: seed_array(:)
 
    integer              :: myproc,ierr,i
+   character(len=32)    :: fmtstring
 
    if (trace_use) call da_trace_entry("da_random_seed")
 
@@ -79,7 +80,8 @@ subroutine da_random_seed
    else                                 ! Random seed set "randomly"
       call random_seed
       call random_seed(get=seed_array(1:seed_size))
-      write(unit=message(1),fmt='(a,100i16)') 'Random number seed array = ', seed_array
+      write(fmtstring, '(a,i3,a)') '(a27,', seed_size, '(i16))'
+      write(unit=message(1),fmt=trim(fmtstring)) 'Random number seed array = ', (seed_array(i), i=1, seed_size)
       call da_message(message(1:1))
    end if
    


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, random seed array size, da_message

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
When running WRFDA in RANDOMCV mode and put_rand_seed=.false.,
the formatted write of the random number seed array has a preceding count of 10.
Depending on compiler versions, the seed array size can be larger than 10.
In that case, the error message is
```
At line 2938 of file da_define_structures.f
Fortran runtime error: End of file
```
The solution is to build a run-time format string based on the seed_size.

LIST OF MODIFIED FILES:
M       var/da/da_define_structures/da_random_seed.inc

TESTS CONDUCTED:
With gnu/7.2.0, the size of the random_seed array is 33, RANDOMCV ran after the format fix.

RELEASE NOTE: Bug fix for WRFDA RANDOMCV when put_rand_seed=.false. and the compiler has a minimum size of random seed array larger than 10.