### PR TITLE
BF: AGL interpolation incorrect for zld diagnostics

### DIFF
--- a/phys/module_diag_zld.F
+++ b/phys/module_diag_zld.F
@@ -104,13 +104,12 @@ CONTAINS
    
                ke_loop_half : DO ke = ke_h , kte-2
    
-                  zm = ABS(z_zl(kz))
+                  zu = ( zp(i,ke+1,j)+zb(i,ke+1,j) + zp(i,ke+2,j)+zb(i,ke+2,j) ) / 2.0 / g
+                  zd = ( zp(i,ke  ,j)+zb(i,ke  ,j) + zp(i,ke+1,j)+zb(i,ke+1,j) ) / 2.0 / g
                   IF ( z_zl(kz) .LT. 1 ) THEN
-                     zu = ( zp(i,ke+1,j)+zb(i,ke+1,j) + zp(i,ke+2,j)+zb(i,ke+2,j) ) / 2.0 / 9.8 - ht(i,j)
-                     zd = ( zp(i,ke  ,j)+zb(i,ke  ,j) + zp(i,ke+1,j)+zb(i,ke+1,j) ) / 2.0 / 9.8 - ht(i,j)
+                     zm = ABS(z_zl(kz)) + ht(i,j)
                   ELSE 
-                     zu = ( zp(i,ke+1,j)+zb(i,ke+1,j) + zp(i,ke+2,j)+zb(i,ke+2,j) ) / 2.0 / 9.8
-                     zd = ( zp(i,ke  ,j)+zb(i,ke  ,j) + zp(i,ke+1,j)+zb(i,ke+1,j) ) / 2.0 / 9.8
+                     zm = z_zl(kz)
                   END IF
                  
                   IF ( ( zd .LE. zm ) .AND. ( zu .GT. zm ) ) THEN
@@ -178,13 +177,12 @@ CONTAINS
    
                ke_loop_full : DO ke = ke_f , kte-1
 
-                  zm = ABS(z_zl(kz))
+                  zu = ( zp(i,ke+1,j)+zb(i,ke+1,j) ) / g
+                  zd = ( zp(i,ke  ,j)+zb(i,ke  ,j) ) / g
                   IF ( z_zl(kz) .LT. 1 ) THEN
-                     zu = ( zp(i,ke+1,j)+zb(i,ke+1,j) ) / 9.8 - ht(i,j)
-                     zd = ( zp(i,ke  ,j)+zb(i,ke  ,j) ) / 9.8 - ht(i,j)
+                     zm = ABS(z_zl(kz)) + ht(i,j)
                   ELSE 
-                     zu = ( zp(i,ke+1,j)+zb(i,ke+1,j) ) / 9.8
-                     zd = ( zp(i,ke  ,j)+zb(i,ke  ,j) ) / 9.8
+                     zm = z_zl(kz)
                   END IF
 
                   IF ( ( zd .LE. zm ) .AND. &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: AGL, ZLD, diagnostics

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The height-level diagnostic routine has an option that the user may specify
either the height above mean sea level or the height above ground level (AGL).
If a user chooses 50 m AGL, the height field should be almost exactly 50 m
over the ocean, and almost exactly 50 m greater than the topo over land.
This is not what was happening.

Solution:
The height trapping levels (in the WRF model, (ph+phb)/g) should be identical
to the WRF model levels (they were not). The AGL level to interpolate to, should be
the requested AGL level + the topo value (it was not).

LIST OF MODIFIED FILES:
M   phys/module_diag_zld.F

TESTS CONDUCTED:
 - [x] Passed small regtest GNU, Intel, PGI on cheyenne

This is purely a diagnostic, and does not impact the model simulation. A valid test
is to look at the height field with a known topography elevation. The AGL height field
should be the AGL level + the topo value at that grid point.
Below is a figure of
LEFT: Terrain
MIDDLE: height at 50 m AGL
RIGHT: height at 100 m AGL

Note that the patterns are similar, and that the local max/min values are in 50 m increments. This new 
figure is correct:
![screen shot 2019-02-11 at 2 29 21 pm](https://user-images.githubusercontent.com/12666234/52595557-607f8a80-2e0b-11e9-9a2c-2bcd65165d21.png)

For the original code, note that the AGL height field is actually above mean sea level. The 50 m AGL and 100 m AGL show (nearly) constant values of 50 m and 100 m for the height field.
![screen shot 2019-02-11 at 3 00 13 pm](https://user-images.githubusercontent.com/12666234/52596674-206dd700-2e0e-11e9-87ff-c65615c8a5c7.png)



RELEASE NOTE:
Since the height level interpolation routine was introduced in v3.8, it has used an incorrect
formulation for the AGL computations.