### PR TITLE
Change DA namelist use_html default from true to false

### DIFF
--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -317,7 +317,7 @@ rconfig   logical   trace_use_dull          namelist,wrfvar9  1  .false.    - "t
 rconfig   logical   trace_memory            namelist,wrfvar9  1  .true.    - "trace_memory"            ""  ""
 rconfig   logical   trace_all_pes           namelist,wrfvar9  1  .false.   - "trace_all_pes"           ""  ""
 rconfig   logical   trace_csv               namelist,wrfvar9  1  .true.    - "trace_csv"               ""  ""
-rconfig   logical   use_html                namelist,wrfvar9  1  .true.    - "use_html"                ""  ""
+rconfig   logical   use_html                namelist,wrfvar9  1  .false.   - "use_html"                ""  ""
 rconfig   logical   warnings_are_fatal      namelist,wrfvar9  1  .false.   - "warnings_are_fatal"      ""  ""
 rconfig   logical   test_transforms         namelist,wrfvar10  1  .false.  - "test_transforms"         ""  ""  
 rconfig   logical   test_gradient           namelist,wrfvar10  1  .false.  - "test_gradient"           ""  ""  


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, use_html default, registry.var

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

With default use_html=.true., HTML <a> href attribute constructed using another
namelist documentation_url (default=http://www.mmm.ucar.edu/people/wrfhelp/wrfvar/code/trunk)
is added for the file mentioned in the warning and error messages.
For example:
```
--------------------------- WARNING ---------------------------
WARNING FROM FILE: <A HREF="http://www.mmm.ucar.edu/people/wrfhelp/wrfvar/code/trunk/da_solve.html">da_solve.inc</a>  LINE:     205
```
```
---------------------------- FATAL ERROR -----------------------
Fatal error in file: <A HREF="http://www.mmm.ucar.edu/people/wrfhelp/wrfvar/code/trunk/da_solve.html">da_solve.inc</a>  LINE:     216
```
Since the URL is invalid and it simply clutters the message,
the PR proposes to have use_html=.false. by default for a cleaner message like this:
```
--------------------------- WARNING ---------------------------
WARNING FROM FILE:  da_solve.inc  LINE:     205
```
```
---------------------------- FATAL ERROR -----------------------
Fatal error in file:  da_solve.inc  LINE:     216
```

LIST OF MODIFIED FILES:
M       Registry/registry.var

TESTS CONDUCTED:

RELEASE NOTE: (too minor to be mentioned)