### PR TITLE
Fix N^2 calculation (1.61->0.61) for LES

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -1637,7 +1637,7 @@ END SUBROUTINE cal_dampkm
       ELSE
         BN2(i,k,j) = g * ( (theta(i,k+1,j) - theta(i,k-1,j) ) /  &
                      theta(i,k,j) / tmpdz +  &
-                     1.61 * ( moist(i,k+1,j,P_QV) - moist(i,k-1,j,P_QV) ) / &
+                     0.61 * ( moist(i,k+1,j,P_QV) - moist(i,k-1,j,P_QV) ) / &
                      tmpdz -   &
                      ( tmp1(i,k+1,j) - tmp1(i,k-1,j) ) / tmpdz )
       ENDIF
@@ -1670,7 +1670,7 @@ END SUBROUTINE cal_dampkm
                     cf3 * moist(i,3,j,P_QV)
 !        BN2(i,k,j) = g * ( ( theta(i,k+1,j) - thetasfc ) /  &
 !                     theta(i,k,j) / tmpdz +  &
-!                     1.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
+!                     0.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
 !                     tmpdz -  &
 !                     ( tmp1(i,k+1,j) - tmp1sfc(i,j) ) / tmpdz  )
 !...... MARTA: change in computation of BN2 at the surface, WCS 040331
@@ -1678,7 +1678,7 @@ END SUBROUTINE cal_dampkm
         tmpdz= 1./rdzw(i,k,j) ! controlare come calcola rdzw
         BN2(i,k,j) = g * ( ( theta(i,k+1,j) - theta(i,k,j)) /  &
                      theta(i,k,j) / tmpdz +  &
-                     1.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
+                     0.61 * ( moist(i,k+1,j,P_QV) - qvsfc ) /  &
                      tmpdz -  &
                      ( tmp1(i,k+1,j) - tmp1sfc(i,j) ) / tmpdz  )
 ! end of MARTA/WCS change


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Stability N2 in LES

SOURCE: internal

DESCRIPTION OF CHANGES: 
calculate_N2 routine contains 1.61 instead of 0.61 when calculating moist version of N2. This has been since the beginning. Extremely small effect on results. Affects both use_theta_m=0 and 1.

ISSUE: no issue reported

LIST OF MODIFIED FILES: 
M       dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
No WTF. Compare use_theta_m=0 before and after (see fig of theta difference in LES case after 4 hours).

<img width="345" alt="screen shot 2018-12-17 at 9 32 13 am" src="https://user-images.githubusercontent.com/17932284/50101675-76444b00-01e0-11e9-9ccb-e680c1996ef1.png">
RELEASE NOTE: 
LES calculation of N2 slightly corrected. Very small effect.


