### PR TITLE
Add the option mp_physics=40 to README.namelist

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -514,6 +514,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 30, HUJI (Hebrew University of Jerusalem, Israel) spectral bin microphysics,
                                            fast version
                                      = 32, HUJI spectral bin microphysics, full version
+                                     = 10, Morrison (2 moments) with consideration of of CESM-NCSU RCP4.5 climatological aerosol 
                                      = 50, P3 1-category
                                      = 51, P3 1-category plus double-moment cloud water
                                      = 95, Ferrier (old Eta) microphysics, operational NAM (WRF NMM) version

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -514,7 +514,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 30, HUJI (Hebrew University of Jerusalem, Israel) spectral bin microphysics,
                                            fast version
                                      = 32, HUJI spectral bin microphysics, full version
-                                     = 40, Morrison (2 moments) with consideration of of CESM-NCSU RCP4.5 climatological aerosol 
+                                     = 40, Morrison (2 moments) with consideration of CESM-NCSU RCP4.5 climatological aerosol 
                                      = 50, P3 1-category
                                      = 51, P3 1-category plus double-moment cloud water
                                      = 95, Ferrier (old Eta) microphysics, operational NAM (WRF NMM) version

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -514,7 +514,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 30, HUJI (Hebrew University of Jerusalem, Israel) spectral bin microphysics,
                                            fast version
                                      = 32, HUJI spectral bin microphysics, full version
-                                     = 10, Morrison (2 moments) with consideration of of CESM-NCSU RCP4.5 climatological aerosol 
+                                     = 40, Morrison (2 moments) with consideration of of CESM-NCSU RCP4.5 climatological aerosol 
                                      = 50, P3 1-category
                                      = 51, P3 1-category plus double-moment cloud water
                                      = 95, Ferrier (old Eta) microphysics, operational NAM (WRF NMM) version


### PR DESCRIPTION
TYPE:  text only

KEYWORDS: README.namelist

SOURCE: internal

DESCRIPTION OF CHANGES: The option mp_physics=40, which is missing previously, is added to README.namelist.  

LIST OF MODIFIED FILES

M      run/README.namelist

TESTS CONDUCTED: not needed   

RELEASE NOTE:  Don't need to include