### PR TITLE
new tslist options for wider variety of usage

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -231,7 +231,7 @@ i1       real   ph_tendf       ikj     dyn_em      1         Z
 i1       real   ph_save        ikj     dyn_em      1         Z 
 
 # Potential Temperature
-state    real   th_phy_m_t0    ikj      dyn_em      1         -     ihd  "t"      "perturbation potential temperature theta-t0" "K"
+state    real   th_phy_m_t0    ikj      dyn_em      1         -     ihd "t"      "perturbation potential temperature theta-t0" "K"
 state    real   t              ikjb     dyn_em      2         -     \
        i0rhusdf=(bdy_interp:dt)   "thm"      "either 1) pert moist pot temp=(1+Rv/Rd Qv)*(theta)-T0, or 2) pert dry pot temp=theta-T0; based on use_theta_m setting" "K"
 

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -231,7 +231,7 @@ i1       real   ph_tendf       ikj     dyn_em      1         Z
 i1       real   ph_save        ikj     dyn_em      1         Z 
 
 # Potential Temperature
-state    real   th_phy_m_t0    ikj      dyn_em      1         -     ihd "t"      "perturbation potential temperature theta-t0" "K"
+state    real   th_phy_m_t0    ikj      dyn_em      1         -     ihd  "t"      "perturbation potential temperature theta-t0" "K"
 state    real   t              ikjb     dyn_em      2         -     \
        i0rhusdf=(bdy_interp:dt)   "thm"      "either 1) pert moist pot temp=(1+Rv/Rd Qv)*(theta)-T0, or 2) pert dry pot temp=theta-T0; based on use_theta_m setting" "K"
 
@@ -693,6 +693,7 @@ state    real   ts_rainnc       ?!       misc      -         -      -        "TS
 # Time series of vertical profile of U, V, GHT, THETA and QVAPOR
 state    real   ts_u_profile   ?!k       misc      -         -      -        "TS_U_PROFILE"   "Wind u-Component, earth relative, vertical profile"
 state    real   ts_v_profile   ?!k       misc      -         -      -        "TS_V_PROFILE"   "Wind v-Component, earth relative, vertical profile"
+state    real   ts_w_profile   ?!k       misc      -         -      -        "TS_W_PROFILE"   "Wind w-Component, earth relative, vertical profile"
 state    real   ts_gph_profile ?!k       misc      -         -      -        "TS_GPH_PROFILE" "Total geopotential height, vertical profile"
 state    real   ts_th_profile  ?!k       misc      -         -      -        "TS_TH_PROFILE"  "Total potential temperature, vertical profile"
 state    real   ts_qv_profile  ?!k       misc      -         -      -        "TS_QV_PROFILE"  "Water vapor mixing ratio, vertical profile"
@@ -2046,6 +2047,8 @@ rconfig   integer alloc_qndropsource      derived               1             0 
 rconfig   integer   num_moves       namelist,domains    1                0
 rconfig   integer   ts_buf_size     namelist,domains    1                200          -       "ts_buf_size"   "Size of time series buffer"
 rconfig   integer   max_ts_locs     namelist,domains    1                5            -       "max_ts_locs"   "Maximum number of time series locations"
+rconfig   logical   tslist_ij             derived       1              .false. rh  "tslist_ij"    "Use i,j locations in tslist"   ""
+rconfig   logical   tslist_unstagger_winds   namelist,domains    1              .false. rh  "tslist_unstagger_winds"    "interpolate u and v to cell centers"   ""
 rconfig   integer   vortex_interval  namelist,domains   max_domains      15  -  "" "" "minutes"
 rconfig   integer   max_vortex_speed namelist,domains   max_domains      40  -  "" "" "meters per second"
 rconfig   integer   corral_dist     namelist,domains    max_domains      8

--- a/main/depend.common
+++ b/main/depend.common
@@ -961,6 +961,7 @@ wrf_fddaobs_in.o: \
 wrf_timeseries.o: wrf_tsin.o \
 		module_model_constants.o \
 		module_llxy.o \
+		module_string_tools.o \
 		../frame/module_domain.o \
 		../frame/module_configure.o \
 		../frame/module_dm.o

--- a/run/README.tslist
+++ b/run/README.tslist
@@ -27,7 +27,7 @@ tower0002                 t0002  20       20
 tower0003                 t0003  30       30
 
 Given a tslist file, for each location inside a model domain (either coarse 
-or nested), below files are created:
+or nested), the following files are created:
 
 1. pfx*.dNN.TS containing the regular time series output of surface variables.
 2. pfx.dNN.UU containing a vertical profile of u wind component for each time step

--- a/run/README.tslist
+++ b/run/README.tslist
@@ -1,9 +1,10 @@
 To activate time series output in WRF, a file named "tslist" must be present
 in the WRF run directory. The tslist file contains a list of locations, given
-by their latitude and longitude, along with a short description and an 
-abbreviation for each location. The first three lines in the file are 
-regarded as header information, and are ignored. The contents of an example 
-tslist file are shown below. 
+by their latitude and longitude, or i/j coordinates, along with a short 
+description and an abbreviation for each location. The first three lines in 
+the file are regarded as header information, and are used to determine if the
+given coordinates are lat/long or i/j. The contents of an example tslist file 
+for coordinate specification are shown below. 
 
 
 #-----------------------------------------------#
@@ -15,15 +16,26 @@ Bogus point A             pt_a   29.718  -75.772
 Bogus point B             pt_b   37.614  -74.650
 
 
+If cell locations are to be used (such as for idealized cases), the i/j 
+locations are to be specified as follows:
+
+#-----------------------------------------------#
+# 24 characters for name | pfx |   J   |    I   |
+#-----------------------------------------------#
+tower0001                 t0001  10       10
+tower0002                 t0002  20       20
+tower0003                 t0003  30       30
+
 Given a tslist file, for each location inside a model domain (either coarse 
 or nested), below files are created:
 
 1. pfx*.dNN.TS containing the regular time series output of surface variables.
 2. pfx.dNN.UU containing a vertical profile of u wind component for each time step
 3. pfx.dNN.VV containing a vertical profile of v wind component for each time step
-4. pfx.dNN.TH containing a vertical profile of potential temperature for time step
-5. pfx.dNN.PH containing a vertical profile of geopotential height in time step
-6. pfx.dNN.QV containing a vertical profile of water vapor mixing ratio time step
+4. pfx.dNN.WW containing a vertical profile of w wind component for each time step
+5. pfx.dNN.TH containing a vertical profile of potential temperature for time step
+6. pfx.dNN.PH containing a vertical profile of geopotential height in time step
+7. pfx.dNN.QV containing a vertical profile of water vapor mixing ratio time step
 
 
 Where pfx is the specified prefix for the dd location in the tslist file, and NN is the domain ID, as given in 
@@ -39,12 +51,17 @@ however, smaller buffers will need to be flushed to disk more often than
 larger buffers. Thus, it is recommended that the size of the buffer be set 
 to the maximum number of time steps for any domain in a model run. 
 
+By default, the u, v, and w component winds are output on the staggered grid. To unstagger them,
+the namelist variable tslist_unstagger_winds can be set to true.
+
 Namelist.input variables related to to this new capability:
 
  * max_ts_locs = maximum number of locations in 'tslist' ( default is 5)
  * ts_buf_size = buffer size for time series output (default is 200)
  * max_ts_level = number of model levels for time series vertical
    profiles (default is 15)
+ * tslist_unstagger_winds = output the unstaggered u, v, and w component
+   winds (default is false)
 
 The first line in a time-series output of surface variables (pfx*.dNN.TS) looks like this:
 

--- a/run/README.tslist
+++ b/run/README.tslist
@@ -20,7 +20,7 @@ If cell locations are to be used (such as for idealized cases), the i/j
 locations are to be specified as follows:
 
 #-----------------------------------------------#
-# 24 characters for name | pfx |   J   |    I   |
+# 24 characters for name | pfx |   I   |    J   |
 #-----------------------------------------------#
 tower0001                 t0001  10       10
 tower0002                 t0002  20       20

--- a/share/Makefile
+++ b/share/Makefile
@@ -14,6 +14,7 @@ MODULES1=                               \
         module_llxy.o                   \
         module_interp_nmm.o             \
         module_interp_store.o           \
+        module_string_tools.o           \
         module_MPP.o 
 
 MODULES2=                               \

--- a/share/module_string_tools.F
+++ b/share/module_string_tools.F
@@ -1,0 +1,30 @@
+MODULE module_string_tools
+
+CONTAINS
+
+    FUNCTION capitalize(str) RESULT(capStr)
+!<DESCRIPTION>
+!
+! Returns a copy of 'str' in which all lower-case letters have been converted
+! to upper-case letters.
+!
+!</DESCRIPTION>
+
+        CHARACTER(LEN=*), INTENT(IN) :: str
+        CHARACTER(LEN=LEN(str)) :: capStr
+
+        INTEGER :: i
+        INTEGER, PARAMETER :: offset = (IACHAR('a') - IACHAR('A'))
+
+
+        DO i=1,LEN(str)
+            IF ( ( IACHAR(str(i:i)) >= IACHAR('a') ) .AND. ( IACHAR(str(i:i)) <= IACHAR('z') ) ) THEN
+               capStr(i:i) = ACHAR(IACHAR(str(i:i)) - offset)
+            ELSE
+               capStr(i:i) = str(i:i)
+            END IF
+        END Do
+
+    END FUNCTION capitalize
+
+END MODULE module_string_tools

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -4,6 +4,9 @@
 !
 ! Michael G. Duda -- 25 August 2005
 ! vertical profiles added by Torge Lorenz -- June 2012
+! ability to output at either i/j or lat/lon locations, and ability to 
+!     output W, added by Pat Hawbecker -- Jan 2019
+! 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 SUBROUTINE calc_ts_locations( grid )
 
@@ -29,7 +32,7 @@ SUBROUTINE calc_ts_locations( grid )
    REAL :: known_lat, known_lon
    CHARACTER (LEN=132) :: message
    CHARACTER (LEN=24) :: ts_profile_filename
-   CHARACTER (LEN=2), DIMENSION(5) :: ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' /)
+   CHARACTER (LEN=2), DIMENSION(6) :: ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' ,'WW'/) 
    TYPE (PROJ_INFO) :: ts_proj
    TYPE (grid_config_rec_type) :: config_flags
 
@@ -148,12 +151,16 @@ SUBROUTINE calc_ts_locations( grid )
          CALL wrf_message(message)
    
          ntsloc_temp = 0
+
+         ! Boolean if/else for ij and lat/lon that sets ts_rx(y) to either ij or lat/lon value from tslist
          DO k=1,grid%ntsloc
-         
-            IF (config_flags%map_proj == 0) THEN  ! For idealized cases, no map transformation needed
+            ! Can be ideal case or specified i,j in tslist
+            IF (config_flags%map_proj == 0 .OR. grid%tslist_ij) THEN 
+                ts_rx = grid%itsloc(k)  
+                ts_ry = grid%jtsloc(k)
+            ELSE
                ts_rx = grid%lattsloc(k)           ! NB: (x,y) = (lat,lon) rather than (x,y) = (lon,lat)
                ts_ry = grid%lontsloc(k)
-            ELSE
                CALL latlon_to_ij(ts_proj, grid%lattsloc(k), grid%lontsloc(k), ts_rx, ts_ry)
             END IF
             
@@ -177,7 +184,7 @@ SUBROUTINE calc_ts_locations( grid )
          grid%ntsloc_domain = ntsloc_temp
    
          DO k=1,grid%ntsloc_domain
-   
+
             ! If location is outside of patch, we need to get lat/lon of TS grid cell from another patch
             IF (grid%itsloc(k) < ips .OR. grid%itsloc(k) > ipe .OR. &
                 grid%jtsloc(k) < jps .OR. grid%jtsloc(k) > jpe) THEN
@@ -232,7 +239,7 @@ SUBROUTINE calc_ts_locations( grid )
                CLOSE(UNIT=iunit)
 
                ts_profile_filename = grid%ts_filename(k)
-               DO j=1,5
+               DO j=1,SIZE(ts_file_endings)
                   ! Create the output files for the vertical profiles, one file for each variable
                   iunit = get_unused_unit()
                   IF ( iunit <= 0 ) THEN
@@ -275,6 +282,7 @@ END SUBROUTINE calc_ts_locations
 SUBROUTINE calc_ts( grid )
 
    USE module_domain
+   USE module_configure, ONLY : model_config_rec, grid_config_rec_type, model_to_grid_config_rec
    USE module_model_constants
 
    IMPLICIT NONE
@@ -290,6 +298,7 @@ SUBROUTINE calc_ts( grid )
            output_t, output_q, clw, xtime_minutes
    REAL, ALLOCATABLE, DIMENSION(:) :: p8w
    REAL, ALLOCATABLE, DIMENSION(:) :: earth_u_profile, earth_v_profile
+   TYPE (grid_config_rec_type) :: config_flags
 
    ! Parameter ts_model_level:  
        ! TRUE to output T, Q, and wind at lowest model level
@@ -310,6 +319,7 @@ SUBROUTINE calc_ts( grid )
    n = grid%next_ts_time
 
    ALLOCATE(p8w(grid%sm32:grid%em32))
+   CALL model_to_grid_config_rec ( grid%id , model_config_rec , config_flags )
 
    DO i=1,grid%ntsloc_domain
 
@@ -342,8 +352,18 @@ SUBROUTINE calc_ts( grid )
             !
 #if (EM_CORE == 1)
             DO k=1,grid%max_ts_level
-            earth_u_profile(k) = grid%u_2(ix,k,iy)*grid%cosa(ix,iy)-grid%v_2(ix,k,iy)*grid%sina(ix,iy)
-            earth_v_profile(k) = grid%v_2(ix,k,iy)*grid%cosa(ix,iy)+grid%u_2(ix,k,iy)*grid%sina(ix,iy)
+                ! interpolation loop: if you want u,v on cell centers, tslist_unstagger_winds = .true.
+                IF (config_flags%tslist_unstagger_winds) THEN
+                    earth_u_profile(k) = &
+                    ((grid%u_2(ix,k,iy)*grid%cosa(ix,iy)-grid%v_2(ix,k,iy)*grid%sina(ix,iy)) + &
+                    (grid%u_2(ix+1,k,iy)*grid%cosa(ix+1,iy)-grid%v_2(ix+1,k,iy)*grid%sina(ix+1,iy)))/2.0 
+                    earth_v_profile(k) = &
+                    ((grid%v_2(ix,k,iy)*grid%cosa(ix,iy)+grid%u_2(ix,k,iy)*grid%sina(ix,iy)) + &
+                    (grid%v_2(ix,k,iy+1)*grid%cosa(ix,iy+1)+grid%u_2(ix,k,iy+1)*grid%sina(ix,iy+1)))/2.0 
+                ELSE
+                    earth_u_profile(k) = grid%u_2(ix,k,iy)*grid%cosa(ix,iy)-grid%v_2(ix,k,iy)*grid%sina(ix,iy) 
+                    earth_v_profile(k) = grid%v_2(ix,k,iy)*grid%cosa(ix,iy)+grid%u_2(ix,k,iy)*grid%sina(ix,iy)
+                END IF
             END DO
             earth_u = grid%u10(ix,iy)*grid%cosa(ix,iy)-grid%v10(ix,iy)*grid%sina(ix,iy)
             earth_v = grid%v10(ix,iy)*grid%cosa(ix,iy)+grid%u10(ix,iy)*grid%sina(ix,iy)
@@ -379,6 +399,7 @@ SUBROUTINE calc_ts( grid )
             DO k=1,grid%max_ts_level
             grid%ts_u_profile(n,i,k)   = earth_u_profile(k)
             grid%ts_v_profile(n,i,k)   = earth_v_profile(k)
+            grid%ts_w_profile(n,i,k)   = (grid%w_2(ix,k,iy)+grid%w_2(ix,k+1,iy))/2.0 ! w on cell center
             grid%ts_gph_profile(n,i,k) = (grid%phb(ix,k,iy)+grid%ph_2(ix,k,iy))/9.81 
             grid%ts_th_profile(n,i,k)  = grid%t_2(ix,k,iy) + 300
             grid%ts_qv_profile(n,i,k)  = grid%moist(ix,k,iy,P_QV)
@@ -408,6 +429,7 @@ SUBROUTINE calc_ts( grid )
          DO k=1,grid%max_ts_level
          grid%ts_u_profile(n,i,k)     = 1.E30
          grid%ts_v_profile(n,i,k)     = 1.E30
+         grid%ts_w_profile(n,i,k)     = 1.E30 
          grid%ts_gph_profile(n,i,k)   = 1.E30
          grid%ts_th_profile(n,i,k)    = 1.E30
          grid%ts_qv_profile(n,i,k)    = 1.E30
@@ -486,6 +508,11 @@ SUBROUTINE write_ts( grid )
    DO k=1,grid%max_ts_level
    ts_buf(:,:) = grid%ts_v_profile(:,:,k)
    CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_v_profile(:,:,k),grid%ts_buf_size*grid%max_ts_locs)
+   END DO
+ 
+   DO k=1,grid%max_ts_level
+   ts_buf(:,:) = grid%ts_w_profile(:,:,k)
+   CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_w_profile(:,:,k),grid%ts_buf_size*grid%max_ts_locs)
    END DO
 
    DO k=1,grid%max_ts_level
@@ -642,6 +669,23 @@ SUBROUTINE write_ts( grid )
             WRITE(UNIT=iunit,FMT=profile_format)  &
                               grid%ts_hour(n,i),             & 
                               grid%ts_v_profile(n,i,1:grid%max_ts_level)                                       
+         END DO
+         CLOSE(UNIT=iunit)
+
+         iunit = get_unused_unit()
+            IF ( iunit <= 0 ) THEN
+            CALL wrf_error_fatal('Error in write_ts: could not find a free Fortran unit.')
+            END IF
+         k = LEN_TRIM(ts_profile_filename)
+         WRITE(ts_profile_filename(k-1:k),'(A2)') 'WW'
+         
+         OPEN(UNIT=iunit, FILE=TRIM(ts_profile_filename), STATUS='unknown', POSITION='append', FORM='formatted')
+
+         DO n=1,grid%next_ts_time - 1
+
+            WRITE(UNIT=iunit,FMT=profile_format)  &
+                              grid%ts_hour(n,i),             & 
+                              grid%ts_w_profile(n,i,1:grid%max_ts_level)                                       
          END DO
          CLOSE(UNIT=iunit)
 

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -154,10 +154,11 @@ SUBROUTINE calc_ts_locations( grid )
 
          ! Boolean if/else for ij and lat/lon that sets ts_rx(y) to either ij or lat/lon value from tslist
          DO k=1,grid%ntsloc
-            ! Can be ideal case or specified i,j in tslist
+            ! Ideal case (which has a cartesian coordinate) or specified (i,j) in tslist
             IF (config_flags%map_proj == 0 .OR. grid%tslist_ij) THEN 
-                ts_rx = grid%itsloc(k)  
-                ts_ry = grid%jtsloc(k)
+               ts_rx = grid%itsloc(k)  
+               ts_ry = grid%jtsloc(k)
+            ! Real-data case with input locations provided as (lat,lon)
             ELSE
                CALL latlon_to_ij(ts_proj, grid%lattsloc(k), grid%lontsloc(k), ts_rx, ts_ry)
             END IF

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -159,8 +159,6 @@ SUBROUTINE calc_ts_locations( grid )
                 ts_rx = grid%itsloc(k)  
                 ts_ry = grid%jtsloc(k)
             ELSE
-               ts_rx = grid%lattsloc(k)           ! NB: (x,y) = (lat,lon) rather than (x,y) = (lon,lat)
-               ts_ry = grid%lontsloc(k)
                CALL latlon_to_ij(ts_proj, grid%lattsloc(k), grid%lontsloc(k), ts_rx, ts_ry)
             END IF
             

--- a/share/wrf_tsin.F
+++ b/share/wrf_tsin.F
@@ -2,6 +2,7 @@ SUBROUTINE wrf_tsin ( grid , ierr )
 
     USE module_domain
     USE module_utility
+    USE module_configure, ONLY : model_config_rec, grid_config_rec_type, model_to_grid_config_rec
 
     IMPLICIT NONE
 
@@ -9,6 +10,7 @@ SUBROUTINE wrf_tsin ( grid , ierr )
 #include "wrf_status_codes.h"
 
     TYPE(domain), INTENT(INOUT) :: grid
+    TYPE (grid_config_rec_type) :: config_flags
     INTEGER, INTENT(INOUT) :: ierr
 
     LOGICAL, EXTERNAL :: wrf_dm_on_monitor
@@ -18,13 +20,14 @@ SUBROUTINE wrf_tsin ( grid , ierr )
     INTEGER :: istatus, iunit
     LOGICAL :: exists
     CHARACTER (LEN=256) :: errmess
+    CHARACTER (LEN=256) :: JorLat,IorLon
 
     ierr = 0
 
 #if ((EM_CORE == 1) && (DA_CORE != 1))
     IF ( grid%dfi_opt == DFI_NODFI .OR. (grid%dfi_opt /= DFI_NODFI .AND. grid%dfi_stage == DFI_SETUP) ) THEN
 #endif
-
+    CALL model_to_grid_config_rec ( grid%id , model_config_rec , config_flags ) 
        grid%ntsloc = 0
        grid%have_calculated_tslocs = .FALSE.
    
@@ -46,17 +49,35 @@ SUBROUTINE wrf_tsin ( grid , ierr )
    
              IF (istatus == 0) THEN
    
-                ! Ignore first three lines, which constitute a header
+                ! The header will be parsed to see if lat/lon or i/j is given...
                 READ(UNIT=iunit, FMT='(1X)')
+                READ(UNIT=iunit, FMT='(32X,A7,2X,A7)') JorLat, IorLon
                 READ(UNIT=iunit, FMT='(1X)')
-                READ(UNIT=iunit, FMT='(1X)')
+                grid%tslist_ij = .false.
+                ! If the header contains "LAT" and "LON" then it will expect
+                !... lat/lon coords in the file
+                ! If the header has "J" and "I", then i,j will be used.
+                if(index(JorLat,'LAT').ne.0 .and. index(IorLon,'LON').ne.0) then
+                    grid%tslist_ij = .false.
+                elseif(index(JorLat,'J').ne.0 .and. index(IorLon,'I').ne.0) then
+                    grid%tslist_ij = .true.
+                endif
+
+
+
    
                 ! Read in time series locations
                 istatus = 0
                 DO WHILE (istatus == 0)
-                   READ(UNIT=iunit, FMT='(A25,1X,A5,1X,F7.3,1X,F8.3)', IOSTAT=istatus)            &
-                        grid%desctsloc(grid%ntsloc+1), grid%nametsloc(grid%ntsloc+1), &
-                        grid%lattsloc(grid%ntsloc+1), grid%lontsloc(grid%ntsloc+1)
+                   IF (config_flags%map_proj == 0 .OR. grid%tslist_ij) THEN !ideal run will only use i,j
+                       READ(UNIT=iunit, FMT='(A25,1X,A5,1X,I9,1X,I10)', IOSTAT=istatus)            &
+                       grid%desctsloc(grid%ntsloc+1), grid%nametsloc(grid%ntsloc+1), &
+                       grid%itsloc(grid%ntsloc+1), grid%jtsloc(grid%ntsloc+1)
+                   ELSE
+                       READ(UNIT=iunit, FMT='(A25,1X,A5,1X,F7.3,1X,F8.3)', IOSTAT=istatus)            &
+                       grid%desctsloc(grid%ntsloc+1), grid%nametsloc(grid%ntsloc+1), &
+                       grid%lattsloc(grid%ntsloc+1), grid%lontsloc(grid%ntsloc+1)
+                   END IF
                    IF (istatus == 0) grid%ntsloc = grid%ntsloc + 1
                    IF (istatus > 0) THEN
                       WRITE(errmess, FMT='(I4)') grid%ntsloc + 3   ! Three extra for the header of the file

--- a/share/wrf_tsin.F
+++ b/share/wrf_tsin.F
@@ -75,7 +75,7 @@ SUBROUTINE wrf_tsin ( grid , ierr )
                 istatus = 0
                 DO WHILE (istatus == 0)
                    IF (config_flags%map_proj == 0 .OR. grid%tslist_ij) THEN !ideal run will only use i,j
-                       READ(UNIT=iunit, FMT='(A25,1X,A5,1X,I9,1X,I10)', IOSTAT=istatus)            &
+                       READ(UNIT=iunit, FMT='(A25,1X,A5,1X,I7,1X,I8)', IOSTAT=istatus)            &
                        grid%desctsloc(grid%ntsloc+1), grid%nametsloc(grid%ntsloc+1), &
                        grid%itsloc(grid%ntsloc+1), grid%jtsloc(grid%ntsloc+1)
                    ELSE
@@ -85,9 +85,20 @@ SUBROUTINE wrf_tsin ( grid , ierr )
                    END IF
                    IF (istatus == 0) grid%ntsloc = grid%ntsloc + 1
                    IF (istatus > 0) THEN
-                      WRITE(errmess, FMT='(I4)') grid%ntsloc + 3   ! Three extra for the header of the file
+                      WRITE(errmess, FMT='(I4)') grid%ntsloc + 4   ! Three extra for the header of the file
+                                                                   ! One extra for the line we incorrectly read
                       CALL wrf_message('Error in tslist, line '//trim(errmess))
+                      CALL wrf_error_fatal('Error --- Maybe check that the header (I,J) vs (LAT,LON) matches the provided information')
                       EXIT    ! (technically unecessary, as we will exit the loop anyway)
+                   END IF
+                   IF ( ( grid%ntsloc == 1 ) .and. ( .NOT. grid%tslist_ij ) ) THEN
+                      IF ( ( ABS(grid%lattsloc(grid%ntsloc)) <= 0.1 ) .and. &
+                           ( ABS(grid%lontsloc(grid%ntsloc)) <= 0.1 ) ) THEN
+                         CALL wrf_message('WARNING ')
+                         CALL wrf_message('WARNING --- Maybe you have (I,J) locations for the (LAT,LON) values in tslist?')
+                         CALL wrf_message('WARNING --- Are you purposefully studying Null Island?')
+                         CALL wrf_message('WARNING ')
+                      END IF
                    END IF
                    IF ( grid%ntsloc >= grid%max_ts_locs ) THEN
                       IF ( istatus == 0 ) THEN                 ! Assume there were more lines in the file

--- a/share/wrf_tsin.F
+++ b/share/wrf_tsin.F
@@ -3,6 +3,7 @@ SUBROUTINE wrf_tsin ( grid , ierr )
     USE module_domain
     USE module_utility
     USE module_configure, ONLY : model_config_rec, grid_config_rec_type, model_to_grid_config_rec
+    USE module_string_tools, ONLY : capitalize
 
     IMPLICIT NONE
 
@@ -20,7 +21,7 @@ SUBROUTINE wrf_tsin ( grid , ierr )
     INTEGER :: istatus, iunit
     LOGICAL :: exists
     CHARACTER (LEN=256) :: errmess
-    CHARACTER (LEN=256) :: JorLat,IorLon
+    CHARACTER (LEN=256) :: IorLat,JorLon
 
     ierr = 0
 
@@ -46,21 +47,25 @@ SUBROUTINE wrf_tsin ( grid , ierr )
 
              ! Input time series locations
              OPEN(UNIT=iunit, FILE='tslist', FORM='formatted', STATUS='old', IOSTAT=istatus)
-   
              IF (istatus == 0) THEN
    
                 ! The header will be parsed to see if lat/lon or i/j is given...
                 READ(UNIT=iunit, FMT='(1X)')
-                READ(UNIT=iunit, FMT='(32X,A7,2X,A7)') JorLat, IorLon
+                READ(UNIT=iunit, FMT='(32X,A7,2X,A7)') IorLat, JorLon
                 READ(UNIT=iunit, FMT='(1X)')
                 grid%tslist_ij = .false.
-                ! If the header contains "LAT" and "LON" then it will expect
-                !... lat/lon coords in the file
-                ! If the header has "J" and "I", then i,j will be used.
-                if(index(JorLat,'LAT').ne.0 .and. index(IorLon,'LON').ne.0) then
+                ! If the header contains "LAT" and "LON", 
+                !    then it will expect lat/lon coords in the file
+                ! If the header has "I" and "J", 
+                !    then it will expect grid index coords in the file
+                IorLat = capitalize(IorLat)
+                JorLon = capitalize(JorLon)
+                if(index(IorLat,'LAT').ne.0 .and. index(JorLon,'LON').ne.0) then
                     grid%tslist_ij = .false.
-                elseif(index(JorLat,'J').ne.0 .and. index(IorLon,'I').ne.0) then
+                elseif(index(IorLat,'I').ne.0 .and. index(JorLon,'J').ne.0) then
                     grid%tslist_ij = .true.
+                else
+                    CALL wrf_error_fatal('Error in wrf_tsin: Header line requires either LAT LON or I J')
                 endif
 
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: tslist, ideal, i/j, W, cell centers, tslist_ij, tslist_interp, time-series

SOURCE: Pat Hawbecker (NREL)

DESCRIPTION OF CHANGES: 
1. This code modification provides a way to generate time-series output for 3d idealized cases, based on the i/j location. The wrf_tsin.F and wrf_timeseries.F files are modified so that if map_proj == 0, tslist will read in integers (as opposed to floats) and assign those to grid%itsloc and grid%jtsloc. Therefore if it's an idealized case, tslist will expect coordinates instead of lat/lon. 

2. This modification also allows a user to use either lat/lon or i/j coordinates for time-series output locations with real data cases. This is now based on the header of tslist. If a user wishes to output at i,j locations, they would replace the lat/lon column headers with i/j.

3. Modifications are made to now output time-series for W.

4. A namelist option tslist_unstagger_winds (&domains) allows users to output all variables at cell centers when set to true (default is false). This now includes UU and VV, which are modified in wrf_timeseries.F and Registry.EM_COMMON. The output uses earth-relative winds for each.

LIST OF MODIFIED FILES: 
M     Registry/Registry.EM_COMMON
M     main/depend.common
M     run/README.tslist
M     share/Makefile
A     share/module_string_tools.F
M     share/wrf_timeseries.F
M     share/wrf_tsin.F

TESTS CONDUCTED: 
1. em_quarter_ss with default namelist, including a tslist (with i/j coordinates listed) in the run directory produces expected output. Contributor performed additional testing to output the full 3d field at every time step, then compared time series output to the 3d solution at the same location with a time-height plot, and took the difference - found that diffs could be attributed to roundoff error.
2. same as above, but with lat/lon specified in tslist, confirmed no time series output.
3. repeated tests 1) and 2) with another ideal case (em_convrad).
4. small real case (default namelist options) using an i/j-specific tslist. The expected time-series output is produced. Contributor performed additional testing to output the full 3d field at every time step, then compared time series output to the 3d solution at the same location with a time-height plot, and took the difference - found that diffs could be attributed to roundoff error.
5. same as above, but with lat/lon specified in tslist, confirmed no time series output.
6. same as 4), but also set tslist_interp = .true. The expected time-series output is produced, and U/V are calculated at the cell centers.
7. same as 4) but had a lat/lon tslist in the run directory. As expected, no time-series files were produced.
8. real case, as in 4), but using a lat/lon specific tslist, setting tslist_interp = .true. As expected, U/V variables are calculated at the cell centers. 
9. time-series files for variable W were produced for all runs that produced time-series output.
10. wrf history files are identical for both real/ideal runs using code before changes, and after changes.
11. TEST1 - use (I,J)
```
#-----------------------------------------------#
# 24 characters for name | pfx |   i   |   j    |
#-----------------------------------------------#
tower0001                 t0001      10       20  
tower0001                 t0003      10       10  
tower0012                 t0012      30       30  
```
12. TEST2 - WRONG use (LAT,LON)
```
#-----------------------------------------------#
# 24 characters for name | pfx |   i   |   j    |
#-----------------------------------------------#
tower0001                 t0001  33.116  -90.380
tower0001                 t0003  30.410  -90.678
tower0012                 t0012  35.072  -83.364
```
In the WRF model output, this tslist file produces this error message:
```
Error in tslist, line    4   
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     237 
Error --- Maybe check that the header (I,J) vs (LAT,LON) matches the provided information
-------------------------------------------
```
13. TEST3 - use (LAT,LON)
```
#-----------------------------------------------#
# 24 characters for name | pfx |  LAT  |  LON   |
#-----------------------------------------------#
tower0001                 t0001  33.116  -90.380
tower0001                 t0003  30.410  -90.678
tower0012                 t0012  35.072  -83.364
```
These are the identical lat,lon coordinates computed from TEST1, so we should get identical output (and we do).
```
> diff TEST1/t0001.d01.TS TEST3/t0001.d01.TS
1c1
< tower0001                  1  1 t0001 (  0.000,   0.000) (  10,  20) ( 33.116, -90.380)   44.5 meters
---
> tower0001                  1  1 t0001 ( 33.116, -90.380) (  10,  20) ( 33.116, -90.380)   44.5 meters
```
14. TEST4 - WRONG use (LAT,LON)
```
#-----------------------------------------------#
# 24 characters for name | pfx |  LAT  |  LON   |
#-----------------------------------------------#
tower0001                 t0001      10       20  
tower0001                 t0003      10       10  
tower0012                 t0012      30       30  
```
These are hard to detect. We can't really do a hard failure. The WRF model prints out a warning message.
```
WARNING
WARNING --- Maybe you have (I,J) locations for the (LAT,LON) values in tslist?
WARNING --- Are you purposefully studying Null Island?
WARNING
```

Example i/j-specific tslist: 
```
#-----------------------------------------------#
# 24 characters for name | pfx |   i   |   j    |
#-----------------------------------------------#
tower0001                 t0001      10       20
tower0001                 t0003      10       10
tower0012                 t0012      30       30
```

 

RELEASE NOTE: The time-series output option has been modified to now allow output at i,j coordinate locations. One must specify i/j coordinates in the tslist and change the column headers to i/j (instead of lat/lon). Both real and ideal cases are capable of outputting all variables (including U/V) at the cell centers by setting the namelist option tslist_unstagger_winds = .true. Additionally, time series output now includes variable W.
