### PR TITLE
Bug fix for RRTMG with o3input=2 option

### DIFF
--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -4292,7 +4292,7 @@ SUBROUTINE ozn_time_int(julday,julian,ozmixm,ozmixt,levsiz,num_months,  &
       do j=jts,jte
       do k=1,levsiz
       do i=its,ite
-            ozmixt(i,k,j) = ozmixm(i,k,j,nm)*fact1 + ozmixm(i,k,j,np)*fact2
+            ozmixt(i,k,j) = ozmixm(i,k,j,nm+1)*fact1 + ozmixm(i,k,j,np+1)*fact2
       end do
       end do
       end do


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RRTMG, CAM Ozone

SOURCE: Takahiro Benno (???)

DESCRIPTION OF CHANGES: When RRTMG is turned on with CAM ozone as input (o3input=2), the variable ozmixm has 13 elements in time dimension, and monthly ozone data is stored in the 2nd to 13th elements, corresponding to 1-12 month. In the subroutine "ozn_time_int", however, the time dimension for "ozmixm" is not specified accordingly. More details are as follows.

(1)  In module_physics_init.F, ozone data is read by subroutine oznini, included in module_ra_cam_support.F. In subroutine oznini, ozmixm has 13 elements in time dimension, and monthly ozone data is stored in the 2nd to 13th elements. ozone is all zero in the 1st element.

(2) In module_radiation_driver.F, ozone is interpolated based on time (julian) in the subroutine ozn_time_int
```
SUBROUTINE ozn_time_int(julday,julian,ozmixm,ozmixt,levsiz,num_months,  &
							  ids , ide , jds , jde , kds , kde ,     &
							  ims , ime , jms , jme , kms , kme ,     &
							  its , ite , jts , jte , kts , kte )
```
This subroutine has two variables: ozmixm, ozmixt. ozmixm is the input data from module_physics_init.F, and ozmixt is the one interpolated.

However, subroutine ozn_time_int assumes ozmixm has monthly ozone data saved in 1st to 12th element, which is wrong because 2nd-13th element of ozmixm actually correspond to monthly ozone data from Jan to Dec.

The piece of code for interpolating ozone (in module_radiation_driver.F) are as follows:
```  
    do j=jts,jte
      do k=1,levsiz
      do i=its,ite
            ozmixt(i,k,j) = ozmixm(i,k,j,nm)*fact1 + ozmixm(i,k,j,np)*fact2
       end do
      end do
      end do
````
Suppose we run a case over a period in January, nm=1, np=2, then ozmixm(i,k,j,nm) is always zero, leading to a small value of ozmixt(i,k,j). 

With the bug fix, monthly ozone data are correctly set to be corresponding to 2nd-13th elements of  4th dimension of ozmixm 

(3) A test case is done with and without the bug fix. The output is like:

```
without the bug fix  
  nm, np=            1             2
  ozmixm (20,1,20,nm) = 0   ozmixm (20,1,20,np)=1.56410192E-06
  
with the bug fix  
nm, np=            1             2
  ozmixm (20,1,20,nm+1) = 1.56410192E-06   ozmixm (20,1,20,np+1)=1.57952547E-06
  
```

LIST OF MODIFIED FILES:
M   phys/module_radiation_driver.F

TESTS CONDUCTED: A single case is tested. 

Release Note: An error in ozone interpolation exists in WRF prior to version V4.0, i.e., the ozone interpolation is off by a month; zero value (which is wrong) and value valid at Jan 16 are used for interpolating dates from Dec 15 - Jan 16.  This fix affects RRTMG radiation.   