### PR TITLE
Error compiling WRF Plus in WRF 4.0.2 on module_wrf_top.f90

### DIFF
--- a/main/module_wrf_top.F
+++ b/main/module_wrf_top.F
@@ -872,13 +872,14 @@ IF ( config_flags%check_TL .or. config_flags%check_AD ) THEN
    CALL allocate_grid ( )
 
    !$OMP PARALLEL DO    &
-   !$OMP DEFAULT (SHARED) PRIVATE ( ij ) &           
+   !$OMP DEFAULT (SHARED) PRIVATE ( ij )           
    DO ij = 1 , head_grid%num_tiles
       CALL copy_grid_to_s ( head_grid , &
                             head_grid%i_start(ij), head_grid%i_end(ij),                &
                             head_grid%j_start(ij), head_grid%j_end(ij)                 )
    ENDDO
-
+   !$OMP END PARALLEL DO
+   
    CALL       wrf_message ( "wrf: calling nonlinear integrate" )
    model_config_rec%dyn_opt = dyn_em
 


### PR DESCRIPTION
TYPE:  Bug fix 

KEYWORDS: WRF Plus, module_wrf_top.F, OpenMP error

SOURCE: Carlos Ross (DFM Consultores)

DESCRIPTION OF CHANGES: 
Problem: 
Getting an error when compiling WRF Plus with Intel compiler
```
../main/module_wrf_top.f90(756): error #6099: An ENDDO statement occurred without a corresponding DO or DO WHILE statement.
```
A DO loop in wrf_adtl_check_spot had a syntax error and a formulation error for one of the 
OpenMP parallel directives. 
1. A unnecessary trailing "&" on the last OpenMP directive caused the following  first line of the
    Fortran DO loop to not be recognized.
2. The OpenMP loop was missing closing directive, "!$OMP END PARALLEL DO",  after the DO loop.

Solution:
Remove the trailing "&" and add in the missing OpenMP directive after the DO loop.
I wasn't trying to compile with OpenMP, I actually chose 
```
option 10. (dmpar) INTEL (ifort/icc): Xeon (SNB with AVX mods) 
```
when I ran the configure. This error occurs only when I was building WRFPLUS.

Fixes #709

LIST OF MODIFIED FILES:  
M main/module_wrf_top.F

TESTS CONDUCTED: 
The code successfully compiled after including the modifications with Intel 19.0.1.

RELEASE NOTE: 
A syntax error was introduced with the v4.0 release that breaks the build of the WRFPLUS code (and only the WRFPLUS code) v19.0.1 of the Intel compiler. An OpenMP parallel loop was incorrectly constructed. That syntax error has been removed, though it is important to note that WRFPLUS never was intended to work with OpenMP, and the WRFPLUS code continues to only work with serial or DM build options.
