### PR TITLE
User defined values for CO2 content in RRTMG and NOAH-MP

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2232,6 +2232,7 @@ rconfig   integer alevsiz_cu              namelist,physics      1             1 
 rconfig   integer aercu_opt               namelist,physics      1             0       -      "aercu_opt"    "aerosol input option for multiscale KF"      ""
 rconfig   real    aercu_fct               namelist,physics      1             1.0     -      "aercu_fct"    "aerosol multiplication factor"               ""
 rconfig   integer aercu_used              derived               1             0       -      "aercu_used"   "derived nml for packaging"      ""
+rconfig   real    co2_content             namelist,physics      1             395.E-06 irh   "co2_content"  "CO2 content in RRTMG"      "ppm"
 
 #BSINGH - added shallowcu_forced_ra, numBins, thBinSize, rBinSize, minDeepFreq, minShallowFreq, shcu_aerosols_opt for CuP scheme
 
@@ -2316,6 +2317,7 @@ rconfig   integer opt_soil    namelist,noah_mp      1           1         h    "
 rconfig   integer opt_pedo    namelist,noah_mp      1           1         h    "opt_pedo" "pedo_transfer function option"   ""
 rconfig   integer opt_crop    namelist,noah_mp      1           0         h    "opt_crop" "crop model option"   ""
 rconfig   real    WTDDT               namelist,physics         max_domains     30.      h     "wtddt"    "minutes between calls to lateral hydro"  ""
+rconfig   real    co2_content_noahmp namelist,noah_mp      1           395.E-06  h    "co2_content_noahmp" "co2 content for NOAHMP"   ""
 
 # For WRF Hydro
 rconfig   integer wrf_hydro               derived              1     0      h     "wrf_hydro"   "descrip"  "unit"

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -405,7 +405,7 @@ BENCH_START(rad_driver_tim)
      &         ,MP_PHYSICS=CONFIG_FLAGS%MP_PHYSICS        &
      &         ,EFCG=grid%EFCG,EFCS=grid%EFCS,EFIG=grid%EFIG &
      &         ,EFIS=grid%EFIS,EFSG=grid%EFSG,aercu_opt=config_flags%aercu_opt & 
-     &         ,EFSS=grid%EFSS,QS_CU=grid%QS_CU)
+     &         ,EFSS=grid%EFSS,QS_CU=grid%QS_CU,CO2_CONTENT=config_flags%co2_content) !Thomas CO2 10/12/2018
 
 BENCH_END(rad_driver_tim)
 
@@ -756,6 +756,7 @@ BENCH_START(surf_driver_tim)
      &        ,   irbxy=grid%irbxy    ,    trxy=grid%trxy    ,   evcxy=grid%evcxy    &
      &        ,chleafxy=grid%chleafxy ,  chucxy=grid%chucxy                          &                       
      &        ,  chv2xy=grid%chv2xy   ,  chb2xy=grid%chb2xy , chstarxy=grid%chstarxy &                       
+     &        , real_co2_content_noahmp=config_flags%co2_content_noahmp              & ! Thomas CO2
            !Optional hydro variables in NOAHMP
      &        ,smcwtdxy=grid%smcwtdxy ,rechxy=grid%rechxy ,deeprechxy=grid%deeprechxy &
      &        ,fdepthxy=grid%fdepthxy, areaxy=grid%areaxy, rivercondxy=grid%rivercondxy  &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -744,7 +744,7 @@ CONTAINS
    INTEGER :: iopt_run
    INTEGER :: aercu_opt !PSH/TWG 
    REAL    :: aercu_fct !PSH/TWG 
-
+   REAL :: CO2_content ! Thomas 2018
 
    INTEGER :: i, j, k, itf, jtf, ktf, n
 integer myproc
@@ -782,6 +782,7 @@ integer myproc
 
    aercu_opt=config_flags%aercu_opt !PSH/TWG 06/10/16
    aercu_fct=config_flags%aercu_fct !PSH/TWG 06/10/16
+   co2_content = config_flags%co2_content
    sf_urban_physics=config_flags%sf_urban_physics
    usemonalb=config_flags%usemonalb
    rdmaxalb=config_flags%rdmaxalb

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -744,7 +744,7 @@ CONTAINS
    INTEGER :: iopt_run
    INTEGER :: aercu_opt !PSH/TWG 
    REAL    :: aercu_fct !PSH/TWG 
-   REAL :: CO2_content ! Thomas 2018
+   REAL :: CO2_content 
 
    INTEGER :: i, j, k, itf, jtf, ktf, n
 integer myproc

--- a/phys/module_ra_goddard.F
+++ b/phys/module_ra_goddard.F
@@ -176,7 +176,7 @@ contains
                    ,swddir,swddni,swddif                          & ! jararias 2013/08
                    ,coszen,julian                                 & ! jararias 2013/08
                    ,aer_opt                                       &
-                                                                  )
+                   ,co2_content                                   )
    implicit none
 
 !------- I / O variables ----------------------------------------------
@@ -360,6 +360,9 @@ contains
    real(Kind=fp_kind)    :: fac,x
    real(Kind=fp_kind)    :: xt24,tloctm,hrang,xxlat
    real, intent(in)    :: center_lat                ! center of latitude
+
+! for user defined CO2 content
+   REAL , INTENT (IN) :: co2_content 
 
 !urban
 !   real, optional, dimension( ims:ime, jms:jme ), intent(out)  :: cosz_urb2d !urban

--- a/phys/module_ra_rrtm.F
+++ b/phys/module_ra_rrtm.F
@@ -1741,7 +1741,7 @@ CONTAINS
                        ,qi3d,qs3d,qg3d,cldfra3d                   &
                        ,f_qv,f_qc,f_qr,f_qi,f_qs,f_qg             &
 !ccc Added for time-varying trace gases.
-                       ,yr, julian                                )
+                       ,yr, julian,co2_content                    )
 !ccc
 !------------------------------------------------------------------
 !ccc
@@ -1831,6 +1831,10 @@ CONTAINS
 ! p_top for vertical nesting
     REAL, INTENT(IN   ) :: p_top
 
+! for user defined CO2 content
+   REAL , INTENT (IN) :: co2_content 
+
+
 !------------------------------------------------------------------
 
     IF ( p_top .GT. 0 ) THEN ! flag value for NMM = -1
@@ -1855,7 +1859,7 @@ CONTAINS
 !  n2ovmr = 0.
 !  ch4vmr = 0.
 ! values updated to RRTMG in V3.5
-   co2vmr = 379.e-6
+   co2vmr = co2_content
    n2ovmr = 319.e-9
    ch4vmr = 1774.e-9
 #endif

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11486,7 +11486,7 @@ CONTAINS
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte,                 &
-                       lwupflx, lwupflxc, lwdnflx, lwdnflxc,co2_content& ! Thomas CO2 2018
+                       lwupflx, lwupflxc, lwdnflx, lwdnflxc,co2_content& 
                                                                   )
 !------------------------------------------------------------------
 !ccc To use clWRF time varying trace gases
@@ -11503,7 +11503,7 @@ CONTAINS
 
    INTEGER, INTENT(IN )      ::        ICLOUD
    INTEGER, INTENT(IN )      ::        MP_PHYSICS
-   REAL , INTENT (IN) :: co2_content ! Thomas CO2 2018
+   REAL , INTENT (IN) :: co2_content 
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -11824,9 +11824,9 @@ CONTAINS
                   266.13,263.96,261.54,258.93,256.15,253.23,      &
                   249.89,246.67,243.48,240.25,236.66,233.86/    
 !------------------------------------------------------------------
-!Thomas 2018 for CO2
+
  co2 = co2_content
-! end Thomas
+
 
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11486,7 +11486,7 @@ CONTAINS
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte,                 &
-                       lwupflx, lwupflxc, lwdnflx, lwdnflxc       &
+                       lwupflx, lwupflxc, lwdnflx, lwdnflxc,co2_content& ! Thomas CO2 2018
                                                                   )
 !------------------------------------------------------------------
 !ccc To use clWRF time varying trace gases
@@ -11503,6 +11503,7 @@ CONTAINS
 
    INTEGER, INTENT(IN )      ::        ICLOUD
    INTEGER, INTENT(IN )      ::        MP_PHYSICS
+   REAL , INTENT (IN) :: co2_content ! Thomas CO2 2018
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -11713,7 +11714,7 @@ CONTAINS
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
 ! carbon dioxide (379 ppmv)
     real :: co2
-    data co2 / 379.e-6 / 
+    data co2 / 395.e-6 / 
 ! methane (1774 ppbv)
     real :: ch4
     data ch4 / 1774.e-9 / 
@@ -11823,6 +11824,10 @@ CONTAINS
                   266.13,263.96,261.54,258.93,256.15,253.23,      &
                   249.89,246.67,243.48,240.25,236.66,233.86/    
 !------------------------------------------------------------------
+!Thomas 2018 for CO2
+ co2 = co2_content
+! end Thomas
+
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then
       IF ( .NOT. &

--- a/phys/module_ra_rrtmg_lwf.F
+++ b/phys/module_ra_rrtmg_lwf.F
@@ -15272,7 +15272,7 @@ integer,external :: omp_get_thread_num
                        progn,                                     & !czhao
                        qndrop3d,f_qndrop,                         & !czhao
 !ccc added for time varying gases.
-                       yr,julian,                                 &
+                       yr,julian,co2_content,                     &
 !ccc
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
@@ -15483,6 +15483,9 @@ integer,external :: omp_get_thread_num
                                                               dz
     real:: snow_mass_factor
 
+! for user defined CO2 content
+   REAL , INTENT (IN) :: co2_content 
+
 !..We can use message interface regardless of what options are running,
 !.. so let us ask for it here.
       CHARACTER(LEN=256)                           :: message
@@ -15608,6 +15611,9 @@ integer,external :: omp_get_thread_num
                   266.13,263.96,261.54,258.93,256.15,253.23,      &
                   249.89,246.67,243.48,240.25,236.66,233.86/    
 !------------------------------------------------------------------
+
+ co2= co2_content
+
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then
       IF ( .NOT. &

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -9949,7 +9949,7 @@ CONTAINS
 
    INTEGER, INTENT(IN )      ::        ICLOUD
    INTEGER, INTENT(IN )      ::        MP_PHYSICS
-   REAL , INTENT (IN) :: co2_content ! Thomas CO2 2018
+   REAL , INTENT (IN) :: co2_content 
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -10283,9 +10283,8 @@ CONTAINS
 
     REAL :: da, eot ! jararias, 14/08/2013
 
-  !Thomas 2018 for CO2
    co2 = co2_content
-  ! end Thomas
+
 !------------------------------------------------------------------
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -9935,7 +9935,7 @@ CONTAINS
                        tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
                        swddir, swddni, swddif,                    & ! jararias 2013/08
                        swdownc, swddnic, swddirc,                 & ! PAJ
-                       xcoszen,julian                             & ! jararias 2013/08
+                       xcoszen,julian,co2_content                 & ! jararias 2013/08
                                                                   )
 !------------------------------------------------------------------
    IMPLICIT NONE
@@ -9949,6 +9949,7 @@ CONTAINS
 
    INTEGER, INTENT(IN )      ::        ICLOUD
    INTEGER, INTENT(IN )      ::        MP_PHYSICS
+   REAL , INTENT (IN) :: co2_content ! Thomas CO2 2018
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -10212,7 +10213,7 @@ CONTAINS
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
 ! carbon dioxide (379 ppmv)
     real :: co2
-    data co2 / 379.e-6 / 
+    data co2 / 395.e-6 /
 ! methane (1774 ppbv)
     real :: ch4
     data ch4 / 1774.e-9 / 
@@ -10282,6 +10283,9 @@ CONTAINS
 
     REAL :: da, eot ! jararias, 14/08/2013
 
+  !Thomas 2018 for CO2
+   co2 = co2_content
+  ! end Thomas
 !------------------------------------------------------------------
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11251,7 +11251,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
                        tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
                        swddir, swddni, swddif,                    & ! jararias 2013/08
                        swdownc, swddnic, swddirc,                 & ! PAJ
-                       xcoszen,julian                             & ! jararias 2013/08
+                       xcoszen,julian,co2_content                 & ! jararias 2013/08
                                                                   )
 !------------------------------------------------------------------
       IMPLICIT NONE
@@ -11516,6 +11516,9 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
     integer:: idx_rei
     real:: corr
 
+! for user defined CO2 content
+   REAL , INTENT (IN) :: co2_content 
+
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
 ! carbon dioxide (379 ppmv)
     real :: co2
@@ -11597,6 +11600,8 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
 
 ! mji - write
 !    REAL, DIMENSION( ims:ime, jms:jme ) ::         SWDB, SWUT
+
+ co2=co2_content
 
 !------------------------------------------------------------------
 #if ( WRF_CHEM == 1 )

--- a/phys/module_ra_rrtmg_swk.F
+++ b/phys/module_ra_rrtmg_swk.F
@@ -10182,7 +10182,7 @@ contains
                        qv3d, qc3d, qr3d, qi3d, qs3d, qg3d,                     &
 !sh
                        o3input, o33d,                                          &
-                       aer_opt, aerod, no_src,                                 &
+                       aer_opt, aerod, no_src,co2_content,                     &
 !sh        
                        ids,ide, jds,jde, kds,kde,                              &
                        ims,ime, jms,jme, kms,kme,                              &
@@ -10323,6 +10323,9 @@ contains
    integer                              :: dyofyr
 
 
+! for user defined CO2 content
+   REAL , INTENT (IN) :: co2_content 
+
 !
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
 ! carbon dioxide (379 ppmv)
@@ -10394,6 +10397,9 @@ contains
    real :: xt24, tloctm, hrang, xxlat
    integer :: i, j, k, na
    logical :: predicate
+
+
+  co2=co2_content
 
 !-------------------------------------------------------------------------------
 !

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -151,7 +151,7 @@ CONTAINS
               ,taod5502d, taod5503d                                       & !  Trude
               ,mp_physics                                                 &
               ,EFCG,EFCS,EFIG,EFIS,EFSG,aercu_opt                         &
-              ,EFSS,QS_CU                                                 &
+              ,EFSS,QS_CU,CO2_CONTENT                                     & ! Thomas CO2 10/12/2018
                                                                           )
 
 
@@ -773,7 +773,7 @@ CONTAINS
      INTEGER, PARAMETER:: taer_angexp_opt = 3                            !  input option for aerosol Angstrom exponent
      INTEGER, PARAMETER:: taer_ssa_opt = 3                               !  input option for aerosol ssa
      INTEGER, PARAMETER:: taer_asy_opt = 3                               !  input option for aerosol asy
-
+     REAL, INTENT(in) :: co2_content !Thomas CO2 2018
 
 #if ( HWRF == 1 )
    CHARACTER(len=255) :: wrf_err_message
@@ -1697,7 +1697,7 @@ CONTAINS
                   ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte,&
                   LWUPFLX=LWUPFLX,LWUPFLXC=LWUPFLXC,                &
                   LWDNFLX=LWDNFLX,LWDNFLXC=LWDNFLXC,                &
-                  mp_physics=mp_physics                             )
+                  mp_physics=mp_physics,CO2_CONTENT=CO2_CONTENT     ) !Thomas CO2 2018/10/18
 
         CASE (RRTMK_LWSCHEME)
 
@@ -2161,7 +2161,7 @@ CONTAINS
                      asyaer3d_sw=asyaer_sw,                             & ! jararias 2013/11
                      swddir=swddir,swddni=swddni,swddif=swddif,         & ! jararias 2013/08/10
                      swdownc=swdownc, swddnic=swddnic, swddirc=swddirc, & ! PAJ
-                     xcoszen=coszen,julian=julian,mp_physics=mp_physics ) ! jararias 2013/08/14
+                     xcoszen=coszen,julian=julian,mp_physics=mp_physics, co2_content=co2_content ) ! jararias 2013/08/14
 
              DO j=jts,jte
              DO k=kts,kte

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -151,7 +151,7 @@ CONTAINS
               ,taod5502d, taod5503d                                       & !  Trude
               ,mp_physics                                                 &
               ,EFCG,EFCS,EFIG,EFIS,EFSG,aercu_opt                         &
-              ,EFSS,QS_CU,CO2_CONTENT                                     & ! Thomas CO2 10/12/2018
+              ,EFSS,QS_CU,CO2_CONTENT                                     & 
                                                                           )
 
 
@@ -773,7 +773,7 @@ CONTAINS
      INTEGER, PARAMETER:: taer_angexp_opt = 3                            !  input option for aerosol Angstrom exponent
      INTEGER, PARAMETER:: taer_ssa_opt = 3                               !  input option for aerosol ssa
      INTEGER, PARAMETER:: taer_asy_opt = 3                               !  input option for aerosol asy
-     REAL, INTENT(in) :: co2_content !Thomas CO2 2018
+     REAL, INTENT(in) :: co2_content 
 
 #if ( HWRF == 1 )
    CHARACTER(len=255) :: wrf_err_message
@@ -1477,7 +1477,7 @@ CONTAINS
                  ,F_QI=F_QI,F_QS=F_QS,F_QG=F_QG                     &
                  ,ICLOUD=icloud,WARM_RAIN=warm_rain                 &
 !ccc Added for time-varying trace gases.
-                 ,YR=YR,JULIAN=JULIAN                               &
+                 ,YR=YR,JULIAN=JULIAN,CO2_CONTENT=CO2_CONTENT       &
 !ccc
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &     
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
@@ -1519,7 +1519,7 @@ CONTAINS
                     ,tauaer3d_sw=tauaer_sw                             & ! jararias, 2013/11
                     ,ssaaer3d_sw=ssaaer_sw                             & ! jararias, 2013/11
                     ,asyaer3d_sw=asyaer_sw                             & ! jararias, 2012/11
-                                                                       )
+                    ,co2_content=co2_content                           )
 
         CASE (GFDLLWSCHEME)
 
@@ -1697,7 +1697,7 @@ CONTAINS
                   ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte,&
                   LWUPFLX=LWUPFLX,LWUPFLXC=LWUPFLXC,                &
                   LWDNFLX=LWDNFLX,LWDNFLXC=LWDNFLXC,                &
-                  mp_physics=mp_physics,CO2_CONTENT=CO2_CONTENT     ) !Thomas CO2 2018/10/18
+                  mp_physics=mp_physics,CO2_CONTENT=CO2_CONTENT     ) 
 
         CASE (RRTMK_LWSCHEME)
 
@@ -1719,7 +1719,7 @@ CONTAINS
                            f_qs, f_qg,                              &
                            qv, qc, qr, qi, qs, qg,                  &
                            o3input, o3rad,                          &
-                           aer_opt, aerod, no_src_types,            &
+                           aer_opt, aerod, no_src_types,co2_content,&
                            ids,ide, jds,jde, kds,kde,               &
                            ims,ime, jms,jme, kms,kme,               &
                            its,ite, jts,jte, kts,kte)
@@ -1774,7 +1774,7 @@ CONTAINS
 #endif
                   QNDROP3D=qndrop,F_QNDROP=f_qndrop,                &
 !ccc Added for time-varying trace gases.
-                  YR=YR,JULIAN=JULIAN,                              &
+                  YR=YR,JULIAN=JULIAN,CO2_CONTENT=CO2_CONTENT,      &
 !ccc
                   IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde,&
                   IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme,&
@@ -2035,7 +2035,7 @@ CONTAINS
                     ,ssaaer3d_sw=ssaaer_sw                             & ! jararias, 2013/11
                     ,asyaer3d_sw=asyaer_sw                             & ! jararias, 2012/11
                     ,aer_opt=aer_opt                                   &
-                                                                       )
+                    ,co2_content=co2_content                           )
 
         CASE (CAMSWSCHEME)
              CALL wrf_debug(100, 'CALL camrad sw')
@@ -2161,7 +2161,8 @@ CONTAINS
                      asyaer3d_sw=asyaer_sw,                             & ! jararias 2013/11
                      swddir=swddir,swddni=swddni,swddif=swddif,         & ! jararias 2013/08/10
                      swdownc=swdownc, swddnic=swddnic, swddirc=swddirc, & ! PAJ
-                     xcoszen=coszen,julian=julian,mp_physics=mp_physics, co2_content=co2_content ) ! jararias 2013/08/14
+                     xcoszen=coszen,julian=julian,mp_physics=mp_physics,&
+                     co2_content=co2_content ) ! jararias 2013/08/14
 
              DO j=jts,jte
              DO k=kts,kte
@@ -2242,7 +2243,7 @@ CONTAINS
                      asyaer3d_sw=asyaer_sw,                             & ! jararias 2013/11
                      swddir=swddir,swddni=swddni,swddif=swddif,         & ! jararias 2013/08/10
                      swdownc=swdownc, swddnic=swddnic, swddirc=swddirc, & ! PAJ
-                     xcoszen=coszen,julian=julian                       ) ! jararias 2013/08/14
+                     xcoszen=coszen,julian=julian,co2_content=co2_content) ! jararias 2013/08/14
 
              DO j=jts,jte
              DO k=kts,kte

--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -101,7 +101,7 @@ CONTAINS
     INTEGER,                                         INTENT(IN   ) ::  IOPT_SOIL ! soil configuration option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_PEDO ! soil pedotransfer function option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.; 2->Gecros)
-    REAL   ,                                         INTENT(IN   ) ::  real_CO2_CONTENT_NOAHMP ! ! Thomas CO2 from namelist 2018
+    REAL   ,                                         INTENT(IN   ) ::  real_CO2_CONTENT_NOAHMP 
     INTEGER,                                         INTENT(IN   ) ::  IZ0TLND   ! option of Chen adjustment of Czil (not used)
     INTEGER,                                         INTENT(IN   ) ::  sf_urban_physics   ! urban physics option
     REAL,    DIMENSION( ims:ime,       8, jms:jme ), INTENT(IN   ) ::  SOILCOMP  ! soil sand and clay percentage
@@ -743,10 +743,9 @@ CONTAINS
        FICEOLD = 0.0
        FICEOLD(ISNOW+1:0) = SNICEXY(I,ISNOW+1:0,J) &  ! snow ice fraction  
            /(SNICEXY(I,ISNOW+1:0,J)+SNLIQXY(I,ISNOW+1:0,J))
-!Thomas CO2 2018
-! PRINT*, "CO2 content in NOAH-MP ",co2_content_noahmp
-        CO2PP = co2_content_noahmp* P_ML
-! End Thomas
+
+       CO2PP = co2_content_noahmp* P_ML
+
        O2PP   = O2_TABLE  * P_ML                      ! partial pressure  o2 [Pa]
        FOLN   = 1.0                                   ! for now, set to nitrogen saturation
        QC     = undefined_value                       ! test dummy value

--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -49,7 +49,7 @@ CONTAINS
 #endif
                ids,ide,  jds,jde,  kds,kde,                    &
                ims,ime,  jms,jme,  kms,kme,                    &
-               its,ite,  jts,jte,  kts,kte,                    &
+               its,ite,  jts,jte,  kts,kte,real_co2_content_noahmp,         &
                MP_RAINC, MP_RAINNC, MP_SHCV, MP_SNOW, MP_GRAUP, MP_HAIL     )
 !----------------------------------------------------------------
     USE MODULE_SF_NOAHMPLSM
@@ -101,6 +101,7 @@ CONTAINS
     INTEGER,                                         INTENT(IN   ) ::  IOPT_SOIL ! soil configuration option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_PEDO ! soil pedotransfer function option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.; 2->Gecros)
+    REAL   ,                                         INTENT(IN   ) ::  real_CO2_CONTENT_NOAHMP ! ! Thomas CO2 from namelist 2018
     INTEGER,                                         INTENT(IN   ) ::  IZ0TLND   ! option of Chen adjustment of Czil (not used)
     INTEGER,                                         INTENT(IN   ) ::  sf_urban_physics   ! urban physics option
     REAL,    DIMENSION( ims:ime,       8, jms:jme ), INTENT(IN   ) ::  SOILCOMP  ! soil sand and clay percentage
@@ -460,7 +461,7 @@ CONTAINS
 
     CALL NOAHMP_OPTIONS(IDVEG  ,IOPT_CRS  ,IOPT_BTR  ,IOPT_RUN  ,IOPT_SFC  ,IOPT_FRZ , &
                      IOPT_INF  ,IOPT_RAD  ,IOPT_ALB  ,IOPT_SNF  ,IOPT_TBOT, IOPT_STC , &
-		     IOPT_RSF  ,IOPT_SOIL ,IOPT_PEDO ,IOPT_CROP )
+		     IOPT_RSF  ,IOPT_SOIL ,IOPT_PEDO ,IOPT_CROP, real_co2_content_noahmp)
 
     IPRINT    =  .false.                     ! debug printout
 
@@ -742,7 +743,10 @@ CONTAINS
        FICEOLD = 0.0
        FICEOLD(ISNOW+1:0) = SNICEXY(I,ISNOW+1:0,J) &  ! snow ice fraction  
            /(SNICEXY(I,ISNOW+1:0,J)+SNLIQXY(I,ISNOW+1:0,J))
-       CO2PP  = CO2_TABLE * P_ML                      ! partial pressure co2 [Pa]
+!Thomas CO2 2018
+! PRINT*, "CO2 content in NOAH-MP ",co2_content_noahmp
+        CO2PP = co2_content_noahmp* P_ML
+! End Thomas
        O2PP   = O2_TABLE  * P_ML                      ! partial pressure  o2 [Pa]
        FOLN   = 1.0                                   ! for now, set to nitrogen saturation
        QC     = undefined_value                       ! test dummy value

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -9068,7 +9068,7 @@ END SUBROUTINE EMERG
   INTEGER,  INTENT(IN) :: iopt_soil !soil parameters set-up option
   INTEGER,  INTENT(IN) :: iopt_pedo !pedo-transfer function
   INTEGER,  INTENT(IN) :: iopt_crop !crop model option (0->none; 1->Liu et al.; 2->Gecros)
-  REAL,  INTENT(IN) :: real_co2_content_noahmp   !Thomas CO2 2018
+  REAL,  INTENT(IN) :: real_co2_content_noahmp   ! namelist controlled co2
 ! -------------------------------------------------------------------------------------------------
 
   dveg = idveg

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -152,6 +152,7 @@ MODULE MODULE_SF_NOAHMPLSM
                       !   1 -> Liu, et al. 2016
 		      !   2 -> Gecros (Genotype-by-Environment interaction on CROp growth Simulator) Yin and van Laar, 2005
 
+  REAL :: CO2_CONTENT_NOAHMP ! CO2 content for NOAHMP
 !------------------------------------------------------------------------------------------!
 ! Physical Constants:                                                                      !
 !------------------------------------------------------------------------------------------!
@@ -9045,7 +9046,7 @@ END SUBROUTINE EMERG
 
   subroutine noahmp_options(idveg     ,iopt_crs  ,iopt_btr  ,iopt_run  ,iopt_sfc  ,iopt_frz , & 
                              iopt_inf  ,iopt_rad  ,iopt_alb  ,iopt_snf  ,iopt_tbot, iopt_stc, &
-			     iopt_rsf , iopt_soil, iopt_pedo, iopt_crop )
+			     iopt_rsf , iopt_soil, iopt_pedo, iopt_crop, real_co2_content_noahmp )
 
   implicit none
 
@@ -9067,7 +9068,7 @@ END SUBROUTINE EMERG
   INTEGER,  INTENT(IN) :: iopt_soil !soil parameters set-up option
   INTEGER,  INTENT(IN) :: iopt_pedo !pedo-transfer function
   INTEGER,  INTENT(IN) :: iopt_crop !crop model option (0->none; 1->Liu et al.; 2->Gecros)
-
+  REAL,  INTENT(IN) :: real_co2_content_noahmp   !Thomas CO2 2018
 ! -------------------------------------------------------------------------------------------------
 
   dveg = idveg
@@ -9087,6 +9088,7 @@ END SUBROUTINE EMERG
   opt_soil = iopt_soil
   opt_pedo = iopt_pedo
   opt_crop = iopt_crop
+  co2_content_noahmp = real_co2_content_noahmp
   
   end subroutine noahmp_options
  

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -71,7 +71,7 @@ CONTAINS
      &          ,bgapxy   ,wgapxy    ,tgvxy     ,tgbxy     ,chvxy     ,chbxy        &    
      &          ,shgxy    ,shcxy     ,shbxy     ,evgxy     ,evbxy     ,ghvxy        &
      &          ,ghbxy    ,irgxy     ,ircxy     ,irbxy     ,trxy      ,evcxy        &
-     &          ,chleafxy ,chucxy    ,chv2xy    ,chb2xy    ,chstarxy, real_co2_content_noahmp & !Thomas CO2 2018  &                      
+     &          ,chleafxy ,chucxy    ,chv2xy    ,chb2xy    ,chstarxy, real_co2_content_noahmp & 
            ! Noah-MP ground water
      &          ,smcwtdxy ,rechxy   ,deeprechxy,fdepthxy,areaxy   ,rivercondxy, riverbedxy &
      &          ,eqzwt    ,pexpxy   ,qrfxy    ,qspringxy,qslatxy  ,qrfsxy   ,qspringsxy &
@@ -3000,7 +3000,7 @@ CONTAINS
 #endif
                 ids,ide, jds,jde, kds,kde,                      &
                 ims,ime, jms,jme, kms,kme,                      &
-                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,real_co2_content_noahmp,  & ! Thomas CO2 2018  
+                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,real_co2_content_noahmp,  & 
 ! variables below are optional
                 MP_RAINC =  RAINCV, MP_RAINNC =    RAINNCV, MP_SHCV = RAINSHV,&
 		MP_SNOW  = SNOWNCV, MP_GRAUP  = GRAUPELNCV, MP_HAIL = HAILNCV )

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -71,7 +71,7 @@ CONTAINS
      &          ,bgapxy   ,wgapxy    ,tgvxy     ,tgbxy     ,chvxy     ,chbxy        &    
      &          ,shgxy    ,shcxy     ,shbxy     ,evgxy     ,evbxy     ,ghvxy        &
      &          ,ghbxy    ,irgxy     ,ircxy     ,irbxy     ,trxy      ,evcxy        &
-     &          ,chleafxy ,chucxy    ,chv2xy    ,chb2xy    ,chstarxy                &                      
+     &          ,chleafxy ,chucxy    ,chv2xy    ,chb2xy    ,chstarxy, real_co2_content_noahmp & !Thomas CO2 2018  &                      
            ! Noah-MP ground water
      &          ,smcwtdxy ,rechxy   ,deeprechxy,fdepthxy,areaxy   ,rivercondxy, riverbedxy &
      &          ,eqzwt    ,pexpxy   ,qrfxy    ,qspringxy,qslatxy  ,qrfsxy   ,qspringsxy &
@@ -844,13 +844,14 @@ CONTAINS
    REAL, DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), INTENT(INOUT)::   SH2O
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN )::   SHDMAX
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN )::   SHDMIN
-   REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT )::   Z0
-
+   REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT )::   Z0 
+   
 !  NoahMP specific fields
 
    INTEGER, OPTIONAL, INTENT(IN) ::    idveg, iopt_crs, iopt_btr, iopt_run, iopt_sfc , iopt_frz, &
                                     iopt_inf, iopt_rad, iopt_alb, iopt_snf, iopt_tbot, iopt_stc, &
 				    iopt_gla, iopt_rsf, iopt_soil,iopt_pedo,iopt_crop
+   REAL, OPTIONAL, INTENT(IN) :: real_co2_content_noahmp
    REAL,    OPTIONAL, DIMENSION(ims:ime ,8, jms:jme), INTENT(IN) :: SOILCOMP
    REAL,    OPTIONAL, DIMENSION(ims:ime , jms:jme)  , INTENT(IN) :: SOILCL1,SOILCL2,SOILCL3,SOILCL4
 
@@ -2999,7 +3000,7 @@ CONTAINS
 #endif
                 ids,ide, jds,jde, kds,kde,                      &
                 ims,ime, jms,jme, kms,kme,                      &
-                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,        &
+                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,real_co2_content_noahmp,  & ! Thomas CO2 2018  
 ! variables below are optional
                 MP_RAINC =  RAINCV, MP_RAINNC =    RAINNCV, MP_SHCV = RAINSHV,&
 		MP_SNOW  = SNOWNCV, MP_GRAUP  = GRAUPELNCV, MP_HAIL = HAILNCV )

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -673,6 +673,18 @@
             model_config_rec%icloud = 1
          END IF
       ENDDO
+
+!-------------------------------------------------------------------
+!check if co2_content for RRTMG and CO2_content for NOAH-MP are the same
+!-------------------------------------------------------------------
+oops=0
+  IF ( model_config_rec%co2_content .ne. model_config_rec%co2_content_noahmp) THEN
+              wrf_err_message = '--- NOTE: CO2 content for RRTMG and NOAH-MP not the same, resetting to RRTMG value'
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         model_config_rec%co2_content_noahmp = model_config_rec%co2_content
+  ENDIF
+!end Thomas
+
 !-----------------------------------------------------------------------
 ! aercu_opt = 1 (CESM-aerosal) only works with MSKF, special Morrison
 !-----------------------------------------------------------------------

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -679,7 +679,7 @@
 !-------------------------------------------------------------------
 oops=0
   IF ( model_config_rec%co2_content .ne. model_config_rec%co2_content_noahmp) THEN
-              wrf_err_message = '--- NOTE: CO2 content for RRTMG and NOAH-MP not the same, resetting to RRTMG value'
+              wrf_err_message = '--- NOTE: CO2 content for RRTMG and NOAH-MP not the same'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
 !         model_config_rec%co2_content_noahmp = model_config_rec%co2_content
   ENDIF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -681,7 +681,7 @@ oops=0
   IF ( model_config_rec%co2_content .ne. model_config_rec%co2_content_noahmp) THEN
               wrf_err_message = '--- NOTE: CO2 content for RRTMG and NOAH-MP not the same, resetting to RRTMG value'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-         model_config_rec%co2_content_noahmp = model_config_rec%co2_content
+!         model_config_rec%co2_content_noahmp = model_config_rec%co2_content
   ENDIF
 !end Thomas
 


### PR DESCRIPTION
TYPE:  new feature

KEYWORDS: CO2 content, RRTMG, NOAH-MP

SOURCE: Thomas Schwitalla (UHOH)

DESCRIPTION OF CHANGES:
Problem: 
Currently, the CO2 content in RRTMG is set to a value of 379 ppm while the CO2 content in NOAH-MP is hard-coded to 395 ppm. Users may wish to change these values without applying CLWRFGHG.

Solution:
Two new namelist settings have been introduced:
- co2_content: sets the CO2 content in RRTMG ( namelist&physics)
- co2_content_noahmp: sets the CO2 content in NOAH-MP (namelist&noahmp)
- In the current version, a check is included whether the user defines different CO2 values in RRTMG and NOAH-MP. If this is the case, the user receives a message in rsl.out.0000 but the model will continue.

LIST OF MODIFIED FILES:
M       Registry/Registry.EM_COMMON
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_physics_init.F
M       phys/module_ra_rrtmg_lw.F
M       phys/module_ra_rrtmg_sw.F
M       phys/module_radiation_driver.F
M       phys/module_sf_noahmpdrv.F
M       phys/module_sf_noahmplsm.F
M       phys/module_surface_driver.F
M       share/module_check_a_mundo.F


TESTS CONDUCTED: Short high-resolution simulation to check for erroneous values in radiation and temperature fields. With default values of CO2=379 ppm in RRTMG and 395 ppm in NOAH-MP the results are identical with the original code.

RELEASE NOTE: RRTMG and NOAH-MP can now work with user-defined CO2 values. New namelist switches "co2_content" and "co2_content_noahmp" have been introduced.