### PR TITLE
Require monotonic vertical pressure decrease: test after hybrid vert coordinate calculation in real 

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -174,6 +174,10 @@ integer::oops1,oops2
 
       INTEGER :: geogrid_flag_error
 
+      !  Vertical pressure checks
+
+      REAL :: press_above, press_below
+
       !  Dimension information stored in grid data structure.
 
       CALL cpu_time(t_start)
@@ -627,6 +631,8 @@ integer::oops1,oops2
          END IF
 
          !  Variables that are named differently between SI and WPS.
+
+grid%ht_gc(10,10)=9000
 
          DO j = jts, MIN(jte,jde-1)
             DO i = its, MIN(ite,ide-1)
@@ -1650,6 +1656,32 @@ integer::oops1,oops2
          DO k=1, kde-1
             grid%c1h(k) = ( grid%c3f(k+1) - grid%c3f(k) ) / ( grid%znw(k+1) - grid%znw(k) )
             grid%c2h(k) = ( 1. - grid%c1h(k) ) * ( p1000mb - grid%p_top )
+         ENDDO
+
+         !  With c3 and c4 on full levels, we can verify that we are maintaining monotonically
+         !  decreasing reference pressure.
+         !  P_dry_ref(k)  = c3f(k) * ( psurf - p_top ) + c4f(k) + p_top
+
+         DO j = jts, MIN(jde-1,jte)
+            DO i = its, MIN(ide-1,ite)
+               p_surf = p00 * EXP ( -t00/a + ( (t00/a)**2 - 2.*g*grid%ht(i,j)/a/r_d ) **0.5 )
+               DO k=1, kde-1
+                  press_above = grid%c3f(k+1)*(p_surf-grid%p_top) + grid%c4f(k+1) + grid%p_top
+                  press_below = grid%c3f(k  )*(p_surf-grid%p_top) + grid%c4f(k  ) + grid%p_top
+                  IF ( press_below - press_above .LE. 0.0 ) THEN
+                     CALL wrf_message ( '----- ERROR: The reference pressure is not monotonically decreasing' )
+                     CALL wrf_message ( '             This tends to be caused by very high topography')
+                     WRITE (a_message,*) '(i,j) = ',i,j,', topography = ',grid%ht(i,j),' m'
+                     CALL wrf_message ( TRIM(a_message) )
+                     WRITE (a_message,*) 'k = ',k,', reference pressure = ',press_below,' Pa'
+                     CALL wrf_message ( TRIM(a_message) )
+                     WRITE (a_message,*) 'k = ',k+1,', reference pressure = ',press_above,' Pa'
+                     CALL wrf_message ( TRIM(a_message) )
+                     WRITE (a_message,*) 'In the dynamics namelist record, reduce etac from ',config_flags%etac
+                     CALL wrf_error_fatal ( TRIM(a_message) )
+                  END IF
+               ENDDO
+            ENDDO
          ENDDO
 
          IF ( config_flags%interp_theta ) THEN

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -632,8 +632,6 @@ integer::oops1,oops2
 
          !  Variables that are named differently between SI and WPS.
 
-grid%ht_gc(10,10)=9000
-
          DO j = jts, MIN(jte,jde-1)
             DO i = its, MIN(ite,ide-1)
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: etac, monotonic pressure, hybrid coordinate, hvc

SOURCE: Found by Michael Toy (NOAA), fix internal

DESCRIPTION OF CHANGES: 
Problem:
Over very high topography, the flattened eta surfaces may intersect the eta surfaces below. The 
WRF model dies quickly, and it is very difficult to figure out what happened. In simple terms, the
reference pressure must decrease as you go up the k-index, for each (i,j). If not, then that is a 
fatal error.

Solution:
Trap this event via looking at the columns of reference pressure. Any column that is NOT monotonic 
flags a fatal error. The user is given the location, the pressure values, and a suggestion to reduce the 
etac (the critical eta surface where the levels becomes isobaric).

A similar warning was issued in 1984, though it dealt with crossing _streams_ and _total protonic 
reversal_ instead of crossing _eta surfaces_.
https://www.youtube.com/watch?v=jyaLZHiJJnE

LIST OF MODIFIED FILES: 
M dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. For the user's case that originally brought up this problem, the real program correctly stopped.
```
----- ERROR: The reference pressure is not monotonically decreasing
             This tends to be caused by very high topography
 (i,j) =          979         414, topography =    7346.500     m
 k =           13, reference pressure =    35442.12     Pa
 k =           14, reference pressure =    35500.98     Pa
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1376
 In the dynamics namelist record, reduce etac from   0.2000000
-------------------------------------------
```
2. For Jan 2000 case, artificially introduced a point with 9000 m elevation: caught by real.
```
----- ERROR: The reference pressure is not monotonically decreasing
             This tends to be caused by very high topography
 (i,j) =           10          10 , topography =    9000.00000      m
 k =            8 , reference pressure =    29485.4062      Pa
 k =            9 , reference pressure =    29518.7754      Pa
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1690
 In the dynamics namelist record, reduce etac from   0.200000003
-------------------------------------------
```