### PR TITLE
chem: Add Grell-Devenyi (GD) scheme if cu_diag = 1

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -391,8 +391,11 @@ call wrf_message("**************************************************************
    endif
 
    if ( config_flags%cu_diag == 1) then
-   if ( config_flags%cu_physics /= 3 .AND. config_flags%cu_physics /= 5 .AND. config_flags%cu_physics /= 10) then !BSINGH(12/17/2013): Added for WRFCUP scheme
-         call wrf_error_fatal(" Time averaged variables (cu_diag = 1) requires cu_physics = 3 or 5 or 10")
+   !BSINGH (12/17/2013): Added Kain–Fritsch Cumulus Potential (KF-CuP) scheme (cu_physics = 10)
+   !HSBADR (02/12/2019): Added Grell-Devenyi (GD) ensemble scheme (cu_physics = 93)
+   if ( config_flags%cu_physics /= 3 .AND. config_flags%cu_physics /= 5 .AND. &
+        config_flags%cu_physics /= 10 .AND. config_flags%cu_physics /= 93 ) then
+         call wrf_error_fatal(" Time averaged variables (cu_diag = 1) requires cu_physics = 3 or 5 or 10 or 93")
    endif
    endif
 

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -801,14 +801,14 @@ Namelist variables for controlling the adaptive time step option:
 
  ishallow                            = 0, !  = 1 turns on shallow convection, used with Grell 3D ensemble schemes (cu_physics = 3 or 5)
  clos_choice                         = 0, !  closure choice (place holder only)
- cu_diag (max_dom)                   = 0, !  additional t-averaged stuff for cu physics (cu_phys = 3, 5 and 93 only)
+ cu_diag (max_dom)                   = 0, !  additional t-averaged stuff for cu physics (cu_phys = 3, 5, 10, and 93 only)
  kf_edrates (max_dom)                = 0, !  Add entrainment/detrainment rates and convective timescale output variables for KF-based 
                                              cumulus schemes (cu_phys = 1, 11 and 99 only) (new in 3.8)
                                      = 0,  !  no output; = 1, additional output
  convtrans_avglen_m                  = 30, !  averaging time for variables used by convective transport (call cu_phys options)  and radiation routines (only cu_phys=3,5 and 93) (minutes) 
  cu_rad_feedback (max_dom)           = .false.  ! sub-grid cloud effect to the optical depth in radiation
                                                   currently it works only for GF, G3, GD and KF scheme
-                                                  One also needs to set cu_diag = 1 for GF, G3 and GD schemes
+                                                  One also needs to set cu_diag = 1 for GF, G3, KF-CuP, and GD schemes
  cudt (max_dom)                      = 0,       ! minutes between cumulus physics calls
  kfeta_trigger                       KF trigger option (cu_physics=1 only):
                                      = 1, default option

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1392,7 +1392,11 @@
                ( model_config_rec%cu_physics(i) .NE. G3SCHEME ) ) THEN
                 wrf_err_message = '--- ERROR: Using cu_diag=1 requires use of one of the following CU schemes:'
                 CALL wrf_message ( wrf_err_message )
-                wrf_err_message = '---          Grell (G3) CU scheme'
+                wrf_err_message = '---          Grell-Freitas (GF) CU scheme'
+                CALL wrf_message ( wrf_err_message )
+                wrf_err_message = '---          Grell 3D (G3) CU scheme'
+                CALL wrf_message ( wrf_err_message )
+                wrf_err_message = '---          Kain–Fritsch Cumulus Potential (KF-CuP) CU scheme'
                 CALL wrf_message ( wrf_err_message )
                 wrf_err_message = '---          Grell-Devenyi (GD) CU scheme'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRF-Chem, Cumulus, GDSCHEME, cu_diag, cu_rad_feedback, namelist

SOURCE: Hamada S. Badr (Johns Hopkins University, USA)

DESCRIPTION OF CHANGES:
Sub-grid cloud effect to the optical depth in radiation (cu_rad_feedback = .true.) requires setting additional time-averaged variables for cumulus physics (cu_diag = 1) that only works for Grell-Freitas (GF), Grell 3D (G3), Kain–Fritsch Cumulus Potential (KF-CuP), and Grell-Devenyi (GD) cumulus schemes, which are equivalent to cu_physics = 3, 5, 10, and 93, respectively.

In the namelist README and consistency checks, cu_diag = 1 is supported by 4 cumulus schemes:
    1) Grell-Freitas (GFSCHEME)
    2) Grell 3D (G3SCHEME)
    3) Kain–Fritsch Cumulus Potential (KFCUPSCHEME), and
    4) Grell-Devenyi (GDSCHEME)

These changes only impact WRF-Chem runs where time-averaged variables for cumulus physics (cu_diag) can now be enabled for GDSCHEME, which by default passes the cu_diag = 1 consistency checks (share/module_check_a_mundo.F) but was failing only in WRF-Chem initialization (chem/chemics_init.F). The namelist README and the error messages in the consistency checks are also updated.

LIST OF MODIFIED FILES:
M chem/chemics_init.F
M share/module_check_a_mundo.F
M run/README.namelist

TESTS CONDUCTED: WRF-Chem GOCART simulations using cu_physics = 93 with cu_rad_feedback = .true. and cu_diag = 1.