### PR TITLE
Ntiedtke wrf mpas unify updates - addition of dx2d variable to clean up module

### DIFF
--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -289,7 +289,9 @@ contains
                                         rcs,                            &
                                         rn,                             &
                                         evap,                           &
-                                        heatflux
+                                        heatflux,                       &
+                                        dx2d
+
       integer  , dimension(its:ite) ::  slimsk
 
 
@@ -376,6 +378,16 @@ contains
         slimsk(i)=int(abs(xland(i,j)-2.))
       enddo
 
+#if defined(mpas)
+      do i=its,ite
+         dx2d(i) = dx(i,j)
+      enddo
+#else
+      do i=its,ite
+         dx2d(i) = dx
+      enddo
+#endif
+
       do k=kts,kte
         kp=k+1
         do i=its,ite
@@ -424,7 +436,7 @@ contains
 !
 !########################################################################
       call tiecnvn(u1,v1,t1,q1,q2,q3,q1b,t1b,ghtl,ghti,omg,prsl,prsi,evap,heatflux,  &
-                  rn,slimsk,im,kx,kx1,delt,dx)
+                  rn,slimsk,im,kx,kx1,delt,dx2d)
 
       do i=its,ite
          raincv(i,j)=rn(i)/stepcu
@@ -574,11 +586,8 @@ contains
      &     zlu(lq,km),     zlude(lq,km), zmfu(lq,km),  zmfd(lq,km), &
      &     zqsat(lq,km),   pqc(lq,km),   pqi(lq,km),   zrain(lq)
       real pqvf(lq,km),    ptf(lq,km)
-#if defined(mpas)
       real dx(lq)
-#elif defined(wrfmodel)
-      real dx
-#endif
+
       integer icbot(lq),   ictop(lq),     ktype(lq),   lndj(lq)
       logical locum(lq)
 !
@@ -694,7 +703,7 @@ contains
      &     pssfc,    ldcum,                              &
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
-     &     pcte,     phhfl,    lndj,     zgeoh,   dx)
+     &     pcte,     phhfl,    lndj,     zgeoh,    dx)
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme
@@ -790,11 +799,7 @@ contains
       real     wup(klon),              zdqcv(klon)            
       real     wbase(klon),            zmfuub(klon)
       real     upbl(klon)
-#if defined(mpas)
       real     dx(klon)
-#elif defined(wrfmodel)
-      real     dx
-#endif
       real     pmfude_rate(klon,klev), pmfdde_rate(klon,klev)
       real     zmfuus(klon,klev),      zmfdus(klon,klev)
       real     zuv2(klon,klev),ztenu(klon,klev),ztenv(klon,klev)
@@ -1022,11 +1027,7 @@ contains
        if(ldcum(jl).and.ktype(jl).eq.1) then
            ikb = kcbot(jl)
            ikt = kctop(jl)
-#if defined(mpas)
            ztau = ztauc(jl) * (1.+1.33e-5*dx(jl))
-#elif defined(wrfmodel)
-           ztau = ztauc(jl) * (1.+1.33e-5*dx)
-#endif
            ztau = max(ztmst,ztau)
            ztau = max(360.,ztau)
            ztau = min(10800.,ztau)

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -703,7 +703,7 @@ contains
      &     pssfc,    ldcum,                              &
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
-     &     pcte,     phhfl,    lndj,     zgeoh,    dx)
+     &     pcte,     phhfl,    lndj,     zgeoh,   dx)
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: ntiedtke, wrf, mpas cu_physics, dx2d

SOURCE: internal

DESCRIPTION OF CHANGES: Toward an effort to use fewer if defined(mpas) (or wrfmodel) statements in the code, a dx2d variable was added to be used until WRF creates a 2d array for dx.

LIST OF MODIFIED FILES: 
M   phys/module_cu_ntiedtke.F

TESTS CONDUCTED: verified that WRF builds okay and that bit-for-bit results are given before/after mods.
