### PR TITLE
Bug Fix: fix some uninitialized Noah-MP variables

### DIFF
--- a/phys/module_sf_noahmp_glacier.F
+++ b/phys/module_sf_noahmp_glacier.F
@@ -1004,6 +1004,7 @@ contains
         NITERB = 5
         MPE    = 1E-6
         DTG    = 0.
+        MOZ    = 0.
         MOZSGN = 0
         MOZOLD = 0.
         H      = 0.

--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -1268,6 +1268,8 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
   use module_sf_noahmplsm
   use noahmp_tables
         
+  implicit none
+        
   integer,                    intent(in   ) :: nsoil     ! number of soil layers
   real, dimension( 1:nsoil ), intent(inout) :: sand
   real, dimension( 1:nsoil ), intent(inout) :: clay
@@ -1283,6 +1285,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
   real, dimension( 1:nsoil ) :: psi_e
     
   type(noahmp_parameters), intent(inout) :: parameters
+  integer :: k
 
   do k = 1,4
     if(sand(k) <= 0 .or. clay(k) <= 0) then

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -1813,6 +1813,7 @@ ENDIF   ! CROPTYPE == 0
     CHLEAF    = 0.
     CHUC      = 0.
     CHV2      = 0.
+    RB        = 0.
 
 ! wind speed at reference height: ur >= 1
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah-MP

SOURCE: David Mocko (NASA), Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:
1. A few Noah-MP variables are not initialized (now set to zero).
2. A routine did not have an 'implicit none'. This allowed default typing for an undeclared variable.

LIST OF MODIFIED FILES: 
M       phys/module_sf_noahmplsm.F
M       phys/module_sf_noahmpdrv.F
M       phys/module_sf_noahmp_glacier.F

TESTS CONDUCTED:
1. 24-hr Noah-MP simulations in a summer and winter configuration using PGI compiler produce no changes (results may change with other compilers)
