### PR TITLE
Additional WRF/MPAS unification to reduce if-defs for MPAS-specific n…

### DIFF
--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -1,7 +1,12 @@
 !=================================================================================================================
-!module_bl_ysu.F was modified to integrate MPAS-specific code 
-!integration took place between WRF Master Repository (from 28Feb2018) and MPAS HWT Repository (from 27Feb2018)
-!WRF version is >V3.9.1.1 and MPAS module_bl_ysu.F was originally modified from WRFV3.8.1
+!module_bl_ysu.F was originally copied from ./phys/module_bl_ysu.F from WRF version 3.8.1.
+!Laura D. Fowler (laura@ucar.edu) / 2016-10-26.
+
+!modifications to sourcecode for MPAS:
+!   * calculated the dry hydrostatic pressure using the dry air density.
+!   * added outputs of the vertical diffusivity coefficients.
+!     Laura D. Fowler (laura@ucar.edu) / 2016-10-26.
+
 !=================================================================================================================
 !WRF:model_layer:physics
 !
@@ -22,11 +27,10 @@ contains
                   rqvblten,rqcblten,rqiblten,flag_qi,                          &
                   cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
                   dz8w,psfc,                                                   &
-                  znu,znw,p_top,                                               &
                   znt,ust,hpbl,psim,psih,                                      &
                   xland,hfx,qfx,wspd,br,                                       &
                   dt,kpbl2d,                                                   &
-                  exch_h,                                                      &
+                  exch_h,exch_m,                                               &
                   wstar,delta,                                                 &
                   u10,v10,                                                     &
                   uoce,voce,                                                   &
@@ -37,7 +41,6 @@ contains
                   its,ite, jts,jte, kts,kte,                                   &
                 !optional
                   regime                                                       &
-                  ,rho,kzhout,kzmout,kzqout                                    &
                  )
 !-------------------------------------------------------------------------------
    implicit none
@@ -148,7 +151,8 @@ contains
                                                                      rqcblten
 !
    real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
-             intent(inout)   ::                                        exch_h
+             intent(inout)   ::                                        exch_h, &
+                                                                       exch_m
    real,     dimension( ims:ime, jms:jme )                                   , &
              intent(inout)   ::                                         wstar
    real,     dimension( ims:ime, jms:jme )                                   , &
@@ -194,14 +198,6 @@ contains
              optional                                                        , &
              intent(inout)   ::                                       rqiblten
 !
-   real,     dimension( kms:kme )                                            , &
-             optional                                                        , &
-             intent(in   )   ::                                           znu, &
-                                                                          znw
-!
-!
-   real,     optional, intent(in   )   ::                               p_top
-!
    real,     dimension( ims:ime, jms:jme )                                   , &
              optional                                                        , &
              intent(in   )   ::                                         ctopo, &
@@ -217,20 +213,7 @@ contains
                                                                         dvsfc, &
                                                                         dtsfc, &
                                                                         dqsfc
-   real,intent(in),dimension(ims:ime,kms:kme,jms:jme),optional:: rho
-   real:: rho_d
-   real,intent(out),dimension(ims:ime,kms:kme,jms:jme),optional:: kzhout,kzmout,kzqout
-   if(present(kzhout) .and. present(kzmout) .and. present(kzqout)) then
-      do j = jts,jte
-      do k = kts,kte
-      do i = its,ite
-         kzhout(i,k,j) = 0.
-         kzmout(i,k,j) = 0.
-         kzqout(i,k,j) = 0.
-      enddo
-      enddo
-      enddo
-   endif
+
 !
    qv2d(its:ite,:) = 0.0
 !
@@ -241,27 +224,6 @@ contains
           pdhi(i,k) = p3di(i,k,j)
         enddo
       enddo
-!For MPAS, we replace the hydrostatic pressures defined at theta and w points by
-!the dry hydrostatic pressures (Laura D. Fowler):
-      if(present(rho)) then
-  203 format(1x,i4,1x,i2,10(1x,e15.8))
-        k = kte+1
-        do i = its,ite
-          pdhi(i,k) = p3di(i,k,j)
-        enddo
-        do k = kte,kts,-1
-        do i = its,ite
-           rho_d = rho(i,k,j) / (1. + qv3d(i,k,j))
-           if(k.le.kte) pdhi(i,k) = pdhi(i,k+1) + g*rho_d*dz8w(i,k,j)
-        enddo
-       enddo
-        do k = kts,kte
-        do i = its,ite
-           pdh(i,k) = 0.5*(pdhi(i,k) + pdhi(i,k+1))
-        enddo
-        enddo
-      endif
-!MPAS specific end.
 
       do k = kts,kte
         do i = its,ite
@@ -291,6 +253,7 @@ contains
               ,dusfc=dusfc,dvsfc=dvsfc,dtsfc=dtsfc,dqsfc=dqsfc                 &
               ,dt=dt,rcl=1.0,kpbl1d=kpbl2d(ims,j)                              &
               ,exch_hx=exch_h(ims,kms,j)                                       &
+              ,exch_mx=exch_m(ims,kms,j)                                       &
               ,wstar=wstar(ims,j)                                              &
               ,delta=delta(ims,j)                                              &
               ,u10=u10(ims,j),v10=v10(ims,j)                                   &
@@ -298,11 +261,6 @@ contains
               ,rthraten=rthraten(ims,kms,j),p2diORG=p3di(ims,kms,j)            &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo(ims,j),ctopo2=ctopo2(ims,j)                         &
-#if defined(mpas)
-              ,kzh=kzhout(ims,kms,j)                                           &
-              ,kzm=kzmout(ims,kms,j)                                           &
-              ,kzq=kzqout(ims,kms,j)                                           &
-#endif
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
               ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &
               ,its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
@@ -330,7 +288,7 @@ contains
                   xland,hfx,qfx,wspd,br,                                       &
                   dusfc,dvsfc,dtsfc,dqsfc,                                     &
                   dt,rcl,kpbl1d,                                               &
-                  exch_hx,                                                     &
+                  exch_hx,exch_mx,                                             &
                   wstar,delta,                                                 &
                   u10,v10,                                                     &
                   uox,vox,                                                     &
@@ -342,7 +300,6 @@ contains
                   its,ite, jts,jte, kts,kte,                                   &
                 !optional
                   regime                                                       &
-                 ,kzh,kzm,kzq                                                  &
                    )
 !-------------------------------------------------------------------------------
    implicit none
@@ -524,7 +481,8 @@ contains
 !jdf added exch_hx
 !
    real,    dimension( ims:ime, kms:kme )                                    , &
-            intent(inout)   ::                                        exch_hx
+            intent(inout)   ::                                        exch_hx, &
+                                                                      exch_mx
 !
    real,    dimension( ims:ime )                                             , &
             intent(inout)    ::                                           u10, &
@@ -586,8 +544,6 @@ contains
                                                                      buoy_ysu
    real,    dimension( ims:ime )             ::                       pblh_ysu,&
                                                                       vconvfx
-!
-   real,intent(out),dimension(ims:ime,kms:kme),optional::kzh,kzm,kzq
 !
 !-------------------------------------------------------------------------------
 !
@@ -690,17 +646,6 @@ contains
      delta(i)  = 0.0
      wstar3_2(i) =  0.0
    enddo
-!
-   if(present(kzh) .and. present(kzm) .and. present(kzq)) then
-      do k = kts,kte
-      do i = its,ite
-         xkzh(i,k)  = 0.0
-         xkzm(i,k)  = 0.0
-         xkzhl(i,k) = 0.0
-         xkzml(i,k) = 0.0
-      enddo
-      enddo
-   endif
 !
    do k = kts,klpbl
      do i = its,ite
@@ -1449,6 +1394,7 @@ contains
        al(i,k)   = -dtodsu*dsdz2
        ad(i,k)   = ad(i,k)-au(i,k)
        ad(i,k+1) = 1.-al(i,k)
+       exch_mx(i,k+1) = xkzm(i,k)
      enddo
    enddo
 !
@@ -1493,16 +1439,6 @@ contains
    do i = its,ite
      kpbl1d(i) = kpbl(i)
    enddo
-!
-   if(present(kzh) .and. present(kzm) .and. present(kzq)) then
-      do i = its,ite
-      do k = kts,kte
-         kzh(i,k) = xkzh(i,k)
-         kzm(i,k) = xkzm(i,k)
-         kzq(i,k) = xkzq(i,k)
-      enddo
-      enddo
-   endif
 !
    end subroutine ysu2d
 !-------------------------------------------------------------------------------

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -1174,7 +1174,6 @@ CONTAINS
               ,FLAG_QI=flag_qi                                      &
               ,CP=cp,G=g,ROVCP=rcp,RD=r_D,ROVG=rovg                 &
               ,DZ8W=dz8w,XLV=XLV,RV=r_v,PSFC=PSFC                   &
-              ,ZNU=znu,ZNW=znw,P_TOP=p_top                          &
               ,ZNT=znt,UST=ust,HPBL=pblh                            &
               ,PSIM=fm,PSIH=fhh,XLAND=xland                         &
               ,HFX=hfx,QFX=qfx                                      &
@@ -1185,7 +1184,7 @@ CONTAINS
               ,YSU_TOPDOWN_PBLMIX=ysu_topdown_pblmix                &
               ,WSPD=wspd,BR=br,DT=dtbl,KPBL2D=kpbl                  &
               ,EP1=ep_1,EP2=ep_2,KARMAN=karman                      &
-              ,EXCH_H=exch_h,REGIME=regime                          &
+              ,EXCH_H=exch_h,EXCH_M=exch_m,REGIME=regime            &
               ,RTHRATEN=RTHRATEN                                    &
 ! for grims shallow convection with ysupbl
               ,WSTAR=wstar,DELTA=delta                              &


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: pbl, ysu, wrf, mpas, unify

SOURCE: internal

DESCRIPTION OF CHANGES: 
These modifications update the previously merged mods to unify the YSU PBL scheme with MPAS code. In an effort to reduce the differences between the necessities of the 2 models, MPAS now computes dry hydrostatic pressure prior to the call to the ysu scheme, and therefore it's no longer done inside this routine. Additionally, the exchange coefficients for MPAS have been updated to adopt the names used in the WRF model, so the if-defs/optional code for MPAS-specific names have been removed.

LIST OF MODIFIED FILES: 
M     phys/module_bl_ysu.F
M     phys/module_pbl_driver.F

TESTS CONDUCTED: Verified that both WRF/MPAS compile and run okay. WRF output is bit-for-bit identical before/after the mods.