### PR TITLE
LES fix for use_theta_m=1

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -1637,7 +1637,7 @@ END SUBROUTINE cal_dampkm
       ELSE
         BN2(i,k,j) = g * ( (theta(i,k+1,j) - theta(i,k-1,j) ) /  &
                      theta(i,k,j) / tmpdz +  &
-                     0.61 * ( moist(i,k+1,j,P_QV) - moist(i,k-1,j,P_QV) ) / &
+                     1.61 * ( moist(i,k+1,j,P_QV) - moist(i,k-1,j,P_QV) ) / &
                      tmpdz -   &
                      ( tmp1(i,k+1,j) - tmp1(i,k-1,j) ) / tmpdz )
       ENDIF
@@ -1670,7 +1670,7 @@ END SUBROUTINE cal_dampkm
                     cf3 * moist(i,3,j,P_QV)
 !        BN2(i,k,j) = g * ( ( theta(i,k+1,j) - thetasfc ) /  &
 !                     theta(i,k,j) / tmpdz +  &
-!                     0.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
+!                     1.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
 !                     tmpdz -  &
 !                     ( tmp1(i,k+1,j) - tmp1sfc(i,j) ) / tmpdz  )
 !...... MARTA: change in computation of BN2 at the surface, WCS 040331
@@ -1678,7 +1678,7 @@ END SUBROUTINE cal_dampkm
         tmpdz= 1./rdzw(i,k,j) ! controlare come calcola rdzw
         BN2(i,k,j) = g * ( ( theta(i,k+1,j) - theta(i,k,j)) /  &
                      theta(i,k,j) / tmpdz +  &
-                     0.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
+                     1.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
                      tmpdz -  &
                      ( tmp1(i,k+1,j) - tmp1sfc(i,j) ) / tmpdz  )
 ! end of MARTA/WCS change

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -1637,7 +1637,7 @@ END SUBROUTINE cal_dampkm
       ELSE
         BN2(i,k,j) = g * ( (theta(i,k+1,j) - theta(i,k-1,j) ) /  &
                      theta(i,k,j) / tmpdz +  &
-                     1.61 * ( moist(i,k+1,j,P_QV) - moist(i,k-1,j,P_QV) ) / &
+                     0.61 * ( moist(i,k+1,j,P_QV) - moist(i,k-1,j,P_QV) ) / &
                      tmpdz -   &
                      ( tmp1(i,k+1,j) - tmp1(i,k-1,j) ) / tmpdz )
       ENDIF
@@ -1670,7 +1670,7 @@ END SUBROUTINE cal_dampkm
                     cf3 * moist(i,3,j,P_QV)
 !        BN2(i,k,j) = g * ( ( theta(i,k+1,j) - thetasfc ) /  &
 !                     theta(i,k,j) / tmpdz +  &
-!                     1.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
+!                     0.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
 !                     tmpdz -  &
 !                     ( tmp1(i,k+1,j) - tmp1sfc(i,j) ) / tmpdz  )
 !...... MARTA: change in computation of BN2 at the surface, WCS 040331
@@ -1678,7 +1678,7 @@ END SUBROUTINE cal_dampkm
         tmpdz= 1./rdzw(i,k,j) ! controlare come calcola rdzw
         BN2(i,k,j) = g * ( ( theta(i,k+1,j) - theta(i,k,j)) /  &
                      theta(i,k,j) / tmpdz +  &
-                     1.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
+                     0.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
                      tmpdz -  &
                      ( tmp1(i,k+1,j) - tmp1sfc(i,j) ) / tmpdz  )
 ! end of MARTA/WCS change
@@ -3418,6 +3418,7 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
                                     tracer_tendf, n_tracer,                   &
                                     u_2, v_2,                                 &
                                     thp,u_base,v_base,t_base,qv_base,tke,     &
+                                    theta,                                    &
                                     config_flags,defor13,defor23,defor33,     &
                                     nba_mij, n_nba_mij,                       &
                                     div,                                      &
@@ -3488,6 +3489,7 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
                                                                     xkhv, &
                                                                     xkmh, &
                                                                      tke, &
+                                                                   theta, &
                                                                      rdz, &
                                                                      u_2, &
                                                                      v_2, &
@@ -3701,6 +3703,10 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
        hfx(i,j)=heat_flux*cpm*rho(i,kts,j)         ! provided for output only
        rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
              -g*heat_flux*rho(i,kts,j)/dnw(kts)
+       if(config_flags%use_theta_m == 1)THEN
+         rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
+             -g*1.61*theta(i,kts,j)*qfx(i,j)/dnw(kts)
+       ENDIF
     ENDDO
     ENDDO
 
@@ -3712,6 +3718,10 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
        heat_flux = hfx(i,j)/cpm
        rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
             -g*heat_flux/dnw(kts)
+       if(config_flags%use_theta_m == 1)THEN
+         rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
+             -g*1.61*theta(i,kts,j)*qfx(i,j)/dnw(kts)
+       ENDIF
 
     ENDDO
     ENDDO

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -911,7 +911,7 @@ BENCH_START(vert_diff_tim)
                                       tracer_tend, num_tracer,                     &
                                       grid%u_2, grid%v_2,                                  &
                                       grid%t_2,grid%u_base,grid%v_base,grid%t_base,grid%qv_base,          &
-                                      grid%tke_2, config_flags,              &
+                                      grid%tke_2, th_phy, config_flags,              &
                                       grid%defor13,grid%defor23,grid%defor33,                   &
                                       nba_mij, num_nba_mij,          & !JDM
                                       grid%div, moist, chem, scalar,tracer,         &


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: LES option, use_theta_m=1, V4.0 bug in surface flux fixed, calculate_N2 minor change

SOURCE: internal plus Xu Zhang (Shanghai Typhoon Institute)

DESCRIPTION OF CHANGES: 
When use_theta_m was updated to V4.0, diffusion was also applied to theta_m. However the surface flux was not modified to include a QFX term. This leads to a cooler PBL than in V3.9 with use_theta_m=1 and is incorrect. The fix is to add a QFX term that restores temperatures to correct values.

ISSUE: none posted

LIST OF MODIFIED FILES:
M       dyn_em/module_diffusion_em.F
M       dyn_em/module_first_rk_step_part2.F

TESTS CONDUCTED: 
No WTF yet. 
LES tests with fix have corrected the problem and give use_theta_m=1 results more like V3.9.1.
Theta profile plots show the cool anomaly with the old use_theta_m=1 (green) code compared to both the fixed version (red) and and use_theta_m=0 (blue). The fixed code shows more similarity with V3.9 too (not shown). The U profile shows more difference in the fixed code from the use_theta_m=0 case.
![profile](https://user-images.githubusercontent.com/17932284/50034495-52072500-ffba-11e8-9fa4-ecfe51869f22.png)


RELEASE NOTE: 
LES options in V4.0 with use_theta_m=1 (default) contained an error with surface fluxes leading to a cooler PBL. QFX term has been added to surface theta_m flux to correct this problem. 

