### PR TITLE
update module_cu_ntiedtke file to identically match MPAS version

### DIFF
--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -49,26 +49,21 @@ module module_cu_ntiedtke
 #if defined(mpas)
      use mpas_atmphys_constants, only: rd=>R_d, rv=>R_v, &
    &       cpd=>cp, alv=>xlv, als=>xls, alf=>xlf, g=>gravity
-#elif defined(wrfmodel)
+#else
      use module_model_constants, only:rd=>r_d, rv=>r_v, &
-   &       cpd=>cp, alv=>xlv, als=>xls, alf=>xlf, t13=>Prandtl, g              
+   &       cpd=>cp, alv=>xlv, als=>xls, alf=>xlf, g
 #endif
 
      implicit none
-     real,private :: rcpd,vtmpc1,tmelt,                &
+     real,private :: t13,rcpd,vtmpc1,tmelt,            &
              c1es,c2es,c3les,c3ies,c4les,c4ies,c5les,c5ies,zrg
-#if defined(mpas)
-     real,private :: t13
-#endif
+
      real,private :: r5alvcp,r5alscp,ralvdcp,ralsdcp,ralfdcp,rtwat,rtber,rtice 
      real,private :: entrdd,cmfcmax,cmfcmin,cmfdeps,zdnoprc,cprcon,pgcoef
      integer,private :: momtrans
 
      parameter(         &
-#if defined(mpas)
-! parameter not present in mpas_atmphy_constants
       t13=1.0/3.0,      &
-#endif
       rcpd=1.0/cpd,     &
       tmelt=273.16,     &
       zrg=1.0/g,        &
@@ -3885,4 +3880,4 @@ contains
       end function  foeldcpm
 
 end module module_cu_ntiedtke
-                                                                                         
+


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: wrf, mpas, unification, ntiedtke, cumulus

SOURCE: internal

DESCRIPTION OF CHANGES: For the purpose of WRF/MPAS physics unification, we want the 2 models to have identical versions of each physics routine. After some mods were made to the MPAS version, this version then was behind. This particular PR defines t13 in the code rather using the Prandtl number since the Prandtl number is different in WRF and MPAS.

LIST OF MODIFIED FILES: 
M   phys/module_cu_ntiedtke.F

TESTS CONDUCTED: Verified that it compiles and runs fine. There were no diffs in output before/after modifications.