### PR TITLE
Remove DA obsolete RTTOV-v11 handling in compile

### DIFF
--- a/compile
+++ b/compile
@@ -354,46 +354,6 @@ else
        setenv CRTM_SRC " "
        setenv CRTM 0
     endif
-    set RTTOV = ( `grep "^RTTOVPATH" configure.wrf | cut -d"=" -f2-` )
-    if ( $RTTOV == "" ) then
-       setenv RTTOV_LIB " "
-       setenv RTTOV_SRC " "
-       unsetenv RTTOV
-    else
-       echo "  "
-       echo "Compiling with RTTOV libraries in:"
-       echo $RTTOV
-       echo "  "
-       if ( ! $?BUFR ) then
-          echo "  "
-          echo "BUFR library is needed for radiance data ingest."
-          echo "setting BUFR=1"
-          echo "  "
-          setenv BUFR 1
-       endif
-       if ( -e ${RTTOV}/lib/librttov11.1.0_main.a ) then
-          setenv RTTOV_LIB "-L${RTTOV}/lib -lrttov11.1.0_coef_io -lrttov11.1.0_emis_atlas -lrttov11.1.0_main"
-          if ( -e ${RTTOV}/lib/librttov11.1.0_hdf.a ) then
-             setenv RTTOV_LIB "${RTTOV_LIB} -lrttov11.1.0_hdf"
-          endif
-       else if ( -e ${RTTOV}/lib/librttov11.2.0_main.a ) then
-          setenv RTTOV_LIB "-L${RTTOV}/lib -lrttov11.2.0_coef_io -lrttov11.2.0_emis_atlas -lrttov11.2.0_main"
-          if ( -e ${RTTOV}/lib/librttov11.2.0_hdf.a ) then
-             setenv RTTOV_LIB "${RTTOV_LIB} -lrttov11.2.0_hdf"
-          endif
-       else if ( -e ${RTTOV}/lib/librttov11_main.a ) then
-          setenv RTTOV_LIB "-L${RTTOV}/lib -lrttov11_coef_io -lrttov11_emis_atlas -lrttov11_main"
-          if ( -e ${RTTOV}/lib/librttov11_hdf.a ) then
-             setenv RTTOV_LIB "${RTTOV_LIB} -lrttov11_hdf"
-          endif
-       else
-          echo "Can not find a compatible RTTOV library! Please ensure that your RTTOV build was successful,"
-          echo "your 'RTTOV' environment variable is set correctly, and you are using a supported version of RTTOV."
-          echo "Currently supported versions are 11.1, 11.2, and 11.3"
-          exit 1
-       endif
-       setenv RTTOV_SRC "-I${RTTOV}/include -I${RTTOV}/mod"
-    endif
     set hdf5path = ( `grep "^HDF5PATH" configure.wrf | cut -d"=" -f2-` )
     if ( $hdf5path == "" ) then
        setenv HDF5_INC ""


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, compile, RTTOV-v11

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
release-v4.0.x supports RTTOV-v11.
develop supports RTTOV-v12.
The change to 'compile' in commit beeba2e is specific to RTTOV-v11/release-v4.0.x.
This PR removes the obsolete RTTOV-v11 part for develop.

LIST OF MODIFIED FILES:
M       compile

TESTS CONDUCTED:
WRFDA with RTTOV compiles after the fix.