### PR TITLE
Remove extraneous HVC comments in module_check_a_mundo

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1593,12 +1593,6 @@
      END DO
 
 !-----------------------------------------------------------------------
-!  The hybrid vertical coordinate (HVC) namelist.input option (hybrid_opt=2)
-!  requires the code to be built with the HVC code enabled.  This is a run-time
-!  test to make sure the correct compile-time capabilities are available.
-!-----------------------------------------------------------------------
-
-!-----------------------------------------------------------------------
 !  DJW Check that we're not using ndown and vertical nesting.
 !-----------------------------------------------------------------------
      DO i=1,model_config_rec%max_dom


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: HVC, check_a_mundo, comments

SOURCE: internal

DESCRIPTION OF CHANGES: 
An original IF block in check_a_mundo that guarded against an inconsistent build was removed
in v4.0. However, the comments ahead of that IF block remained. That block of comments, which
now describe nothing but empty lines, is removed.

LIST OF MODIFIED FILES: 
M  share/module_check_a_mundo.F

TESTS CONDUCTED: 
No tests required as these changes are only removing incorrect comments.