### PR TITLE
Use linear vertical interpolation for pos def fields

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2089,7 +2089,7 @@ rconfig   logical use_levels_below_ground namelist,domains	1             .true. 
 rconfig   logical use_tavg_for_tsk        namelist,domains	1             .false.  irh    "use_tavg_for_tsk"   "T/F: use diurnal avg sfc temp for tsk" ""
 rconfig   logical use_surface             namelist,domains	1             .true.   irh    "use_surface"   "T/F: use input surface level in interpolation" ""
 rconfig   integer lagrange_order          namelist,domains	1              2       irh    "lagrange_order"   "1=linear, 2=quadratic vertical interpolation, 9=cubic spline"      ""
-rconfig   integer pos_def_vert_interp     namelist,domains	1              1       irh    "pos_def_vert_interp"   "1=linear"      ""
+rconfig   integer linear_interp           namelist,domains	1              1       irh    "linear_interp"   "1=linear"      ""
 rconfig   integer force_sfc_in_vinterp    namelist,domains	1              1       irh    "force_sfc_in_vinterp"   "number of eta levels forced to use sfc in vert interp"      ""
 rconfig   real    zap_close_levels        namelist,domains	1              500     irh    "zap_close_levels"   "delta p where level is removed in vert interp"      "Pa"
 rconfig   real    maxw_horiz_pres_diff    namelist,domains	1              5000    irh    "maxw_horiz_pres_diff"   "pressure limit (Pa), when horiz diff exceeded do not use max_wind level in real"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2089,6 +2089,7 @@ rconfig   logical use_levels_below_ground namelist,domains	1             .true. 
 rconfig   logical use_tavg_for_tsk        namelist,domains	1             .false.  irh    "use_tavg_for_tsk"   "T/F: use diurnal avg sfc temp for tsk" ""
 rconfig   logical use_surface             namelist,domains	1             .true.   irh    "use_surface"   "T/F: use input surface level in interpolation" ""
 rconfig   integer lagrange_order          namelist,domains	1              2       irh    "lagrange_order"   "1=linear, 2=quadratic vertical interpolation, 9=cubic spline"      ""
+rconfig   integer pos_def_vert_interp     namelist,domains	1              1       irh    "pos_def_vert_interp"   "1=linear"      ""
 rconfig   integer force_sfc_in_vinterp    namelist,domains	1              1       irh    "force_sfc_in_vinterp"   "number of eta levels forced to use sfc in vert interp"      ""
 rconfig   real    zap_close_levels        namelist,domains	1              500     irh    "zap_close_levels"   "delta p where level is removed in vert interp"      "Pa"
 rconfig   real    maxw_horiz_pres_diff    namelist,domains	1              5000    irh    "maxw_horiz_pres_diff"   "pressure limit (Pa), when horiz diff exceeded do not use max_wind level in real"

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -131,7 +131,7 @@ integer::oops1,oops2
       REAL    :: zap_close_levels
       INTEGER :: force_sfc_in_vinterp
       INTEGER :: interp_type , lagrange_order , extrap_type , t_extrap_type
-      INTEGER :: pos_def_vert_interp
+      INTEGER :: linear_interp
       LOGICAL :: lowest_lev_from_sfc , use_levels_below_ground , use_surface
       LOGICAL :: we_have_tavgsfc , we_have_tsk
 
@@ -1682,7 +1682,7 @@ integer::oops1,oops2
 
             interp_type = 2
             lagrange_order = grid%lagrange_order
-            pos_def_vert_interp = grid%pos_def_vert_interp
+            linear_interp = grid%linear_interp
             lowest_lev_from_sfc = .FALSE.
             use_levels_below_ground = .TRUE.
             use_surface = .TRUE.
@@ -1776,7 +1776,7 @@ integer::oops1,oops2
                             config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                             config_flags%maxw_above_this_level , &
                             num_metgrid_levels , 'Q' , &
-                            interp_type , pos_def_vert_interp , extrap_type , &
+                            interp_type , linear_interp , extrap_type , &
                             lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                             zap_close_levels , force_sfc_in_vinterp , grid%id , &
                             ids , ide , jds , jde , kds , kde , &
@@ -1895,7 +1895,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1925,7 +1925,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1955,7 +1955,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1975,7 +1975,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1995,7 +1995,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2015,7 +2015,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2035,7 +2035,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2055,7 +2055,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2075,7 +2075,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2095,7 +2095,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2115,7 +2115,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2135,7 +2135,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2160,7 +2160,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2176,7 +2176,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2213,7 +2213,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2228,7 +2228,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , pos_def_vert_interp , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2322,7 +2322,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , pos_def_vert_interp , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2374,7 +2374,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , pos_def_vert_interp , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2426,7 +2426,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , pos_def_vert_interp , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2550,7 +2550,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , pos_def_vert_interp , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2611,7 +2611,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , pos_def_vert_interp , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1776,7 +1776,7 @@ integer::oops1,oops2
                             config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                             config_flags%maxw_above_this_level , &
                             num_metgrid_levels , 'Q' , &
-                            interp_type , linear_interp , extrap_type , &
+                            interp_type , lagrange_order , extrap_type , &
                             lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                             zap_close_levels , force_sfc_in_vinterp , grid%id , &
                             ids , ide , jds , jde , kds , kde , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -131,6 +131,7 @@ integer::oops1,oops2
       REAL    :: zap_close_levels
       INTEGER :: force_sfc_in_vinterp
       INTEGER :: interp_type , lagrange_order , extrap_type , t_extrap_type
+      INTEGER :: pos_def_vert_interp
       LOGICAL :: lowest_lev_from_sfc , use_levels_below_ground , use_surface
       LOGICAL :: we_have_tavgsfc , we_have_tsk
 
@@ -1681,6 +1682,7 @@ integer::oops1,oops2
 
             interp_type = 2
             lagrange_order = grid%lagrange_order
+            pos_def_vert_interp = grid%pos_def_vert_interp
             lowest_lev_from_sfc = .FALSE.
             use_levels_below_ground = .TRUE.
             use_surface = .TRUE.
@@ -1774,7 +1776,7 @@ integer::oops1,oops2
                             config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                             config_flags%maxw_above_this_level , &
                             num_metgrid_levels , 'Q' , &
-                            interp_type , lagrange_order , extrap_type , &
+                            interp_type , pos_def_vert_interp , extrap_type , &
                             lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                             zap_close_levels , force_sfc_in_vinterp , grid%id , &
                             ids , ide , jds , jde , kds , kde , &
@@ -1893,7 +1895,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1923,7 +1925,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1953,7 +1955,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1973,7 +1975,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1993,7 +1995,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2013,7 +2015,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2033,7 +2035,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2053,7 +2055,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2073,7 +2075,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2093,7 +2095,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2113,7 +2115,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2133,7 +2135,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2158,7 +2160,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2174,7 +2176,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2211,7 +2213,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2226,7 +2228,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , pos_def_vert_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2320,7 +2322,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , pos_def_vert_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2372,7 +2374,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , pos_def_vert_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2424,7 +2426,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , pos_def_vert_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2548,7 +2550,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , pos_def_vert_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2609,7 +2611,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , pos_def_vert_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: positive definite, vertical interpolation, real

SOURCE: Found by Pedro Jimenez (NCAR), fixed internally

DESCRIPTION OF CHANGES:
Problem:
Users noticed that the constituent for P_QI was negative after running real.

Solution:
The order of the vertical interpolation was originally handled by the
`lagrange_order` namelist variable. By default, this value was set to
2, meaning a quadratic was used for vertical iterpolation. For positive
definite fields, we should use only linear vertical interpolation. The
results of a linear interpolation will maintain a positive definite
field. The new namelist variable `linear_interp` is always set
to 1, and is used in the calling function for all of the known positive
definite fields (for example, constituents of moist).

LIST OF MODIFIED FILES:
M Registry/Registry.EM_COMMON
M dyn_em/module_initialize_real.F

TESTS CONDUCTED:
 - [x] Original moisture field, RH, stays the same.

RELEASE NOTE: For the real program, the order of the vertical interpolation option is now always set to a linear interpolation for meteorological fields that are supposed to be positive definite (for example, moist process constituents and number concentration). However, the RH field in the real program continues to use the original vertical interpolation option.