### PR TITLE
Capability to prescribe building fraction for air conditioning in BEM urban model

### DIFF
--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -289,6 +289,8 @@ MODULE module_sf_bep_bem
       real z_u(nz_um)         ! Height of the urban grid levels
 !FS
       real cop_u(nurbm)
+      real bldac_frc_u(nurbm)
+      real cooled_frc_u(nurbm)
       real pwin_u(nurbm)
       real beta_u(nurbm)
       integer sw_cond_u(nurbm)
@@ -389,6 +391,7 @@ MODULE module_sf_bep_bem
            albg_u,albw_u,albr_u,emg_u,emw_u,emr_u,                       &
            z0g_u,z0r_u, nd_u,strd_u,drst_u,ws_u,bs_u,h_b,d_b,ss_u,pb_u,  &
            nz_u,z_u,albwin_u,emwind_u,cop_u,pwin_u,beta_u,sw_cond_u,     &
+           bldac_frc_u,cooled_frc_u,                                     &
            time_on_u,time_off_u,targtemp_u,gaptemp_u,targhum_u,gaphum_u, &
            perflo_u,hsesf_u,hsequip 
 
@@ -593,6 +596,7 @@ MODULE module_sf_bep_bem
                 twini_u,trini_u,tgini_u,albg_u,albw_u,albr_u,albwin_u,emg_u,emw_u,&
                 emr_u,emwind_u,z0g_u,z0r_u,nd_u,strd_u,drst_u,ws_u,bs_u,h_b,d_b,  &
                 cop_u,pwin_u,beta_u,sw_cond_u,time_on_u,time_off_u,targtemp_u,    &
+                bldac_frc_u,cooled_frc_u,                                         &
                 gaptemp_u,targhum_u,gaphum_u,perflo_u,hsesf_u,hsequip)
 
 !Initialisation of the urban parameters and calculation of the view factor
@@ -897,6 +901,7 @@ MODULE module_sf_bep_bem
          meso_urb=(1./4.)*FRC_URB2D(ix,iy)/((bs_urb(1,iurb)+ws_urb(1,iurb))*bs_urb(2,iurb))+ &
                   (1./4.)*FRC_URB2D(ix,iy)/((bs_urb(2,iurb)+ws_urb(2,iurb))*bs_urb(1,iurb))
 
+         meso_urb= meso_urb*bldac_frc_u(iurb)*cooled_frc_u(iurb)   !! adjust for fraction AC
          
          ibui=0
          nlev=0
@@ -4032,6 +4037,7 @@ MODULE module_sf_bep_bem
         twini_u,trini_u,tgini_u,albg_u,albw_u,albr_u,albwin_u,emg_u,emw_u,&
         emr_u,emwind_u,z0g_u,z0r_u,nd_u,strd_u,drst_u,ws_u,bs_u,h_b,d_b,  &
         cop_u,pwin_u,beta_u,sw_cond_u,time_on_u,time_off_u,targtemp_u,    &
+        bldac_frc_u,cooled_frc_u,                                         &
         gaptemp_u, targhum_u,gaphum_u,perflo_u,hsesf_u,hsequip)
 
 ! initialization routine, where the variables from the table are read
@@ -4077,6 +4083,8 @@ MODULE module_sf_bep_bem
       integer i,iu
       integer nurb ! number of urban classes used
       real, intent(out) :: cop_u(nurbm)
+      real, intent(out) :: bldac_frc_u(nurbm)
+      real, intent(out) :: cooled_frc_u(nurbm)
       real, intent(out) :: pwin_u(nurbm)
       real, intent(out) :: beta_u(nurbm)
       integer, intent(out) :: sw_cond_u(nurbm)
@@ -4124,6 +4132,8 @@ MODULE module_sf_bep_bem
        nd_u=NUMDIR_TBL
 !FS
        cop_u = cop_tbl
+       bldac_frc_u = bldac_frc_tbl
+       cooled_frc_u = cooled_frc_tbl
        pwin_u = pwin_tbl
        beta_u = beta_tbl
        sw_cond_u = sw_cond_tbl

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -26,6 +26,8 @@ MODULE module_sf_urban
    REAL, ALLOCATABLE, DIMENSION(:) :: FRC_URB_TBL
 
    REAL, ALLOCATABLE, DIMENSION(:) :: COP_TBL
+   REAL, ALLOCATABLE, DIMENSION(:) :: BLDAC_FRC_TBL
+   REAL, ALLOCATABLE, DIMENSION(:) :: COOLED_FRC_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: PWIN_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: BETA_TBL
    INTEGER, ALLOCATABLE, DIMENSION(:) :: SW_COND_TBL
@@ -2101,6 +2103,10 @@ ENDIF
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating HPERCENT_BIN_TBL in urban_param_init')
             ALLOCATE( COP_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating COP_TBL in urban_param_init')
+            ALLOCATE( BLDAC_FRC_TBL(ICATE), stat=allocate_status )
+            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating BLDAC_FRC_TBL in urban_param_init')
+            ALLOCATE( COOLED_FRC_TBL(ICATE), stat=allocate_status )
+            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating COOLED_FRC_TBL in urban_param_init')
             ALLOCATE( PWIN_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating PWIN_TBL in urban_param_init')
             ALLOCATE( BETA_TBL(ICATE), stat=allocate_status )
@@ -2287,6 +2293,10 @@ ENDIF
          read(string(indx+1:),*) Z0R_tbl(1:icate)
       else if ( name == "COP") then
          read(string(indx+1:),*) cop_tbl(1:icate)
+      else if ( name == "BLDAC_FRC") then
+         read(string(indx+1:),*) bldac_frc_tbl(1:icate)
+      else if ( name == "COOLED_FRC") then
+         read(string(indx+1:),*) cooled_frc_tbl(1:icate)
       else if ( name == "PWIN") then
          read(string(indx+1:),*) pwin_tbl(1:icate)
       else if ( name == "BETA") then

--- a/run/URBPARM.TBL
+++ b/run/URBPARM.TBL
@@ -371,6 +371,19 @@ TGLEND: 293.00, 293.00, 293.00
 COP: 3.5, 3.5, 3.5
 
 #
+# BLDAC_FRC: fraction of buildings installed with A/C systems [ - ] 
+#      (sf_urban_physics=3)
+#
+
+BLDAC_FRC: 1.0, 1.0, 1.0
+
+#
+# COOLED_FRC: fraction of cooled floor area in buildings [ - ]
+#      (sf_urban_physics=3)
+#
+COOLED_FRC: 1.0, 1.0, 1.0
+
+#
 # PWIN:  Coverage area fraction of windows in the walls of the building [ - ]
 #      (sf_urban_physics=3)
 #


### PR DESCRIPTION
Capability to prescribe buidling fraction for air conditioning in BEM urban model

TYPE: enhancement

KEYWORDS: urban, BEM

SOURCE: Xiaoyu Xu (IUM), Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

Two urban parameter tables options are added to prescribe the fraction of building (BLDAC_FRC) and fraction of floors in a building (COOLED_FRC) that have air conditioning. 

LIST OF MODIFIED FILES: 

M       phys/module_sf_urban.F
M       phys/module_sf_bep_bem.F
M       run/URBPARM.TBL

TESTS CONDUCTED:
1. 24-hour winter CONUS simulation produces no difference; with fractions set to 1, summer simulation produces machine precision differences 5 hours into simulation
2. Small, GNU-only regtest OK on cheyenne. This used serial / openmp / MPI, the full suite of builds, a single test case per build, and bit-for-bit comparisons where appropriate.

RELEASE NOTE:

Currently, the BEM model applies air conditioning to all floors of all buildings on a model grid. Two additional urban parameter tables options are added to prescribe the fraction of building (BLDAC_FRC) and fraction of floors in a building (COOLED_FRC) that have air conditioning. This reduced the air conditioning energy load and compares better with observations. 
