### PR TITLE
Explicitly include share and frame directories in the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,11 @@
 /arch/					@wrf-model/infrastructure
 /tools/					@wrf-model/infrastructure
 
+#	Common directories
+
+/share/					@wrf-model/infrastructure
+/frame/					@wrf-model/infrastructure
+
 #	Chemistry
 /chem/					@wrf-model/chem
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CODEOWNERS, share, frame

SOURCE: internal

DESCRIPTION OF CHANGES:
Both the frame and the share directories were accidentally excluded
from being assigned in the CODEOWNERS file. This puts all of those
files and directories under the default control of global-owner.
Since these are infrastructure directories, that is the group that
should have ownership.

LIST OF MODIFIED FILES:
M	.github/CODEOWNERS

TESTS CONDUCTED:
 [x] Default CODEOWNER was notified of required review.

RELEASE NOTE: These mods are for the internal workings of the merge
procedure to the develop branch, so no need to mention this PR in the
release notes.
