### PR TITLE
Fix DA warning message for cv_options=3 and cloud_cv_options>0

### DIFF
--- a/var/da/da_main/da_solve.inc
+++ b/var/da/da_main/da_solve.inc
@@ -202,7 +202,7 @@
       write(unit=message(2),fmt='(A)') &
          'Resetting cloud_cv_options = 0 for cv_options = 3'
       cloud_cv_options = 0
-      call da_warning(__FILE__,__LINE__,message(1:1))
+      call da_warning(__FILE__,__LINE__,message(1:2))
    end if
 
    if ( use_radarobs ) then


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, warning print

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
cloud_cv_options is reset to be 0 in var/da/da_main/da_solve.inc when cv_options = 3.
The second line of the warning messages stating that the cloud_cv_options = 0 were not originally printed.

LIST OF MODIFIED FILES:
M       var/da/da_main/da_solve.inc

TESTS CONDUCTED:
1. After the fix, the intended full warning messages are printed.
```
--------------------------- WARNING ---------------------------
WARNING FROM FILE:  da_solve.inc  LINE:     205
Cloud control variables are not implemented for cv_options = 3
Resetting cloud_cv_options = 0 for cv_options = 3
---------------------------------------------------------------
```

RELEASE NOTE: (too minor to be mentioned)