### PR TITLE
Fix mismatch isltyp and landmask 

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3002,7 +3002,7 @@ integer::oops1,oops2
          change_soilw = 0
          DO j = jts, MIN(jde-1,jte)
             DO i = its, MIN(ide-1,ite)
-!              IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
+               IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
                   IF ( grid%landmask(i,j) .GT. 0.5 .AND. grid%isltyp(i,j) .EQ. grid%isoilwater ) THEN
                      grid%isltyp(i,j) = 8
                      change_soilw =  change_soilw + 1
@@ -3012,7 +3012,7 @@ integer::oops1,oops2
                      change_soil =  change_soil + 1
                      iforce =  iforce + 1
                   END IF
-!              END IF
+               END IF
             END DO
          END DO
          IF ( change_soilw .GT. 0 .OR. change_soil .GT. 0 ) THEN
@@ -3023,11 +3023,9 @@ integer::oops1,oops2
          END IF
 
       END IF
-      END IF
 
       !  Split NUDAPT  Urban Parameters
 
-      IF ( any_valid_points ) THEN
       IF ( ( config_flags%sf_urban_physics == 1 ) .OR. ( config_flags%sf_urban_physics == 2 ) .OR. ( config_flags%sf_urban_physics == 3 ) ) THEN
          DO j = jts , MIN(jde-1,jte)
             DO i = its , MIN(ide-1,ite)

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -165,6 +165,7 @@ integer::oops1,oops2
       LOGICAL :: vnest !T if using vertical nesting with vet_refine_method=2, otherwise F
 
       INTEGER :: j_save
+      INTEGER :: change_soil, change_soilw, iforce
 
       LOGICAL :: wif_upside_down = .FALSE.
       
@@ -2994,10 +2995,39 @@ integer::oops1,oops2
             CALL wrf_error_fatal ( a_message )
          END IF
 
+         !  Need to match isltyp to landmask
+
+         iforce = 0
+         change_soil = 0
+         change_soilw = 0
+         DO j = jts, MIN(jde-1,jte)
+            DO i = its, MIN(ide-1,ite)
+!              IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
+                  IF ( grid%landmask(i,j) .GT. 0.5 .AND. grid%isltyp(i,j) .EQ. grid%isoilwater ) THEN
+                     grid%isltyp(i,j) = 8
+                     change_soilw =  change_soilw + 1
+                     iforce =  iforce + 1
+                  ELSE IF ( grid%landmask(i,j) .LT. 0.5 .AND. grid%isltyp(i,j) .NE. grid%isoilwater ) THEN
+                     grid%isltyp(i,j) = grid%isoilwater
+                     change_soil =  change_soil + 1
+                     iforce =  iforce + 1
+                  END IF
+!              END IF
+            END DO
+         END DO
+         IF ( change_soilw .GT. 0 .OR. change_soil .GT. 0 ) THEN
+            WRITE(a_message,FMT='(A,I4,A,I6)' ) &
+                  'forcing artificial silty clay loam at ',iforce,' points, out of ',&
+                  (MIN(ide-1,ite)-its+1)*(MIN(jde-1,jte)-jts+1)
+                  CALL wrf_debug(0,a_message)
+         END IF
+
+      END IF
       END IF
 
       !  Split NUDAPT  Urban Parameters
 
+      IF ( any_valid_points ) THEN
       IF ( ( config_flags%sf_urban_physics == 1 ) .OR. ( config_flags%sf_urban_physics == 2 ) .OR. ( config_flags%sf_urban_physics == 3 ) ) THEN
          DO j = jts , MIN(jde-1,jte)
             DO i = its , MIN(ide-1,ite)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: surface_input_source, isltyp, landmask

SOURCE: internal (reported by many users, including Priscilla Mooney from Norway)

DESCRIPTION OF CHANGES: 
To accommodate users who would like to change _LU_INDEX_ after running geogrid program, we changed namelist surface_input_source from default value of 1 (recomputing dominant categories in real) to 3 (using dominant categories from geogrid) in v3.8. 

Unfortunately, we neglected to consider in the v3.8 fix that when dominant categories for land and soil are recomputed in real, the real program also does mismatch checks: ensuring that the lower resolution _ISLTYP_ matches with _LANDMASK_ data. This check in real has two two effects:
1. the actual _ISLTYP_, _IVGTYP_, and _XLAND_ can be different from that from surface_input_source = 1 (a check later in real program effectively matched _IVGTYP_ based on _ISLTYP_); 
2. for certain cases, the real program would stop due to un-matched _ISLTYP_ and P_. 

This PR fixes the problem of this missing consistency check in the real program when surface_input_source = 3. The _ISLTYP_, _IVGTYP_, and _XLAND_ are now identical to those coming from real after setting surface_input_source = 1. 

Below, the right image shows the wrong _XLAND_ field from the wrong code, and left image shows the correct _XLAND_ field after the fix. These images are created on a 1 km grid.

![before](https://user-images.githubusercontent.com/12705680/50613028-6fccf900-0e99-11e9-9256-ce9c6ab67004.png)

LIST OF MODIFIED FILES: 
M   dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. Ran real before and after the change and results are correct. 
2. Ran real for a case that failed before and now it succeeds (thanks to Kelly).

RELEASE NOTE: 
In V3.8, we changed default surface_input_source option value from 1 to 3, which uses the dominant categories computed in geogrid. But we neglected that when dominant categories for land and soil are recomputed in real, it also does mismatch checks, making sure the lower resolution isltyp matches with landmask data. This has two two effects: one is the actual isltyp, ivgtyp and xland can be different from that from surface_input_source = 1 (a check later in real program effectively matched ivgtyp based on isltyp); and the other effect is that for certain cases, the real program would stop due to un-matched isltyp and ivgtyp. This change fixes this problem, and isltyp, ivgtyp, and xland are now identical to those coming from surface_input_source = 1.

 
