### PR TITLE
fix restart problem

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -6301,8 +6301,9 @@ END SUBROUTINE set_tend
 
 !------------------------------------------------------------------------------
 ! Begin: Assign limits of spatial loops depending on variable to be diffused.
-! The halo regions are already filled with values by the time this subroutine
-! is called, which allows the stencil to extend beyond the domains' edges.
+! The halo regions outside the physical domain are not defined, hence the loop
+! indices should start 3 rows and columns in for specified boundary conditions.
+! Also modified to work with idealized boundary conditions.
 
     ktf = MIN( kte, kde-1 )
 
@@ -6312,6 +6313,24 @@ END SUBROUTINE set_tend
       i_end   = ite
       j_start = jts
       j_end   = MIN(jde-1,jte)
+      IF ( config_flags%open_xs ) THEN
+      i_start = MAX(its,ids+3)
+      END IF
+      IF ( config_flags%open_ys ) THEN
+      j_start = MAX(jts,jds+3)
+      END IF
+      IF ( config_flags%open_xe ) THEN
+      i_end   = MIN(ite,ide-3)
+      END IF
+      IF ( config_flags%open_ye ) THEN
+      j_end   = MIN(jte,jde-4)
+      END IF
+      IF ( specified ) THEN
+      i_start = MAX(its,ids+3)
+      i_end   = MIN(ite,ide-3)
+      j_start = MAX(jts,jds+3)
+      j_end   = MIN(jte,jde-4)
+      END IF
       k_start = kts
       k_end   = ktf
 
@@ -6321,6 +6340,24 @@ END SUBROUTINE set_tend
       i_end   = MIN(ide-1,ite)
       j_start = jts
       j_end   = jte
+      IF ( config_flags%open_xs ) THEN
+      i_start = MAX(its,ids+3)
+      END IF
+      IF ( config_flags%open_ys ) THEN
+      j_start = MAX(jts,jds+3)
+      END IF
+      IF ( config_flags%open_xe ) THEN
+      i_end   = MIN(ite,ide-4)
+      END IF
+      IF ( config_flags%open_ye ) THEN
+      j_end   = MIN(jte,jde-3)
+      END IF
+      IF ( config_flags%open_xs .or. specified ) THEN
+      i_start = MAX(its,ids+3)
+      i_end   = MIN(ite,ide-4)
+      j_start = MAX(jts,jds+3)
+      j_end   = MIN(jte,jde-3)
+      END IF
       k_start = kts
       k_end   = ktf
 
@@ -6330,6 +6367,24 @@ END SUBROUTINE set_tend
       i_end   = MIN(ide-1,ite)
       j_start = jts
       j_end   = MIN(jde-1,jte)
+      IF ( config_flags%open_xs ) THEN
+      i_start = MAX(its,ids+3)
+      END IF
+      IF ( config_flags%open_ys ) THEN
+      j_start = MAX(jts,jds+3)
+      END IF
+      IF ( config_flags%open_xe ) THEN
+      i_end   = MIN(ite,ide-4)
+      END IF
+      IF ( config_flags%open_ye ) THEN
+      j_end   = MIN(jte,jde-4)
+      END IF
+      IF ( specified ) THEN
+      i_start = MAX(its,ids+3)
+      i_end   = MIN(ide-4,ite)
+      j_start = MAX(jts,jds+3)
+      j_end   = MIN(jde-4,jte)
+      END IF
       k_start = kts+1
       k_end   = ktf
 
@@ -6339,6 +6394,24 @@ END SUBROUTINE set_tend
       i_end   = MIN(ide-1,ite)
       j_start = jts
       j_end   = MIN(jde-1,jte)
+      IF ( config_flags%open_xs ) THEN
+      i_start = MAX(its,ids+3)
+      END IF
+      IF ( config_flags%open_ys ) THEN
+      j_start = MAX(jts,jds+3)
+      END IF
+      IF ( config_flags%open_xe ) THEN
+      i_end   = MIN(ite,ide-4)
+      END IF
+      IF ( config_flags%open_ye ) THEN
+      j_end   = MIN(jte,jde-4)
+      END IF
+      IF ( specified ) THEN
+      i_start = MAX(its,ids+3)
+      i_end   = MIN(ide-4,ite)
+      j_start = MAX(jts,jds+3)
+      j_end   = MIN(jde-4,jte)
+      END IF
       k_start = kts
       k_end   = ktf
 


### PR DESCRIPTION
YPE: bug fix
  
KEYWORDS: diff_6th_opt, restart

SOURCE: internal, reported by J. Fidel González Rouco Instituto de Geociencias (UCM-CSIC) of Spain

DESCRIPTION OF CHANGES:
When diff_6th_opt is turned on, restart fails in producing bit-for-bit results in real-data (reported) as well as idealized cases. This is due to the start and end indices too close to the domain boundaries when doing 6th order horizontal diffusions. This is a bug since this option was put in in V3.1.

LIST OF MODIFIED FILES: list of changed files:
M dyn_em/module_big_step_utilities_em.F

TESTS CONDUCTED:
No regression test yet. But tested with real-data case, quarter_ss case with periodic and open boundary conditions, and b_wave case with symmetric boundary condition in y.

RELEASE NOTE:
Fixed a restart problem with diff_6th_opt option. This was a bug since this option was added to the model in V3.1. Thanks for J. Fidel González Rouco of Spain for reporting the problem.
