### PR TITLE
Fix adjustment of urban type in REAL program when NLCD and MODIS used together

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3003,7 +3003,7 @@ integer::oops1,oops2
             DO i = its , MIN(ide-1,ite)
               IF ( MMINLU == 'NLCD40' .OR. MMINLU == 'MODIFIED_IGBP_MODIS_NOAH') THEN
                   IF ( grid%FRC_URB2D(i,j) .GE. 0.5 .AND.  &
-                      (grid%ivgtyp(i,j).NE.13 .OR. grid%ivgtyp(i,j).NE.24 .OR. grid%ivgtyp(i,j).NE.25 .OR. grid%ivgtyp(i,j).NE.26)) grid%ivgtyp(i,j)=13
+                      (grid%ivgtyp(i,j).NE.13 .AND. grid%ivgtyp(i,j).NE.24 .AND. grid%ivgtyp(i,j).NE.25 .AND. grid%ivgtyp(i,j).NE.26)) grid%ivgtyp(i,j)=13
               ELSE IF ( MMINLU == "USGS" ) THEN
                   IF ( grid%FRC_URB2D(i,j) .GE. 0.5 .AND.  &
                        grid%ivgtyp(i,j).NE.1 ) grid%ivgtyp(i,j)=1


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: urban, land use, MODIS, REAL, NLCD

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem: 
When NLCD and MODIS are used together, the land use type will be adjusted for all grid cells where  the urban fraction is greater than 0.5 in the real program. Due to an incorrect application of DeMorgan's Law, all of the urban land use categories became category 13. While 13 for MODIS is indeed urban, 13 is not the NLCD high-resolution urban categories: 24, 25, 26. These NLCD urban categories should be preferentially used if available.

Solution:
The logic is supposed to be:
if ( the grid point is urban (based on percentage) ) and 
( the grid cell is not one of the special NLCD points ) then 
   reset this to the MODIS urban category.
```
if (urban>0.5)
   if ((cat != 24) AND cat(!=25) AND cat(!=26))
      cat = 13
```
Note that with our incorrect implementation of the logic, the if test above is ALWAYS true: we always reset the urban points to the MODIS value. Here is the line that we need:
```
if ((cat != 24) OR cat(!=25) OR cat(!=26))
```
The incorrect logic in the IF test means that all urban points (based on percentage) become category 13, which is the MODIS urban category. The correct logic excludes urban points that are identified as NLCD urban points.

This bug fix retains the correct urban type defined in NLCD.

LIST OF MODIFIED FILES:
M       dyn_em/module_initialize_real.F

TESTS CONDUCTED:   
1. Application to a user case confirms the modified code works as expected.

- [x] Figures that show the wrong and correct land categories near an urban area.

Incorrect: The urban area around Los Angeles and San Diego are all category 13.
![screen shot 2018-11-26 at 2 38 58 pm](https://user-images.githubusercontent.com/17932265/49043712-18948400-f189-11e8-969c-0d2df52ac3a8.png)
 
Correct: The urban area around Los Angeles and San Diego are a combination of categories 24, 25, 26, and 13.
![screen shot 2018-11-26 at 2 39 14 pm](https://user-images.githubusercontent.com/17932265/49043740-2813cd00-f189-11e8-82b3-5fa54e7d3550.png)
![screen shot 2018-11-26 at 3 07 01 pm](https://user-images.githubusercontent.com/17932265/49045081-0f0d1b00-f18d-11e8-8ae7-a4d5b0dd9aaf.png)

RELEASE NOTE: When using a combination of NLCD and MODIS, all of the urban grid points from NLCD were lost when running the real program. A fix returns the preferred NLCD categories of urban grid cells. Users with NLCD + MODIS should check their existing results, specifically the land categories that are defined as urban. There should be points with category values of 24, 25, or 26. If not, you should re-run the real program with this version.