### PR TITLE
Syntax errors: (a ** -b) becomes (a ** (-b)); in new Jensen and Goddard MP schemes

### DIFF
--- a/phys/module_mp_gsfcgce_4ice_nuwrf.F
+++ b/phys/module_mp_gsfcgce_4ice_nuwrf.F
@@ -2044,7 +2044,7 @@ CONTAINS
 
        ftnw=1.                                                       
            if(ql.lt.cmin .and. tair .gt. t0)then                      
-             bin_factor=0.11*(1000.*qri)**-1.27 + 0.98      
+             bin_factor=0.11*(1000.*qri)**(-1.27) + 0.98      
              bin_factor=min(bin_factor, 1.30)       
              ftnw=1./bin_factor**3.35                             
              ftnwmin=r00*qri/draimax                        
@@ -4137,7 +4137,7 @@ CONTAINS
              fdwv    = dd(i)/(term1+term2*dwv0/dwv(i))
              ftnw=1.
              if (qr(i) .gt. cmin.and.tair(i).gt.t0) then   !no need to check qc, no qc if ssw < 0
-                 bin_factor(i)=0.11*(1000.*qr(i))**-1.27 + 0.98
+                 bin_factor(i)=0.11*(1000.*qr(i))**(-1.27) + 0.98
                  bin_factor(i)=min(bin_factor(i),1.30)
                  ftnw=1./bin_factor(i)**3.35
                  ftnwmin=r00(i)*qr(i)/draimax
@@ -4301,7 +4301,7 @@ CONTAINS
 
         ftnw=1.
         if(qr(i).gt.cmin .and. qc(i).lt.cmin)then
-             bin_factor(i)=0.11*(1000.*qr(i))**-1.27 + 0.98
+             bin_factor(i)=0.11*(1000.*qr(i))**(-1.27) + 0.98
 !            bin_factor(i)=min(bin_factor(i),1.35)
              bin_factor(i)=min(bin_factor(i),1.30)
              ftnw=1./bin_factor(i)**3.50

--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -1296,7 +1296,7 @@ contains
                          anfr = rnfr
                          cnfr = rnfr
                       elseif(phibr.gt.1.25) then !.. Prolate ice
-                         phifr = phibr*(((rnfr/rni(cc))**3)**-0.5)
+                         phifr = phibr*(((rnfr/rni(cc))**3)**(-0.5))
                          anfr = (ani(cc)/rni(cc)**(1.5))*rnfr**(1.5)
                       elseif(phibr.lt.0.8) then !.. Oblate ice
                          phifr = phibr*(rnfr/rni(cc))**3
@@ -3195,12 +3195,12 @@ contains
        alpha = (dv*fvdum*svpi*xxls)/(RV*kt*fhdum*temp)
        if(nidum.gt.0.0.and.rimesum.gt.0.0) then
           del1 = (xxlf*(rimesum/nidum)/(4.*PI*kt*fhdum*capgam)) * &
-               ((temp + alpha*((xxls/(RV*temp))-1.))**-1.0)
+               ((temp + alpha*((xxls/(RV*temp))-1.))**(-1.0))
        else
           del1 = 0.0
        endif
        del2 = sui * &
-            (((temp/alpha) + ((xxls/(RV*temp))-1.))**-1.0)
+            (((temp/alpha) + ((xxls/(RV*temp))-1.))**(-1.0))
        del = del1 + del2
        afn = ((dv*fvdum*polysvp(temp,1))/(RV*temp)) * &
             (sui - del*((xxls/(RV*temp))-1.))
@@ -4065,7 +4065,7 @@ contains
        if(phieffmax.le.0.03) then
           phieff = 1.
        elseif(phieffmax.gt.0.03.and.phieffmax.lt.0.5) then
-          phieff = 0.0001*((phieffmax+0.07)**-4.)
+          phieff = 0.0001*((phieffmax+0.07)**(-4.))
        else
           phieff = 0.
        endif
@@ -4104,7 +4104,7 @@ contains
        if(phieffmax.le.0.03) then
           phieff = 1.
        elseif(phieffmax.gt.0.03.and.phieffmax.lt.0.5) then
-          phieff = 0.0001*((phieffmax+0.07)**-4.)
+          phieff = 0.0001*((phieffmax+0.07)**(-4.))
        else
           phieff = 0.
        endif
@@ -4139,7 +4139,7 @@ contains
        if(phieffmax.le.0.03) then
           phieff = 1.
        elseif(phieffmax.gt.0.03.and.phieffmax.lt.0.5) then
-          phieff = 0.0001*((phieffmax+0.07)**-4.)
+          phieff = 0.0001*((phieffmax+0.07)**(-4.))
        else
           phieff = 0.
        endif
@@ -4174,7 +4174,7 @@ contains
        if(phieffmax.le.0.03) then
           phieff = 1.
        elseif(phieffmax.gt.0.03.and.phieffmax.lt.0.5) then
-          phieff = 0.0001*((phieffmax+0.07)**-4.)
+          phieff = 0.0001*((phieffmax+0.07)**(-4.))
        else
           phieff = 0.
        endif
@@ -4209,7 +4209,7 @@ contains
        if(phieffmax.le.0.03) then
           phieff = 1.
        elseif(phieffmax.gt.0.03.and.phieffmax.lt.0.5) then
-          phieff = 0.0001*((phieffmax+0.07)**-4.)
+          phieff = 0.0001*((phieffmax+0.07)**(-4.))
        else
           phieff = 0.
        endif


### PR DESCRIPTION
Type: bug fix

KEYWORDS: cray, exponent, syntax

SOURCE: Found by Peter Johnsen and Patricia Balle (Cray, Inc.), fixed internally

DESCRIPTION OF CHANGES: 
A few  illegal syntax examples of the form below were found by the Cray compiler in release-v4.1. 
These are the only instances in the phys directory (excluding comments).
```
a ** -b
```
The correct form is
```
a ** (-b)
```
None of the NCAR cheyenne compilers (Intel, PGI, GNU) complain about this particular syntax, 
since it is treated as an extension of the standard.
However, the code cannot compile with the CRAY compiler. 

If the Fortran 2003 standard is enforced with Intel, this construct flags a fatal error. 
```
> cat foo.f90
program foo1
print *, 'Expecting 5/9 = ',5./9., 3. ** -2 * 5.
end program foo1
```
With Intel as the compiler:
```
> ml
Currently Loaded Modules:
  1) ncarenv/1.2   2) intel/17.0.1   3) ncarcompilers/0.4.1   4) mpt/2.19   5) netcdf/4.6.1

> ifort -e03 foo.f90
foo.f90(2): error #8810: Consecutive operators are an extension to the Fortran 2003 standard.
print *, 'Expecting 5/9 = ',5./9., 3. ** -2 * 5.
-----------------------------------------^
compilation aborted for foo.f90 (code 1)
```
Even with newer GNU compilers, we can get a warning by default:
```
> ml gnu/8.1.0
Lmod is automatically replacing "intel/17.0.1" with "gnu/8.1.0".

Due to MODULEPATH changes, the following have been reloaded:
  1) mpt/2.19     2) ncarcompilers/0.4.1     3) netcdf/4.6.1

> gfortran foo.f90
foo.f90:2:42:

 print *, 'Expecting 5/9 = ',5./9., 3. ** -2 * 5.
                                          1
Warning: Extension: Unary operator following arithmetic operator (use parentheses) at (1)
```

LIST OF MODIFIED FILES:
M  phys/module_mp_gsfcgce_4ice_nuwrf.F
M  phys/module_mp_jensen_ishmael.F

TESTS CONDUCTED: 
 - [x] Model results are bit-for-bit (before vs after)