### PR TITLE
typo in WRF Chem chem/chemics_init.F

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -706,7 +706,7 @@ end if
    if( .NOT. config_flags%restart ) then
    kpp_select: SELECT CASE(config_flags%chem_opt)
 CASE(GOCARTRACM_KPP,RACM_KPP,RACMPM_KPP,RACMSORG_KPP,RACM_MIM_KPP,RACM_ESRLSORG_KPP,&
-           RACMSORG_AQCHEM_KPP,RACM_ESRLSORG_AQCHEM_KPP,RACM_SOA_VBS_KPP,RACM_SOA_VBS_KPP_AQCHEM)
+           RACMSORG_AQCHEM_KPP,RACM_ESRLSORG_AQCHEM_KPP,RACM_SOA_VBS_KPP,RACM_SOA_VBS_AQCHEM_KPP)
         if(config_flags%chem_in_opt == 0 )then
           do j=jts,jte
              do k=kts,kte


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRF Chem, chemics_init.F

SOURCE: internal

DESCRIPTION OF CHANGES:
A typo was introduced in SHA d4c8bb2085b4
This is PR #606 "Updates for completeness of gas initialization and plumerise"
In a case statement, the line incorrectly included
```
RACM_SOA_VBS_KPP_AQCHEM
```
and should have had
```
RACM_SOA_VBS_AQCHEM_KPP
```

LIST OF MODIFIED FILES: 
M   chem/chemics_init.F

TESTS CONDUCTED: 
 - [x] WRF Chem code compiles with mod.