### PR TITLE
Helpful printout info: 1) gross check for d01 time step, 2) current and sim start date in printout

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1980,6 +1980,8 @@ rconfig   integer time_step_fract_num     namelist,domains	1             0      
 rconfig   integer time_step_fract_den     namelist,domains	1             1       ih   "time_step_fract_den"     
 rconfig   integer time_step_dfi           namelist,domains      1            -1       ih   "time_step_dfi"
 
+rconfig   real    reasonable_time_step_ratio namelist,domains   1            10.      ih   "reasonable_time_step_ratio" "Any d01, real-data case with a time step ratio larger than this is stopped"
+
 rconfig   integer min_time_step           namelist,domains      max_domains   -1      h    "min_time_step"
 rconfig   integer min_time_step_den       namelist,domains      max_domains    0      h    "min_time_step denominator"
 rconfig   integer max_time_step           namelist,domains      max_domains   -1      h    "max_time_step"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1980,7 +1980,7 @@ rconfig   integer time_step_fract_num     namelist,domains	1             0      
 rconfig   integer time_step_fract_den     namelist,domains	1             1       ih   "time_step_fract_den"     
 rconfig   integer time_step_dfi           namelist,domains      1            -1       ih   "time_step_dfi"
 
-rconfig   real    reasonable_time_step_ratio namelist,domains   1            10.      ih   "reasonable_time_step_ratio" "Any d01, real-data case with a time step ratio larger than this is stopped"
+rconfig   real    reasonable_time_step_ratio namelist,domains   1             6.      ih   "reasonable_time_step_ratio" "Any d01, real-data case with a time step ratio larger than this is stopped"
 
 rconfig   integer min_time_step           namelist,domains      max_domains   -1      h    "min_time_step"
 rconfig   integer min_time_step_den       namelist,domains      max_domains    0      h    "min_time_step denominator"

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -165,8 +165,6 @@
 ! projection is not Cartesian), and only look at user-specified time steps
 ! (not the adaptive dt option).
 !-----------------------------------------------------------------------
-print *,'dt = ',config_flags%time_step
-print *,'dx = ',config_flags%dx
       IF ( ( grid%id .EQ. 1 ) .AND. &
            ( config_flags%map_proj .NE. 0 ) .AND. &
            ( .NOT. config_flags%use_adaptive_time_step ) ) THEN

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -128,7 +128,6 @@
 
    REAL :: dt_s, dx_km
 
-
    REAL :: max_mf, max_rot_angle
    CALL get_ijk_from_grid ( grid ,                              &
                            ids, ide, jds, jde, kds, kde,        &
@@ -155,29 +154,6 @@
          jde,jds,config_flags%parent_grid_ratio
       CALL wrf_error_fatal ( message )
    END IF
-
-!-----------------------------------------------------------------------
-! Do a gross check on the time step for the most coarse grid (not for
-! adaptive time steps. If the value is significantly larger than reasonable,
-! then stop immediately. Likely the user made a mistake.
-! If the rule of thumb is 6 DX = DT, then anything > 10 is flagged.
-! Only look at domain 1, only look at real-data cases (where the map
-! projection is not Cartesian), and only look at user-specified time steps
-! (not the adaptive dt option).
-!-----------------------------------------------------------------------
-      IF ( ( grid%id .EQ. 1 ) .AND. &
-           ( config_flags%map_proj .NE. 0 ) .AND. &
-           ( .NOT. config_flags%use_adaptive_time_step ) ) THEN
-         dt_s = REAL(config_flags%time_step) + &
-                REAL(config_flags%time_step_fract_num) / &
-                REAL(config_flags%time_step_fract_den)
-         dx_km = MIN ( config_flags%dx , config_flags%dy ) / 1000.
-         IF ( dt_s / dx_km > config_flags%reasonable_time_step_ratio ) THEN
-            WRITE (message,*) 'Time step = ',dt_s, ' (s), Grid distance = ',dx_km, ' (km)'
-            CALL wrf_message ( TRIM(message) ) 
-            CALL wrf_error_fatal ( '--- ERROR: The time step is too large for this grid distance')
-         END IF
-      END IF
 
    IF ( config_flags%polar ) THEN
 !write(0,*)"<stdin>",__LINE__,' clat ',ips,ipe,jps,jpe
@@ -259,23 +235,59 @@
        first_trip_for_this_domain = .TRUE.
    ENDIF
 
-      ! Print out the maximum map scale factor on the coarse domain
+   ! Print out the maximum map scale factor on the coarse domain
 
-      IF ( ( first_trip_for_this_domain ) .AND. ( grid%id .EQ. 1 ) .AND. &
-           ( .NOT. config_flags%polar ) ) THEN
-         max_mf = grid%msft(its,jts)
-         DO j=jts,MIN(jde-1,jte)
-            DO i=its,MIN(ide-1,ite)
-               max_mf = MAX ( max_mf , grid%msft(i,j) )
-            END DO
+   IF ( ( first_trip_for_this_domain ) .AND. ( grid%id .EQ. 1 ) .AND. &
+        ( .NOT. config_flags%polar ) ) THEN
+      max_mf = grid%msft(its,jts)
+      DO j=jts,MIN(jde-1,jte)
+         DO i=its,MIN(ide-1,ite)
+            max_mf = MAX ( max_mf , grid%msft(i,j) )
          END DO
+      END DO
 #if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )
-         max_mf = wrf_dm_max_real ( max_mf )
+      max_mf = wrf_dm_max_real ( max_mf )
 #endif
-         WRITE ( a_message , FMT='(A,F5.2,A)' ) 'Max map factor in domain 1 = ',max_mf, &
-                                                '. Scale the dt in the model accordingly.'
-         CALL wrf_message ( a_message )
+      WRITE ( a_message , FMT='(A,F5.2,A)' ) 'Max map factor in domain 1 = ',max_mf, &
+                                             '. Scale the dt in the model accordingly.'
+      CALL wrf_message ( a_message )
+   END IF
+
+!-----------------------------------------------------------------------
+! Do a gross check on the time step for the most coarse grid (not for
+! adaptive time steps. If the value is significantly larger than reasonable,
+! then stop immediately. Likely the user made a mistake.
+! If the rule of thumb is 6 DX = DT, then anything > 10 is flagged.
+! Only look at domain 1, only do this for the firt time into this routine,
+! only look at real-data cases (where the map projection is not Cartesian), 
+! and only look at user-specified time steps (not the adaptive dt option).
+!-----------------------------------------------------------------------
+   IF ( ( grid%id .EQ. 1 ) .AND. &
+        ( first_trip_for_this_domain ) .AND. &
+        ( config_flags%map_proj .NE. 0 ) .AND. &
+        ( .NOT. config_flags%use_adaptive_time_step ) ) THEN
+      dt_s = REAL(config_flags%time_step) + &
+             REAL(config_flags%time_step_fract_num) / &
+             REAL(config_flags%time_step_fract_den)
+      dx_km = MIN ( config_flags%dx , config_flags%dy ) / 1000.
+      WRITE (message,*) 'D01: Time step                              = ',dt_s ,' (s)'
+      CALL wrf_message ( TRIM(message) ) 
+      WRITE (message,*) 'D01: Grid Distance                          = ',dx_km ,' (km)'
+      CALL wrf_message ( TRIM(message) ) 
+      WRITE (message,*) 'D01: Grid Distance Ratio dt/dx              = ', dt_s / dx_km, ' (s/km)'
+      CALL wrf_message ( TRIM(message) ) 
+      WRITE (message,*) 'D01: Ratio Including Maximum Map Factor     = ', dt_s / (dx_km / max_mf) , ' (s/km)'
+      CALL wrf_message ( TRIM(message) ) 
+      WRITE (message,*) 'D01: NML defined reasonable_time_step_ratio = ', config_flags%reasonable_time_step_ratio
+      CALL wrf_message ( TRIM(message) ) 
+      IF ( dt_s / dx_km > config_flags%reasonable_time_step_ratio ) THEN
+         CALL wrf_message ( 'The time step is probably too large for this grid distance, reduce it.' )
+         WRITE (message, * ) 'If you are sure of your settings, set reasonable_time_step_ratio in namelist.input > ' &
+                             ,dt_s / (dx_km / max_mf)
+         CALL wrf_message ( TRIM(message) ) 
+         CALL wrf_error_fatal ( '--- ERROR: Time step too large')
       END IF
+   END IF
 
     if(config_flags%cycling) then
 ! Clear the buckets for diagnostics at initial time

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -200,6 +200,7 @@
         CALL wrf_message ( TRIM(alloc_err_message) )
         CALL wrf_error_fatal ( 'Error allocating entire domain size of 2d array CLAT for global domain' )
      END IF
+     
      CALL wrf_patch_to_global_real ( grid%clat, clat_glob, grid%domdesc, 'xy', 'xy', &
                                      ids, ide, jds, jde, 1, 1, &
                                      ims, ime, jms, jme, 1, 1, &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -200,7 +200,7 @@
         CALL wrf_message ( TRIM(alloc_err_message) )
         CALL wrf_error_fatal ( 'Error allocating entire domain size of 2d array CLAT for global domain' )
      END IF
-     
+
      CALL wrf_patch_to_global_real ( grid%clat, clat_glob, grid%domdesc, 'xy', 'xy', &
                                      ids, ide, jds, jde, 1, 1, &
                                      ims, ime, jms, jme, 1, 1, &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -126,6 +126,9 @@
 !  CCN for MP=18 initializatio
    REAL :: ccn_max_val
 
+   REAL :: dt_s, dx_km
+
+
    REAL :: max_mf, max_rot_angle
    CALL get_ijk_from_grid ( grid ,                              &
                            ids, ide, jds, jde, kds, kde,        &
@@ -153,6 +156,31 @@
       CALL wrf_error_fatal ( message )
    END IF
 
+!-----------------------------------------------------------------------
+! Do a gross check on the time step for the most coarse grid (not for
+! adaptive time steps. If the value is significantly larger than reasonable,
+! then stop immediately. Likely the user made a mistake.
+! If the rule of thumb is 6 DX = DT, then anything > 10 is flagged.
+! Only look at domain 1, only look at real-data cases (where the map
+! projection is not Cartesian), and only look at user-specified time steps
+! (not the adaptive dt option).
+!-----------------------------------------------------------------------
+print *,'dt = ',config_flags%time_step
+print *,'dx = ',config_flags%dx
+      IF ( ( grid%id .EQ. 1 ) .AND. &
+           ( config_flags%map_proj .NE. 0 ) .AND. &
+           ( .NOT. config_flags%use_adaptive_time_step ) ) THEN
+         dt_s = REAL(config_flags%time_step) + &
+                REAL(config_flags%time_step_fract_num) / &
+                REAL(config_flags%time_step_fract_den)
+         dx_km = MIN ( config_flags%dx , config_flags%dy ) / 1000.
+         IF ( dt_s / dx_km > config_flags%reasonable_time_step_ratio ) THEN
+            WRITE (message,*) 'Time step = ',dt_s, ' (s), Grid distance = ',dx_km, ' (km)'
+            CALL wrf_message ( TRIM(message) ) 
+            CALL wrf_error_fatal ( '--- ERROR: The time step is too large for this grid distance')
+         END IF
+      END IF
+
    IF ( config_flags%polar ) THEN
 !write(0,*)"<stdin>",__LINE__,' clat ',ips,ipe,jps,jpe
 !do j = jps,jpe
@@ -174,7 +202,6 @@
         CALL wrf_message ( TRIM(alloc_err_message) )
         CALL wrf_error_fatal ( 'Error allocating entire domain size of 2d array CLAT for global domain' )
      END IF
-
      CALL wrf_patch_to_global_real ( grid%clat, clat_glob, grid%domdesc, 'xy', 'xy', &
                                      ids, ide, jds, jde, 1, 1, &
                                      ims, ime, jms, jme, 1, 1, &

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -430,6 +430,10 @@
 
 #if (EM_CORE == 1)
 
+       IF ( switch .EQ. input_only ) then
+          CALL wrf_get_dom_ti_char ( fid , 'SIMULATION_START_DATE' , simulation_start_date , ierr )
+       END IF
+
        !  Test to make sure that the grid distances are the right size.
 
        CALL wrf_get_dom_ti_real ( fid , 'DX' ,  dx_compare , 1 , icnt , ierr )
@@ -1140,6 +1144,12 @@
             CALL domain_clock_get( grid, current_time=currtime, &
                                          current_timestr=currtimestr )
 #if (DA_CORE != 1) 
+            IF ( (switch .EQ. input_only) .and. (grid%id .EQ. 1) .and. (grid%itimestep .EQ. 0) ) THEN
+               WRITE( wrf_err_message , * ) 'CURRENT DATE          = ',TRIM( currtimestr )
+               CALL wrf_message ( trim(wrf_err_message) )
+               WRITE( wrf_err_message , * ) 'SIMULATION START DATE = ', simulation_start_date(1:19)
+               CALL wrf_message ( TRIM(wrf_err_message ) )
+            END IF
 ! Don't perform the check for WRFVAR, as we're not passing the right dates
 ! around
             CALL domain_clockprint(150, grid, &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -66,6 +66,7 @@
 !END FASDAS
 !
       INTEGER :: count_fatal_error
+      REAL :: dt_s, dx_km
 
 !-----------------------------------------------------------------------
 ! Set up the WRF Hydro namelist option to allow dynamic allocation of
@@ -1724,6 +1725,24 @@
            ( lon_extent_is_global .AND. lat_extent_is_global ) ) THEN
          CALL wrf_debug ( 0, '--- ERROR: Domain size is global, set &bdy_control polar=.TRUE.' )
          count_fatal_error = count_fatal_error + 1
+      END IF
+
+!-----------------------------------------------------------------------
+! Do a gross check on the time step for the most coarse grid (not for
+! adaptive time steps. If the value is significantly larger than 
+! stop immediately. Likely the user made a mistake.
+! If the rule of thumb is 6 DX = DT, then anything > 10 is flagged.
+! Only look at domain 1.
+!-----------------------------------------------------------------------
+      IF ( .NOT. model_config_rec % use_adaptive_time_step ) THEN
+         dt_s = REAL(model_config_rec % time_step) + &
+                REAL(model_config_rec % time_step_fract_num) / &
+                REAL(model_config_rec % time_step_fract_den)
+         dx_km = MIN ( model_config_rec % dx(1) ,  model_config_rec % dy(1) ) / 1000.
+         IF ( dt_s / dx_km > 10 )THEN
+            CALL wrf_debug ( 0, '--- ERROR: The time step is too large for this grid distance')
+            count_fatal_error = count_fatal_error + 1
+         END IF
       END IF
 
 !-----------------------------------------------------------------------

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -66,7 +66,6 @@
 !END FASDAS
 !
       INTEGER :: count_fatal_error
-      REAL :: dt_s, dx_km
 
 !-----------------------------------------------------------------------
 ! Set up the WRF Hydro namelist option to allow dynamic allocation of
@@ -1725,24 +1724,6 @@
            ( lon_extent_is_global .AND. lat_extent_is_global ) ) THEN
          CALL wrf_debug ( 0, '--- ERROR: Domain size is global, set &bdy_control polar=.TRUE.' )
          count_fatal_error = count_fatal_error + 1
-      END IF
-
-!-----------------------------------------------------------------------
-! Do a gross check on the time step for the most coarse grid (not for
-! adaptive time steps. If the value is significantly larger than 
-! stop immediately. Likely the user made a mistake.
-! If the rule of thumb is 6 DX = DT, then anything > 10 is flagged.
-! Only look at domain 1.
-!-----------------------------------------------------------------------
-      IF ( .NOT. model_config_rec % use_adaptive_time_step ) THEN
-         dt_s = REAL(model_config_rec % time_step) + &
-                REAL(model_config_rec % time_step_fract_num) / &
-                REAL(model_config_rec % time_step_fract_den)
-         dx_km = MIN ( model_config_rec % dx(1) ,  model_config_rec % dy(1) ) / 1000.
-         IF ( dt_s / dx_km > 10 )THEN
-            CALL wrf_debug ( 0, '--- ERROR: The time step is too large for this grid distance')
-            count_fatal_error = count_fatal_error + 1
-         END IF
       END IF
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: time_step, dx, cfl, ratio, current date, simulation start date

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Users accidentally forget to change the model time step when adjusting
the grid distance. It sometimes takes the model a while to become unstable
enough to die, and it is not always easy to determine why the model stopped.
However, we can't provide a simple "if the time step ratio > 6,
then always stop", because ideal cases would be unintentionally 
impacted. Likely there are also real-data cases, maybe LES-scale or urban heat 
island studies, where a user could realistically get a stable solution at a dt/dx ratio > 6.

Solution:
For domain 1 only, for real data cases only, for explicit dt cases (no adaptive dt):
Check to see if the time step ratio is greater than a prescribed value (default = 6),
which is defined in the Registry as a namelist option. If so, and the user's time does exceed
the provided limit, then stop immediately. If the user _is_ running a special scenario 
where a time step ratio of 8 (for example) would be acceptable, there is an option to 
make that workable at run-time.

Whether a user specifies a questionable dt ratio or not, always output a few important nml
settings up towards the top of the model printout (right after the max map factor).

Additionally, to help the users, add the start date and simulation start date into the print-out
that is at the very beginning of the WRF model standard out.

LIST OF MODIFIED FILES:
M dyn_em/start_em.F
M share/input_wrf.F
M Registry/Registry.EM_COMMON

ISSUE:
Fixes #772 "time_step check in the code"

 - [x] The model now always outputs the following for real-data cases:
```
 D01: Time step                              =    320.000000      (s)
 D01: Grid Distance                          =    30.0000000      (km)
 D01: Grid Distance Ratio dt/dx              =    10.6666670      (s/km)
 D01: Ratio Including Maximum Map Factor     =    10.9600906      (s/km)
 D01: NML defined reasonable_time_step_ratio =    8.00000000
```

TESTS CONDUCTED:
 - [x] With a reasonable time step, the model processes as normal.
```
 &domains
 time_step                           = 180,
 dx                                  = 30000, 10000,  3333.33,
 dy                                  = 30000, 10000,  3333.33,
 /
```

- [x] With a time step that is too large for a real-data case.
```
 &domains
 time_step                           = 320! 180,
 dx                                  = 30000, 10000,  3333.33,
 dy                                  = 30000, 10000,  3333.33,
 /
```
```
The time step is probably too large for this grid distance, reduce it.
 If you are sure of your settings, set reasonable_time_step_ratio in namelist.input >    10.9600906
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     335
--- ERROR: Time step too large
-------------------------------------------
```

 - [x] With a real data case, and a ratio < than the namelist ratio, the model runs (for just a bit):
```
 &domains
 time_step                           = 320
 reasonable_time_step_ratio          = 12.
 dx                                  = 30000, 10000,  3333.33,
 dy                                  = 30000, 10000,  3333.33,
```

 - [x] With a time step ratio greater than 10 for the LES case, the model integrates fine.
```
 &domains
 time_step                           = 1,
 dx                                  = 90,    50,    16.6667,
 dy                                  = 90,    50,    16.6667,
```