### PR TITLE
Make random seeds for stochastic schemes able to be in restart file and be allocatable

### DIFF
--- a/Registry/registry.dimspec
+++ b/Registry/registry.dimspec
@@ -30,6 +30,7 @@ dimspec    nndgvar -     namelist=nobs_ndg_vars            c     nobs_ndg_vars
 dimspec    [       -     namelist=obs_prt_max              c     obs_prt_max
 dimspec    obsstid -     constant=40                       c     obs station id names
 dimspec    &       2     namelist=lagday                   z     lagday
+dimspec    seed    1     namelist=seed_dim                 z     seed_dim
 endif
 
 

--- a/Registry/registry.stoch
+++ b/Registry/registry.stoch
@@ -55,14 +55,14 @@ state    real  SPPT_AMP       ij   misc   1 -   r          "SPPT_AMP"       "amp
 
 
 # 1d arrays
-state    real  VERTAMPT        k   misc   1 -   r          "VERTAMPT"       "vert. amplitude of stoch. temperature perturb." "" ""
-state    real  VERTAMPUV       k   misc   1 -   r          "VERTAMPUV"      "vert. amplitude of stoch. u,v perturb." "" ""
-state integer  ISEEDARR_SPPT      k   misc   1  -   rh     "ISEEDARR_SPPT"         "Array to hold seed for restart, SPPT" "" ""
-state integer  ISEEDARR_SKEBS     k   misc   1  -   rh     "ISEEDARR_SKEBS"        "Array to hold seed for restart, SKEBS" "" ""
-state integer  ISEEDARR_RAND_PERT k   misc   1  -   rh     "ISEEDARR_RAND_PERTURB" "Array to hold seed for restart, RAND_PERT" "" ""
-state integer  iseedarr_spp_conv k  misc   1  -   rh     "iseedarray_spp_conv"   "Array to hold seed for restart, RAND_PERT2" "" ""
-state integer  iseedarr_spp_pbl k   misc   1  -   rh     "iseedarray_spp_pbl"    "Array to hold seed for restart, RAND_PERT3" "" ""
-state integer  iseedarr_spp_lsm k   misc   1  -   rh     "iseedarray_spp_lsm"    "Array to hold seed for restart, RAND_PERT4" "" ""
+state    real  VERTAMPT           k       misc   1 -    r      "VERTAMPT"              "vert. amplitude of stoch. temperature perturb." "" ""
+state    real  VERTAMPUV          k       misc   1 -    r      "VERTAMPUV"             "vert. amplitude of stoch. u,v perturb." "" ""
+state integer  ISEEDARR_SPPT      {seed}  misc   1  -   rh     "ISEEDARR_SPPT"         "Array to hold seed for restart, SPPT" "" ""
+state integer  ISEEDARR_SKEBS     {seed}  misc   1  -   rh     "ISEEDARR_SKEBS"        "Array to hold seed for restart, SKEBS" "" ""
+state integer  ISEEDARR_RAND_PERT {seed}  misc   1  -   rh     "ISEEDARR_RAND_PERTURB" "Array to hold seed for restart, RAND_PERT" "" ""
+state integer  iseedarr_spp_conv  {seed}  misc   1  -   rh     "iseedarray_spp_conv"   "Array to hold seed for restart, RAND_PERT2" "" ""
+state integer  iseedarr_spp_pbl   {seed}  misc   1  -   rh     "iseedarray_spp_pbl"    "Array to hold seed for restart, RAND_PERT3" "" ""
+state integer  iseedarr_spp_lsm   {seed}  misc   1  -   rh     "iseedarray_spp_lsm"    "Array to hold seed for restart, RAND_PERT4" "" ""
 
 # 1d arrays for FFT transpose
 state    real   RAND_REAL_xxx   i{stoclev}jx dyn_em 1 XYZ
@@ -177,6 +177,7 @@ rconfig   integer     sppt_on                 derived    1        0        - "sp
 rconfig   integer     spp_on                  derived    1        0        - "skebs_on"         "skebs arrays are declared&filled for all domains"          ""
 rconfig   integer     rand_perturb_on         derived    1        0        - "rand_perturb_on " "random perturb. array is declared&filled for all domains"  ""
 rconfig   integer     num_stoch_levels        derived    1        1        - "num_stoch_levels" "number of vertical levels of random fields"  ""
+rconfig   integer     seed_dim                derived    1        0        - "seed_dim"         "output of CALL RANDOM_SEED(SIZE=seed_dim)"   ""
 
 # Package declarations
 

--- a/Registry/registry.stoch
+++ b/Registry/registry.stoch
@@ -57,12 +57,12 @@ state    real  SPPT_AMP       ij   misc   1 -   r          "SPPT_AMP"       "amp
 # 1d arrays
 state    real  VERTAMPT           k       misc   1 -    r      "VERTAMPT"              "vert. amplitude of stoch. temperature perturb." "" ""
 state    real  VERTAMPUV          k       misc   1 -    r      "VERTAMPUV"             "vert. amplitude of stoch. u,v perturb." "" ""
-state integer  ISEEDARR_SPPT      {seed}  misc   1  -   rh     "ISEEDARR_SPPT"         "Array to hold seed for restart, SPPT" "" ""
-state integer  ISEEDARR_SKEBS     {seed}  misc   1  -   rh     "ISEEDARR_SKEBS"        "Array to hold seed for restart, SKEBS" "" ""
-state integer  ISEEDARR_RAND_PERT {seed}  misc   1  -   rh     "ISEEDARR_RAND_PERTURB" "Array to hold seed for restart, RAND_PERT" "" ""
-state integer  iseedarr_spp_conv  {seed}  misc   1  -   rh     "iseedarray_spp_conv"   "Array to hold seed for restart, RAND_PERT2" "" ""
-state integer  iseedarr_spp_pbl   {seed}  misc   1  -   rh     "iseedarray_spp_pbl"    "Array to hold seed for restart, RAND_PERT3" "" ""
-state integer  iseedarr_spp_lsm   {seed}  misc   1  -   rh     "iseedarray_spp_lsm"    "Array to hold seed for restart, RAND_PERT4" "" ""
+state integer  ISEEDARR_SPPT      {seed}  misc   1  Z   rh     "ISEEDARR_SPPT"         "Array to hold seed for restart, SPPT" "" ""
+state integer  ISEEDARR_SKEBS     {seed}  misc   1  Z   rh     "ISEEDARR_SKEBS"        "Array to hold seed for restart, SKEBS" "" ""
+state integer  ISEEDARR_RAND_PERT {seed}  misc   1  Z   rh     "ISEEDARR_RAND_PERTURB" "Array to hold seed for restart, RAND_PERT" "" ""
+state integer  iseedarr_spp_conv  {seed}  misc   1  Z   rh     "iseedarray_spp_conv"   "Array to hold seed for restart, RAND_PERT2" "" ""
+state integer  iseedarr_spp_pbl   {seed}  misc   1  Z   rh     "iseedarray_spp_pbl"    "Array to hold seed for restart, RAND_PERT3" "" ""
+state integer  iseedarr_spp_lsm   {seed}  misc   1  Z   rh     "iseedarray_spp_lsm"    "Array to hold seed for restart, RAND_PERT4" "" ""
 
 # 1d arrays for FFT transpose
 state    real   RAND_REAL_xxx   i{stoclev}jx dyn_em 1 XYZ
@@ -121,32 +121,32 @@ rconfig   real        gridpt_stddev_sppt      namelist,stoch      max_domains   
 rconfig   real        stddev_cutoff_sppt      namelist,stoch      max_domains          2.0  - "cutoff tails of pdf above this threshold standard deviation"
 rconfig   real        lengthscale_sppt        namelist,stoch      max_domains     150000.0  - "Correlation length scale in meters for SPPT"
 rconfig   real        timescale_sppt          namelist,stoch      max_domains      21600.0  - "Decorrelation time scale in s for SPPT"
-rconfig   integer     sppt_vertstruc          namelist,stoch      1                      0 -  "vertical structure for sppt: 0=constant, 1=random phase"
+rconfig   integer     sppt_vertstruc          namelist,stoch      1                      0  - "vertical structure for sppt: 0=constant, 1=random phase"
 rconfig   integer     iseed_sppt              namelist,stoch      1                     53  - "ISEED_SPPT"            "RANDOM SEED FOR SPPT "  ""
 
 # Namelist parameters for random perturbations
 
 rconfig   integer     rand_perturb            namelist,stoch      max_domains           0  - "generate array with random perturbations: 0=off, 1=on"
-rconfig   real        gridpt_stddev_rand_pert namelist,stoch      max_domains         0.03  - "gridpoint standard deviation of random perturbations"
+rconfig   real        gridpt_stddev_rand_pert namelist,stoch      max_domains         0.03 - "gridpoint standard deviation of random perturbations"
 rconfig   real        stddev_cutoff_rand_pert namelist,stoch      max_domains         3.0  - "cutoff tails of pdf above this threshold standard deviation"
 rconfig   real        lengthscale_rand_pert   namelist,stoch      max_domains    500000.0  - "Correlation length scale in meters"
 rconfig   real        timescale_rand_pert     namelist,stoch      max_domains     21600.0  - "Decorrelation time scale in s"
-rconfig   integer     rand_pert_vertstruc     namelist,stoch      1                      0 -  "vertical structure for random perturb: 0=constant, 1=random phase"
+rconfig   integer     rand_pert_vertstruc     namelist,stoch      1                     0  - "vertical structure for random perturb: 0=constant, 1=random phase"
 rconfig   integer     iseed_rand_pert         namelist,stoch      1                    17  - "ISEED_RAND_PERT"       "RANDOM SEED FOR RAND_PERT "  ""
 
 # Namelist parameters for stochastic perturbed parameters 
 
 rconfig   integer     spp                    namelist,stoch       max_domains           0  - "generate array with random perturbations: 0=off, 1=on"
-rconfig   logical     hrrr_cycling           namelist,stoch       1               .false.  - "switch to control restart in quasi-cycled hrrr-forecasts"
+rconfig   logical     hrrr_cycling           namelist,stoch       1               .true.   - "switch to control restart in quasi-cycled hrrr-forecasts"
 
 # Namelist parameters for stochastic perturbed parameters (SPP) for convective scheme
 
-rconfig   integer     spp_conv               namelist,stoch       max_domains           0  - "generate array with random perturbations: 0=off, 1=on"
+rconfig   integer     spp_conv               namelist,stoch       max_domains          0  - "generate array with random perturbations: 0=off, 1=on"
 rconfig   real        gridpt_stddev_spp_conv namelist,stoch      max_domains         0.3  - "gridpoint standard deviation of random perturbations"
 rconfig   real        stddev_cutoff_spp_conv namelist,stoch      max_domains         3.0  - "cutoff tails of pdf above this threshold standard deviation"
 rconfig   real        lengthscale_spp_conv   namelist,stoch      max_domains    150000.0  - "Correlation length scale in meters"
 rconfig   real        timescale_spp_conv     namelist,stoch      max_domains     21600.0  - "Decorrelation time scale in s"
-rconfig   integer     vertstruc_spp_conv     namelist,stoch      1                      0 -  "vertical structure for random perturb: 0=constant, 1=random phase"
+rconfig   integer     vertstruc_spp_conv     namelist,stoch      1                     0  - "vertical structure for random perturb: 0=constant, 1=random phase"
 rconfig   integer     iseed_spp_conv         namelist,stoch      1                   171  - "ISEED_RAND_PERT"       "RANDOM SEED FOR RAND_PERT "  ""
 
 # Namelist parameters for stochastic perturbed parameters (SPP) for pbl 
@@ -156,7 +156,7 @@ rconfig   real        gridpt_stddev_spp_pbl namelist,stoch      max_domains     
 rconfig   real        stddev_cutoff_spp_pbl namelist,stoch      max_domains         2.0  - "cutoff tails of pdf above this threshold standard deviation"
 rconfig   real        lengthscale_spp_pbl   namelist,stoch      max_domains    700000.0  - "Correlation length scale in meters"
 rconfig   real        timescale_spp_pbl     namelist,stoch      max_domains     21600.0  - "Decorrelation time scale in s"
-rconfig   integer     vertstruc_spp_pbl     namelist,stoch      1                      0 -  "vertical structure for random perturb: 0=constant, 1=random phase"
+rconfig   integer     vertstruc_spp_pbl     namelist,stoch      1                     0  - "vertical structure for random perturb: 0=constant, 1=random phase"
 rconfig   integer     iseed_spp_pbl         namelist,stoch      1                   217  - "ISEED_RAND_PERT"       "RANDOM SEED FOR RAND_PERT "  ""
 
 
@@ -167,7 +167,7 @@ rconfig   real        gridpt_stddev_spp_lsm namelist,stoch      max_domains     
 rconfig   real        stddev_cutoff_spp_lsm namelist,stoch      max_domains         3.0  - "cutoff tails of pdf above this threshold standard deviation"
 rconfig   real        lengthscale_spp_lsm   namelist,stoch      max_domains     50000.0  - "Correlation length scale in meters"
 rconfig   real        timescale_spp_lsm     namelist,stoch      max_domains     86400.0  - "Decorrelation time scale in s"
-rconfig   integer     vertstruc_spp_lsm     namelist,stoch      1                      0 -  "vertical structure for random perturb: 0=constant, 1=random phase"
+rconfig   integer     vertstruc_spp_lsm     namelist,stoch      1                     0  - "vertical structure for random perturb: 0=constant, 1=random phase"
 rconfig   integer     iseed_spp_lsm         namelist,stoch      1                   317  - "ISEED_RAND_PERT"       "RANDOM SEED FOR RAND_PERT "  ""
 
 # Derived namelist parameters used in share/module_check_amundo.F

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -162,6 +162,7 @@ CONTAINS
                           grid%num_stoch_levels,grid%num_stoch_levels,        &
                           grid%num_stoch_levels,grid%num_stoch_levels,        &
                           config_flags%restart, grid%iseedarr_skebs,          &
+                          config_flags%seed_dim,                              &
                           grid%DX,grid%DY,grid%skebs_vertstruc,               &
                           grid%rt_tendf_stoch,                                &
                           grid%stddev_cutoff_sppt,grid%gridpt_stddev_sppt, & 
@@ -181,6 +182,7 @@ CONTAINS
                            grid% num_stoch_levels,grid% num_stoch_levels,     &
                            grid% num_stoch_levels,grid% num_stoch_levels,     &
                            config_flags%restart, grid%iseedarr_skebs,         &
+                           config_flags%seed_dim,                             &
                            grid%DX,grid%DY,grid%skebs_vertstruc,              &
                            grid%ru_tendf_stoch,                               &
                            grid%stddev_cutoff_sppt,grid%gridpt_stddev_sppt, & 
@@ -200,6 +202,7 @@ CONTAINS
                            grid% num_stoch_levels,grid% num_stoch_levels,     &
                            grid% num_stoch_levels,grid% num_stoch_levels,     &
                            config_flags%restart, grid%iseedarr_skebs,         &
+                           config_flags%seed_dim,                             &
                            grid%DX,grid%DY,grid%skebs_vertstruc,              &
                            grid%rv_tendf_stoch,                               &
                            grid%stddev_cutoff_sppt,grid%gridpt_stddev_sppt, & 
@@ -221,6 +224,7 @@ CONTAINS
                           grid%num_stoch_levels,grid%num_stoch_levels,        &
                           grid%num_stoch_levels,grid%num_stoch_levels,        &
                           config_flags%restart, grid%iseedarr_sppt,           &
+                          config_flags%seed_dim,                              &
                           grid%DX,grid%DY,grid%sppt_vertstruc,                &
                           grid%rstoch,                                        &
                           grid%stddev_cutoff_sppt,grid%gridpt_stddev_sppt, & 
@@ -242,6 +246,7 @@ CONTAINS
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            config_flags%restart, grid%iseedarr_rand_pert,      &
+                           config_flags%seed_dim,                              &
                            grid%DX,grid%DY,grid%rand_pert_vertstruc,           &
                            grid%RAND_PERT,                                     &
                            grid%stddev_cutoff_rand_pert,grid%gridpt_stddev_rand_pert, & 
@@ -261,9 +266,10 @@ CONTAINS
                            ipsy,ipey,jpsy,jpey,kpsy,kpey,                      &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
-                           config_flags%restart, grid%iseedarr_spp_conv,          &
+                           config_flags%restart, grid%iseedarr_spp_conv,       &
+                           config_flags%seed_dim,                              &
                            grid%DX,grid%DY,grid%vertstruc_spp_conv,            &
-                           grid%pattern_spp_conv,                             & 
+                           grid%pattern_spp_conv,                              & 
                            grid%stddev_cutoff_spp_conv,grid%gridpt_stddev_spp_conv, & 
                            grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT       )
       ENDIF !spp_conv
@@ -281,9 +287,10 @@ CONTAINS
                            ipsy,ipey,jpsy,jpey,kpsy,kpey,                      &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
-                           config_flags%restart, grid%iseedarr_spp_pbl,           &
+                           config_flags%restart, grid%iseedarr_spp_pbl,        &
+                           config_flags%seed_dim,                              &
                            grid%DX,grid%DY,grid%vertstruc_spp_pbl,             &
-                           grid%pattern_spp_pbl,                             & 
+                           grid%pattern_spp_pbl,                               & 
                            grid%stddev_cutoff_spp_pbl,grid%gridpt_stddev_spp_pbl, & 
                            grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT       )
       ENDIF !spp_pbl
@@ -301,9 +308,10 @@ CONTAINS
                            ipsy,ipey,jpsy,jpey,kpsy,kpey,                      &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
-                           config_flags%restart, grid%iseedarr_spp_lsm,           &
+                           config_flags%restart, grid%iseedarr_spp_lsm,        &
+                           config_flags%seed_dim,                              &
                            grid%DX,grid%DY,grid%vertstruc_spp_lsm,             &
-                           grid%pattern_spp_lsm,                             & 
+                           grid%pattern_spp_lsm,                               & 
                            grid%stddev_cutoff_spp_lsm,grid%gridpt_stddev_spp_lsm, & 
                            grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT       )
       ENDIF !spp_lsm

--- a/dyn_em/module_stoch.F
+++ b/dyn_em/module_stoch.F
@@ -148,7 +148,7 @@ contains
 ! Initialize SKEBS
 !    Initialize streamfunction (1)
      if ((.not.config_flags%restart) .or. (.not.config_flags%hrrr_cycling)) then
-         call rand_seed (config_flags, grid%ISEED_SKEBS, grid%iseedarr_skebs , kms, kme)
+         call rand_seed (config_flags, grid%ISEED_SKEBS, grid%iseedarr_skebs , 1, config_flags%seed_dim)
      endif
      call SETUP_RAND_PERTURB('W',                                         &
                        grid%skebs_vertstruc,config_flags%restart,         &
@@ -190,7 +190,7 @@ contains
 IF (grid%sppt_on==1) then
 ! Initialize SPPT (3)
      if ((.not.config_flags%restart) .or. (.not.config_flags%hrrr_cycling)) then
-         call rand_seed (config_flags, grid%ISEED_SPPT, grid%iseedarr_sppt  , kms, kme)
+         call rand_seed (config_flags, grid%ISEED_SPPT, grid%iseedarr_sppt  , 1, config_flags%seed_dim)
      endif
      call SETUP_RAND_PERTURB('P',                                         &
                        grid%sppt_vertstruc,config_flags%restart,          &
@@ -214,7 +214,7 @@ IF (grid%sppt_on==1) then
 ! Initialize RAND_PERTURB (4)
      IF (grid%rand_perturb_on==1) then
      if ((.not.config_flags%restart) .or. (.not.config_flags%hrrr_cycling)) then
-         call rand_seed (config_flags, grid%ISEED_RAND_PERT, grid%iseedarr_rand_pert  , kms, kme)
+         call rand_seed (config_flags, grid%ISEED_RAND_PERT, grid%iseedarr_rand_pert  , 1, config_flags%seed_dim)
      endif
      call SETUP_RAND_PERTURB('R',                                         &
                        grid%rand_pert_vertstruc,config_flags%restart,     &
@@ -250,10 +250,11 @@ IF (grid%sppt_on==1) then
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            grid%num_stoch_levels,grid%num_stoch_levels,        &
                            config_flags%restart, grid%iseedarr_rand_pert,      &
+                           config_flags%seed_dim,                              &
                            grid%DX,grid%DY,grid%rand_pert_vertstruc,           &
                            grid%RAND_PERT,                                     &
-                           grid%gridpt_stddev_rand_pert,                      &
-                           grid%lengthscale_rand_pert,                        &
+                           grid%gridpt_stddev_rand_pert,                       &
+                           grid%lengthscale_rand_pert,                         &
                            grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT       )
          enddo
        ENDIF !rand_perturb_on
@@ -262,10 +263,10 @@ IF (grid%sppt_on==1) then
 ! Initialize Stochastic Parameter Perturbations to convection scheme
      IF (grid%spp_conv==1) then
      if (.not.config_flags%restart) then ! set random number seed (else  iseedarray is read in from restart files)
-         call rand_seed (config_flags, grid%iseed_spp_conv, grid%iseedarr_spp_conv , kms, kme)
+         call rand_seed (config_flags, grid%iseed_spp_conv, grid%iseedarr_spp_conv , 1, config_flags%seed_dim)
      endif
-     call SETUP_RAND_PERTURB('S',                                        &
-                       grid%vertstruc_spp_conv,config_flags%restart,    &
+     call SETUP_RAND_PERTURB('S',                                         &
+                       grid%vertstruc_spp_conv,config_flags%restart,      &
                        grid%SP_AMP2,                                      &
                        grid%SPFORCC2,grid%SPFORCS2,grid%ALPH_RAND2,       &
                        grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT,     &
@@ -273,9 +274,9 @@ IF (grid%sppt_on==1) then
                        grid%LMINFORCT,grid%LMAXFORCT,                     &
                        grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
                        grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_spp_conv,                     &
-                       grid%lengthscale_spp_conv,                       &
-                       grid%timescale_spp_conv,                         &
+                       grid%gridpt_stddev_spp_conv,                       &
+                       grid%lengthscale_spp_conv,                         &
+                       grid%timescale_spp_conv,                           &
                        grid%TOT_BACKSCAT_PSI,grid%ZTAU_PSI,               &
                        grid%REXPONENT_PSI,                                &
                        ids, ide, jds, jde, kds, kde,                      &
@@ -285,10 +286,10 @@ IF (grid%sppt_on==1) then
 ! Initialize Stochastic Parameter Peturbations (SPP) to PBL scheme
      IF (grid%spp_pbl==1) then
      if (.not.config_flags%restart) then ! set random number seed (else  iseedarray is read in from restart files)
-         call rand_seed (config_flags, grid%iseed_spp_pbl, grid%iseedarr_spp_pbl , kms, kme)
+         call rand_seed (config_flags, grid%iseed_spp_pbl, grid%iseedarr_spp_pbl , 1, config_flags%seed_dim)
      endif
-     call SETUP_RAND_PERTURB('Q',                                        &
-                       grid%vertstruc_spp_pbl,config_flags%restart,    &
+     call SETUP_RAND_PERTURB('Q',                                         &
+                       grid%vertstruc_spp_pbl,config_flags%restart,       &
                        grid%SP_AMP3,                                      &
                        grid%SPFORCC3,grid%SPFORCS3,grid%ALPH_RAND3,       &
                        grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT,     &
@@ -296,9 +297,9 @@ IF (grid%sppt_on==1) then
                        grid%LMINFORCT,grid%LMAXFORCT,                     &
                        grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
                        grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_spp_pbl,                     &
-                       grid%lengthscale_spp_pbl,                       &
-                       grid%timescale_spp_pbl,                         &
+                       grid%gridpt_stddev_spp_pbl,                        &
+                       grid%lengthscale_spp_pbl,                          &
+                       grid%timescale_spp_pbl,                            &
                        grid%TOT_BACKSCAT_PSI,grid%ZTAU_PSI,               &
                        grid%REXPONENT_PSI,                                &
                        ids, ide, jds, jde, kds, kde,                      &
@@ -308,10 +309,10 @@ IF (grid%sppt_on==1) then
 ! Initialize Stochastic Parameter Peturbations (SPP) to LSM scheme
      IF (grid%spp_lsm==1) then
      if (.not.config_flags%restart) then ! set random number seed (else  iseedarray is read in from restart files)
-         call rand_seed (config_flags, grid%iseed_spp_lsm, grid%iseedarr_spp_lsm , kms, kme)
+         call rand_seed (config_flags, grid%iseed_spp_lsm, grid%iseedarr_spp_lsm , 1, config_flags%seed_dim)
      endif
-     call SETUP_RAND_PERTURB('O',                                        &
-                       grid%vertstruc_spp_lsm,config_flags%restart,    &
+     call SETUP_RAND_PERTURB('O',                                         &
+                       grid%vertstruc_spp_lsm,config_flags%restart,       &
                        grid%SP_AMP4,                                      &
                        grid%SPFORCC4,grid%SPFORCS4,grid%ALPH_RAND4,       &
                        grid%VERTSTRUCC,grid%VERTSTRUCS,grid%VERTAMPT,     &
@@ -319,9 +320,9 @@ IF (grid%sppt_on==1) then
                        grid%LMINFORCT,grid%LMAXFORCT,                     &
                        grid%KMAXFORCTH,grid%LMAXFORCTH,                   &
                        grid%time_step,grid%DX,grid%DY,                    &
-                       grid%gridpt_stddev_spp_lsm,                     &
-                       grid%lengthscale_spp_lsm,                       &
-                       grid%timescale_spp_lsm,                         &
+                       grid%gridpt_stddev_spp_lsm,                        &
+                       grid%lengthscale_spp_lsm,                          &
+                       grid%timescale_spp_lsm,                            &
                        grid%TOT_BACKSCAT_PSI,grid%ZTAU_PSI,               &
                        grid%REXPONENT_PSI,                                &
                        ids, ide, jds, jde, kds, kde,                      &
@@ -659,7 +660,7 @@ IF (grid%sppt_on==1) then
 
      subroutine UPDATE_STOCH(                                         &
                       SPFORCS,SPFORCC,SP_AMP,ALPH,                    &
-                      restart,iseedarr,                             &
+                      restart,iseedarr,seed_dim,                      &
                       ids, ide, jds, jde, kds, kde,                   &
                       ims, ime, jms, jme, kms, kme,                   &
                       its, ite, jts, jte, kts, kte                    )
@@ -670,8 +671,9 @@ IF (grid%sppt_on==1) then
      INTEGER , INTENT(IN)     ::               ids, ide, jds, jde, kds, kde,   &
                                                ims, ime, jms, jme, kms, kme,   &
                                                its, ite, jts, jte, kts, kte
+     INTEGER , INTENT(IN)     ::               seed_dim
    
-     INTEGER, DIMENSION (kms:kme),             INTENT(INOUT) :: iseedarr
+     INTEGER, DIMENSION (seed_dim) , INTENT(INOUT) :: iseedarr
      INTEGER , ALLOCATABLE , DIMENSION(:) :: iseed
      REAL :: Z,ALPH
      REAL, PARAMETER :: thresh = 3.0
@@ -916,8 +918,8 @@ IF (grid%sppt_on==1) then
                           imsy,imey,jmsy,jmey,kmsy,kmey,                      &
                           ipsy,ipey,jpsy,jpey,kpsy,kpey,                      &
                           kpe_stoch,kde_stoch,kme_stoch,kte_stoch,            &
-                          restart,iseedarr,                                   &
-                          DX,DY,skebs_vertstruc,                          &
+                          restart,iseedarr,seed_dim,                          &
+                          DX,DY,skebs_vertstruc,                              &
                           RAND_PERT,thresh_fact,gridpt_stddev,                &
                           VERTSTRUCC,VERTSTRUCS,VERTAMP                       )
 
@@ -943,6 +945,7 @@ IF (grid%sppt_on==1) then
                                                 ipsx,ipex,jpsx,jpex,kpsx,kpex, &
                                                 imsy,imey,jmsy,jmey,kmsy,kmey, &
                                                 ipsy,ipey,jpsy,jpey,kpsy,kpey
+      INTEGER , INTENT(IN)     ::               seed_dim
       INTEGER                  ::               kpe_stoch,kde_stoch,kme_stoch,kte_stoch
 
       REAL    , INTENT(IN)     ::               ALPH_RAND,dx,dy,thresh_fact,gridpt_stddev
@@ -952,7 +955,7 @@ IF (grid%sppt_on==1) then
                                                ! U          ! first derivative of streamfunction with regard to y; for skebs: U
                                                ! V          ! first derivative of streamfunction with regard to x; for skebs: V
 
-      INTEGER, DIMENSION (kms:kme),             INTENT(INOUT) :: iseedarr
+      INTEGER, DIMENSION (seed_dim),            INTENT(INOUT) :: iseedarr
       REAL, DIMENSION(ims:ime,kms:kme, jms:jme),INTENT(IN)    :: VERTSTRUCC,VERTSTRUCS
       REAL, DIMENSION(ims:ime,jms:jme)         ,INTENT(INOUT) :: SPFORCS,SPFORCC,SP_AMP
       REAL, DIMENSION(kms:kme )                ,INTENT(IN)    :: VERTAMP
@@ -985,7 +988,7 @@ IF (grid%sppt_on==1) then
              IF (variable .ne. 'V') THEN  !T, random field, U, don't update for V 
               CALL UPDATE_STOCH( &
                          SPFORCS,SPFORCC,SP_AMP,ALPH_RAND,                   &
-                         restart,iseedarr,                         &
+                         restart,iseedarr,seed_dim,                          &
                          ids, ide, jds, jde, kds, kde,                       &
                          ims, ime, jms, jme, kms, kme,                       &
                          grid%i_start(ij), grid%i_end(ij), grid%j_start(ij), grid%j_end(ij), kts, kte                        )      
@@ -1321,7 +1324,7 @@ IF (grid%sppt_on==1) then
 
      end subroutine gauss_noise
 !     ------------------------------------------------------------------
-     SUBROUTINE rand_seed (config_flags, iseed1, iseedarr, kms, kme)
+     SUBROUTINE rand_seed (config_flags, iseed1, iseedarr, seed_start, seed_dim )
      USE module_configure
      IMPLICIT NONE
 !
@@ -1329,8 +1332,8 @@ IF (grid%sppt_on==1) then
       TYPE (grid_config_rec_type)                       :: config_flags
 !
 ! Arguments
-     INTEGER             :: kms, kme, iseed1
-     INTEGER, DIMENSION (kms:kme), INTENT(OUT)           :: iseedarr
+     INTEGER             :: seed_start, seed_dim, iseed1
+     INTEGER, DIMENSION (seed_start:seed_dim), INTENT(OUT)           :: iseedarr
 
 ! Local
       integer*8          :: fctime, one_big
@@ -1340,7 +1343,7 @@ IF (grid%sppt_on==1) then
 
       one_big = 1
       iseedarr=0.0
-      do i = kms,kme-3,4
+      do i = seed_start,seed_dim-3,4
          iseedarr(i  )= iseed1+config_flags%nens*1000000
          iseedarr(i+1)= mod(fctime+iseed1*config_flags%nens*1000000,19211*one_big)
          iseedarr(i+2)= mod(fctime+iseed1*config_flags%nens*1000000,71209*one_big)

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2117,6 +2117,12 @@
       
 #if ( (NMM_CORE != 1) && (DA_CORE != 1) )
 !-----------------------------------------------------------------------
+! How big to allocate random seed arrays.
+!-----------------------------------------------------------------------
+
+      CALL RANDOM_SEED ( SIZE = model_config_rec % seed_dim )
+
+!-----------------------------------------------------------------------
 ! If this is a WRF run with polar boundary conditions, then this is a
 ! global domain. A global domain needs to have the FFT arrays allocated.
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: stochastic, restart, b4b, hrrr_cycling

SOURCE: internal

DESCRIPTION OF CHANGES: 
1. Made the random number seed to have a dimension that is intrinsic to the compiler.
2. Force hrrr_cycling = .true. to avoid resetting seeds on restart (the logic was broken).
3. The seeds now have a "Z" stagger (no empty or zero value in last entry).
4. Modify code to accommodate the swap from vertical dimension of seed to the new `seed_dim`.

ISSUE: 
Fixes #799 random seed length for stochastic option

LIST OF MODIFIED FILES:
M Registry/registry.dimspec
M Registry/registry.stoch
M dyn_em/module_first_rk_step_part2.F
M dyn_em/module_stoch.F
M share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. The patterns are identical after a restart.
👍 

RELEASE NOTE: After hrrr_cycling was introduced to WRF, the stochastic solutions were not bit reproducible when compared to the solutions that used a restart. Also, with the newer GNU compilers, the size of the seed array exceeded the vertical dimensions in WRF (the vertical dimension was originally used as an easy and safe value). Both problems have been addressed.