### PR TITLE
Correct README for vert refinement: RRTM + Dudhia rad only, no HVC allowed

### DIFF
--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -475,7 +475,8 @@ to turn on the option (vert_refine_method).  The namelist array eta_levels
 is manually filled in for each domain.  Below is an example for two 
 domains.  
 
-NOTE: The user is restricted to either the RRTM or RRTMG radiation schemes.
+NOTE: The user is restricted to using the RRTM LW and Dudhia SW radiation schemes.
+NOTE: The user is restricted from using the hybrid vertical coordinate.
 
  &domains
  max_dom                             = 2,


### PR DESCRIPTION
TYPE: text only

KEYWORDS: vertical refinement, README, radiation, HVC

SOURCE: internal

DESCRIPTION OF CHANGES: 
In the description of the vertical refinement option, the available radiation schemes are now correctly
listed as RRTM LW only and Dudhia SW only. Also, the user is reminded that the vertical 
refinement does not work with the hybrid vertical coordinate.

LIST OF MODIFIED FILES: 
M test/em_real/examples.namelist

TESTS CONDUCTED: 
Text only, no testing required.
 - [x] Passed small regtest GNU, Intel, PGI on cheyenne