### PR TITLE
SH2O had two appearances in call to ssttep routine

### DIFF
--- a/phys/module_sf_noahlsm.F
+++ b/phys/module_sf_noahlsm.F
@@ -2689,7 +2689,7 @@ CONTAINS
       REAL, DIMENSION(1:NSOIL), INTENT(IN)   :: ET,ZSOIL
       REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: SMC, SH2O
       REAL, DIMENSION(1:NSOIL)             :: AI, BI, CI, STCF,RHSTS, RHSTT, &
-                                              SICE, SH2OA, SH2OFG
+                                              SICE, SH2OA, SH2OFG, SH2OIN
       REAL                  :: DUMMY, EXCESS,FRZFACT,PCPDRP,RHSCT,TRHSCT
       REAL :: FAC2
       REAL :: FLIMIT
@@ -2784,7 +2784,8 @@ CONTAINS
                     DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
                     RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
                     SFHEAD1RT,INFXS1RT)
-         CALL SSTEP (SH2O,SH2O,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,         &
+         SH2OIN=SH2O
+         CALL SSTEP (SH2O,SH2OIN,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,       &
                         CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
 
       ELSE
@@ -2792,7 +2793,8 @@ CONTAINS
                     DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
                     RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
                    SFHEAD1RT,INFXS1RT)
-         CALL SSTEP (SH2O,SH2O,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,         &
+         SH2OIN=SH2O
+         CALL SSTEP (SH2O,SH2OIN,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,       &
                      CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
 !      RUNOF = RUNOFF
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah LSM sh2o unified MPAS

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
A single variable was used as two calling arguments in a subroutine. Inside the subroutine, the 
separate names were pointing to the same memory and were treated differently.

Solution:
Since the two instances of the array were treated as IN and OUT, a copy of the array was made and
passed in as separately named input field. There were two locations to fix.

LIST OF MODIFIED FILES: 
M phys/module_sf_noahlsm.F

TESTS CONDUCTED: 
1. Comparing the results before vs after show no bit-for-bit differences (what we wanted).
```
../../external/io_netcdf/diffwrf INIT_develop/wrfout_d01_2000-01-24_12:00:00 INIT_FIX_dev/wrfout_d01_2000-01-24_12:00:00 
 Just plot  F
Diffing INIT_develop/wrfout_d01_2000-01-24_12:00:00 INIT_FIX_dev/wrfout_d01_2000-01-24_12:00:00
 Next Time 2000-01-24_12:00:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-24_12:03:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-24_12:06:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-24_12:09:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
 Next Time 2000-01-24_12:12:00
     Field   Ndifs    Dims       RMS (1)            RMS (2)     DIGITS    RMSE     pntwise max
```
2. When the code was instrumented, the only differences were diagnostic only. No differences in any other WRF output fields. See davegill/WRF#5