### PR TITLE
Compile-time bug fixes em initialize and cu mskf

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3004,15 +3004,14 @@ integer::oops1,oops2
          DO j = jts, MIN(jde-1,jte)
             DO i = its, MIN(ide-1,ite)
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
-                  IF ( grid%landmask(i,j) .GT. 0.5 .AND. grid%isltyp(i,j) .EQ. grid%isoilwater ) THEN
-                     grid%isltyp(i,j) = 8
-                     change_soilw =  change_soilw + 1
-                     iforce =  iforce + 1
-                  ELSE IF ( grid%landmask(i,j) .LT. 0.5 .AND. grid%isltyp(i,j) .NE. grid%isoilwater ) THEN
-                     grid%isltyp(i,j) = grid%isoilwater
-                     change_soil =  change_soil + 1
-                     iforce =  iforce + 1
-                  END IF
+               IF ( grid%landmask(i,j) .GT. 0.5 .AND. grid%isltyp(i,j) .EQ. grid%isoilwater ) THEN
+                  grid%isltyp(i,j) = 8
+                  change_soilw =  change_soilw + 1
+                  iforce =  iforce + 1
+               ELSE IF ( grid%landmask(i,j) .LT. 0.5 .AND. grid%isltyp(i,j) .NE. grid%isoilwater ) THEN
+                  grid%isltyp(i,j) = grid%isoilwater
+                  change_soil =  change_soil + 1
+                  iforce =  iforce + 1
                END IF
             END DO
          END DO

--- a/phys/module_cu_mskf.F
+++ b/phys/module_cu_mskf.F
@@ -5564,7 +5564,7 @@ updraft:    DO NK=K,KL-1
  
          NIC=NINT(TIMEC/DT)
          TIMEC=FLOAT(NIC)*DT
-         TIMEC=AMIN1(TIMEC,86400)  !JRJ Ramboll: cap convective time scale at 24 hrs
+         TIMEC=MIN(TIMEC,86400.)  !JRJ Ramboll: cap convective time scale at 24 hrs
 !     
 !...COMPUTE WIND SHEAR AND PRECIPITATION EFFICIENCY.
 !     


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile-time, MIN function, END IF

SOURCE: internal

DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
1. dyn_em/module_initialize_real.F had an extra END IF
Also, un-indented the code where the nonexisting IF () THEN ... ENDIF existed.

2. phys/module_cu_mskf.F had both a real and integer in the MIN function. Added a decimal point to the integer constant.

LIST OF MODIFIED FILES: 
M      dyn_em/module_initialize_real.F
M      phys/module_cu_mskf.F

TESTS CONDUCTED: 
1. Both codes now build with EM and NMM.
2. A regtest on the develop branch including this mod = OK
