### PR TITLE
Adjust da_update_bc for Moist Theta

### DIFF
--- a/var/da/da_update_bc/da_update_bc.f90
+++ b/var/da/da_update_bc/da_update_bc.f90
@@ -43,7 +43,7 @@ program da_update_bc
 
    ! for WRF hybrid coordinate
    integer           :: nlevf, nlevh
-   integer           :: hybrid_opt
+   integer           :: hybrid_opt, use_theta_m
    real, allocatable :: c1f(:), c2f(:), c1h(:), c2h(:)
 
    integer           :: ids, ide, jds, jde, kds, kde
@@ -273,6 +273,11 @@ program da_update_bc
       allocate ( c1h(nlevh) )
       allocate ( c2h(nlevh) )
    end if
+
+   ! initialize as use_theta_m = 0
+   use_theta_m = 0
+   call da_get_gl_att_int_cdf(da_file, 'USE_THETA_M', use_theta_m, debug, io_status)
+   write(stdout,*) 'use_theta_m = ', use_theta_m
 
    ! initialize as hybrid_opt = 0
    hybrid_opt = 0
@@ -776,11 +781,19 @@ program da_update_bc
       case ('T', 'PH') ;
          var_pref=trim(var3d(n))
  
-         call da_get_var_3d_real_cdf( da_file, trim(var3d(n)), &
-            full3d, dims(1), dims(2), dims(3), 1, debug)
-         if ( var4d_lbc ) &
-            call da_get_var_3d_real_cdf( da_file_02, trim(var3d(n)), &
-               full3d2, dims(1), dims(2), dims(3), 1, debug)
+         if ( use_theta_m > 0 .and. trim(var3d(n) == 'T' ) then
+           call da_get_var_3d_real_cdf( da_file, 'THM', &
+              full3d, dims(1), dims(2), dims(3), 1, debug)
+           if ( var4d_lbc ) &
+              call da_get_var_3d_real_cdf( da_file_02, 'THM', &
+                 full3d2, dims(1), dims(2), dims(3), 1, debug)
+         else
+           call da_get_var_3d_real_cdf( da_file, trim(var3d(n)), &
+              full3d, dims(1), dims(2), dims(3), 1, debug)
+           if ( var4d_lbc ) &
+              call da_get_var_3d_real_cdf( da_file_02, trim(var3d(n)), &
+                 full3d2, dims(1), dims(2), dims(3), 1, debug)
+         end if
 
          if (debug) then
             write(unit=stdout, fmt='(3a,e20.12,4x)') &
@@ -1247,8 +1260,13 @@ program da_update_bc
       case ('T', 'PH') ;
          var_pref=trim(var3d(n))
  
-         call da_get_var_3d_real_cdf( da_file_02, trim(var3d(n)), &
-            full3d, dims(1), dims(2), dims(3), 1, debug)
+         if ( use_theta_m > 0 .and. trim(var3d(n) == 'T' ) then
+           call da_get_var_3d_real_cdf( da_file_02, 'THM', &
+              full3d, dims(1), dims(2), dims(3), 1, debug)
+         else
+           call da_get_var_3d_real_cdf( da_file_02, trim(var3d(n)), &
+              full3d, dims(1), dims(2), dims(3), 1, debug)
+         end if
 
          if (debug) then
             write(unit=stdout, fmt='(3a,e20.12,4x)') &

--- a/var/da/da_update_bc/da_update_bc.f90
+++ b/var/da/da_update_bc/da_update_bc.f90
@@ -781,7 +781,7 @@ program da_update_bc
       case ('T', 'PH') ;
          var_pref=trim(var3d(n))
  
-         if ( use_theta_m > 0 .and. trim(var3d(n) == 'T' ) then
+         if ( use_theta_m > 0 .and. trim(var3d(n)) == 'T' ) then
            call da_get_var_3d_real_cdf( da_file, 'THM', &
               full3d, dims(1), dims(2), dims(3), 1, debug)
            if ( var4d_lbc ) &
@@ -1260,7 +1260,7 @@ program da_update_bc
       case ('T', 'PH') ;
          var_pref=trim(var3d(n))
  
-         if ( use_theta_m > 0 .and. trim(var3d(n) == 'T' ) then
+         if ( use_theta_m > 0 .and. trim(var3d(n)) == 'T' ) then
            call da_get_var_3d_real_cdf( da_file_02, 'THM', &
               full3d, dims(1), dims(2), dims(3), 1, debug)
          else


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Moist Theta, DA, update_bc

SOURCE: internal

DESCRIPTION OF CHANGES:

1.  Following PR #750 (sha 1a93c97a142), Moist theta now works with WRFDA for non-4DVAR mode. WRFDA analysis file (i.e., wrfvar_output) contains both 'T' (dry theta perturbation) and 'THM' (moist theta perturbation). They are identical when use_theta_m=0, and different when use_theta_m=1. Note that wrfbdy file includes only the variable 'T', which represents either dry or moist theta perturbation according to 'USE_THETA_M'. 

2. da_update_bc program only read 'T' from the analysis and wrfbdy files and update 'T' in wrfbdy. In the case of use_theta_m=1, 'T' in wrfbdy is moist variable and 'T' in the analysis is dry variable. Modified code now reads 'THM' from the analysis file when use_theta_m=1.

LIST OF MODIFIED FILES:
M var/da/da_update_bc/da_update_bc.f90

TESTS CONDUCTED:
Cycling test case (cycle_sens_hires) of WRFDA regtests with use_theta_m=1 passed.

RELEASE NOTE: None.