### PR TITLE
em_scm_xy compile bug fix: add 'flag_sm_adj' to call to process_soil_real in module_initialize_scm_xy

### DIFF
--- a/dyn_em/module_initialize_scm_xy.F
+++ b/dyn_em/module_initialize_scm_xy.F
@@ -287,7 +287,7 @@ CONTAINS
                    grid%landmask , grid%sst , grid%ht, grid%toposoil, &
                    st_input , sm_input , sw_input , &
                    st_levels_input , sm_levels_input , sw_levels_input , &
-                   grid%zs , grid%dzs , grid%tslb , grid%smois , grid%sh2o , &
+                   grid%zs , grid%dzs , grid%flag_sm_adj , grid%tslb , grid%smois , grid%sh2o , &
                    flag_sst , flag_tavgsfc, flag_soilhgt, flag_soil_layers, flag_soil_levels,  &
                    ids , ide , jds , jde , kds , kde , &
                    ims , ime , jms , jme , kms , kme , &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: scm_xy, process_soil_real, flag_sm_adj, compile 

SOURCE: internal

DESCRIPTION OF CHANGES: 
In ([commit b4c8515](https://github.com/wrf-model/WRF/commit/b4c851585654)), a soil moisture
flag (flag_sm_adj) was added to module_soil_pre.F in subroutine process_soil_real. This subroutine 
is called in module_initialize_scm_xy, and therefore needed the addition of the flag in the 
declarations list for that call, as well. Since it wasn't in there, em_scm_xy was unable to compile. 
Once added, the ideal program compiles correctly. With this change, all occurrences of the call to 
subroutine process_soil_real are now handled.

LIST OF MODIFIED FILES: 
M       dyn_em/module_initialize_scm_xy.F

TESTS CONDUCTED: 
[x] Verified that the code builds with this addition.