### PR TITLE
Additional variables like PWAT, LWP, and Sea level pressure are available without using AFWA switches

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1434,10 +1434,8 @@ state    real  CLDFRA_OLD      ikj      misc        1         -      r        "C
 state    real  CLDFRA_BL       ikj      misc        1         -      -        "CLDFRA_BL"             "CLOUD FRACTION pbl"                                   ""
 state    real  CLDT             ij      misc        1         -      -        "CFRACT"                "TOTAL CLOUD FRACTION"                                 ""
 #state    real  CLDL             ij      misc        1         -      -        "CFRACL"                "LOW CLOUD FRACTION (ETA GREATER THAN 0.69)"           ""
-#Thomas
 state    real  PWAT             ij      misc        1         -      rh       "PWAT"                  "INTEGRATED WATER VAPOR"         "kg m-2"
 state    real  LWP              ij      misc        1         -      rh        "LWP"                   "LIQUID CLOUD WATER PATH"                              "kg m-2"
-# end Thomas
 state    real  SWDOWN           ij      misc        1         -      rhd      "SWDOWN"                "DOWNWARD SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
 state    real  SWDOWNC          ij      misc        1         -      -        "SWDOWNC"               "DOWNWARD CLEAR-SKY SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
 state    real  GSW              ij      misc        1         -      rd       "GSW"                   "NET SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -397,6 +397,8 @@ state    real   Q2               ij     misc        1         -     irh01{22}{23
 state    real   T2               ij     misc        1         -     i01rh01{22}{23}du  "T2"                   "TEMP at 2 M"       "K"
 state    real   TH2              ij     misc        1         -     irhdu     "TH2"                  "POT TEMP at 2 M"   "K"
 state    real   PSFC             ij     misc        1         -     i01rhdu   "PSFC"                 "SFC PRESSURE"      "Pa"
+# new diag
+state    real   PMSL_DIAG             ij     misc        1         -     rh   "PMSL_DIAG"                 "SEA LEVEL PRESSURE"      "hPa"
 
 # these next 2 are for the HFSoLE/PET demo; writing these to auxhist1 output over MCEL for coupling
 # with wave model, only if compiled with -DMCELIO, JM 2003/05/29
@@ -1432,7 +1434,10 @@ state    real  CLDFRA_OLD      ikj      misc        1         -      r        "C
 state    real  CLDFRA_BL       ikj      misc        1         -      -        "CLDFRA_BL"             "CLOUD FRACTION pbl"                                   ""
 state    real  CLDT             ij      misc        1         -      -        "CFRACT"                "TOTAL CLOUD FRACTION"                                 ""
 #state    real  CLDL             ij      misc        1         -      -        "CFRACL"                "LOW CLOUD FRACTION (ETA GREATER THAN 0.69)"           ""
-#state    real  LWP              ij      misc        1         -      -        "LWP"                   "LIQUID CLOUD WATER PATH"                              "kg m-2"
+#Thomas
+state    real  PWAT             ij      misc        1         -      rh       "PWAT"                  "INTEGRATED WATER VAPOR"         "kg m-2"
+state    real  LWP              ij      misc        1         -      rh        "LWP"                   "LIQUID CLOUD WATER PATH"                              "kg m-2"
+# end Thomas
 state    real  SWDOWN           ij      misc        1         -      rhd      "SWDOWN"                "DOWNWARD SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
 state    real  SWDOWNC          ij      misc        1         -      -        "SWDOWNC"               "DOWNWARD CLEAR-SKY SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
 state    real  GSW              ij      misc        1         -      rd       "GSW"                   "NET SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      

--- a/Registry/registry.afwa
+++ b/Registry/registry.afwa
@@ -75,7 +75,7 @@ state    real   AFWA_CAPE_MU     ij     misc        1         -      rh02       
 state    real   AFWA_CIN_MU      ij     misc        1         -      rh02       "AFWA_CIN_MU"     "AFWA Diagnostic: Most unstable CIN 0-180mb"    "J kg-1"
 state    real   AFWA_ZLFC        ij     misc        1         -      rh02       "AFWA_ZLFC"       "AFWA Diagnostic: Level of Free Convection"     "m"
 state    real   AFWA_PLFC        ij     misc        1         -      rh02       "AFWA_PLFC"       "AFWA Diagnostic: Pressure of LFC"              "Pa"
-state    real   AFWA_LIDX        ij     misc        1         -      rh02       "AFWA_LIDX"       "AFWA Diagnostic: Surface Lifted Index"         "K"
+state    real   AFWA_LIDX        ij     misc        1         -      rh02       "AFWA_LIDX"       "AFWA Diagnostic: Surface Lifted Index"         "deg C"
 state    real   AFWA_PWAT        ij     misc        1         -      rh02       "AFWA_PWAT"       "AFWA Diagnostic: Precipitable Water"           "kg m-2"
 state    real   MIDRH_MIN        ij     misc        1         -      -          "MIDRH_MIN"       "Min Mid-level relative humidity"               "%"
 state    real   MIDRH_MIN_OLD    ij     misc        1         -      r          "MIDRH_MIN_OLD"   "Previous Min Mid-level relative humidity"      "%"

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -3760,8 +3760,8 @@ BENCH_START(micro_driver_tim)
       &        ,WACT=grid%WACT,CCN1_GS=grid%CCN1_GS,CCN2_GS=grid%CCN2_GS,CCN3_GS=grid%CCN3_GS  &
       &        ,CCN4_GS=grid%CCN4_GS,CCN5_GS=grid%CCN5_GS,CCN6_GS=grid%CCN6_GS &
       &        ,CCN7_GS=grid%CCN7_GS,NR_CU=grid%NR_CU,QR_CU=grid%QR_CU,NS_CU=grid%NS_CU &
-      &        ,QS_CU=grid%QS_CU,CU_UAF=grid%CU_UAF,mskf_refl_10cm=grid%mskf_refl_10cm, & 
-      &        pwat=grid%pwat, lwp=grid%lwp)
+      &        ,QS_CU=grid%QS_CU,CU_UAF=grid%CU_UAF,MSKF_REFL_10CM=grid%mskf_refl_10cm & 
+      &        , LWP=grid%pwat, LWP=grid%lwp)
                                                                           
 BENCH_END(micro_driver_tim)
 

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -174,10 +174,11 @@ SUBROUTINE solve_em ( grid , config_flags  &
 ! variables for flux-averaging code 20091223
    CHARACTER*256                              :: message, message2, message3
    REAL                                       :: old_dt
-   TYPE(WRFU_Time)                            :: temp_time, CurrTime, restart_time
+   TYPE(WRFU_Time)                            :: temp_time, CurrTime, restart_time, hist_time,Starttime !Thomas
    INTEGER, PARAMETER                         :: precision = 100
    INTEGER                                    :: num, den
-   TYPE(WRFU_TimeInterval)                    :: dtInterval, intervaltime,restartinterval
+   TYPE(WRFU_TimeInterval)                    :: dtInterval, intervaltime,restartinterval, histint, dtint! Thomas
+   CHARACTER*256 :: timestr  ! Thomas
 
 ! Define benchmarking timers if -DBENCH is compiled
 #include "bench_solve_em_def.h"
@@ -3759,7 +3760,8 @@ BENCH_START(micro_driver_tim)
       &        ,WACT=grid%WACT,CCN1_GS=grid%CCN1_GS,CCN2_GS=grid%CCN2_GS,CCN3_GS=grid%CCN3_GS  &
       &        ,CCN4_GS=grid%CCN4_GS,CCN5_GS=grid%CCN5_GS,CCN6_GS=grid%CCN6_GS &
       &        ,CCN7_GS=grid%CCN7_GS,NR_CU=grid%NR_CU,QR_CU=grid%QR_CU,NS_CU=grid%NS_CU &
-      &        ,QS_CU=grid%QS_CU,CU_UAF=grid%CU_UAF,mskf_refl_10cm=grid%mskf_refl_10cm)
+      &        ,QS_CU=grid%QS_CU,CU_UAF=grid%CU_UAF,mskf_refl_10cm=grid%mskf_refl_10cm, & 
+      &        pwat=grid%pwat, lwp=grid%lwp)
                                                                           
 BENCH_END(micro_driver_tim)
 
@@ -4537,6 +4539,31 @@ BENCH_END(bc_2d_tim)
                             ipsy, ipey, jpsy, jpey, kpsy, kpey   )
 
 
+!Thomas compute mean sea level pressure
+! Get domain clock
+    ! ----------------
+ CALL WRFU_ALARMGET( grid%alarms( HISTORY_ALARM ), prevringtime=hist_time, &
+         ringinterval=histint)
+   ! Get domain clock
+    ! ----------------
+    CALL domain_clock_get ( grid, current_time=CurrTime, &
+         simulationStartTime=StartTime, &            
+         current_timestr=timestr, time_step=dtint )
+!Thomas
+! IF(currtime .ge. hist_time + histint - dtint) THEN
+ DO j = jps, jpe
+ DO i = ips, ipe
+ grid%pmsl_diag(i,j) = 0.
+ CALL MSLP ( grid % ht ( i, j )           & 
+                                              , grid % psfc ( i, j )         &
+                                              , grid % z ( i, kms, j )       & 
+                                              , moist(i,kms,j,P_QV)          &  
+                                              , grid % t_phy ( i, kms, j ) &
+                                              , grid % pmsl_diag(i,j))
+ ENDDO
+ ENDDO
+!ENDIF
+! end Thomas
 
 #ifdef DM_PARALLEL
 !-----------------------------------------------------------------------
@@ -4632,3 +4659,60 @@ BENCH_END(bc_2d_tim)
    RETURN
 
 END SUBROUTINE solve_em
+
+! diagnostics routines borrowed from AFWA module
+!Thomas
+  Subroutine MSLP ( zsfc, psfc, zlev1, qlev1, tlev1,pmsl )
+
+      implicit none
+     
+     
+!     DECLARE VARIABLES
+
+      REAL,    INTENT ( IN )  :: zsfc         !~ Surface height ( m )
+      REAL,    INTENT ( IN )  :: psfc         !~ Surface height ( m )
+      REAL,    INTENT ( IN )  :: zlev1        !~ Level 1 height ( m )
+      REAL,    INTENT ( IN )  :: qlev1        !~ Level 1 mixing ratio ( kg/kg )
+      REAL,    INTENT ( IN )  :: tlev1        !~ Level 1 temperature ( K )
+!Thomas 
+      REAL,     INTENT (OUT) :: pmsl
+      real,PARAMETER :: G=9.81
+      real,PARAMETER :: GI=1./G
+      real,PARAMETER :: RD=287.0
+      real,PARAMETER :: ZSL=0.0
+      real,PARAMETER :: TAUCR=RD*GI*290.66,CONST=0.005*G/RD
+      real,PARAMETER :: GORD=G/RD,DP=60.E2
+      real,PARAMETER :: GAMMA=6.5E-3
+
+      real TVRT,TVRSFC,TAUSFC,TVRSL,TAUSL,TAUAVG
+!    
+!**********************************************************************
+!     START NGMSLP HERE.
+!
+         pmsl = PSFC
+!
+!        COMPUTE LAYER TAU (VIRTUAL TEMP*RD/G).
+         TVRT = TLEV1*(1.0+0.608*QLEV1)
+         !TAU  = TVRT*RD*GI
+!    
+!        COMPUTE TAU AT THE GROUND (Z=ZSFC) AND SEA LEVEL (Z=0)
+!        ASSUMING A CONSTANT LAPSE RATE OF GAMMA=6.5DEG/KM.
+         TVRSFC = TVRT + (ZLEV1 - ZSFC)*GAMMA
+         TAUSFC = TVRSFC*RD*GI
+         TVRSL  = TVRT + (ZLEV1 - ZSL)*GAMMA
+         TAUSL  = TVRSL*RD*GI
+!    
+!        IF NEED BE APPLY SHEULL CORRECTION.
+         IF ((TAUSL.GT.TAUCR).AND.(TAUSFC.LE.TAUCR)) THEN
+            TAUSL=TAUCR
+         ELSEIF ((TAUSL.GT.TAUCR).AND.(TAUSFC.GT.TAUCR)) THEN
+            TAUSL = TAUCR-CONST*(TAUSFC-TAUCR)**2
+         ENDIF
+!    
+!        COMPUTE MEAN TAU.
+         TAUAVG = 0.5*(TAUSL+TAUSFC)
+!    
+!        COMPUTE SEA LEVEL PRESSURE.
+         pmsl = (PSFC*EXP(ZSFC/TAUAVG))/100.
+
+  END subroutine MSLP

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -174,11 +174,10 @@ SUBROUTINE solve_em ( grid , config_flags  &
 ! variables for flux-averaging code 20091223
    CHARACTER*256                              :: message, message2, message3
    REAL                                       :: old_dt
-   TYPE(WRFU_Time)                            :: temp_time, CurrTime, restart_time, hist_time,Starttime
+   TYPE(WRFU_Time)                            :: temp_time, CurrTime, restart_time
    INTEGER, PARAMETER                         :: precision = 100
    INTEGER                                    :: num, den
-   TYPE(WRFU_TimeInterval)                    :: dtInterval, intervaltime,restartinterval, histint, dtint
-   CHARACTER*256 :: timestr 
+   TYPE(WRFU_TimeInterval)                    :: dtInterval, intervaltime,restartinterval
 
 ! Define benchmarking timers if -DBENCH is compiled
 #include "bench_solve_em_def.h"
@@ -4539,30 +4538,6 @@ BENCH_END(bc_2d_tim)
                             ipsy, ipey, jpsy, jpey, kpsy, kpey   )
 
 
-! Get domain clock
-    ! ----------------
-     CALL WRFU_ALARMGET( grid%alarms( HISTORY_ALARM ), prevringtime=hist_time, &
-         ringinterval=histint)
-    ! Get domain clock
-    ! ----------------
-    CALL domain_clock_get ( grid, current_time=CurrTime, &
-         simulationStartTime=StartTime, &            
-         current_timestr=timestr, time_step=dtint )
-
-! IF(currtime .ge. hist_time + histint - dtint) THEN
- DO j = jps, jpe
- DO i = ips, ipe
- grid%pmsl_diag(i,j) = 0.
- CALL MSLP ( grid % ht ( i, j )           & 
-                                              , grid % psfc ( i, j )         &
-                                              , grid % z ( i, kms, j )       & 
-                                              , moist(i,kms,j,P_QV)          &  
-                                              , grid % t_phy ( i, kms, j ) &
-                                              , grid % pmsl_diag(i,j))
- ENDDO
- ENDDO
-!ENDIF
-
 #ifdef DM_PARALLEL
 !-----------------------------------------------------------------------
 ! see above
@@ -4657,58 +4632,3 @@ BENCH_END(bc_2d_tim)
    RETURN
 
 END SUBROUTINE solve_em
-
-! diagnostics routines borrowed from AFWA module
-  Subroutine MSLP ( zsfc, psfc, zlev1, qlev1, tlev1,pmsl )
-
-      implicit none
-     
-     
-!     DECLARE VARIABLES
-
-      REAL,    INTENT ( IN )  :: zsfc         !~ Surface height ( m )
-      REAL,    INTENT ( IN )  :: psfc         !~ Surface height ( m )
-      REAL,    INTENT ( IN )  :: zlev1        !~ Level 1 height ( m )
-      REAL,    INTENT ( IN )  :: qlev1        !~ Level 1 mixing ratio ( kg/kg )
-      REAL,    INTENT ( IN )  :: tlev1        !~ Level 1 temperature ( K )
-      REAL,     INTENT (OUT) :: pmsl
-      real,PARAMETER :: G=9.81
-      real,PARAMETER :: GI=1./G
-      real,PARAMETER :: RD=287.0
-      real,PARAMETER :: ZSL=0.0
-      real,PARAMETER :: TAUCR=RD*GI*290.66,CONST=0.005*G/RD
-      real,PARAMETER :: GORD=G/RD,DP=60.E2
-      real,PARAMETER :: GAMMA=6.5E-3
-
-      real TVRT,TVRSFC,TAUSFC,TVRSL,TAUSL,TAUAVG
-!    
-!**********************************************************************
-!     START NGMSLP HERE.
-!
-         pmsl = PSFC
-!
-!        COMPUTE LAYER TAU (VIRTUAL TEMP*RD/G).
-         TVRT = TLEV1*(1.0+0.608*QLEV1)
-         !TAU  = TVRT*RD*GI
-!    
-!        COMPUTE TAU AT THE GROUND (Z=ZSFC) AND SEA LEVEL (Z=0)
-!        ASSUMING A CONSTANT LAPSE RATE OF GAMMA=6.5DEG/KM.
-         TVRSFC = TVRT + (ZLEV1 - ZSFC)*GAMMA
-         TAUSFC = TVRSFC*RD*GI
-         TVRSL  = TVRT + (ZLEV1 - ZSL)*GAMMA
-         TAUSL  = TVRSL*RD*GI
-!    
-!        IF NEED BE APPLY SHEULL CORRECTION.
-         IF ((TAUSL.GT.TAUCR).AND.(TAUSFC.LE.TAUCR)) THEN
-            TAUSL=TAUCR
-         ELSEIF ((TAUSL.GT.TAUCR).AND.(TAUSFC.GT.TAUCR)) THEN
-            TAUSL = TAUCR-CONST*(TAUSFC-TAUCR)**2
-         ENDIF
-!    
-!        COMPUTE MEAN TAU.
-         TAUAVG = 0.5*(TAUSL+TAUSFC)
-!    
-!        COMPUTE SEA LEVEL PRESSURE.
-         pmsl = (PSFC*EXP(ZSFC/TAUAVG))/100.
-
-  END subroutine MSLP

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -174,11 +174,11 @@ SUBROUTINE solve_em ( grid , config_flags  &
 ! variables for flux-averaging code 20091223
    CHARACTER*256                              :: message, message2, message3
    REAL                                       :: old_dt
-   TYPE(WRFU_Time)                            :: temp_time, CurrTime, restart_time, hist_time,Starttime !Thomas
+   TYPE(WRFU_Time)                            :: temp_time, CurrTime, restart_time, hist_time,Starttime
    INTEGER, PARAMETER                         :: precision = 100
    INTEGER                                    :: num, den
-   TYPE(WRFU_TimeInterval)                    :: dtInterval, intervaltime,restartinterval, histint, dtint! Thomas
-   CHARACTER*256 :: timestr  ! Thomas
+   TYPE(WRFU_TimeInterval)                    :: dtInterval, intervaltime,restartinterval, histint, dtint
+   CHARACTER*256 :: timestr 
 
 ! Define benchmarking timers if -DBENCH is compiled
 #include "bench_solve_em_def.h"
@@ -4539,17 +4539,16 @@ BENCH_END(bc_2d_tim)
                             ipsy, ipey, jpsy, jpey, kpsy, kpey   )
 
 
-!Thomas compute mean sea level pressure
 ! Get domain clock
     ! ----------------
- CALL WRFU_ALARMGET( grid%alarms( HISTORY_ALARM ), prevringtime=hist_time, &
+     CALL WRFU_ALARMGET( grid%alarms( HISTORY_ALARM ), prevringtime=hist_time, &
          ringinterval=histint)
-   ! Get domain clock
+    ! Get domain clock
     ! ----------------
     CALL domain_clock_get ( grid, current_time=CurrTime, &
          simulationStartTime=StartTime, &            
          current_timestr=timestr, time_step=dtint )
-!Thomas
+
 ! IF(currtime .ge. hist_time + histint - dtint) THEN
  DO j = jps, jpe
  DO i = ips, ipe
@@ -4563,7 +4562,6 @@ BENCH_END(bc_2d_tim)
  ENDDO
  ENDDO
 !ENDIF
-! end Thomas
 
 #ifdef DM_PARALLEL
 !-----------------------------------------------------------------------
@@ -4661,7 +4659,6 @@ BENCH_END(bc_2d_tim)
 END SUBROUTINE solve_em
 
 ! diagnostics routines borrowed from AFWA module
-!Thomas
   Subroutine MSLP ( zsfc, psfc, zlev1, qlev1, tlev1,pmsl )
 
       implicit none
@@ -4674,7 +4671,6 @@ END SUBROUTINE solve_em
       REAL,    INTENT ( IN )  :: zlev1        !~ Level 1 height ( m )
       REAL,    INTENT ( IN )  :: qlev1        !~ Level 1 mixing ratio ( kg/kg )
       REAL,    INTENT ( IN )  :: tlev1        !~ Level 1 temperature ( K )
-!Thomas 
       REAL,     INTENT (OUT) :: pmsl
       real,PARAMETER :: G=9.81
       real,PARAMETER :: GI=1./G

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -3761,7 +3761,7 @@ BENCH_START(micro_driver_tim)
       &        ,CCN4_GS=grid%CCN4_GS,CCN5_GS=grid%CCN5_GS,CCN6_GS=grid%CCN6_GS &
       &        ,CCN7_GS=grid%CCN7_GS,NR_CU=grid%NR_CU,QR_CU=grid%QR_CU,NS_CU=grid%NS_CU &
       &        ,QS_CU=grid%QS_CU,CU_UAF=grid%CU_UAF,MSKF_REFL_10CM=grid%mskf_refl_10cm & 
-      &        , LWP=grid%pwat, LWP=grid%lwp)
+      &        ,PWAT=grid%pwat, LWP=grid%lwp)
                                                                           
 BENCH_END(micro_driver_tim)
 

--- a/phys/module_diag_afwa.F
+++ b/phys/module_diag_afwa.F
@@ -561,8 +561,9 @@ CONTAINS
 
             ! Add 273.15 to lifted index per some standard I don't understand
             ! ---------------------------------------------------------------
+            ! lifted indes is defined in (K) so 273.15 should not be added
             IF ( grid % afwa_lidx ( i, j ) .ne. 999. ) THEN
-              grid % afwa_lidx ( i, j ) = grid % afwa_lidx ( i, j ) + 273.15
+              grid % afwa_lidx ( i, j ) = grid % afwa_lidx ( i, j ) ! + 273.15
             ENDIF
  
             ! Calculate buoyancy again for most unstable layer

--- a/phys/module_diagnostics_driver.F
+++ b/phys/module_diagnostics_driver.F
@@ -11,6 +11,62 @@ MODULE module_diagnostics_driver
 
 CONTAINS
 
+! subroutine borrowed from AFWA to calculate Sea level pressure
+! independently from AFWA module
+  Subroutine MSLP ( zsfc, psfc, zlev1, qlev1, tlev1,pmsl )
+
+      implicit none
+     
+     
+!     DECLARE VARIABLES
+
+      REAL,    INTENT ( IN )  :: zsfc         !~ Surface height ( m )
+      REAL,    INTENT ( IN )  :: psfc         !~ Surface height ( m )
+      REAL,    INTENT ( IN )  :: zlev1        !~ Level 1 height ( m )
+      REAL,    INTENT ( IN )  :: qlev1        !~ Level 1 mixing ratio ( kg/kg )
+      REAL,    INTENT ( IN )  :: tlev1        !~ Level 1 temperature ( K )
+      REAL,     INTENT (OUT) :: pmsl
+      real,PARAMETER :: G=9.81
+      real,PARAMETER :: GI=1./G
+      real,PARAMETER :: RD=287.0
+      real,PARAMETER :: ZSL=0.0
+      real,PARAMETER :: TAUCR=RD*GI*290.66,CONST=0.005*G/RD
+      real,PARAMETER :: GORD=G/RD,DP=60.E2
+      real,PARAMETER :: GAMMA=6.5E-3
+
+      real TVRT,TVRSFC,TAUSFC,TVRSL,TAUSL,TAUAVG
+!    
+!**********************************************************************
+!     START NGMSLP HERE.
+!
+         pmsl = PSFC
+!
+!        COMPUTE LAYER TAU (VIRTUAL TEMP*RD/G).
+         TVRT = TLEV1*(1.0+0.608*QLEV1)
+         !TAU  = TVRT*RD*GI
+!    
+!        COMPUTE TAU AT THE GROUND (Z=ZSFC) AND SEA LEVEL (Z=0)
+!        ASSUMING A CONSTANT LAPSE RATE OF GAMMA=6.5DEG/KM.
+         TVRSFC = TVRT + (ZLEV1 - ZSFC)*GAMMA
+         TAUSFC = TVRSFC*RD*GI
+         TVRSL  = TVRT + (ZLEV1 - ZSL)*GAMMA
+         TAUSL  = TVRSL*RD*GI
+!    
+!        IF NEED BE APPLY SHEULL CORRECTION.
+         IF ((TAUSL.GT.TAUCR).AND.(TAUSFC.LE.TAUCR)) THEN
+            TAUSL=TAUCR
+         ELSEIF ((TAUSL.GT.TAUCR).AND.(TAUSFC.GT.TAUCR)) THEN
+            TAUSL = TAUCR-CONST*(TAUSFC-TAUCR)**2
+         ENDIF
+!    
+!        COMPUTE MEAN TAU.
+         TAUAVG = 0.5*(TAUSL+TAUSFC)
+!    
+!        COMPUTE SEA LEVEL PRESSURE.
+         pmsl = (PSFC*EXP(ZSFC/TAUAVG))/100.
+
+  END subroutine MSLP
+
    !  This subroutine is the driver for the diagnostics packages.
 
 
@@ -154,6 +210,8 @@ CONTAINS
                               imsy,imey,jmsy,jmey,kmsy,kmey,    &
                               ipsy,ipey,jpsy,jpey,kpsy,kpey
 
+      INTEGER :: i,j
+
 
       !=============================================================
       !  Local Variables
@@ -261,6 +319,19 @@ CONTAINS
         END DO
         !$OMP END PARALLEL DO
       END IF HAILCAST
+
+! sea level pressure diagnostics
+  DO j = jms, jme
+  DO i = ims, ime
+  grid%pmsl_diag(i,j) = 0.
+  CALL MSLP ( grid % ht ( i, j )           & 
+                                               , grid % psfc ( i, j )         &
+                                              , grid % z ( i, kms, j )       & 
+                                              , moist(i,kms,j,P_QV)          &  
+                                              , grid % t_phy ( i, kms, j ) &
+                                              , grid % pmsl_diag(i,j))
+  ENDDO
+  ENDDO
 
       TRADITIONAL_FIELDS: IF ( config_flags%diag_nwp2 == do_trad_fields ) THEN 
          !$OMP PARALLEL DO   &
@@ -1173,8 +1244,6 @@ CONTAINS
            ,NUM_TILES=grid%num_tiles                                          &
                                                                    )
       END IF RASM_DIAGS_DIURNAL
-
-
 
 
    END SUBROUTINE diagnostics_driver

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -570,9 +570,9 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
    REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(INOUT) ::  & ! G. Thompson
                  re_cloud, re_ice, re_snow
    INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
-! new vars for LWP and PWAT diagnostics
-  REAL , DIMENSION( ims:ime , jms:jme ), OPTIONAL, INTENT(INOUT) :: lwp
-  REAL, DIMENSION(ims:ime,jms:jme), INTENT(INOUT) :: PWAT
+
+  REAL , DIMENSION( ims:ime , jms:jme ), OPTIONAL,  INTENT(INOUT) :: LWP
+  REAL, DIMENSION(ims:ime,jms:jme), OPTIONAL, INTENT(INOUT) :: PWAT
 
   INTEGER,           INTENT(IN   )    :: aercu_opt
 # if (EM_CORE == 1)
@@ -602,7 +602,6 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
    REAL, OPTIONAL, DIMENSION( ims:ime , kms:kme, jms:jme ) , INTENT(OUT) :: mskf_refl_10cm
 # endif
 
-!  REAL , DIMENSION( ims:ime , jms:jme ), OPTIONAL, INTENT(INOUT) :: lwp
 
 ! LOCAL  VAR
 
@@ -750,9 +749,12 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
        END IF
 
   ! Zero out pwat and lwp before calculation
+  IF(PRESENT (pwat) ) THEN
   pwat(its:ite,jts:jte)  = 0.
+  ENDIF
+  IF (PRESENT (lwp))THEN
   lwp(its:ite,jts:jte)  = 0.
-  !print*,pwat(its:ite,jts:jte)
+  ENDIF
 
      micro_select: SELECT CASE(mp_physics)
 
@@ -2340,16 +2342,27 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 
       END SELECT micro_select
 
-    DO j = jts,jte
-      DO i = its,ite
-       pwat(i,j) = 0.0
-       lwp(i,j) = 0.0
+    IF(PRESENT(pwat)) THEN
+     DO j = jts,jte
+       DO i = its,ite
+        pwat(i,j) = 0.0
          DO k = kts,kte
-        pwat(i,j) = pwat(i,j) + qv_curr(i,k,j)*dz8w(i,k,j)* rho(i,k,j)
-        lwp(i,j) = lwp(i,j) + qc_curr(i,k,j)*dz8w(i,k,j)* rho(i,k,j)
+          pwat(i,j) = pwat(i,j) + qv_curr(i,k,j)*dz8w(i,k,j)* rho(i,k,j)
+         ENDDO
         ENDDO
-       ENDDO
-    ENDDO
+     ENDDO
+    ENDIF 
+
+    IF(PRESENT(lwp)) THEN
+     DO j = jts,jte
+       DO i = its,ite
+        lwp(i,j) = 0.0
+         DO k = kts,kte
+          lwp(i,j) = lwp(i,j) + qc_curr(i,k,j)*dz8w(i,k,j)* rho(i,k,j)
+         ENDDO
+        ENDDO
+     ENDDO
+    ENDIF
 
    ENDDO
    !$OMP END PARALLEL DO

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -107,7 +107,7 @@ SUBROUTINE microphysics_driver(                                          &
                       ,aerocu,aercu_fct,no_src_types_cu                  &
                       ,PBL,EFCG,EFIG,EFSG,WACT,CCN1_GS,CCN2_GS           &
                       ,CCN3_GS,CCN4_GS,CCN5_GS,CCN6_GS,CCN7_GS           &
-                      ,NR_CU,QR_CU,NS_CU,QS_CU,CU_UAF,mskf_refl_10cm     &
+                      ,NR_CU,QR_CU,NS_CU,QS_CU,CU_UAF,mskf_refl_10cm, pwat, lwp     &
 # endif
                                                                          )
 
@@ -569,6 +569,9 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
    REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(INOUT) ::  & ! G. Thompson
                  re_cloud, re_ice, re_snow
    INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
+! new vars for LWP and PWAT diagnostics
+  REAL , DIMENSION( ims:ime , jms:jme ), OPTIONAL, INTENT(INOUT) :: lwp
+  REAL, DIMENSION(ims:ime,jms:jme), INTENT(INOUT) :: PWAT ! Thomas
 
   INTEGER,           INTENT(IN   )    :: aercu_opt
 # if (EM_CORE == 1)
@@ -744,6 +747,12 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
              "SETTINGS ERROR: Prognostic cloud droplet number can only be used with the mp_physics=LINSCHEME or MORRISON or NSSL_2MOM.")
        END IF
        END IF
+
+  !Thomas
+  ! Zero out pwat and lwp before calculation
+  pwat(its:ite,jts:jte)  = 0.
+  lwp(its:ite,jts:jte)  = 0.
+  !print*,pwat(its:ite,jts:jte)
 
      micro_select: SELECT CASE(mp_physics)
 
@@ -2330,6 +2339,18 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
          CALL wrf_error_fatal ( wrf_err_message )
 
       END SELECT micro_select
+
+  !Thomas for pwat and lwp
+    DO j = jts,jte
+      DO i = its,ite
+       pwat(i,j) = 0.0
+       lwp(i,j) = 0.0
+         DO k = kts,kte
+        pwat(i,j) = pwat(i,j) + qv_curr(i,k,j)*dz8w(i,k,j)* rho(i,k,j)
+        lwp(i,j) = lwp(i,j) + qc_curr(i,k,j)*dz8w(i,k,j)* rho(i,k,j)
+        ENDDO
+       ENDDO
+    ENDDO
 
    ENDDO
    !$OMP END PARALLEL DO

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -571,7 +571,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
    INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
 ! new vars for LWP and PWAT diagnostics
   REAL , DIMENSION( ims:ime , jms:jme ), OPTIONAL, INTENT(INOUT) :: lwp
-  REAL, DIMENSION(ims:ime,jms:jme), INTENT(INOUT) :: PWAT ! Thomas
+  REAL, DIMENSION(ims:ime,jms:jme), INTENT(INOUT) :: PWAT
 
   INTEGER,           INTENT(IN   )    :: aercu_opt
 # if (EM_CORE == 1)
@@ -748,7 +748,6 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
        END IF
        END IF
 
-  !Thomas
   ! Zero out pwat and lwp before calculation
   pwat(its:ite,jts:jte)  = 0.
   lwp(its:ite,jts:jte)  = 0.
@@ -2340,7 +2339,6 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 
       END SELECT micro_select
 
-  !Thomas for pwat and lwp
     DO j = jts,jte
       DO i = its,ite
        pwat(i,j) = 0.0

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -107,7 +107,8 @@ SUBROUTINE microphysics_driver(                                          &
                       ,aerocu,aercu_fct,no_src_types_cu                  &
                       ,PBL,EFCG,EFIG,EFSG,WACT,CCN1_GS,CCN2_GS           &
                       ,CCN3_GS,CCN4_GS,CCN5_GS,CCN6_GS,CCN7_GS           &
-                      ,NR_CU,QR_CU,NS_CU,QS_CU,CU_UAF,mskf_refl_10cm, pwat, lwp     &
+                      ,NR_CU,QR_CU,NS_CU,QS_CU,CU_UAF,MSKF_REFL_10CM     &
+                      ,PWAT,LWP                                          &
 # endif
                                                                          )
 


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: Integrated water vapor, cloud water path, sea level pressure

SOURCE: Thomas Schwitalla (UHOH)

DESCRIPTION OF CHANGES: 
Problem: 
So far integrated water vapor (PWAT) and sea level pressure are only available within the AFWA framework. Cloud liquid water path (LWP) is not available but is interesting to compare with satellite data. Lifted Index (LIDX) should have "K" as default unit. 

Solution: 
PWAT, LWP, and mean sea level pressure (PMSL_DIAG) have been introduced without the need of using the whole AFWA code. The PMSL diagnostic routing is borrowed from the AFWA modules. 
The cloud microphysics driver is modified in a way that PWAT and LWP is diagnosed after the MP physics call so that it is independent of the applied microphysics scheme. 
I hope, the memory indices are correct.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       Registry/registry.afwa
M       dyn_em/solve_em.F
M       phys/module_diag_afwa.F
M       phys/module_microphysics_driver.F


TESTS CONDUCTED: Short simulation to verify that the numbers are correct. Does not impact any other results.