### PR TITLE
Bug fix to allow old OBSGRID input to be used in V4.0* real.exe

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -1903,6 +1903,7 @@
 
     IF ( &
          ( INDEX(TRIM(input_title_char),'METGRID'     ) .NE. 0 ) .OR. &
+         ( INDEX(TRIM(input_title_char),'OBSGRID'     ) .NE. 0 ) .OR. &
          ( INDEX(TRIM(input_title_char),'SFCFDDA'     ) .NE. 0 ) .OR. &
          ( INDEX(TRIM(input_title_char),'EMISSIONS'   ) .NE. 0 ) .OR. &
          ( INDEX(TRIM(input_title_char),'XYZZY'       ) .NE. 0 )      &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: obsgrid, metoa, v4, old

SOURCE: internal

DESCRIPTION OF CHANGES: Due to vetting in input_wrf.F, some older (than v4.0) input data is not allowed to run with v4.0+ real.exe. This included older OBSGRID input, which should be excluded from this rule, as the version of OBSGRID is irrelevant. Added OBSGRID to the clause that excludes it from this vetting process.

LIST OF MODIFIED FILES: 
M      share/input_wrf.F

TESTS CONDUCTED: Tested code before/after with new metoa* input data to make sure it behaves correctly. Compiles okay.

RELEASE NOTE: 
OBSGRID input data may now be used with V4.1 real.exe, regardless of the version of OBSGRID. 