### PR TITLE
including check-a-mundo routines in ideal_em

### DIFF
--- a/main/ideal_em.F
+++ b/main/ideal_em.F
@@ -6,6 +6,7 @@ PROGRAM ideal
    USE module_domain , ONLY : domain
    USE module_initialize_ideal
    USE module_configure , ONLY : grid_config_rec_type
+   USE module_check_a_mundo
 
    USE module_timing
    USE module_wrf_error
@@ -93,6 +94,8 @@ PROGRAM ideal
    CALL set_wrf_debug_level ( debug_level )
 
    CALL  wrf_message ( program_name )
+   CALL  set_physics_rconfigs
+   CALL  check_nml_consistency
 
 
    ! allocated and configure the mother domain


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ideal, check-a-mundo, namelist consistency, physics, num_soil_layers

SOURCE: internal

DESCRIPTION OF CHANGES: ideal runs were not using any of the routines from module_check_a_mundo, so there were no namelist consistency checks, and no physics configurations set. For example, in the subroutine "set_physics_rconfigs" the num_soil_layers is set to the appropriate number of layers, depending on the surface physics used. If one is not using a surface physics with 5 layers (which is default in the registry), an error would occur when running ideal. This modification adds a USE statement for module_check_a_mundo, and sets CALLs to set_physics_rconfigs and check_nml_consistency.

LIST OF MODIFIED FILES: 
M    main/ideal_em.F

TESTS CONDUCTED: Confirmed that all ideal cases are able to compile and give bit-for-bit results before and after modification.