### PR TITLE
BF input_wrf.F: error messages now match nml variable names

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -906,25 +906,25 @@
        !  Test to make sure that the input data is the right size: real into WRF.
 
        IF ( ide .NE. ide_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I namelist e_we                         = ',ide
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_we                         = ',ide
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I input file WEST-EAST_GRID_DIMENSION   = ',ide_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file WEST-EAST_GRID_DIMENSION   = ',ide_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1
        ENDIF
        IF ( jde .NE. jde_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J namelist e_sn                         = ',jde
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_sn                         = ',jde
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1
        ENDIF
        IF ( kde .NE. kde_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K namelist e_vert                       = ',kde
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_vert                       = ',kde
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K input file BOTTOM-TOP_GRID_DIMENSION  = ',kde_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file BOTTOM-TOP_GRID_DIMENSION  = ',kde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1
@@ -935,25 +935,25 @@
        !  Test to make sure that the input data is the right size: metgrid into real.
 
        IF ( ide                             .NE. ide_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I namelist e_we                         = ',ide
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_we                         = ',ide
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I input file WEST-EAST_GRID_DIMENSION   = ',ide_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file WEST-EAST_GRID_DIMENSION   = ',ide_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1
        ENDIF
        IF ( jde                             .NE. jde_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J namelist e_se                         = ',jde
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_se                         = ',jde
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1
        ENDIF
        IF ( config_flags%num_metgrid_levels .NE. kde_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K namelist num_metgrid_levels           = ',config_flags%num_metgrid_levels
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist num_metgrid_levels           = ',config_flags%num_metgrid_levels
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K input file BOTTOM-TOP_GRID_DIMENSION  = ',kde_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file BOTTOM-TOP_GRID_DIMENSION  = ',kde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -943,7 +943,7 @@
           count_fatal_error = count_fatal_error + 1
        ENDIF
        IF ( jde                             .NE. jde_compare ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_se                         = ',jde
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist e_sn                         = ',jde
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -903,14 +903,28 @@
             ( ( switch .EQ. auxinput1_only ) .AND. &
               ( config_flags%auxinput1_inname(1:8) .EQ. 'wrf_real' ) ) ) THEN
 
-       !  Test to make sure that the input data is the right size.
+       !  Test to make sure that the input data is the right size: real into WRF.
 
-       IF ( ( ide .NE. ide_compare    ) .OR. &
-            ( kde .NE. kde_compare    ) .OR. &
-            ( jde .NE. jde_compare    ) ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist   ide,jde,kde=',ide,jde,kde
+       IF ( ide .NE. ide_compare ) THEN
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I namelist e_we                         = ',ide
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file ide,jde,kde=',ide_compare , jde_compare , kde_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I input file WEST-EAST_GRID_DIMENSION   = ',ide_compare
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
+          count_fatal_error = count_fatal_error + 1
+       ENDIF
+       IF ( jde .NE. jde_compare ) THEN
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J namelist e_sn                         = ',jde
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
+          count_fatal_error = count_fatal_error + 1
+       ENDIF
+       IF ( kde .NE. kde_compare ) THEN
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K namelist e_vert                       = ',kde
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K input file BOTTOM-TOP_GRID_DIMENSION  = ',kde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1
@@ -918,14 +932,28 @@
 
     ELSE IF ( switch .EQ. auxinput1_only ) THEN
 
-       !  Test to make sure that the input data is the right size.
+       !  Test to make sure that the input data is the right size: metgrid into real.
 
-       IF ( ( ide                             .NE. ide_compare ) .OR. &
-            ( config_flags%num_metgrid_levels .NE. kde_compare ) .OR. &
-            ( jde                             .NE. jde_compare ) ) THEN
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  namelist   ide,jde,num_metgrid_levels=',ide,jde,config_flags%num_metgrid_levels
+       IF ( ide                             .NE. ide_compare ) THEN
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I namelist e_we                         = ',ide
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  input file ide,jde,kde               =',ide_compare , jde_compare , kde_compare
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  I input file WEST-EAST_GRID_DIMENSION   = ',ide_compare
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
+          count_fatal_error = count_fatal_error + 1
+       ENDIF
+       IF ( jde                             .NE. jde_compare ) THEN
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J namelist e_se                         = ',jde
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  J input file SOUTH-NORTH_GRID_DIMENSION = ',jde_compare
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
+          count_fatal_error = count_fatal_error + 1
+       ENDIF
+       IF ( config_flags%num_metgrid_levels .NE. kde_compare ) THEN
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K namelist num_metgrid_levels           = ',config_flags%num_metgrid_levels
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+          WRITE(wrf_err_message,*)'input_wrf.F: SIZE MISMATCH:  K input file BOTTOM-TOP_GRID_DIMENSION  = ',kde_compare
           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
           CALL wrf_debug ( 0, "---- ERROR: Mismatch between namelist and input file dimensions" )
           count_fatal_error = count_fatal_error + 1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: input_wrf.F, error messages

SOURCE: internal

DESCRIPTION OF CHANGES: 
One of the changes due to students chatting with us at the WRF Tutorial ...

When a mismatch between domain sizes (in grid units) was identified by the input_wrf.F file, previously the error message referred to a variable that was neither in the namelist or in the input file (such as IDE, JDE, KDE). Also, if any of the dimensions were inconsistent between the namelist and the input file, all three of the i,j,k indices were all printed out. Basically, "user, figure this out".

Now the error message is specific to the dimension, and the printed names of the offending dimensions are those that are in the namelist and in the metadata of the input file.
```
d01 2000-01-24_12:00:00  input_wrf.F: SIZE MISMATCH:  namelist num_metgrid_levels           =           32
d01 2000-01-24_12:00:00  input_wrf.F: SIZE MISMATCH:  input file BOTTOM-TOP_GRID_DIMENSION  =           26
d01 2000-01-24_12:00:00 ---- ERROR: Mismatch between namelist and input file dimensions
```

LIST OF MODIFIED FILES: 
M      share/input_wrf.F

TESTS CONDUCTED: 
 - [x] With new mods, the code (still) stops correctly.
 - [x] With new mods, the error message is easier to interpret.
 - [x] With new mods, each and only every incorrect index is given an error message.
 - [x] Passed small regtest GNU, Intel, PGI on cheyenne

