### PR TITLE
Deng convection scheme only works with MYJ or MYNN PBL, and deep convection must be turned off 

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -798,6 +798,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 2, Park and Bretherton shallow cumulus from CAM5 (CESM 1_0_1)
                                      = 3, GRIMS shallow cumulus from YSU group
                                      = 5, Deng shallow cumulus from PSU and WRF-Solar
+                                          This scheme only works with MYJ and MYNN PBL schemes 
 
  ishallow                            = 0, !  = 1 turns on shallow convection, used with Grell 3D ensemble schemes (cu_physics = 3 or 5)
  clos_choice                         = 0, !  closure choice (place holder only)

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -797,8 +797,8 @@ Namelist variables for controlling the adaptive time step option:
                                      = 1, Grell 3D ensemble scheme (use with cu_physics=93 or 5) (PLACEHOLDER: SWITCH NOT YET IMPLEMENTED--use ishallow)
                                      = 2, Park and Bretherton shallow cumulus from CAM5 (CESM 1_0_1)
                                      = 3, GRIMS shallow cumulus from YSU group
-                                     = 5, Deng shallow cumulus from PSU and WRF-Solar
-                                          This scheme only works with MYJ and MYNN PBL schemes 
+                                     = 5, Deng cumulus scheme (including both shallow and deep convections) from PSU and WRF-Solar
+                                          This scheme only works with MYJ or MYNN PBL schemes 
 
  ishallow                            = 0, !  = 1 turns on shallow convection, used with Grell 3D ensemble schemes (cu_physics = 3 or 5)
  clos_choice                         = 0, !  closure choice (place holder only)

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -198,10 +198,10 @@
 ! Check that Deng Shallow Convection Must work with MYJ or MYNN PBL
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
-         IF ( model_config_rec % shcu_physics(i) .EQ. 5 .AND. &
-              (model_config_rec % bl_pbl_physics(i) .NE. 2 .OR. &
-               model_config_rec % bl_pbl_physics(i) .NE. 5 ) ) THEN
-            wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ and MYNN PBL '
+         IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
+              (model_config_rec % bl_pbl_physics(i) /= myjpblscheme .OR. &
+               model_config_rec % bl_pbl_physics(i) /= mynnpblscheme2 ) ) THEN
+            wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL '
             CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- ERROR: Fix shcu_physics and bl_pbl_physics in namelist.input.'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -203,7 +203,7 @@
                model_config_rec % bl_pbl_physics(i) /= mynnpblscheme2 ) ) THEN
             wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL '
             CALL wrf_message ( wrf_err_message )
-            wrf_err_message = '--- ERROR: Fix shcu_physics and bl_pbl_physics in namelist.input.'
+            wrf_err_message = '--- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
          END IF
@@ -211,7 +211,7 @@
               model_config_rec % cu_physics(i) /= nocuscheme  ) THEN
             wrf_err_message = '--- ERROR: Deng shallow convection must run with cu_physics=0 '
             CALL wrf_message ( wrf_err_message )
-            wrf_err_message = '--- ERROR: Fix shcu_physics and cu_physics in namelist.input.'
+            wrf_err_message = '--- ERROR: Fix shcu_physics or cu_physics in namelist.input.'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
          END IF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -194,6 +194,20 @@
          count_fatal_error = count_fatal_error + 1
          END IF
       ENDDO
+!-----------------------------------------------------------------------
+! Check that Deng Shallow Convection Must work with MYJ or MYNN PBL
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( model_config_rec % shcu_physics(i) .EQ. 5 .AND. &
+              (model_config_rec % bl_pbl_physics(i) .NE. 2 .OR. &
+               model_config_rec % bl_pbl_physics(i) .NE. 5 ) ) THEN
+            wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ and MYNN PBL '
+            CALL wrf_message ( wrf_err_message )
+            wrf_err_message = '--- ERROR: Fix shcu_physics and bl_pbl_physics in namelist.input.'
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+         END IF
+      ENDDO
 
 #endif
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -207,6 +207,14 @@
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
          END IF
+         IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
+              model_config_rec % cu_physics(i) /= nocuscheme  ) THEN
+            wrf_err_message = '--- ERROR: Deng shallow convection must run with cu_physics=0 '
+            CALL wrf_message ( wrf_err_message )
+            wrf_err_message = '--- ERROR: Fix shcu_physics and cu_physics in namelist.input.'
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+         END IF
       ENDDO
 
 #endif


### PR DESCRIPTION
TYPE:  Text only

KEYWORDS:  Deng shallow convection

SOURCE: Internal

DESCRIPTION OF CHANGES: 
The Deng shallow convection scheme only works with MYJ or MYNN PBL schemes. In addition, when this scheme is turned on, cumulus scheme must be turned off.
The README file which describes many of the namelist settings is updated to make 
this restriction clear. 

LIST OF MODIFIED FILES:
M   run/README.namelist
M  share/module_check_a_mundo.F

TESTS CONDUCTED: a test case with the wrong settings is conducted. Below is the error message
```
Quilting with   1 groups of   0 I/O tasks.
 Ntasks in X            2 , ntasks in Y            2
--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL
  --- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.
--- ERROR: Deng shallow convection must run with cu_physics=0
  --- ERROR: Fix shcu_physics or cu_physics in namelist.input.
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1780
NOTE:       2 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```