### PR TITLE
Jensen microphysics: negative qi in vapor growth

### DIFF
--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -1647,7 +1647,7 @@ contains
   !.. If vapor growth of ice is going to cause
   !.. subsaturated condtions, reduce vapor growth
   !.. rates (done above) and rediagnose the axes
-             if(vgflag) then
+             if(vgflag.and.qi(cc,k).gt.QSMALL) then
                 alphstr=ao**(1.-deltastr(cc))
                 alphv=fourthirdspi*alphstr
                 betam=2.+deltastr(cc)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: jensen, mp_physics, qi, floating_point

SOURCE: internal

DESCRIPTION OF CHANGES: In the vapor growth check in Jensen microphysics, qi had the ability to be negative, which means that in the equation for ani(cc), there was potential to raise a negative number to an exponent of a non-logical fractional value, which caused a floating point error. This only stopped the model from running when compiled with a check for floating point traps. Inserting an if statement to prevent this from happening corrects the problem.

LIST OF MODIFIED FILES: 
M    phys/module_mp_jensen_ishmael.F

TESTS CONDUCTED: Verified that code builds and runs to completion, even when compiled with floating point trap checks.