### PR TITLE
 HWRF 2018 operational model updates - part 2

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2163,6 +2163,7 @@ rconfig   real    GSMDT                   namelist,physics	max_domains    0     
 rconfig   integer ISFFLX                  namelist,physics 	1             1       irh    "ISFFLX"                        ""      ""
 rconfig   integer IFSNOW                  namelist,physics	1             1       irh    "IFSNOW"                        ""      ""
 rconfig   integer ICLOUD                  namelist,physics	1             1       irh    "ICLOUD"                        ""      ""
+rconfig   integer cldovrlp                namelist,physics      1             2       irh    "cldovrlp"                      "1=random, 2=maximum-random, 3=maximum, 4=exponential, 5=exponential-random"      ""
 rconfig   integer ideal_xland             namelist,physics	1             1        rh    "IDEAL_XLAND"  "land=1(def), water=2, for ideal cases with no land-use"      ""
 rconfig   real    swrad_scat              namelist,physics	1             1       irh    "SWRAD_SCAT" "SCATTERING FACTOR IN SWRAD"      ""
 rconfig   integer surface_input_source    namelist,physics	1             3       irh    "surface_input_source"          "1=static (fractional), 2=time dependent (dominant), 3=dominant cateogry from metgrid"      ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1442,6 +1442,7 @@ rconfig   integer ISFFLX                  namelist,physics 	1             1     
 rconfig   integer ideal_xland             namelist,physics      1             1        rh    "IDEAL_XLAND"  "land=1(def), water=2, for ideal cases with no land-use"      ""
 rconfig   integer IFSNOW                  namelist,physics	1             1       irh    "IFSNOW"                        ""      ""
 rconfig   integer ICLOUD                  namelist,physics	1             1       irh    "ICLOUD"                        ""      ""
+rconfig   integer cldovrlp                namelist,physics      1             2       irh    "cldovrlp"                      "1=random, 2=maximum-random, 3=maximum, 4=exponential, 5=exponential-random"      ""
 rconfig   real    swrad_scat              namelist,physics      1             1       irh    "SWRAD_SCAT" "SCATTERING FACTOR IN SWRAD"      ""
 rconfig   integer surface_input_source    namelist,physics	1             1       irh    "surface_input_source"          "1=static (fractional), 2=time dependent (dominant), 3=hybrid (not yet implemented)"      ""
 rconfig   integer num_soil_layers         namelist,physics	1             5       irh    "num_soil_layers"               ""      ""

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -335,6 +335,7 @@ BENCH_START(rad_driver_tim)
      &        , CLDFRA_DP=grid%cldfra_dp                                  & ! ckay for subgrid cloud
      &        , CLDFRA_SH=grid%cldfra_sh                                  &
      &        , icloud_bl=config_flags%icloud_bl                          & !JOE: subgrid BL clouds
+     &        , cldovrlp=config_flags%cldovrlp                            & ! J. Henderson AER: cldovrlp namelist value
      &        , qc_bl=grid%qc_bl,cldfra_bl=grid%cldfra_bl                 & !JOE: subgrid bl clouds
      &        , re_cloud=grid%re_cloud, re_ice=grid%re_ice, re_snow=grid%re_snow & ! G. Thompson
      &        , has_reqc=grid%has_reqc, has_reqi=grid%has_reqi, has_reqs=grid%has_reqs & ! G. Thompson

--- a/dyn_nmm/module_PHYSICS_CALLS.F
+++ b/dyn_nmm/module_PHYSICS_CALLS.F
@@ -449,6 +449,7 @@
      &                 ,SW_PHYSICS=CONFIG_FLAGS%RA_SW_PHYSICS           &
      &                 ,RADT=RADT,RA_CALL_OFFSET=GRID%RA_CALL_OFFSET    &
      &                 ,STEPRA=NRAD,ICLOUD=config_flags%ICLOUD          &
+     &                 ,cldovrlp=config_flags%cldovrlp                  & ! J. Henderson AER: cldovrlp namelist value
      &                 ,WARM_RAIN=WARM_RAIN                             &
      &                 ,SWDOWNC=TOTSWDNC,CLDFRA=CLFR                    &
      &                 ,SWUPT=SWUPT                                     &

--- a/phys/module_cu_mskf.F
+++ b/phys/module_cu_mskf.F
@@ -5564,7 +5564,7 @@ updraft:    DO NK=K,KL-1
  
          NIC=NINT(TIMEC/DT)
          TIMEC=FLOAT(NIC)*DT
-         TIMEC=AMIN1(TIMEC,86400)  !JRJ Ramboll: cap convective time scale at 24 hrs
+         TIMEC=AMIN1(TIMEC,86400.)  !JRJ Ramboll: cap convective time scale at 24 hrs
 !     
 !...COMPUTE WIND SHEAR AND PRECIPITATION EFFICIENCY.
 !     

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -2086,7 +2086,7 @@ contains
 ! Public subroutines
 !------------------------------------------------------------------
 
-      subroutine mcica_subcol_lw(iplon, ncol, nlay, icld, permuteseed, irng, play, &
+      subroutine mcica_subcol_lw(iplon, ncol, nlay, icld, permuteseed, irng, play, hgt, &
                        cldfrac, ciwp, clwp, cswp, rei, rel, res, tauc, cldfmcl, &
                        ciwpmcl, clwpmcl, cswpmcl, reicmcl, relqmcl, resnmcl, taucmcl)
 
@@ -2106,6 +2106,9 @@ contains
 
 ! Atmosphere
       real(kind=rb), intent(in) :: play(:,:)          ! layer pressures (mb) 
+                                                      !    Dimensions: (ncol,nlay)
+
+      real(kind=rb), intent(in) :: hgt(:,:)           ! layer height (m)
                                                       !    Dimensions: (ncol,nlay)
 
 ! Atmosphere/clouds - cldprop
@@ -2167,7 +2170,7 @@ contains
 
 ! Return if clear sky; or stop if icld out of range
       if (icld.eq.0) return
-      if (icld.lt.0.or.icld.gt.3) then 
+      if (icld.lt.0.or.icld.gt.5) then 
          stop 'MCICA_SUBCOL: INVALID ICLD'
       endif 
 
@@ -2198,14 +2201,14 @@ contains
 !      enddo
 
 !  Generate the stochastic subcolumns of cloud optical properties for the longwave;
-      call generate_stochastic_clouds (ncol, nlay, nsubclw, icld, irng, pmid, cldfrac, clwp, ciwp, cswp, tauc, &
+      call generate_stochastic_clouds (ncol, nlay, nsubclw, icld, irng, pmid, hgt, cldfrac, clwp, ciwp, cswp, tauc, &
                                cldfmcl, clwpmcl, ciwpmcl, cswpmcl, taucmcl, permuteseed)
 
       end subroutine mcica_subcol_lw
 
 
 !-------------------------------------------------------------------------------------------------
-      subroutine generate_stochastic_clouds(ncol, nlay, nsubcol, icld, irng, pmid, cld, clwp, ciwp, cswp, tauc, &
+      subroutine generate_stochastic_clouds(ncol, nlay, nsubcol, icld, irng, pmid, hgt, cld, clwp, ciwp, cswp, tauc, &
                                    cld_stoch, clwp_stoch, ciwp_stoch, cswp_stoch, tauc_stoch, changeSeed) 
 !-------------------------------------------------------------------------------------------------
 
@@ -2215,10 +2218,13 @@ contains
   ! 
   ! Original code: Based on Raisanen et al., QJRMS, 2004.
   ! 
-  ! Modifications: Generalized for use with RRTMG and added Mersenne Twister as the default
+  ! Modifications:
+  !   1) Generalized for use with RRTMG and added Mersenne Twister as the default
   !   random number generator, which can be changed to the optional kissvec random number generator
   !   with flag 'irng'. Some extra functionality has been commented or removed.  
   !   Michael J. Iacono, AER, Inc., February 2007
+  !   2) Activated exponential and exponential/random cloud overlap method
+  !   Michael J. Iacono, AER, November 2017
   !
   ! Given a profile of cloud fraction, cloud water and cloud ice, we produce a set of subcolumns.
   ! Each layer within each subcolumn is homogeneous, with cloud fraction equal to zero or one 
@@ -2227,12 +2233,11 @@ contains
   ! and obeys an overlap assumption in the vertical.   
   ! 
   ! Overlap assumption:
-  !  The cloud are consistent with 4 overlap assumptions: random, maximum, maximum-random and exponential. 
-  !  The default option is maximum-random (option 3)
-  !  The options are: 1=random overlap, 2=max/random, 3=maximum overlap, 4=exponential overlap
-  !  This is set with the variable "overlap" 
-  !mji - Exponential overlap option (overlap=4) has been deactivated in this version
-  !  The exponential overlap uses also a length scale, Zo. (real,    parameter  :: Zo = 2500. ) 
+  !  The cloud are consistent with 5 overlap assumptions: random, maximum, maximum-random, exponential and exponential random.
+  !  The default option is maximum-random (option 2)
+  !  The options are: 1=random overlap, 2=max/random, 3=maximum overlap, 4=exponential overlap, 5=exp/random
+  !  This is set with the variable "overlap"
+  !  The exponential overlap uses also a length scale, Zo. (real,    parameter  :: Zo = 2500. )
   ! 
   ! Seed:
   !  If the stochastic cloud generator is called several times during the same timestep, 
@@ -2284,6 +2289,8 @@ contains
 ! Column state (cloud fraction, cloud water, cloud ice) + variables needed to read physics state 
       real(kind=rb), intent(in) :: pmid(:,:)          ! layer pressure (Pa)
                                                       !    Dimensions: (ncol,nlay)
+      real(kind=rb), intent(in) :: hgt(:,:)           ! layer height (m)
+                                                      !    Dimensions: (ncol,nlay)
       real(kind=rb), intent(in) :: cld(:,:)           ! cloud fraction 
                                                       !    Dimensions: (ncol,nlay)
       real(kind=rb), intent(in) :: clwp(:,:)          ! in-cloud liquid water path
@@ -2330,11 +2337,11 @@ contains
 !      real(kind=rb) :: mean_asmc_stoch(ncol, nlay)   ! cloud asymmetry parameter
 
 ! Set overlap
-      integer(kind=im) :: overlap                     ! 1 = random overlap, 2 = maximum/random,
-                                                      ! 3 = maximum overlap, 
-!      real(kind=rb), parameter  :: Zo = 2500._rb        ! length scale (m) 
-!      real(kind=rb) :: zm(ncol,nlay)                 ! Height of midpoints (above surface)
-!      real(kind=rb), dimension(nlay) :: alpha=0.0_rb    ! overlap parameter  
+      integer(kind=im) :: overlap                     ! 1 = random overlap, 2 = maximum-random,
+                                                      ! 3 = maximum overlap, 4 = exponential,
+                                                      ! 5 = exponential-random
+      real(kind=rb), parameter  :: Zo = 2500._rb      ! length scale (m) 
+      real(kind=rb), dimension(ncol,nlay) :: alpha    ! overlap parameter
 
 ! Constants (min value for cloud fraction and cloud water and ice)
       real(kind=rb), parameter :: cldmin = 1.0e-20_rb ! min cloud fraction
@@ -2481,39 +2488,56 @@ contains
              enddo
          endif
 
-!    case(4) - inactive
-!       ! Exponential overlap: weighting between maximum and random overlap increases with the distance. 
-!       ! The random numbers for exponential overlap verify:
-!       ! j=1   RAN(j)=RND1
-!       ! j>1   if RND1 < alpha(j,j-1) => RAN(j) = RAN(j-1)
-!       !                                 RAN(j) = RND2
-!       ! alpha is obtained from the equation
-!       ! alpha = exp(- (Zi-Zj-1)/Zo) where Zo is a characteristic length scale    
+        case(4)
+            ! Exponential overlap: weighting between maximum and random overlap increases with the distance.
+            ! The random numbers for exponential overlap verify:
+            ! j=1   RAN(j)=RND1
+            ! j>1   if RND1 < alpha(j,j-1) => RAN(j) = RAN(j-1)
+            !                                 RAN(j) = RND2
+            ! alpha is obtained from the equation
+            ! alpha = exp(-(Z(j)-Z(j-1))/Zo) where Zo is a characteristic length scale
 
+            ! compute alpha
+            do i = 1, ncol
+               alpha(i, 1) = 0._rb
+               do ilev = 2,nlay
+                  alpha(i, ilev) = exp( -( hgt (i, ilev) -  hgt (i, ilev-1)) / Zo)
+               enddo
+            enddo
 
-!       ! compute alpha
-!       zm    = state%zm     
-!       alpha(:, 1) = 0.
-!       do ilev = 2,nlay
-!          alpha(:, ilev) = exp( -( zm (:, ilev-1) -  zm (:, ilev)) / Zo)
-!       end do
-       
-!       ! generate 2 streams of random numbers
-!       do isubcol = 1,nsubcol
-!          do ilev = 1,nlay
-!             call kissvec(seed1, seed2, seed3, seed4, rand_num)
-!             CDF(isubcol, :, ilev) = rand_num
-!             call kissvec(seed1, seed2, seed3, seed4, rand_num)
-!             CDF2(isubcol, :, ilev) = rand_num
-!          end do
-!       end do
+            ! generate 2 streams of random numbers
+            if (irng.eq.0) then
+               do isubcol = 1,nsubcol
+                  do ilev = 1,nlay
+                     call kissvec(seed1, seed2, seed3, seed4, rand_num)
+                     CDF(isubcol, :, ilev) = rand_num
+                     call kissvec(seed1, seed2, seed3, seed4, rand_num)
+                     CDF2(isubcol, :, ilev) = rand_num
+                  enddo
+               enddo
+            elseif (irng.eq.1) then
+               do isubcol = 1, nsubcol
+                  do i = 1, ncol
+                     do ilev = 1, nlay
+                        rand_num_mt = getRandomReal(randomNumbers)
+                        CDF(isubcol,i,ilev) = rand_num_mt
+                        rand_num_mt = getRandomReal(randomNumbers)
+                        CDF2(isubcol,i,ilev) = rand_num_mt
+                     enddo
+                  enddo
+               enddo
+            endif
 
-!       ! generate random numbers
-!       do ilev = 2,nlay
-!          where (CDF2(:, :, ilev) < spread(alpha (:,ilev), dim=1, nCopies=nsubcol) )
-!             CDF(:,:,ilev) = CDF(:,:,ilev-1) 
-!          end where
-!       end do
+            ! generate random numbers
+            do ilev = 2,nlay
+               where (CDF2(:, :, ilev) < spread(alpha (:,ilev), dim=1, nCopies=nsubcol) )
+                  CDF(:,:,ilev) = CDF(:,:,ilev-1)
+               end where
+            end do
+
+         case(5)
+            ! Exponential-random overlap:
+            call wrf_error_fatal("Cloud Overlap case 5: ER has not yet been implemented. Stopping...") 
 
       end select
 
@@ -10687,6 +10711,8 @@ contains
                                                       !    1: Random
                                                       !    2: Maximum/random
                                                       !    3: Maximum
+                                                      !    4: Exponential
+                                                      !    5: Exponential/random
       real(kind=rb), intent(in) :: play(:,:)          ! Layer pressures (hPa, mb)
                                                       !    Dimensions: (ncol,nlay)
       real(kind=rb), intent(in) :: plev(:,:)          ! Interface pressures (hPa, mb)
@@ -10927,7 +10953,8 @@ contains
 ! icld = 1, with clouds using random cloud overlap
 ! icld = 2, with clouds using maximum/random cloud overlap
 ! icld = 3, with clouds using maximum cloud overlap (McICA only)
-      if (icld.lt.0.or.icld.gt.3) icld = 2
+! icld = 4, with clouds using exponential cloud overlap (McICA only)
+! icld = 5, with clouds using exponential/random cloud overlap (McICA only)
 
 ! Set iaer to select aerosol option
 ! iaer = 0, no aerosols
@@ -11461,6 +11488,7 @@ CONTAINS
                        p8w, p3d, pi3d,                            &
                        dz8w, tsk, t3d, t8w, rho3d, r, g,          &
                        icloud, warm_rain, cldfra3d,               &
+                       cldovrlp,                                  & 
                        lradius,iradius,                           & 
                        is_cammgmp_used,                           & 
                        f_ice_phy, f_rain_phy,                     &
@@ -11634,6 +11662,7 @@ CONTAINS
     integer ::                                              ncol, &
                                                             nlay, &
                                                             icld, &
+                                                        cldovrlp, &
                                                          inflglw, &
                                                         iceflglw, &
                                                         liqflglw
@@ -11653,6 +11682,10 @@ CONTAINS
                                                         cfc22vmr, &
                                                          ccl4vmr
     real, dimension( kts:nlayers )  ::                     o3mmr
+! Add height of each layer for exponential-random cloud overlap
+! This will be derived below from the dz in each layer
+    real, dimension( 1, kts:nlayers )  ::                   hgt
+    real ::                                               dzsum
 ! For old cloud property specification for rrtm_lw
     real, dimension( kts:kte )  ::                          clwp, &
                                                             ciwp, &
@@ -12046,6 +12079,8 @@ CONTAINS
 ! Steven Cavallo, December 2010
           nlay = nlayers ! Keep these indices the same
 
+! Select cloud overlap assumption (1 = random, 2 = maximum-random, 3 = maximum, 4 = exponential, 5 = exponential-random
+         icld=cldovrlp ! J. Henderson AER assign namelist variable cldovrlp to existing icld
 
 ! Select cloud liquid and ice optics parameterization options
 ! For passing in cloud optical properties directly:
@@ -12054,7 +12089,6 @@ CONTAINS
 !         iceflglw = 0
 !         liqflglw = 0
 ! For passing in cloud physical properties; cloud optics parameterized in RRTMG:
-         icld = 2
          inflglw = 2
          iceflglw = 3
          liqflglw = 1
@@ -12168,6 +12202,15 @@ CONTAINS
             ccl4vmr(ncol,k) = ccl4
          enddo
 
+! Derive height of each layer mid-point from layer thickness.
+! Needed for exponential (icld=4) and exponential-random overlap (icld=5) options only.
+         dzsum = 0.0
+         do k = kts, kte
+            dz = dz1d(k)
+            hgt(ncol,k) = dzsum + 0.5*dz
+            dzsum = dzsum + dz
+         enddo
+
 ! This section is replaced with a new method to deal with model top
          if ( 1 == 0 ) then
 
@@ -12204,6 +12247,11 @@ CONTAINS
        do L=kte+1,nlayers,1
           plev(ncol,L+1) = plev(ncol,L) - deltap
           play(ncol,L) = 0.5*(plev(ncol,L) + plev(ncol,L+1))
+! Fill in height array above model top to top of atmosphere using
+! dz from model top layer for completeness, though this information is not
+! likely to be used by the exponential-random cloud overlap method.
+          hgt(ncol,L) = dzsum + 0.5*dz
+          dzsum = dzsum + dz
        enddo          
        ! Add zero as top level.  This gets the temperature max at the
        ! stratopause, reducing the downward flux errors in the top 
@@ -12552,7 +12600,7 @@ CONTAINS
          permuteseed = 150
 
 ! Sub-column generator for McICA
-         call mcica_subcol_lw(iplon, ncol, nlay, icld, permuteseed, irng, play, &
+         call mcica_subcol_lw(iplon, ncol, nlay, icld, permuteseed, irng, play, hgt, &
                        cldfrac, ciwpth, clwpth, cswpth, rei, rel, res, taucld, cldfmcl, &
                        ciwpmcl, clwpmcl, cswpmcl, reicmcl, relqmcl, resnmcl, taucmcl)
 

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -1389,7 +1389,8 @@
 ! Public subroutines
 !------------------------------------------------------------------
 
-      subroutine mcica_subcol_sw(iplon, ncol, nlay, icld, permuteseed, irng, play, &
+! mji - Add height needed for exponential-ranom cloud overlap method (icld=4)
+      subroutine mcica_subcol_sw(iplon, ncol, nlay, icld, permuteseed, irng, play, hgt, &
                        cldfrac, ciwp, clwp, cswp, rei, rel, res, tauc, ssac, asmc, fsfc, &
                        cldfmcl, ciwpmcl, clwpmcl, cswpmcl, reicmcl, relqmcl, resnmcl, &
                        taucmcl, ssacmcl, asmcmcl, fsfcmcl)
@@ -1411,7 +1412,9 @@
 ! Atmosphere
       real(kind=rb), intent(in) :: play(:,:)          ! layer pressures (mb) 
                                                       !    Dimensions: (ncol,nlay)
-
+! mji - Add height
+      real(kind=rb), intent(in) :: hgt(:,:)           ! layer height (m)
+                                                      !    Dimensions: (ncol,nlay)
 ! Atmosphere/clouds - cldprop
       real(kind=rb), intent(in) :: cldfrac(:,:)       ! layer cloud fraction
                                                       !    Dimensions: (ncol,nlay)
@@ -1473,11 +1476,8 @@
 !      real(kind=rb) :: ql(ncol,nlay)                 ! liq water (specific humidity)
 
 
-! Return if clear sky; or stop if icld out of range
+! Return if clear sky
       if (icld.eq.0) return
-      if (icld.lt.0.or.icld.gt.3) then 
-         stop 'MCICA_SUBCOL: INVALID ICLD'
-      endif 
 
 ! NOTE: For GCM mode, permuteseed must be offset between LW and SW by at least number of subcolumns
 
@@ -1506,7 +1506,7 @@
 !      enddo
 
 !  Generate the stochastic subcolumns of cloud optical properties for the shortwave;
-      call generate_stochastic_clouds_sw (ncol, nlay, nsubcsw, icld, irng, pmid, cldfrac, clwp, ciwp, cswp, &
+      call generate_stochastic_clouds_sw (ncol, nlay, nsubcsw, icld, irng, pmid, hgt, cldfrac, clwp, ciwp, cswp, &
                                tauc, ssac, asmc, fsfc, cldfmcl, clwpmcl, ciwpmcl, cswpmcl, &
                                taucmcl, ssacmcl, asmcmcl, fsfcmcl, permuteseed)
 
@@ -1514,7 +1514,7 @@
 
 
 !-------------------------------------------------------------------------------------------------
-      subroutine generate_stochastic_clouds_sw(ncol, nlay, nsubcol, icld, irng, pmid, cld, clwp, ciwp, cswp, &
+      subroutine generate_stochastic_clouds_sw(ncol, nlay, nsubcol, icld, irng, pmid, hgt, cld, clwp, ciwp, cswp, &
                                tauc, ssac, asmc, fsfc, cld_stoch, clwp_stoch, ciwp_stoch, cswp_stoch,        &
                                tauc_stoch, ssac_stoch, asmc_stoch, fsfc_stoch, changeSeed) 
 !-------------------------------------------------------------------------------------------------
@@ -1594,6 +1594,8 @@
 ! Column state (cloud fraction, cloud water, cloud ice) + variables needed to read physics state 
       real(kind=rb), intent(in) :: pmid(:,:)          ! layer pressure (Pa)
                                                       !    Dimensions: (ncol,nlay)
+      real(kind=rb), intent(in) :: hgt(:,:)           ! layer height (m)
+                                                      !    Dimensions: (ncol,nlay)
       real(kind=rb), intent(in) :: cld(:,:)           ! cloud fraction 
                                                       !    Dimensions: (ncol,nlay)
       real(kind=rb), intent(in) :: clwp(:,:)          ! in-cloud liquid water path (g/m2)
@@ -1642,11 +1644,11 @@
 !      real(kind=rb) :: mean_fsfc_stoch(ncol,nlay)    ! cloud forward scattering fraction
 
 ! Set overlap
-      integer(kind=im) :: overlap                     ! 1 = random overlap, 2 = maximum/random,
-                                                      ! 3 = maximum overlap, 
-!      real(kind=rb), parameter  :: Zo = 2500._rb        ! length scale (m) 
-!      real(kind=rb) :: zm(ncon,nlay)                    ! Height of midpoints (above surface)
-!      real(kind=rb), dimension(nlay) :: alpha=0.0_rb    ! overlap parameter  
+      integer(kind=im) :: overlap                     ! 1 = random overlap, 2 = maximum-random,
+                                                      ! 3 = maximum overlap, 4 = exponential,
+                                                      ! 5 = exponential-random
+      real(kind=rb), parameter  :: Zo = 2500._rb      ! length scale (m) 
+      real(kind=rb), dimension(ncol,nlay) :: alpha    ! overlap parameter
 
 ! Constants (min value for cloud fraction and cloud water and ice)
       real(kind=rb), parameter :: cldmin = 1.0e-20_rb ! min cloud fraction
@@ -1793,39 +1795,58 @@
              enddo
          endif
 
-!    case(4)  - inactive
-!       ! Exponential overlap: weighting between maximum and random overlap increases with the distance. 
-!       ! The random numbers for exponential overlap verify:
-!       ! j=1   RAN(j)=RND1
-!       ! j>1   if RND1 < alpha(j,j-1) => RAN(j) = RAN(j-1)
-!       !                                 RAN(j) = RND2
-!       ! alpha is obtained from the equation
-!       ! alpha = exp(- (Zi-Zj-1)/Zo) where Zo is a characteristic length scale    
+! mji - Activate exponential cloud overlap option
+         case(4)
+            ! Exponential overlap: weighting between maximum and random overlap increases with the distance.
+            ! The random numbers for exponential overlap verify:
+            ! j=1   RAN(j)=RND1
+            ! j>1   if RND1 < alpha(j,j-1) => RAN(j) = RAN(j-1)
+            !                                 RAN(j) = RND2
+            ! alpha is obtained from the equation
+            ! alpha = exp(-(Z(j)-Z(j-1))/Zo) where Zo is a characteristic length scale
 
+            ! compute alpha
+            do i = 1, ncol
+               alpha(i, 1) = 0._rb
+               do ilev = 2,nlay
+                  alpha(i, ilev) = exp( -( hgt (i, ilev) -  hgt (i, ilev-1)) / Zo)
+               enddo
+            enddo
 
-!       ! compute alpha
-!       zm    = state%zm     
-!       alpha(:, 1) = 0._rb
-!       do ilev = 2,nlay
-!          alpha(:, ilev) = exp( -( zm (:, ilev-1) -  zm (:, ilev)) / Zo)
-!       end do
-       
-!       ! generate 2 streams of random numbers
-!       do isubcol = 1,nsubcol
-!          do ilev = 1,nlay
-!             call kissvec(seed1, seed2, seed3, seed4, rand_num)
-!             CDF(isubcol, :, ilev) = rand_num
-!             call kissvec(seed1, seed2, seed3, seed4, rand_num)
-!             CDF2(isubcol, :, ilev) = rand_num
-!          end do
-!       end do
+            ! generate 2 streams of random numbers
+            if (irng.eq.0) then
+               do isubcol = 1,nsubcol
+                  do ilev = 1,nlay
+                     call kissvec(seed1, seed2, seed3, seed4, rand_num)
+                     CDF(isubcol, :, ilev) = rand_num
+                     call kissvec(seed1, seed2, seed3, seed4, rand_num)
+                     CDF2(isubcol, :, ilev) = rand_num
+                  enddo
+               enddo
+            elseif (irng.eq.1) then
+            do isubcol = 1, nsubcol
+               do i = 1, ncol
+                  do ilev = 1, nlay
+                     rand_num_mt = getRandomReal(randomNumbers)
+                     CDF(isubcol,i,ilev) = rand_num_mt
+                     rand_num_mt = getRandomReal(randomNumbers)
+                     CDF2(isubcol,i,ilev) = rand_num_mt
+                  enddo
+               enddo
+            enddo
+         endif
 
-!       ! generate random numbers
-!       do ilev = 2,nlay
-!          where (CDF2(:, :, ilev) < spread(alpha (:,ilev), dim=1, nCopies=nsubcol) )
-!             CDF(:,:,ilev) = CDF(:,:,ilev-1) 
-!          end where
-!       end do
+         ! generate random numbers
+         do ilev = 2,nlay
+            where (CDF2(:, :, ilev) < spread(alpha (:,ilev), dim=1, nCopies=nsubcol) )
+               CDF(:,:,ilev) = CDF(:,:,ilev-1)
+            end where
+         end do
+
+! mji - Exponential-random cloud overlap option
+         case(5)
+            ! Exponential-random overlap:
+            call wrf_error_fatal("Cloud Overlap case 5: ER has not yet been implemented. Stopping...") 
 
       end select
 
@@ -8855,7 +8876,8 @@
                                                       !    1: Random
                                                       !    2: Maximum/random
                                                       !    3: Maximum
-
+                                                      !    4: Exponential
+                                                      !    5: Exponential/random
       real(kind=rb), intent(in) :: play(:,:)          ! Layer pressures (hPa, mb)
                                                       !    Dimensions: (ncol,nlay)
       real(kind=rb), intent(in) :: plev(:,:)          ! Interface pressures (hPa, mb)
@@ -9182,7 +9204,8 @@
 ! icld = 1, with clouds using random cloud overlap (McICA only)
 ! icld = 2, with clouds using maximum/random cloud overlap (McICA only)
 ! icld = 3, with clouds using maximum cloud overlap (McICA only)
-      if (icld.lt.0.or.icld.gt.3) icld = 2
+! icld = 4, with clouds using exponential cloud overlap (McICA only)
+! icld = 5, with clouds using exponential/random cloud overlap (McICA only)
 
 ! Set iaer to select aerosol option
 ! iaer = 0, no aerosols
@@ -9907,6 +9930,7 @@ CONTAINS
                        re_cloud,re_ice,re_snow,                   &
                        has_reqc,has_reqi,has_reqs,                &
                        icloud, warm_rain,                         &
+                       cldovrlp,                                  & ! J. Henderson AER: cldovrlp namelist value
                        f_ice_phy, f_rain_phy,                     &
                        xland, xice, snow,                         &
                        qv3d, qc3d, qr3d,                          &
@@ -10127,6 +10151,7 @@ CONTAINS
     integer ::                                              ncol, &
                                                             nlay, &
                                                             icld, &
+                                                        cldovrlp, & ! J. Henderson AER
                                                          inflgsw, &
                                                         iceflgsw, &
                                                         liqflgsw
@@ -10142,6 +10167,10 @@ CONTAINS
                                                           ch4vmr, &
                                                           n2ovmr
     real, dimension( kts:kte+1 )  ::                       o3mmr
+! mji - Add height of each layer for exponential-random cloud overlap
+! This will be derived below from the dz in each layer
+    real, dimension( 1, kts:kte+1 )  ::                     hgt
+    real ::                                               dzsum
 ! Surface albedo (for UV/visible and near-IR spectral regions,
 ! and for direct and diffuse radiation)
     real, dimension( 1 )  ::                               asdir, &
@@ -10497,14 +10526,15 @@ CONTAINS
 ! Add extra layer from top of model to top of atmosphere
          nlay = (kte - kts + 1) + 1
 
+! Select cloud overlap assumption (1 = random, 2 = maximum-random, 3 = maximum, 4 = exponential, 5 = exponential-random
+         icld=cldovrlp ! J. Henderson AER assign namelist variable cldovrlp to existing icld
+
 ! Select cloud liquid and ice optics parameterization options
 ! For passing in cloud optical properties directly:
-!         icld = 2
 !         inflgsw = 0
 !         iceflgsw = 0
 !         liqflgsw = 0
 ! For passing in cloud physical properties; cloud optics parameterized in RRTMG:
-         icld = 2
          inflgsw = 2
          iceflgsw = 3
          liqflgsw = 1
@@ -10631,6 +10661,15 @@ CONTAINS
             n2ovmr(ncol,k) = n2o
          enddo
 
+! mji - Derive height of each layer mid-point from layer thickness.
+! Needed for exponential (icld=4) and exponential-random overlap option (icld=5) only.
+         dzsum = 0.0
+         do k = kts, kte
+            dz = dz1d(k)
+            hgt(ncol,k) = dzsum + 0.5*dz
+            dzsum = dzsum + dz
+         enddo
+
 !  Define profile values for extra layer from model top to top of atmosphere. 
 !  The top layer temperature for all gridpoints is set to the top layer-1 
 !  temperature plus a constant (0 K) that represents an isothermal layer    
@@ -10647,6 +10686,11 @@ CONTAINS
          o2vmr(ncol,kte+1) = o2vmr(ncol,kte) 
          ch4vmr(ncol,kte+1) = ch4vmr(ncol,kte) 
          n2ovmr(ncol,kte+1) = n2ovmr(ncol,kte) 
+
+! mji - Fill in height array above model top to top of atmosphere using
+! dz from model top layer for completeness, though this information is not
+! likely to be used by the exponential-random cloud overlap method.
+         hgt(ncol,kte+1) = dzsum + 0.5*dz
 
 ! Get ozone profile including amount in extra layer above model top
          call inirad (o3mmr,plev,kts,kte)
@@ -10942,8 +10986,8 @@ CONTAINS
          permuteseed = 1
 
 ! Sub-column generator for McICA
-
-         call mcica_subcol_sw(iplon, ncol, nlay, icld, permuteseed, irng, play, &
+! mji - Add layer height needed for exponential (icld=4) and exponential-random (icld=5) overlap options
+         call mcica_subcol_sw(iplon, ncol, nlay, icld, permuteseed, irng, play, hgt, &
                        cldfrac, ciwpth, clwpth, cswpth, rei, rel, res, taucld, ssacld, asmcld, fsfcld, &
                        cldfmcl, ciwpmcl, clwpmcl, cswpmcl, reicmcl, relqmcl, resnmcl, &
                        taucmcl, ssacmcl, asmcmcl, fsfcmcl)

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -15,6 +15,7 @@ CONTAINS
               ,GMT    ,GSW    ,HBOT    &
               ,HTOP   ,HBOTR  ,HTOPR   &
               ,ICLOUD                  &
+              ,cldovrlp                 & 
               ,ITIMESTEP,JULDAY, JULIAN &
               ,JULYR  ,LW_PHYSICS       &
               ,NCFRCV ,NCFRST ,NPHS     &
@@ -386,6 +387,7 @@ CONTAINS
                 i_start,i_end,j_start,j_end
 
    INTEGER,      INTENT(IN   )    ::   STEPRA,ICLOUD,ra_call_offset
+   INTEGER,      INTENT(IN   )    ::   cldovrlp                  ! J. Henderson AER: cldovrlp namelist value
    INTEGER,      INTENT(IN   )    ::   alevsiz, no_src_types
    INTEGER,      INTENT(IN   )    ::   levsiz, n_ozmixm
    INTEGER,      INTENT(IN   )    ::   paerlev, n_aerosolc, cam_abs_dim1, cam_abs_dim2
@@ -1658,6 +1660,7 @@ CONTAINS
                   P8W=p8w,P3D=p,PI3D=pi,DZ8W=dz8w,TSK=tsk,T3D=t,    &
                   T8W=t8w,RHO3D=rho,R=R_d,G=G,                      &
                   ICLOUD=icloud,WARM_RAIN=warm_rain,CLDFRA3D=CLDFRA,&
+                  cldovrlp=cldovrlp,                                & ! J. Henderson AER: cldovrlp namelist value
 #if (EM_CORE == 1)
                   LRADIUS=lradius, IRADIUS=iradius,                 &
 #endif
@@ -2123,6 +2126,7 @@ CONTAINS
 !ckay
 !                    CLDFRA_KF3D=cldfra_KF,QC_KF3D=qc_KF,QI_KF3D=qi_KF,&
                      ICLOUD=icloud,WARM_RAIN=warm_rain,                &
+                     cldovrlp=cldovrlp,                                & ! J. Henderson AER: cldovrlp namelist value
                      F_ICE_PHY=F_ICE_PHY,F_RAIN_PHY=F_RAIN_PHY,        &
                      XLAND=XLAND,XICE=XICE,SNOW=SNOW,                  &
                      QV3D=qv,QC3D=qc,QR3D=qr,                          &


### PR DESCRIPTION

TYPE: enhancement

KEYWORDS: HWRF, RRTMG, cloud overlap

SOURCE: John Henderson and Mike Iacono (AER)

DESCRIPTION OF CHANGES:  Update RRMTG cloud overlap method options
Add a namelist switch to select various methods of handling cloud overlap in RRTMG LW/SW schemes.  Default (2) should give same results as previous code (without the switch)

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       Registry/Registry.NMM
M       dyn_em/module_first_rk_step_part1.F
M       dyn_nmm/module_PHYSICS_CALLS.F
M       phys/module_cu_mskf.F
M       phys/module_ra_rrtmg_lw.F
M       phys/module_ra_rrtmg_sw.F
M       phys/module_radiation_driver.F

TESTS CONDUCTED: Limited WTF (cheyenne/intel, handful of cases).  ToBeCompleted:  test to verify no changes in ARW for default setting of this switch.  

RELEASE NOTE: see #758 
