### PR TITLE
BF: tslist ij mods need to have NMM Registry support

### DIFF
--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1367,6 +1367,7 @@ rconfig   integer irand                   namelist,domains	1             0      
 rconfig   real    dt                      derived              max_domains    2.      h0123     "dt"        "TEMPORAL RESOLUTION"      "SECONDS"
 rconfig   integer   ts_buf_size     namelist,domains    1                200          -       "ts_buf_size"   "Size of time series buffer"
 rconfig   integer   max_ts_locs     namelist,domains    1                5            -       "max_ts_locs"   "Maximum number of time series locations"
+rconfig   logical   tslist_ij             derived       1              .false. rh  "tslist_ij"    "Use i,j locations in tslist"   ""
 rconfig   integer   num_moves       namelist,domains    1                0
 rconfig   integer   vortex_interval namelist,domains    max_domains      15  -  "" "" "minutes"
 rconfig   integer   corral_dist     namelist,domains    max_domains      8


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: tslist, NMM

SOURCE: internal

DESCRIPTION OF CHANGES:
The tslist_ij logical flag is used in the part of the timeseries code
that is seen by both NMM and ARW. The identical line defining the tslist_ij
flag in the Registry.EM_COMMON file is put into the Registry.NMM file.
This change means that the derived namelist variable tslist_ij is now defined in the
Registry.NMM.

No effort is made to test or support any new tslist functionality in NMM.

LIST OF MODIFIED FILES:
M   Registry/Registry.NMM

TESTS CONDUCTED:
 - [x] NMM code does not build without mod.
 - [x] NMM code builds with mod.
 - [x] Running small reggie GNU, Intel, PGI