### PR TITLE
KSAS: scale dependent trigger, conversion parameter, xmb trigger condition

### DIFF
--- a/phys/module_cu_ksas.F
+++ b/phys/module_cu_ksas.F
@@ -353,6 +353,11 @@ CONTAINS
 !   16-11-01  ji-young han     revised pgcon & bug fix in vshear
 !   17-02-23  ji-young han     revised xlamb
 !   18-03-01  ji-young han     kim sas
+!   19-03-01  ji-yeon jang     revised triggering ftn for higher resolution<10km
+!             yong-hee lee
+!             young cheol kwon
+!             eun-jeong lee    bug fix in c0 for overshooting layer
+!             seung-bu park    bug fix in xmb trigger
 !
 ! usage:    call phys_cps_sas(delt,delx,del,prsl,prsi,prslk,prsik,zl,          &
 !                             q2,q1,t1,u1,v1,rcs,slimsk,dot,cldwrk,rain,       &
@@ -405,6 +410,7 @@ CONTAINS
 !   lim et al.    (2014, wea. forecasting)
 !   han et al.    (2016, mon wea rev)
 !   kwon and hong (2017, mon wea rev)
+!   han and hong  (2018, wea. forecasting)
 !
 !-------------------------------------------------------------------------------
    implicit none
@@ -576,7 +582,7 @@ CONTAINS
      sigma = min(sigma - 0.01684 * delx/1000. + 0.0842, 1.0)
    endif
 !
-   cinpcr = cinpcrmn + 0.5*(cinpcrmx-cinpcrmn) * (1.-sigma)
+   cinpcr = (cinpcrmn + 0.5*(cinpcrmx-cinpcrmn)) * (1.-sigma)
 !
 !  initialize arrays
 !
@@ -1061,6 +1067,20 @@ CONTAINS
 !
    do k = kts1,kmax
      do i = its,ite
+       if (cnvflg(i).and.k.gt.kb(i)) then
+         alpha1 = min((-0.7*log(100.)+24.)*0.0001,c0)
+         beta1 = 0.07
+!
+         if (to(i,k).gt.t0c_) then
+           c0fac = alpha1
+         else
+           c0fac = alpha1*exp(beta1*(to(i,k)-t0c_))
+         endif
+!
+         c0fac = max(0.0,c0fac)
+         c0t(i,k) = c0fac
+       endif
+!
        if(cnvflg(i).and.k.gt.kb(i).and.k.lt.ktcon(i)) then
          dz1 = (zi(i,k+1) - zi(i,k))
          gamma = el2orc * qeso(i,k) / (to(i,k)**2)
@@ -1076,17 +1096,6 @@ CONTAINS
 ! check if there is excess moisture to release latent heat
 !
          if(qcirs(i,k).gt.0. .and. k.ge.kbcon(i)) then
-           alpha1 = min((-0.7*log(100.)+24.)*0.0001,c0)
-           beta1 = 0.07
-!
-           if (to(i,k).gt.t0c_) then
-             c0fac = alpha1
-           else
-             c0fac = alpha1*exp(beta1*(to(i,k)-t0c_))
-           endif
-!
-           c0fac = max(0.0,c0fac)
-           c0t(i,k) = c0fac
            etah = .5 * (eta(i,k) + eta(i,k-1))
            if(ncloud.gt.0..and.k.gt.jmin(i)) then
              dp = 1000. * del(i,k)
@@ -1819,6 +1828,18 @@ CONTAINS
    do k = kts1,kmax1
      do i = its,ite
        if(cnvflg(i).and.k.gt.kb(i).and.k.lt.ktcon(i)) then
+         alpha1 = min((-0.7*log(100.)+24.)*0.0001,c0)
+         beta1 = 0.07
+!
+         if (to(i,k).gt.t0c_) then
+           c0fac = alpha1
+         else
+           c0fac = alpha1*exp(beta1*(to(i,k)-t0c_))
+         endif
+!
+         c0fac = max(0.0,c0fac)
+         c0t(i,k) = c0fac
+!
          dz = zi(i,k+1) - zi(i,k)
          gamma = el2orc * qeso(i,k) / (to(i,k)**2)
          xdby = hcko(i,k) - heso(i,k)
@@ -2024,7 +2045,8 @@ CONTAINS
      endif
      pden(i) = p(i,kbcon(i))/to(i,kbcon(i))/rd_
      pdot(i) = 10.* dot(i,kbcon(i))
-     if (pden(i)*pdot(i).gt.xmb(i)) cnvflg(i) = .false.
+!    if (pden(i)*pdot(i).gt.xmb(i)) cnvflg(i) = .false.
+     if (xmb(i).lt.pdot(i)/g_) cnvflg(i) = .false.
    enddo
    totflg = .true.
    do i = its,ite


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: KSAS

SOURCE: Ji-Young Han and Songyou Hong (KIAPS)

DESCRIPTION OF CHANGES: 
1. Revised scale-dependent triggering function (cinpcr). This makes suppression of the convection triggering at resolutions less than 10 km more significant as compared to the original KSAS.

2. Fix the conversion parameter that determines the fraction of condensate converted to precipitation (c0) for convective overshooting layer. This leads to an increase in detrained moisture near the cloud top, resulting a decreased LW cooling effect in the tropical upper troposphere.

3. Fix cloud base mass flux xmb trigger condition, and this has a minor effect.

LIST OF MODIFIED FILES: 
M  phys/module_cu_ksas.F

TESTS CONDUCTED: 
It compiles. More later.

RELEASE NOTE:
For KSAS, the scale-dependent trigger function is revised to suppress more convection at model resolution less than 10 km. Fixed the conversion parameter that determines the fraction of condensate converted to precipitation (c0) for convective overshooting layer. This leads to an increase in detrained moisture near the cloud top, resulting a decreased LW cooling effect in the tropical upper troposphere.