### PR TITLE
Fix -j parallel make option for compile script

### DIFF
--- a/compile
+++ b/compile
@@ -24,7 +24,9 @@ endif
 set ZAP = .foofoo
 set arglist=""
 set prev_was_j = false
+set count = 0
 foreach a ( $argv )
+  @ count ++
   if ( "$a" == "-h" ) then
     goto hlp
   else if ( "$a" == "all_wrfvar" || "$a" == "gen_be" ) then
@@ -76,8 +78,8 @@ foreach a ( $argv )
     set arglist = ( $arglist $a )
     set ZAP = ( main/wrf.exe )
   else if ( "$a" == "-j" ) then
-    shift argv
-    setenv J "-j $argv[1]"
+    @ JJ = $count + 1
+    setenv J "-j $argv[$JJ]"
     set prev_was_j = true
   else if ( "$prev_was_j" == "true" ) then
     set prev_was_j = false


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile, -j, parallel

SOURCE: Found by Michael Duda (NCAR), internal fix

DESCRIPTION OF CHANGES:
Problem:
The user is able to specify directly the env variable for a parallel make:
```
setenv J = "-j 4"
```
The user is supposed to be able to also specify this on the command line for
the compile script:
```
compile em_real -j 4
```
However, depending on the order of the arguments, the intended number of parallel builds 
that are selected is incorrectly assigned in the compile script. What is used is ALWAYS the
second argument of `$argv`.

Solution:
The arguments, `$argv`, to the compile command can either be processed sequentially
via the `$argv` list and a `shift` command, or the entire `$argv` can be used
in a `foreach` loop. The script intermingled these methods. The new approach keeps the
`foreach` loop and removes the assignment of the argument for `-j` via the incorrect
`shift argv`.

ISSUE:
Fixes #778 "compile -j X not working"

LIST OF MODIFIED FILES: 
M   compile

TESTS CONDUCTED:
 - [x] Passed small regtest GNU, Intel, PGI on cheyenne

 - [x] If `-j 5` are first two arguments, everything is OK:
```
> compile -j 5 em_real
next arg is 5
```
 - [x] If `-j 5` are middle two arguments, everything is OK:
```
> compile io -j 5 em_real
next arg is 5
```
 - [x] If `-j 5` are last two arguments, everything is OK:
```
> compile em_real -j 5
next arg is 5
```