### PR TITLE
BF: TSLIST broken for (i,j) with MPI rank > 1

### DIFF
--- a/share/wrf_tsin.F
+++ b/share/wrf_tsin.F
@@ -17,7 +17,6 @@ SUBROUTINE wrf_tsin ( grid , ierr )
     LOGICAL, EXTERNAL :: wrf_dm_on_monitor
     INTEGER, EXTERNAL :: get_unused_unit
 
-    REAL, ALLOCATABLE, DIMENSION(:) :: lattslocs, lontslocs
     INTEGER :: istatus, iunit
     LOGICAL :: exists
     CHARACTER (LEN=256) :: errmess

--- a/share/wrf_tsin.F
+++ b/share/wrf_tsin.F
@@ -120,8 +120,11 @@ SUBROUTINE wrf_tsin ( grid , ierr )
 
 #ifdef DM_PARALLEL
        CALL wrf_dm_bcast_integer(grid%ntsloc, 1)
+       CALL wrf_dm_bcast_integer(grid%tslist_ij, 1)
        CALL wrf_dm_bcast_real(grid%lattsloc, grid%max_ts_locs)
        CALL wrf_dm_bcast_real(grid%lontsloc, grid%max_ts_locs)
+       CALL wrf_dm_bcast_integer(grid%itsloc, grid%max_ts_locs)
+       CALL wrf_dm_bcast_integer(grid%jtsloc, grid%max_ts_locs)
 #endif
 #if ((EM_CORE == 1) && (DA_CORE != 1))
     END IF


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: tslist, mpi, bcast, ij

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
With the introduction of the ability to use (i,j) as the location for a time series output from WRF,
the code failed to work for (i,j) using MPI with more than one rank (SHA [43ac4e93f](https://github.com/wrf-model/WRF/commit/43ac4e93fb29a753893152d8e228f3b8c8b96f42), 
PR #712 "new tslist options: add W; cell-centered u,v; (i,j) and (lat,lon) locations").
The original (lat,lon) capability, both serial and DM parallel, continue to work.

Solution:
The `tslist_ij` flag, determined on the master process, needed to be communicated to the other
MPI processes. Additionally, the (i,j) locations needed to be communicated.

Also, for code clean up: removed two arrays that were never used.

LIST OF MODIFIED FILES: 
M share/wrf_tsin.F

TESTS CONDUCTED:
- [x] Verified that this builds/runs correctly with the modification. Output is now provided for the correct tslist-assigned locations. 

- [x] Compared output from time series (7 files, at each of 3 locations) - they are bit-wise identical with MPI and serial.
```
#-----------------------------------------------#
# 24 characters for name | pfx |  LAT  |  LON   |
#-----------------------------------------------#
tower0001                 t0001  33.116  -90.380
tower0001                 t0003  30.410  -90.678
tower0012                 t0012  35.072  -83.364
```
```
#-----------------------------------------------#
# 24 characters for name | pfx |   i   |   j    |
#-----------------------------------------------#
tower0001                 t0001      10       20  
tower0001                 t0003      10       10  
tower0012                 t0012      30       30 
```
