### PR TITLE
Bug Fix: use Noah-MP table roughness length in urban areas when using bulk scheme (no urban option used)

### DIFF
--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -1857,6 +1857,15 @@ ENDIF   ! CROPTYPE == 0
         ZPD  = ZPDG
      END IF
 
+! special case for urban
+
+     IF (parameters%urban_flag) THEN
+       Z0MG = parameters%Z0MVT
+       ZPDG  = 0.65 * parameters%HVT
+       Z0M  = Z0MG
+       ZPD  = ZPDG
+     END IF
+
      ZLVL = MAX(ZPD,parameters%HVT) + ZREF
      IF(ZPDG >= ZLVL) ZLVL = ZPDG + ZREF
 !     UR   = UR*LOG(ZLVL/Z0M)/LOG(10./Z0M)       !input UR is at 10m


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah-MP

SOURCE:  Jorge Navarro (CIEMAT, Spain), Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:
Problem:
When running Noah-MP with no urban scheme (bulk method), the roughness length in urban areas
was not used from the MPTABLE and instead was set to a bare soil value. This resulted in a high 
temperature, high wind speed, and low sensible heat flux over cities.

Fix: use z0 from the MPTABLE

LIST OF MODIFIED FILES: 
M       phys/module_sf_noahmplsm.F

TESTS CONDUCTED:
1. 24-hr Noah-MP simulations in a summer and winter configuration

RELEASE NOTES:
When running Noah-MP with no urban scheme (bulk method), the roughness length in urban areas 
used a bare soil value. This resulted in a high temperature, high wind speed, and low sensible heat 
flux over cities. The correction uses z0 from the Noah-MP look-up table.