### PR TITLE
Address MSKF cu_physics prob with convective time scale

### DIFF
--- a/phys/module_cu_mskf.F
+++ b/phys/module_cu_mskf.F
@@ -5564,6 +5564,7 @@ updraft:    DO NK=K,KL-1
  
          NIC=NINT(TIMEC/DT)
          TIMEC=FLOAT(NIC)*DT
+         TIMEC=AMIN1(TIMEC,86400)  !JRJ Ramboll: cap convective time scale at 24 hrs
 !     
 !...COMPUTE WIND SHEAR AND PRECIPITATION EFFICIENCY.
 !     


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MSKF, multi-scale, kain-fritsch, convective, time-scale, 24hrs, cap

SOURCE: Jeremiah Johnson and Bart Brashers, _Ramboll_

DESCRIPTION OF CHANGES: Due to intermittent crashes (error: QG, QG(NK).LT.0) users were experiencing in 5.5 day runs over NW Australia, it was proposed that the convective time scale (set at 3.5 days) was unrealistic and that it should be shortened to 24 hours. 

LIST OF MODIFIED FILES: 
M    phys/module_cu_mskf.F

TESTS CONDUCTED: confirmed compiles and runs with no problems, user confirmed that out of a year of 5.5 overlapping day runs, none crashed (about 50% crashed prior to the change). 

RELEASE NOTE: Shortened the convective time-scale to 24 hours (previously 3.5 days) in the multi-scale KF scheme. 