### PR TITLE
Adding hydro team to the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,11 @@
 /dyn_em/				@wrf-model/arw_dev
 /dyn_nmm/				@wrf-model/hwrf_dev
 
+#       WRF-Hydro
+
+/hydro/                                 @wrf-model/hydro
+/doc/README.hydro                       @wrf-model/hydro
+
 #	Registry
 
 /Registry/				@wrf-model/infrastructure


### PR DESCRIPTION
TYPE: text only

KEYWORDS: CODEOWNERS, hydro, WRF-hydro, README.hydro

SOURCE: internal

DESCRIPTION OF CHANGES: Adding the hydro team to the CODEOWNERS file so that they will have access to approve WRF-hydro-releated PR's. They now have access to the full hydro/ directory and the doc/README.hydro file.

LIST OF MODIFIED FILES: 
M     .github/CODEOWNERS

TESTS CONDUCTED: no tests - text only