### PR TITLE
MP=8,28 initialize_real additions for cloud droplet number, cloud ice number, rain number

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -131,6 +131,7 @@ integer::oops1,oops2
       REAL    :: zap_close_levels
       INTEGER :: force_sfc_in_vinterp
       INTEGER :: interp_type , lagrange_order , extrap_type , t_extrap_type
+      INTEGER :: linear_interp
       LOGICAL :: lowest_lev_from_sfc , use_levels_below_ground , use_surface
       LOGICAL :: we_have_tavgsfc , we_have_tsk
 
@@ -1682,6 +1683,7 @@ integer::oops1,oops2
             !  scaled by the eta levels.
 
             interp_type = 2
+            linear_interp = grid%linear_interp
             lagrange_order = grid%lagrange_order
             lowest_lev_from_sfc = .FALSE.
             use_levels_below_ground = .TRUE.
@@ -1895,7 +1897,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1925,7 +1927,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1955,7 +1957,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1975,7 +1977,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1995,7 +1997,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2015,7 +2017,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2035,7 +2037,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2055,7 +2057,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2075,7 +2077,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2095,7 +2097,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2115,7 +2117,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2135,7 +2137,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2160,7 +2162,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2176,7 +2178,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2213,7 +2215,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2228,7 +2230,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , lagrange_order , extrap_type , &
+                                     interp_type , linear_interp , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2322,7 +2324,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2374,7 +2376,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2426,7 +2428,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2550,7 +2552,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2611,7 +2613,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , lagrange_order , extrap_type , &
+                               interp_type , linear_interp , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -131,7 +131,6 @@ integer::oops1,oops2
       REAL    :: zap_close_levels
       INTEGER :: force_sfc_in_vinterp
       INTEGER :: interp_type , lagrange_order , extrap_type , t_extrap_type
-      INTEGER :: linear_interp
       LOGICAL :: lowest_lev_from_sfc , use_levels_below_ground , use_surface
       LOGICAL :: we_have_tavgsfc , we_have_tsk
 
@@ -1682,7 +1681,6 @@ integer::oops1,oops2
 
             interp_type = 2
             lagrange_order = grid%lagrange_order
-            linear_interp = grid%linear_interp
             lowest_lev_from_sfc = .FALSE.
             use_levels_below_ground = .TRUE.
             use_surface = .TRUE.
@@ -1895,7 +1893,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1925,7 +1923,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1955,7 +1953,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1975,7 +1973,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -1995,7 +1993,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2015,7 +2013,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2035,7 +2033,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2055,7 +2053,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2075,7 +2073,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2095,7 +2093,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2115,7 +2113,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2135,7 +2133,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2160,7 +2158,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2176,7 +2174,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2213,7 +2211,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2228,7 +2226,7 @@ integer::oops1,oops2
                                      config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
-                                     interp_type , linear_interp , extrap_type , &
+                                     interp_type , lagrange_order , extrap_type , &
                                      lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
@@ -2322,7 +2320,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
+                               interp_type , lagrange_order , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2374,7 +2372,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
+                               interp_type , lagrange_order , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2426,7 +2424,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
+                               interp_type , lagrange_order , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2550,7 +2548,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
+                               interp_type , lagrange_order , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
@@ -2611,7 +2609,7 @@ integer::oops1,oops2
                                config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
+                               interp_type , lagrange_order , extrap_type , &
                                lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -167,6 +167,8 @@ integer::oops1,oops2
       INTEGER :: j_save
       INTEGER :: change_soil, change_soilw, iforce
 
+      REAL:: temp_rho
+
       LOGICAL :: wif_upside_down = .FALSE.
       
       !  Test on consistency between namelist settings and the available data from geogrid.
@@ -4414,7 +4416,73 @@ endif
          enddo
          enddo
       ENDIF
+
 !+---+-----------------------------------------------------------------+
+!..Let us ensure that double-moment microphysics variables have numbers
+!.. where there is mass.  Currently doing this for Thompson-MP only, but
+!.. can consider doing it for every MP scheme that has 2-moment variables.
+!.. This is important because pressure-level RAP/HRRR files have mass but
+!.. not number values for example (whereas native model level files have
+!.. both).
+!+---+-----------------------------------------------------------------+
+
+      IF ( config_flags%mp_physics .EQ. THOMPSON .OR.                   &
+                   config_flags%mp_physics .EQ. THOMPSONAERO ) THEN
+
+         !..As it occurs up above, temporarily utilizing the v_1 variable,
+         !.. to hold temperature, which it does when time_loop=0.
+
+         IF ( internal_time_loop .GT. 1 ) THEN
+            grid%v_1 = grid%t_2+t0
+
+            CALL theta_to_t ( grid%v_1 , grid%p_hyd  , p00 , &
+                           ids , ide , jds , jde , kds , kde , &
+                           ims , ime , jms , jme , kms , kme , &
+                           its , ite , jts , jte , kts , kte )
+         ENDIF
+
+
+         do j = jts, MIN(jte,jde-1)
+         do i = its, MIN(ite,ide-1)
+
+            IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
+
+            do k = kts, kte-1
+               temp_rho = 1./grid%alt(i,k,j)
+
+               !..Produce a sensible cloud droplet number concentration
+
+               if (P_QNC.gt.1 .AND. moist(i,k,j,P_QC).gt.0.0 .AND. scalar(i,k,j,P_QNC).le.0.0) then
+                  if (P_QNWFA .gt. 1) then
+                     scalar(i,k,j,P_QNC) = make_DropletNumber (moist(i,k,j,P_QC)*temp_rho,       &
+     &                           scalar(i,k,j,P_QNWFA)*temp_rho, grid%xland(i,j))
+                  else
+                     scalar(i,k,j,P_QNC) = make_DropletNumber (moist(i,k,j,P_QC)*temp_rho,       &
+     &                           0.0, grid%xland(i,j))
+                  endif
+                  scalar(i,k,j,P_QNC) = scalar(i,k,j,P_QNC) / temp_rho
+               endif
+
+               !..Produce a sensible cloud ice number concentration
+
+               if (P_QNI.gt.1 .AND. moist(i,k,j,P_QI).gt.0.0 .AND. scalar(i,k,j,P_QNI).le.0.0) then
+                  scalar(i,k,j,P_QNI) = make_IceNumber (moist(i,k,j,P_QI)*temp_rho, grid%v_1(i,k,j))
+                  scalar(i,k,j,P_QNI) = scalar(i,k,j,P_QNI) / temp_rho
+               endif
+
+               !..Produce a sensible rain number concentration
+
+               if (P_QNR.gt.1 .AND. moist(i,k,j,P_QR).gt.0.0 .AND. scalar(i,k,j,P_QNR).le.0.0) then
+                  scalar(i,k,j,P_QNR) = make_RainNumber (moist(i,k,j,P_QR)*temp_rho, grid%v_1(i,k,j))
+                  scalar(i,k,j,P_QNR) = scalar(i,k,j,P_QNR) / temp_rho
+               endif
+
+            enddo
+
+         enddo
+         enddo
+
+      ENDIF
 
 !+---+-----------------------------------------------------------------+
       !  Added by Greg Thompson.  Pre-set snow depth by latitude, elevation, and day-of-year.
@@ -8548,6 +8616,162 @@ end do
 
       END FUNCTION snowHires
 
+!+---+-----------------------------------------------------------------+
+!+---+-----------------------------------------------------------------+
+
+      real function make_IceNumber (Q_ice, temp)
+
+      IMPLICIT NONE
+      REAL, PARAMETER:: Ice_density = 890.0
+      REAL, PARAMETER:: PI = 3.1415926536
+      integer idx_rei
+      real corr, reice, deice, Q_ice, temp
+      double precision lambda
+
+!+---+-----------------------------------------------------------------+
+!..Table of lookup values of radiative effective radius of ice crystals
+!.. as a function of Temperature from -94C to 0C.  Taken from WRF RRTMG
+!.. radiation code where it is attributed to Jon Egill Kristjansson
+!.. and coauthors.
+!+---+-----------------------------------------------------------------+
+
+      real retab(95)
+      data retab /                                                      &
+         5.92779, 6.26422, 6.61973, 6.99539, 7.39234,                   &
+         7.81177, 8.25496, 8.72323, 9.21800, 9.74075, 10.2930,          &
+         10.8765, 11.4929, 12.1440, 12.8317, 13.5581, 14.2319,          &
+         15.0351, 15.8799, 16.7674, 17.6986, 18.6744, 19.6955,          &
+         20.7623, 21.8757, 23.0364, 24.2452, 25.5034, 26.8125,          &
+         27.7895, 28.6450, 29.4167, 30.1088, 30.7306, 31.2943,          &
+         31.8151, 32.3077, 32.7870, 33.2657, 33.7540, 34.2601,          &
+         34.7892, 35.3442, 35.9255, 36.5316, 37.1602, 37.8078,          &
+         38.4720, 39.1508, 39.8442, 40.5552, 41.2912, 42.0635,          &
+         42.8876, 43.7863, 44.7853, 45.9170, 47.2165, 48.7221,          &
+         50.4710, 52.4980, 54.8315, 57.4898, 60.4785, 63.7898,          &
+         65.5604, 71.2885, 75.4113, 79.7368, 84.2351, 88.8833,          &
+         93.6658, 98.5739, 103.603, 108.752, 114.025, 119.424,          &
+         124.954, 130.630, 136.457, 142.446, 148.608, 154.956,          &
+         161.503, 168.262, 175.248, 182.473, 189.952, 197.699,          &
+         205.728, 214.055, 222.694, 231.661, 240.971, 250.639/
+
+!+---+-----------------------------------------------------------------+
+!..From the model 3D temperature field, subtract 179K for which
+!.. index value of retab as a start.  Value of corr is for
+!.. interpolating between neighboring values in the table.
+!+---+-----------------------------------------------------------------+
+
+      idx_rei = int(temp-179.)
+      idx_rei = min(max(idx_rei,1),94)
+      corr = temp - int(temp)
+      reice = retab(idx_rei)*(1.-corr) + retab(idx_rei+1)*corr
+      deice = 2.*reice * 1.E-6
+
+!+---+-----------------------------------------------------------------+
+!..Now we have the final radiative effective size of ice (as function
+!.. of temperature only).  This size represents 3rd moment divided by
+!.. second moment of the ice size distribution, so we can compute a
+!.. number concentration from the mean size and mass mixing ratio.
+!.. The mean (radiative effective) diameter is 3./Slope for an inverse
+!.. exponential size distribution.  So, starting with slope, work
+!.. backwords to get number concentration.
+!+---+-----------------------------------------------------------------+
+
+      lambda = 3.0 / deice
+      make_IceNumber = Q_ice * lambda*lambda*lambda / (PI*Ice_density)
+
+!+---+-----------------------------------------------------------------+
+!..Example1: Common ice size coming from Thompson scheme is about 30 microns.
+!.. An example ice mixing ratio could be 0.001 g/kg for a temperature of -50C.
+!.. Remember to convert both into MKS units.  This gives N_ice=357652 per kg.
+!..Example2: Lower in atmosphere at T=-10C matching ~162 microns in retab,
+!.. and assuming we have 0.1 g/kg mixing ratio, then N_ice=28122 per kg,
+!.. which is 28 crystals per liter of air if the air density is 1.0.
+!+---+-----------------------------------------------------------------+
+
+      return
+      end function make_IceNumber
+
+!+---+-----------------------------------------------------------------+
+!+---+-----------------------------------------------------------------+
+
+      real function make_DropletNumber (Q_cloud, qnwfa, xland)
+
+      IMPLICIT NONE
+
+      real:: Q_cloud, qnwfa, xland
+
+      real, parameter:: PI = 3.1415926536
+      real, parameter:: am_r = PI*1000./6.
+      real, dimension(15), parameter:: g_ratio = (/24,60,120,210,336,   &
+     &                504,720,990,1320,1716,2184,2730,3360,4080,4896/)
+      double precision:: lambda, qnc
+      real:: q_nwfa, x1, xDc
+      integer:: nu_c
+
+!+---+
+
+      if (qnwfa .le. 0.0) then
+
+         if ((xland-1.5).gt.0.) then                                     !--- Ocean
+            xDc = 17.E-6
+            nu_c = 12
+         else                                                            !--- Land
+            xDc = 11.E-6
+            nu_c = 4
+         endif
+
+      else
+         q_nwfa = MAX(99.E6, MIN(qnwfa,5.E10))
+         nu_c = MAX(2, MIN(NINT(2.5E10/q_nwfa), 15))
+
+         x1 = MAX(1., MIN(q_nwfa*1.E-9, 10.)) - 1.
+         xDc = (30. - x1*20./9.) * 1.E-6
+      endif
+
+      lambda = (4.0D0 + nu_c) / xDc
+      qnc = Q_cloud / g_ratio(nu_c) * lambda*lambda*lambda / am_r
+      make_DropletNumber = SNGL(qnc)
+
+      return
+      end function make_DropletNumber
+
+!+---+-----------------------------------------------------------------+
+!+---+-----------------------------------------------------------------+
+
+      real function make_RainNumber (Q_rain, temp)
+
+      IMPLICIT NONE
+
+      real, intent(in):: Q_rain, temp
+      double precision:: lambda, N0, qnr
+      real, parameter:: PI = 3.1415926536
+      real, parameter:: am_r = PI*1000./6.
+
+      !+---+-----------------------------------------------------------------+ 
+      !.. Not thrilled with it, but set Y-intercept parameter to Marshal-Palmer value
+      !.. that basically assumes melting snow becomes typical rain. However, for
+      !.. -2C < T < 0C, make linear increase in exponent to attempt to keep
+      !.. supercooled collision-coalescence (warm-rain) similar to drizzle rather
+      !.. than bigger rain drops.  While this could also exist at T>0C, it is
+      !.. more difficult to assume it directly from having mass and not number.
+      !+---+-----------------------------------------------------------------+ 
+
+      N0 = 8.E6
+
+      if (temp .le. 271.15) then
+         N0 = 8.E8      
+      elseif (temp .gt. 271.15 .and. temp.lt.273.15) then
+         N0 = 8. * 10**(279.15-temp)
+      endif
+
+      lambda = SQRT(SQRT(N0*am_r*6.0/Q_rain))
+      qnr = Q_rain / 6.0 * lambda*lambda*lambda / am_r
+      make_RainNumber = SNGL(qnr)
+
+      return
+      end function make_RainNumber
+
+!+---+-----------------------------------------------------------------+
 !+---+-----------------------------------------------------------------+
 
 

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1683,8 +1683,8 @@ integer::oops1,oops2
             !  scaled by the eta levels.
 
             interp_type = 2
-            linear_interp = grid%linear_interp
             lagrange_order = grid%lagrange_order
+            linear_interp = grid%linear_interp
             lowest_lev_from_sfc = .FALSE.
             use_levels_below_ground = .TRUE.
             use_surface = .TRUE.


### PR DESCRIPTION
TYPE: NEW FEATURE

KEYWORDS: number concentrations, initial and boundary conditions, microphysics, 2-moment

SOURCE: Greg Thompson (NCAR-RAL)

DESCRIPTION OF CHANGES: 
Problem: 
Some incoming data from WPS/ungrib/metgrid (for example, RAP/HRRR pressure level data) only have mass mixing ratios but not number concentrations. This forces a number to be made up later for 2-moment microphysics (MP) schemes. 

Solution:
For a more fully integrated approach with initial and boundary conditions, we can calculate reasonable values of number concentration from mass (together with other variables) in module_initialize_real. Very simple functions, one each to create number of cloud droplets, cloud ice, and rain number concentrations are isolated functions added for IC/BC creation time. 

Proper mass and number result in proper calculations of derived variables such as synthetic satellite 
brightness temperatures which will someday be included as observations in DA systems. The size of 
ice and water affect radiance calculations in forward operators and giving mass without number in 
2-moment schemes would involve many downstream errors for size calculations. Making this fix here 
could ensure those radiances start out properly. The solution implemented herein therefore also 
permits more direct integration with DA codes.

LIST OF MODIFIED FILES:
dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. Using this code for past 2 months without problems. From WPS/metgrid, I used the RAP native model level GRIB2 files from NCEP from 2019Mar07 test case.
2. Original vs new
   a. number concentration with ORIGINAL version of real when this field _is not_ an input variable
   b. number concentration with ORIGINAL version of real when this field _is_ an input variable 
   c. number concentration with NEW version of real when this field _is not_ an input variable
   d. number concentration with NEW version of real when this field _is_ an input variable

These produce the proper behaviors. Below is a graphic of rain mixing ratio (top-left); rain number (2d, top-right); rain number (2b, bottom-right); rain number (2c, bottom-left). Not shown, but confirmed test 2a: all values of rain number become zero in wrfinput file.
![real_2moment_number](https://user-images.githubusercontent.com/35609171/55110497-c2374380-509d-11e9-926e-b0598859faa6.png)


RELEASE NOTE: Thompson MP options 8 and 28: Most GRIB files contain mass mixing ratios for cloud/precip variables, but not all of them contain number concentrations. A good example is pressure level RAP/HRRR files whereas the native level model files contain both mass and number. Initializing a model with the associated number concentration fields will cause greatly inferior assumptions at run time versus fixing the number concentration variables with something sensible during real.exe to get both initial and boundary condition 2-moment variables reasonably in sync. The solution here is creating number of cloud droplets, cloud ice, and rain for any of those which have mass but not number.