### PR TITLE
In real, supply base pressure at full levels at model top

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3662,6 +3662,7 @@ endif
                grid%t_init(i,k,j) = temp*(p00/grid%pb(i,k,j))**(r_d/cp) - t0
                grid%alb(i,k,j) = (r_d/p1000mb)*(grid%t_init(i,k,j)+t0)*(grid%pb(i,k,j)/p1000mb)**cvpm
             END DO
+            grid%php(i,kte,j) = grid%p_top
             !  Base state mu is defined as base state surface pressure minus grid%p_top
             grid%MUB(i,j) = p_surf - grid%p_top
             !  Dry surface pressure is defined as the following (this mu is from the input file


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: real, full-levels, base pressure, model top

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
In the module_initialize_real file, the `php` array is temporarily used to hold the base state pressure on full levels. While the correct `c3` and `c4` for full-levels are used, the DO loop only extends up to `kte-1`. This leaves the top level pressure as a zero value.

Solution:
Outside of the k-index DO loop, an assignment is directly made to the `kte` index for the `php` field. This value is necessarily assigned as the model lid, `p_top`.

Impact:
This incorrect `php` array is only used when a user has asked for a rebalancing between the surface pressure field and the 500 mb height field, the `adjust_heights` option. This option is only valid if the input data is isobaric. The `adjust_heights` option is off by default, so this is unlikely to have caused anyone troubles.

LIST OF MODIFIED FILES: 
M      module_initialize_real.F

TESTS CONDUCTED: 
 - [x] Passed small regtest GNU, Intel, PGI on cheyenne

 - [x] Vertical column of pressure is now correct. The only difference in this column is the last entry, the top full level of base pressure, which is now correctly set to the user-defined model lid.
```
             PB (Pa)          PB (Pa)
 K (full)    Before           After
              mods            mods 
     1    100000.0000      100000.0000    
     2     99412.3984       99412.3984    
     3     98665.3125       98665.3125    
     4     97721.3594       97721.3594    
     5     96537.9609       96537.9609    
     6     95068.8438       95068.8438    
     7     93266.7578       93266.7578    
     8     91088.1641       91088.1641    
     9     88499.5234       88499.5234    
    10     85484.7578       85484.7578    
    11     82052.3828       82052.3828    
    12     78240.1562       78240.1562    
    13     74114.9141       74114.9141    
    14     69766.7578       69766.7578    
    15     65277.8438       65277.8438    
    16     60672.8984       60672.8984    
    17     55981.7617       55981.7617    
    18     51239.3438       51239.3438    
    19     46485.3750       46485.3750    
    20     41763.8359       41763.8359    
    21     37122.1172       37122.1172    
    22     32609.8242       32609.8242    
    23     28277.1504       28277.1504    
    24     24173.0586       24173.0586    
    25     20343.0938       20343.0938    
    26     17070.1035       17070.1035    
    27     14323.7012       14323.7012    
    28     12019.1660       12019.1660    
    29     10085.4082       10085.4082    
    30     8462.77441       8462.77441    
    31     7101.20068       7101.20068    
    32     5958.69189       5958.69189    
    33     0.00000000       5000.00000
```
