### PR TITLE
make refl_10cm available if nwp_diagnostics is on

### DIFF
--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -299,6 +299,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
    if ( Is_alarm_tstep(grid%domain_clock, grid%alarms(HISTORY_ALARM)) ) then
       diag_flag = .true.
    endif
+   IF (config_flags%nwp_diagnostics == 1) diag_flag = .true.
 
    grid%itimestep = grid%itimestep + 1
    grid%dtbc = grid%dtbc + grid%dt

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2176,7 +2176,14 @@
          CALL wrf_debug ( 1, wrf_err_message )
 
       END IF
-      
+
+!-----------------------------------------------------------------------
+! If a user sets nwp_diagnostics = 1, then radar reflectivity computation
+! needs to happen
+!-----------------------------------------------------------------------
+
+      IF ( model_config_rec % nwp_diagnostics == 1 ) model_config_rec % do_radar_ref = 1     
+
 !-----------------------------------------------------------------------
 ! If a user requested to compute the radar reflectivity .OR. if this is
 ! one of the schemes that ALWAYS computes the radar reflectivity, then


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: nwp_diagnostics, do_radar_ref

SOURCE: internal

DESCRIPTION OF CHANGES: 
When we introduced 'do_radar_ref' namelist to control whether radar reflectivity will be computed by a microphysics,  we decided to do this calculation only at model history output time. But this broke one diagnostic output when nwp_diagnostics is turned on. The diagnostic output is the maximum lowest level reflectivity in a time interval, which requires radar reflectivity to be computed at every model time step. This PR fixes it. It turns on do_radar_ref and makes radar reflectivity calculation at every model time step is nwp_diagnostics is on. 

LIST OF MODIFIED FILES: 
M   dyn_em/solve_em.F
M   share/module_check_a_mundo.F

TESTS CONDUCTED: 
Tested with various switches on and off to make sure the output is as intended. No reg test yet.

RELEASE NOTE: 
When nwp_diagnostics = 1, the max radar reflectivity output is not the maximum value between history output, because it is only computed once at the history output time. This change fixes it and will also turn on radar reflectivity calculation (do_radar_ref) if it isn't turned on.
