### PR TITLE
mm5 sfclay adding 'defined(mpas)' to call to SFCLAY1D

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -258,7 +258,7 @@ CONTAINS
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
-#if ( EM_CORE == 1 )
+#if ( ( EM_CORE == 1 ) || ( defined(mpas) ) )
                 ,isftcflx,iz0tlnd,scm_force_flux,                  &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
                 CD(ims,j),CDA(ims,j)                               &


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: mm5, Monin-Obukhov, sfclay, mpas, wrf, SFCLAY1D

SOURCE: internal

DESCRIPTION OF CHANGES: When mods were made to unify wrf/mpas code, MPAS was left out of an if statement within the call to SFCLAY1D. Added it in to correct for MPAS purpose.

LIST OF MODIFIED FILES: 
M    phys/module_sf_sfclay.F

TESTS CONDUCTED: 
1. Verified that it compiles and runs give bit-for-bit results before and after mods.

2. Simple test: does this CPP directive do what we want.
Source code
```
> cat foo.F
program foo
#if ( ( EM_CORE == 1 ) || ( defined(mpas) ) )
print *,'yep on EM_CORE == 1 || defined mpas'
#else
print *,'Nothing special at all'
#endif
end
```
 - [x] Works for WRF
```
> cpp -DEM_CORE=1 foo.F > foo.f90 ; gfortran foo.f90  ; a.out
 yep on EM_CORE == 1 || defined mpas
```
 - [x] Work for MPAS
```
> cpp -Dmpas foo.F > foo.f90 ; gfortran foo.f90 ; a.out
 yep on EM_CORE == 1 || defined mpas
```
 - [x] Expected null result
```
> cpp -DABC foo.F > foo.f90 ; gfortran foo.f90 ; a.out
 Nothing special at all
```