### PR TITLE
Fix to allow ./clean -a to clean DA crtm_2.3.0 build

### DIFF
--- a/var/Makefile
+++ b/var/Makefile
@@ -14,7 +14,7 @@ superclean :
           depend inc/*.inc inc/*.h preproc.sh )
 	( cd da; /bin/rm -f *.exe )
 	( cd external/bufr; make clean )
-	( cd external/crtm_2.2.3; make clean )
+	( cd external/crtm_2.3.0; make clean )
 	( cd external/wavelet ; make superclean )
 	( cd da/makedepf90-2.8.8; /bin/rm -f makedepf90 config.log Makefile config.status )
 	( cd gen_be; /bin/rm -f *.exe )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, clean, crtm_2.3.0

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
The crtm directory name in var/Makefile was not updated when CRTM version changed, so that
./clean -a does not clean up crtm_2.3.0 build.
Simply change crtm_2.2.3 to crtm_2.3.0.

LIST OF MODIFIED FILES:
M       var/Makefile

TESTS CONDUCTED:
1. Aftert the fix, ./clean -a removes var/external/crtm_2.3.0/libsrc/*.o, *.mod, *.a files.