### PR TITLE
W[SD]M[67] accretion mods for freezing rain

### DIFF
--- a/phys/module_mp_wdm6.F
+++ b/phys/module_mp_wdm6.F
@@ -1304,6 +1304,8 @@
 !-------------------------------------------------------------
               acrfac = 6.*rslope2(i,k,1)+4.*diameter*rslope(i,k,1) + diameter**2
               praci(i,k) = pi*qci(i,k,2)*ncr(i,k,3)*abs(vt2r-vt2i)*acrfac/4.
+              ! reduce collection efficiency (suggested by B. Wilt)
+              praci(i,k) = praci(i,k)*min(max(0.0,qrs(i,k,1)/qci(i,k,2)),1.)**2
               praci(i,k) = min(praci(i,k),qci(i,k,2)/dtcld)
 !-------------------------------------------------------------
 ! piacr: Accretion of rain by cloud ice [HL A19] [LFO 26]
@@ -1312,6 +1314,8 @@
               piacr(i,k) = pi*pi*avtr*ncr(i,k,3)*denr*xni(i,k)*denfac(i,k)     &
                           *g7pbr*rslope3(i,k,1)*rslope2(i,k,1)*rslopeb(i,k,1)  &
                           /24./den(i,k)
+              ! reduce collection efficiency (suggested by B. Wilt)
+              piacr(i,k) = piacr(i,k)*min(max(0.0,qci(i,k,2)/qrs(i,k,1)),1.)**2
               piacr(i,k) = min(piacr(i,k),qrs(i,k,1)/dtcld)
             endif
 !-------------------------------------------------------------
@@ -1321,6 +1325,8 @@
             if(ncr(i,k,3).gt.nrmin) then
               niacr(i,k) = pi*avtr*ncr(i,k,3)*xni(i,k)*denfac(i,k)*g4pbr       &
                           *rslope2(i,k,1)*rslopeb(i,k,1)/4.
+              ! reduce collection efficiency (suggested by B. Wilt)
+              niacr(i,k) = niacr(i,k)*min(max(0.0,qci(i,k,2)/qrs(i,k,1)),1.)**2
               niacr(i,k) = min(niacr(i,k),ncr(i,k,3)/dtcld)
             endif
 !-------------------------------------------------------------
@@ -1352,6 +1358,8 @@
 !-------------------------------------------------------------
           if(qrs(i,k,2).gt.qcrmin .and. qci(i,k,1).gt.qmin) then
             psacw(i,k) = min(pacrc*n0sfac(i,k)*rslope3(i,k,2)*rslopeb(i,k,2)   &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,2)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1360,6 +1368,8 @@
 !-------------------------------------------------------------
          if(qrs(i,k,2).gt.qcrmin .and. ncr(i,k,2).gt.ncmin) then
            nsacw(i,k) = min(pacrc*n0sfac(i,k)*rslope3(i,k,2)*rslopeb(i,k,2)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                       *min(max(0.0,qrs(i,k,2)/qci(i,k,1)),1.)**2              &
                        *ncr(i,k,2)*denfac(i,k),ncr(i,k,2)/dtcld)
          endif
 !-------------------------------------------------------------
@@ -1368,6 +1378,8 @@
 !-------------------------------------------------------------
           if(qrs(i,k,3).gt.qcrmin .and. qci(i,k,1).gt.qmin) then
             pgacw(i,k) = min(pacrg*rslope3(i,k,3)*rslopeb(i,k,3)*qci(i,k,1)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,3)/qci(i,k,1)),1.)**2             &
                         *denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1376,6 +1388,8 @@
 !-------------------------------------------------------------
           if(qrs(i,k,3).gt.qcrmin .and. ncr(i,k,2).gt.ncmin) then
             ngacw(i,k) = min(pacrg*rslope3(i,k,3)*rslopeb(i,k,3)*ncr(i,k,2)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,3)/qci(i,k,1)),1.)**2             &
                         *denfac(i,k),ncr(i,k,2)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1401,6 +1415,8 @@
                       + 1.5*rslope2(i,k,2)*rslope2(i,k,2)*rslope2(i,k,1)
               pracs(i,k) = pi*pi*ncr(i,k,3)*n0s*n0sfac(i,k)*abs(vt2r-vt2ave)   &
                           *(dens/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+              pracs(i,k) = pracs(i,k)*min(max(0.0,qrs(i,k,1)/qrs(i,k,2)),1.)**2
               pracs(i,k) = min(pracs(i,k),qrs(i,k,2)/dtcld)
             endif
 !-------------------------------------------------------------
@@ -1412,6 +1428,8 @@
                      + 2.*rslope3(i,k,1)*rslope3(i,k,2)
             psacr(i,k) = pi*pi*ncr(i,k,3)*n0s*n0sfac(i,k)*abs(vt2ave-vt2r)     &
                         *(denr/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            psacr(i,k) = psacr(i,k)*min(max(0.0,qrs(i,k,2)/qrs(i,k,1)),1.)**2
             psacr(i,k) = min(psacr(i,k),qrs(i,k,1)/dtcld)
           endif
           if(qrs(i,k,2).gt.qcrmin .and. ncr(i,k,3).gt.nrmin) then
@@ -1423,6 +1441,8 @@
                     + 1.0*rslope(i,k,1)*rslope2(i,k,2)+.5*rslope3(i,k,2)        
             nsacr(i,k) = pi*ncr(i,k,3)*n0s*n0sfac(i,k)*abs(vt2ave-vt2r)        &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            nsacr(i,k) = nsacr(i,k)*min(max(0.0,qrs(i,k,2)/qrs(i,k,1)),1.)**2
             nsacr(i,k) = min(nsacr(i,k),ncr(i,k,3)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1435,6 +1455,8 @@
                     + 2.*rslope3(i,k,1)*rslope3(i,k,3)
             pgacr(i,k) = pi*pi*ncr(i,k,3)*n0g*abs(vt2ave-vt2r)*(denr/den(i,k)) &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            pgacr(i,k) = pgacr(i,k)*min(max(0.0,qrs(i,k,3)/qrs(i,k,1)),1.)**2
             pgacr(i,k) = min(pgacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1445,6 +1467,8 @@
             acrfac = 1.5*rslope2(i,k,1)*rslope(i,k,3)                          &
                     + 1.0*rslope(i,k,1)*rslope2(i,k,3) + .5*rslope3(i,k,3)   
             ngacr(i,k) = pi*ncr(i,k,3)*n0g*abs(vt2ave-vt2r)*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            ngacr(i,k) = ngacr(i,k)*min(max(0.0,qrs(i,k,3)/qrs(i,k,1)),1.)**2
             ngacr(i,k) = min(ngacr(i,k),ncr(i,k,3)/dtcld)
           endif
 !

--- a/phys/module_mp_wdm7.F
+++ b/phys/module_mp_wdm7.F
@@ -132,9 +132,9 @@ CONTAINS
 !
 !  WDM7 cloud scheme
 !
-!  Coded by Soo Ya Bae (KIAPS)         Winter 2015
+!  Coded and implemented by Soo Ya Bae (KIAPS) Fall 2015
 !
-!  Implemented by Soo Ya Bae (KIAPS)   Winter 2018
+!  Implemented by Soo Ya Bae (KIAPS) Winter 2018
 !
 !  further modifications :
 !        semi-lagrangian sedimentation (JH,2010),hong, aug 2009
@@ -1354,6 +1354,8 @@ CONTAINS
 !
               acrfac = 6.*rslope2(i,k,1)+4.*diameter*rslope(i,k,1) + diameter**2
               praci(i,k) = pi*qci(i,k,2)*ncr(i,k,3)*abs(vt2r-vt2i)*acrfac/4.
+              ! reduce collection efficiency (suggested by B. Wilt)
+              praci(i,k) = praci(i,k)*min(max(0.0,qrs(i,k,1)/qci(i,k,2)),1.)**2
               praci(i,k) = min(praci(i,k),qci(i,k,2)/dtcld)
 !
 ! piacr: Accretion of rain by cloud ice [HL A19] [LFO 26]
@@ -1362,6 +1364,8 @@ CONTAINS
               piacr(i,k) = pi*pi*avtr*ncr(i,k,3)*denr*xni(i,k)*denfac(i,k)     &
                           *g7pbr*rslope3(i,k,1)*rslope2(i,k,1)*rslopeb(i,k,1)  &
                           /24./den(i,k)
+              ! reduce collection efficiency (suggested by B. Wilt)
+              piacr(i,k) = piacr(i,k)*min(max(0.0,qci(i,k,2)/qrs(i,k,1)),1.)**2
               piacr(i,k) = min(piacr(i,k),qrs(i,k,1)/dtcld)
             endif
 !
@@ -1371,6 +1375,8 @@ CONTAINS
             if(ncr(i,k,3).gt.nrmin) then
               niacr(i,k) = pi*avtr*ncr(i,k,3)*xni(i,k)*denfac(i,k)*g4pbr       &
                           *rslope2(i,k,1)*rslopeb(i,k,1)/4.
+              ! reduce collection efficiency (suggested by B. Wilt)
+              niacr(i,k) = niacr(i,k)*min(max(0.0,qci(i,k,2)/qrs(i,k,1)),1.)**2
               niacr(i,k) = min(niacr(i,k),ncr(i,k,3)/dtcld)
             endif
 !
@@ -1413,6 +1419,8 @@ CONTAINS
 !
           if(qrs(i,k,2).gt.qcrmin .and. qci(i,k,1).gt.qmin) then
             psacw(i,k) = min(pacrc*n0sfac(i,k)*rslope3(i,k,2)*rslopeb(i,k,2)   &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,2)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !
@@ -1421,6 +1429,8 @@ CONTAINS
 !
          if(qrs(i,k,2).gt.qcrmin .and. ncr(i,k,2).gt.ncmin) then
            nsacw(i,k) = min(pacrc*n0sfac(i,k)*rslope3(i,k,2)*rslopeb(i,k,2)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                       *min(max(0.0,qrs(i,k,2)/qci(i,k,1)),1.)**2              &
                        *ncr(i,k,2)*denfac(i,k),ncr(i,k,2)/dtcld)
          endif
 !
@@ -1429,6 +1439,8 @@ CONTAINS
 !
           if(qrs(i,k,3).gt.qcrmin .and. qci(i,k,1).gt.qmin) then
             pgacw(i,k) = min(pacrg*rslope3(i,k,3)*rslopeb(i,k,3)*qci(i,k,1)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,3)/qci(i,k,1)),1.)**2             &
                         *denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !
@@ -1437,6 +1449,8 @@ CONTAINS
 !
           if(qrs(i,k,3).gt.qcrmin .and. ncr(i,k,2).gt.ncmin) then
             ngacw(i,k) = min(pacrg*rslope3(i,k,3)*rslopeb(i,k,3)*ncr(i,k,2)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,3)/qci(i,k,1)),1.)**2             &
                         *denfac(i,k),ncr(i,k,2)/dtcld)
           endif
 !
@@ -1457,6 +1471,8 @@ CONTAINS
 !
           if(qrs(i,k,4).gt.qcrmin .and. qci(i,k,1).gt.qmin) then
             phacw(i,k) = min(pacrh*rslope3(i,k,4)*rslopeb(i,k,4)*qci(i,k,1)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,4)/qci(i,k,1)),1.)**2             &
                         *denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !
@@ -1465,6 +1481,8 @@ CONTAINS
 !
           if(qrs(i,k,4).gt.qcrmin .and. ncr(i,k,2).gt.ncmin) then
             nhacw(i,k) = min(pacrh*rslope3(i,k,4)*rslopeb(i,k,4)*ncr(i,k,2)    &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,4)/qci(i,k,1)),1.)**2             &
                         *denfac(i,k),ncr(i,k,2)/dtcld)
           endif
 !
@@ -1478,6 +1496,8 @@ CONTAINS
                       + 1.5*rslope2(i,k,2)*rslope2(i,k,2)*rslope2(i,k,1)
               pracs(i,k) = pi*pi*ncr(i,k,3)*n0s*n0sfac(i,k)*abs(vt2r-vt2ave)   &
                           *(dens/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+              pracs(i,k) = pracs(i,k)*min(max(0.0,qrs(i,k,1)/qrs(i,k,2)),1.)**2
               pracs(i,k) = min(pracs(i,k),qrs(i,k,2)/dtcld)
             endif
 !
@@ -1489,6 +1509,8 @@ CONTAINS
                      + 2.*rslope3(i,k,1)*rslope3(i,k,2)
             psacr(i,k) = pi*pi*ncr(i,k,3)*n0s*n0sfac(i,k)*abs(vt2ave-vt2r)     &
                         *(denr/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            psacr(i,k) = psacr(i,k)*min(max(0.0,qrs(i,k,2)/qrs(i,k,1)),1.)**2
             psacr(i,k) = min(psacr(i,k),qrs(i,k,1)/dtcld)
           endif
           if(qrs(i,k,2).gt.qcrmin .and. ncr(i,k,3).gt.nrmin) then
@@ -1500,6 +1522,8 @@ CONTAINS
                     + 1.0*rslope(i,k,1)*rslope2(i,k,2)+.5*rslope3(i,k,2)        
             nsacr(i,k) = pi*ncr(i,k,3)*n0s*n0sfac(i,k)*abs(vt2ave-vt2r)        &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            nsacr(i,k) = nsacr(i,k)*min(max(0.0,qrs(i,k,2)/qrs(i,k,1)),1.)**2
             nsacr(i,k) = min(nsacr(i,k),ncr(i,k,3)/dtcld)
           endif
 !
@@ -1513,6 +1537,8 @@ CONTAINS
                       +1.5*rslope2(i,k,3)*rslope2(i,k,3)*rslope2(i,k,1)
               pracg(i,k) = pi*pi*ncr(i,k,3)*n0g*abs(vt2r-vt2ave)               &
                           *(deng/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+              pracg(i,k) = pracg(i,k)*min(max(0.0,qrs(i,k,1)/qrs(i,k,3)),1.)**2
               pracg(i,k) = min(pracg(i,k),qrs(i,k,3)/dtcld)
             endif
 !
@@ -1524,6 +1550,8 @@ CONTAINS
                     + 2.*rslope3(i,k,1)*rslope3(i,k,3)
             pgacr(i,k) = pi*pi*ncr(i,k,3)*n0g*abs(vt2ave-vt2r)*(denr/den(i,k)) &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            pgacr(i,k) = pgacr(i,k)*min(max(0.0,qrs(i,k,3)/qrs(i,k,1)),1.)**2
             pgacr(i,k) = min(pgacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !
@@ -1534,6 +1562,8 @@ CONTAINS
             acrfac = 1.5*rslope2(i,k,1)*rslope(i,k,3)                          &
                     + 1.0*rslope(i,k,1)*rslope2(i,k,3) + .5*rslope3(i,k,3)   
             ngacr(i,k) = pi*ncr(i,k,3)*n0g*abs(vt2ave-vt2r)*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            ngacr(i,k) = ngacr(i,k)*min(max(0.0,qrs(i,k,3)/qrs(i,k,1)),1.)**2
             ngacr(i,k) = min(ngacr(i,k),ncr(i,k,3)/dtcld)
           endif
 !
@@ -1554,6 +1584,8 @@ CONTAINS
                     + 2.*rslope3(i,k,1)*rslope3(i,k,4)
             phacr(i,k) = pi*pi*ncr(i,k,3)*n0h*abs(vt2h-vt2r)*(denr/den(i,k))   &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            phacr(i,k) = phacr(i,k)*min(max(0.0,qrs(i,k,4)/qrs(i,k,1)),1.)**2
             phacr(i,k) = min(phacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !
@@ -1564,6 +1596,8 @@ CONTAINS
             acrfac = 1.5*rslope2(i,k,1)*rslope(i,k,4)                          &
                     + 1.0*rslope(i,k,1)*rslope2(i,k,4) + .5*rslope3(i,k,4)
             nhacr(i,k) = pi*ncr(i,k,3)*n0h*abs(vt2h-vt2r)*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            nhacr(i,k) = nhacr(i,k)*min(max(0.0,qrs(i,k,4)/qrs(i,k,1)),1.)**2
             nhacr(i,k) = min(nhacr(i,k),ncr(i,k,3)/dtcld)
           endif
 !

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -1016,6 +1016,8 @@ CONTAINS
               acrfac = 2.*rslope3(i,k,1)+2.*diameter*rslope2(i,k,1)            &
                       +diameter**2*rslope(i,k,1)
               praci(i,k) = pi*qci(i,k,2)*n0r*abs(vt2r-vt2i)*acrfac/4.
+              ! reduce collection efficiency (suggested by B. Wilt)
+              praci(i,k) = praci(i,k)*min(max(0.0,qrs(i,k,1)/qci(i,k,2)),1.)**2
               praci(i,k) = min(praci(i,k),qci(i,k,2)/dtcld)
 !-------------------------------------------------------------
 ! piacr: Accretion of rain by cloud ice [HL A19] [LFO 26]
@@ -1024,6 +1026,8 @@ CONTAINS
               piacr(i,k) = pi**2*avtr*n0r*denr*xni(i,k)*denfac(i,k)            &
                           *g6pbr*rslope3(i,k,1)*rslope3(i,k,1)                 &
                           *rslopeb(i,k,1)/24./den(i,k)
+              ! reduce collection efficiency (suggested by B. Wilt)
+              piacr(i,k) = piacr(i,k)*min(max(0.0,qci(i,k,2)/qrs(i,k,1)),1.)**2
               piacr(i,k) = min(piacr(i,k),qrs(i,k,1)/dtcld)
             endif
 !-------------------------------------------------------------
@@ -1055,6 +1059,8 @@ CONTAINS
 !-------------------------------------------------------------
           if(qrs(i,k,2).gt.qcrmin.and.qci(i,k,1).gt.qmin) then
             psacw(i,k) = min(pacrc*n0sfac(i,k)*rslope3(i,k,2)*rslopeb(i,k,2)   &    
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,2)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1063,6 +1069,8 @@ CONTAINS
 !-------------------------------------------------------------
           if(qrs(i,k,3).gt.qcrmin.and.qci(i,k,1).gt.qmin) then
             pgacw(i,k) = min(pacrg*rslope3(i,k,3)*rslopeb(i,k,3)               &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,3)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1084,6 +1092,8 @@ CONTAINS
                       +.5*rslope2(i,k,2)*rslope2(i,k,2)*rslope3(i,k,1)
               pracs(i,k) = pi**2*n0r*n0s*n0sfac(i,k)*abs(vt2r-vt2ave)          &
                           *(dens/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+              pracs(i,k) = pracs(i,k)*min(max(0.0,qrs(i,k,1)/qrs(i,k,2)),1.)**2
               pracs(i,k) = min(pracs(i,k),qrs(i,k,2)/dtcld)
             endif
 !-------------------------------------------------------------
@@ -1095,6 +1105,8 @@ CONTAINS
                     +.5*rslope2(i,k,1)*rslope2(i,k,1)*rslope3(i,k,2)
             psacr(i,k) = pi**2*n0r*n0s*n0sfac(i,k)*abs(vt2ave-vt2r)            &
                         *(denr/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            psacr(i,k) = psacr(i,k)*min(max(0.0,qrs(i,k,2)/qrs(i,k,1)),1.)**2
             psacr(i,k) = min(psacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !-------------------------------------------------------------
@@ -1107,6 +1119,8 @@ CONTAINS
                     +.5*rslope2(i,k,1)*rslope2(i,k,1)*rslope3(i,k,3)
             pgacr(i,k) = pi**2*n0r*n0g*abs(vt2ave-vt2r)*(denr/den(i,k))        &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            pgacr(i,k) = pgacr(i,k)*min(max(0.0,qrs(i,k,3)/qrs(i,k,1)),1.)**2
             pgacr(i,k) = min(pgacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !

--- a/phys/module_mp_wsm7.F
+++ b/phys/module_mp_wsm7.F
@@ -1098,6 +1098,8 @@ CONTAINS
               acrfac = 2.*rslope3(i,k,1)+2.*diameter*rslope2(i,k,1)            &
                       +diameter**2*rslope(i,k,1)
               praci(i,k) = pi*qci(i,k,2)*n0r*abs(vt2r-vt2i)*acrfac/4.
+              ! reduce collection efficiency (suggested by B. Wilt)
+              praci(i,k) = praci(i,k)*min(max(0.0,qrs(i,k,1)/qci(i,k,2)),1.)**2
               praci(i,k) = min(praci(i,k),qci(i,k,2)/dtcld)
 !
 ! piacr: Accretion of rain by cloud ice [HL A19] [LFO 26]
@@ -1106,6 +1108,8 @@ CONTAINS
               piacr(i,k) = pi**2*avtr*n0r*denr*xni(i,k)*denfac(i,k)            &
                           *g6pbr*rslope3(i,k,1)*rslope3(i,k,1)                 &
                           *rslopeb(i,k,1)/24./den(i,k)
+              ! reduce collection efficiency (suggested by B. Wilt)
+              piacr(i,k) = piacr(i,k)*min(max(0.0,qci(i,k,2)/qrs(i,k,1)),1.)**2
               piacr(i,k) = min(piacr(i,k),qrs(i,k,1)/dtcld)
             endif
 !
@@ -1148,6 +1152,8 @@ CONTAINS
 !
           if(qrs(i,k,2).gt.qcrmin.and.qci(i,k,1).gt.qmin) then
             psacw(i,k) = min(pacrc*n0sfac(i,k)*rslope3(i,k,2)*rslopeb(i,k,2)   &    
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,2)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !
@@ -1156,6 +1162,8 @@ CONTAINS
 !
           if(qrs(i,k,3).gt.qcrmin.and.qci(i,k,1).gt.qmin) then
             pgacw(i,k) = min(pacrg*rslope3(i,k,3)*rslopeb(i,k,3)               &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,3)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif
 !
@@ -1172,6 +1180,8 @@ CONTAINS
 !
           if(qrs(i,k,4).gt.qcrmin.and.qci(i,k,1).gt.qmin) then
             phacw(i,k) = min(pacrh*rslope3(i,k,4)*rslopeb(i,k,4)               &
+              ! reduce collection efficiency (suggested by B. Wilt)
+                        *min(max(0.0,qrs(i,k,4)/qci(i,k,1)),1.)**2             &
                         *qci(i,k,1)*denfac(i,k),qci(i,k,1)/dtcld)
           endif 
 !
@@ -1185,6 +1195,8 @@ CONTAINS
                       +.5*rslope2(i,k,2)*rslope2(i,k,2)*rslope3(i,k,1)
               pracs(i,k) = pi**2*n0r*n0s*n0sfac(i,k)*abs(vt2r-vt2ave)          &
                           *(dens/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+              pracs(i,k) = pracs(i,k)*min(max(0.0,qrs(i,k,1)/qrs(i,k,2)),1.)**2
               pracs(i,k) = min(pracs(i,k),qrs(i,k,2)/dtcld)
             endif
 !
@@ -1196,6 +1208,8 @@ CONTAINS
                     +.5*rslope2(i,k,1)*rslope2(i,k,1)*rslope3(i,k,2)
             psacr(i,k) = pi**2*n0r*n0s*n0sfac(i,k)*abs(vt2ave-vt2r)            &
                         *(denr/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            psacr(i,k) = psacr(i,k)*min(max(0.0,qrs(i,k,2)/qrs(i,k,1)),1.)**2
             psacr(i,k) = min(psacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !
@@ -1209,6 +1223,8 @@ CONTAINS
                       +.5*rslope2(i,k,3)*rslope2(i,k,3)*rslope3(i,k,1)
               pracg(i,k) = pi**2*n0r*n0g*abs(vt2r-vt2ave)                      &
                           *(deng/den(i,k))*acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+              pracg(i,k) = pracg(i,k)*min(max(0.0,qrs(i,k,1)/qrs(i,k,3)),1.)**2
               pracg(i,k) = min(pracg(i,k),qrs(i,k,3)/dtcld)
             endif
 !
@@ -1220,6 +1236,8 @@ CONTAINS
                     +.5*rslope2(i,k,1)*rslope2(i,k,1)*rslope3(i,k,3)
             pgacr(i,k) = pi**2*n0r*n0g*abs(vt2ave-vt2r)*(denr/den(i,k))        &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            pgacr(i,k) = pgacr(i,k)*min(max(0.0,qrs(i,k,3)/qrs(i,k,1)),1.)**2
             pgacr(i,k) = min(pgacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !
@@ -1240,6 +1258,8 @@ CONTAINS
                     +.5*rslope2(i,k,1)*rslope2(i,k,1)*rslope3(i,k,4)
             phacr(i,k) = pi**2*n0r*n0h*abs(vt2h-vt2r)*(denr/den(i,k))          &
                         *acrfac
+              ! reduce collection efficiency (suggested by B. Wilt)
+            phacr(i,k) = phacr(i,k)*min(max(0.0,qrs(i,k,4)/qrs(i,k,1)),1.)**2
             phacr(i,k) = min(phacr(i,k),qrs(i,k,1)/dtcld)
           endif
 !


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: WSM6, WSM7, WDM6, WDM7, accretion terms

SOURCE: KIAPS and Brett Wilt (IBM)

DESCRIPTION OF CHANGES: 
Brett Wilt noted a problem where these schemes froze rainfall too easily with even very small 
amounts of ice. The fix is to reduce the efficiency proportional to the square of the ratio of ice to 
water in accretion processes. This allows rain more easily, which is in better agreement with 
observations. The changes in all 4 schemes are the same.

ISSUE: 

LIST OF MODIFIED FILES: 
M       phys/module_mp_wdm6.F
M       phys/module_mp_wdm7.F
M       phys/module_mp_wsm6.F
M       phys/module_mp_wsm7.F

TESTS CONDUCTED: 
compile only

RELEASE NOTE: 
WSM and WDM schemes fixed to allow more freezing rain (KIAPS mods as suggested by Brett Wilt, IBM)