### PR TITLE
Add time slot information in DA gts_omb_oma diagnostics

### DIFF
--- a/var/da/da_obs_io/da_read_omb_tmp.inc
+++ b/var/da/da_obs_io/da_read_omb_tmp.inc
@@ -33,6 +33,7 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
                    rain_obs, rain_inv, rain_error, rain_inc, zk
    integer     :: u_qc, v_qc, t_qc, p_qc, q_qc, tpw_qc, spd_qc, ref_qc, rain_qc
    integer     :: eph_qc
+   integer     :: ifgat
 
    if (trace_use_dull) call da_trace_entry("da_read_omb_tmp")
 
@@ -52,9 +53,9 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('synop', 'ships', 'buoy', 'metar', 'sonde_sfc', 'tamdar_sfc')
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)')levels
+               read(unit_in,'(2i8)')levels, ifgat
                if (if_write) then
-                  write(omb_unit,'(i8)')levels
+                  write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                end if
                do k = 1, levels
@@ -91,9 +92,9 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('pilot', 'profiler', 'geoamv', 'qscat', 'polaramv')
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)')levels
+               read(unit_in,'(2i8)')levels, ifgat
                if (if_write) then
-                  write(omb_unit,'(i8)')levels
+                  write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                end if
                do k = 1, levels
@@ -124,9 +125,9 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('gpspw' )
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)')levels
+               read(unit_in,'(2i8)')levels, ifgat
                if (if_write) then
-                  write(omb_unit,'(i8)')levels
+                  write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                end if
                do k = 1, levels
@@ -148,9 +149,9 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('sound', 'tamdar', 'airep')
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)')levels
+               read(unit_in,'(2i8)')levels, ifgat
                if (if_write) then
-                   write(omb_unit,'(i8)')levels
+                   write(omb_unit,'(2i8)')levels, ifgat
                    num = num + 1 
                end if
                do k = 1, levels
@@ -341,8 +342,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('airsr' )          
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)') levels
-               if (if_write) write(omb_unit,'(i8)')levels
+               read(unit_in,'(2i8)') levels, ifgat
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
@@ -365,8 +366,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('gpsref' )          
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)') levels
-               if (if_write) write(omb_unit,'(i8)')levels
+               read(unit_in,'(2i8)') levels, ifgat
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
@@ -387,8 +388,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('gpseph' )
          if (num_obs > 0) then
             do n = 1, num_obs
-               read(unit_in,'(i8)') levels
-               if (if_write) write(omb_unit,'(i8)')levels
+               read(unit_in,'(2i8)') levels, ifgat
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
@@ -409,8 +410,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
       case ('rain' )          
          if (num_obs > 0) then
             do n = 1, num_obs    
-               read(unit_in,'(i8)') levels
-               if (if_write) write(omb_unit,'(i8)')levels
+               read(unit_in,'(2i8)') levels, ifgat
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
                num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&

--- a/var/da/da_obs_io/da_write_obs.inc
+++ b/var/da/da_obs_io/da_write_obs.inc
@@ -14,6 +14,7 @@ subroutine da_write_obs(it,ob, iv, re)
    integer                     :: n, k, num_obs, ios
    integer                     :: ounit     ! Output unit           
    character(len=filename_len) :: filename
+   integer :: itime, ifgat
 
    if (trace_use) call da_trace_entry("da_write_obs")
 
@@ -44,9 +45,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'synop', num_obs  
       num_obs = 0
       do n = 1, iv%info(synop)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(synop)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(synop)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(synop)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1                                 
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                num_obs , 1, iv%info(synop)%id(n), &  ! Station
                iv%info(synop)%lat(1,n), &       ! Latitude
@@ -79,9 +87,16 @@ subroutine da_write_obs(it,ob, iv, re)
      write(ounit,'(a20,i8)')'metar', num_obs  
      num_obs = 0
      do n = 1, iv%info(metar)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(metar)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(metar)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
         if (iv%info(metar)%proc_domain(1,n)) then
            num_obs = num_obs + 1
-           write(ounit,'(i8)') 1                                 
+           write(ounit,'(2i8)') 1, ifgat
            write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
               num_obs  , 1, iv%info(metar)%id(n), &  ! Station
               iv%info(metar)%lat(1,n), &       ! Latitude
@@ -114,8 +129,15 @@ subroutine da_write_obs(it,ob, iv, re)
      write(ounit,'(a20,i8)')'ships', num_obs    
      num_obs = 0
      do n = 1, iv%info(ships)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(ships)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(ships)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
         if (iv%info(ships)%proc_domain(1,n)) then
-           write(ounit,'(i8)') 1                                 
+           write(ounit,'(2i8)') 1, ifgat
            num_obs = num_obs + 1
            write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
               num_obs,1, iv%info(ships)%id(n), &  ! Station
@@ -149,9 +171,16 @@ subroutine da_write_obs(it,ob, iv, re)
      write(ounit,'(a20,i8)')'geoamv', num_obs    
      num_obs = 0
      do n = 1, iv%info(geoamv)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(geoamv)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(geoamv)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
         if (iv%info(geoamv)%proc_domain(1,n)) then                  
            num_obs = num_obs + 1
-           write(ounit,'(i8)')iv%info(geoamv)%levels(n)
+           write(ounit,'(2i8)')iv%info(geoamv)%levels(n), ifgat
            do k = 1, iv%info(geoamv)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                   num_obs, 1, iv%info(geoamv)%id(n), &  ! Station
@@ -177,9 +206,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'polaramv', num_obs      
       num_obs = 0
       do n = 1, iv%info(polaramv)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(polaramv)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(polaramv)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(polaramv)%proc_domain(1,n)) then                    
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(polaramv)%levels(n)
+            write(ounit,'(2i8)')iv%info(polaramv)%levels(n), ifgat
             do k = 1, iv%info(polaramv)%levels(n)
                 write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                    num_obs, 1, iv%info(polaramv)%id(n), &  ! Station
@@ -205,9 +241,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'gpspw', num_obs    
       num_obs = 0
       do n = 1, iv%info(gpspw)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(gpspw)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(gpspw)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(gpspw)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1                                 
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                num_obs, 1, iv%info(gpspw)%id(n), &  ! Station
                iv%info(gpspw)%lat(1,n), &       ! Latitude
@@ -228,9 +271,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'sound', num_obs    
       num_obs = 0
       do n = 1, iv%info(sound)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(sound)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(sound)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(sound)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(sound)%levels(n)
+            write(ounit,'(2i8)')iv%info(sound)%levels(n), ifgat
             do k = 1, iv%info(sound)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                   num_obs,k, iv%info(sound)%id(n), &  ! Station
@@ -258,9 +308,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'sonde_sfc', num_obs    
       num_obs = 0
       do n = 1, iv%info(sonde_sfc)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(sonde_sfc)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(sonde_sfc)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(sound)%proc_domain(1,n)) then 
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                num_obs , 1, iv%info(sonde_sfc)%id(n), &  ! Station
                iv%info(sonde_sfc)%lat(1,n), &       ! Latitude
@@ -293,9 +350,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'airep', num_obs  
       num_obs = 0
       do n = 1, iv%info(airep)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(airep)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(airep)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(airep)%proc_domain(1,n)) then                  
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(airep)%levels(n)
+            write(ounit,'(2i8)')iv%info(airep)%levels(n), ifgat
             do k = 1, iv%info(airep)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,4(2f17.7,i8,2f17.7),f12.2)')&
                   num_obs, k, iv%info(airep)%id(n), &  ! Station
@@ -327,9 +391,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'pilot', num_obs   
       num_obs = 0
       do n = 1, iv%info(pilot)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(pilot)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(pilot)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(pilot)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(pilot)%levels(n)
+            write(ounit,'(2i8)')iv%info(pilot)%levels(n), ifgat
             do k = 1, iv%info(pilot)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                   num_obs, k, iv%info(pilot)%id(n), &  ! Station
@@ -504,9 +575,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'qscat', num_obs   
       num_obs = 0
       do n = 1, iv%info(qscat)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(qscat)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(qscat)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(qscat)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                 num_obs, 1, iv%info(qscat)%id(n), &  ! Station
                 iv%info(qscat)%lat(1,n), &       ! Latitude
@@ -530,9 +608,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'profiler',  num_obs
       num_obs = 0
       do n = 1, iv%info(profiler)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(profiler)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(profiler)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(profiler)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(profiler)%levels(n)
+            write(ounit,'(2i8)')iv%info(profiler)%levels(n), ifgat
             do k = 1, iv%info(profiler)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                   num_obs, k, iv%info(profiler)%id(n), &  ! Station
@@ -558,9 +643,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'buoy', num_obs
       num_obs = 0
       do n = 1, iv%info(buoy)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(buoy)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(buoy)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(buoy)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                num_obs,1, iv%info(buoy)%id(n), &  ! Station
                iv%info(buoy)%lat(1,n), &       ! Latitude
@@ -636,9 +728,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'airsr', num_obs    
       num_obs = 0
       do n = 1, iv%info(airsr)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(airsr)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(airsr)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(airsr)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(airsr)%levels(n)
+            write(ounit,'(2i8)')iv%info(airsr)%levels(n), ifgat
             do k = 1, iv%info(airsr)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                   num_obs,k, iv%info(airsr)%id(n), &  ! Station
@@ -664,9 +763,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'gpsref', num_obs
        num_obs = 0
       do n = 1, iv%info(gpsref)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(gpsref)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(gpsref)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(gpsref)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(gpsref)%levels(n)
+            write(ounit,'(2i8)')iv%info(gpsref)%levels(n), ifgat
             do k = 1, iv%info(gpsref)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                   num_obs,k, iv%info(gpsref)%id(n), &  ! Station
@@ -689,10 +795,17 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'gpseph', num_obs
       num_obs = 0
       do n = 1, iv%info(gpseph)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(gpseph)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(gpseph)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(gpseph)%proc_domain(1,n)) then
             num_obs = num_obs + 1
             !write(ounit,'(i8)')iv%info(gpseph)%levels(n)
-            write(ounit,'(i8)') iv%gpseph(n)%level2 - iv%gpseph(n)%level1 + 1
+            write(ounit,'(2i8)') iv%gpseph(n)%level2 - iv%gpseph(n)%level1 + 1, ifgat
             !do k = 1, iv%info(gpseph)%levels(n)
             do k = iv%gpseph(n)%level1, iv%gpseph(n)%level2
                write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
@@ -716,9 +829,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'tamdar', num_obs
       num_obs = 0
       do n = 1, iv%info(tamdar)%nlocal
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(tamdar)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(tamdar)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(tamdar)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)')iv%info(tamdar)%levels(n)
+            write(ounit,'(2i8)')iv%info(tamdar)%levels(n), ifgat
             do k = 1, iv%info(tamdar)%levels(n)
                write(ounit,'(2i8,a5,2f9.2,f17.7,4(2f17.7,i8,2f17.7),f12.2)')&
                   num_obs,k, iv%info(tamdar)%id(n), &  ! Station
@@ -752,9 +872,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'tamdar_sfc', num_obs  
       num_obs = 0
       do n = 1, iv%info(tamdar_sfc)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(tamdar_sfc)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(tamdar_sfc)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(tamdar_sfc)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1                                 
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7),f12.2)')&
                num_obs , 1, iv%info(tamdar_sfc)%id(n), &  ! Station
                iv%info(tamdar_sfc)%lat(1,n), &       ! Latitude
@@ -787,9 +914,16 @@ subroutine da_write_obs(it,ob, iv, re)
       write(ounit,'(a20,i8)')'rain', num_obs
       num_obs = 0
       do n = 1, iv%info(rain)%nlocal  
+         do itime = 1, num_fgat_time
+            if ( n >= iv%info(rain)%plocal(itime-1)+1 .and. &
+                 n <= iv%info(rain)%plocal(itime) ) then
+               ifgat = itime
+               exit
+            end if
+         end do
          if (iv%info(rain)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            write(ounit,'(i8)') 1
+            write(ounit,'(2i8)') 1, ifgat
             write(ounit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))')&
                num_obs,1, iv%info(rain)%id(n), &  ! Station  
                iv%info(rain)%lat(1,n), &          ! Latitude


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, gts_omb_oma, time_slot

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
For diagnostic purpose, write out additional time slot information in the gts_omb_oma output
so that innovation and residual information can be distinguished and evaluated for each time slot.
Since the additional i8-formatted integer is written out in the end of an existing line,
it should not have impact on users' existing programs that read the ascii gts_omb_oma.

LIST OF MODIFIED FILES:
M       var/da/da_obs_io/da_read_omb_tmp.inc
M       var/da/da_obs_io/da_write_obs.inc

TESTS CONDUCTED:
1. The same NCL script can process both old and new gts_omb_oma files.
2. WRFDA regtests on Cheyenne with intel 17.0.1.

RELEASE NOTE: Enhance the gts_omb_oma diagnostics by appending time slot information after the level information.