### PR TITLE
WSM6: remove unnecessary ifdef for purpose of WRF/MPAS unification

### DIFF
--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -8,10 +8,6 @@
 
 MODULE module_mp_wsm6
 !
-#if ( defined(wrfmodel) )
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
-#endif
    USE module_mp_radar
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: wsm6, wrf, mpas, unify, if loop

SOURCE: internal

DESCRIPTION OF CHANGES: 
At the top of the wsm6 module was an if defined (wrfmodel) loop that included a few 'use' 
statements for models/routines that are currently not used in this MP scheme. Removed that 
loop to unify this routine with MPAS and to clean-up unnecessary dependencies.

LIST OF MODIFIED FILES: 
M   phys/module_mp_wsm6.F

TESTS CONDUCTED: 
 - [x] verified that this builds without problems and produces bit-for-bit results before and after mods.
