### PR TITLE
Remove the *.dSYM directories from Darwin when "clean" command issued

### DIFF
--- a/clean
+++ b/clean
@@ -19,6 +19,7 @@ endif
 
 ( cd inc ; /bin/rm -f *.inc namelist.default )
 
+find . -name \*.dSYM -exec rm {} \;
 
 set arg="$1"
 if ( "$arg" == '-a' || "$arg" == '-aa' ) then

--- a/clean
+++ b/clean
@@ -19,7 +19,7 @@ endif
 
 ( cd inc ; /bin/rm -f *.inc namelist.default )
 
-find . -name \*.dSYM -exec rm {} \;
+find . -name \*.dSYM -exec rm -rf {} \; >& /dev/null
 
 set arg="$1"
 if ( "$arg" == '-a' || "$arg" == '-aa' ) then


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Darwin, clean, dSYM

SOURCE: internal

DESCRIPTION OF CHANGES: 
When building the WRF system, Darwin machines may create several *.dSYM directories, 
depending on the compiler. Remove these *.dSYM directories when issuing a `clean` command.

LIST OF MODIFIED FILES: 
M ./clean

TESTS CONDUCTED: 
1. Able to remove directories
```
> git status
On branch clean_dSYM
Your branch is up to date with 'dave/clean_dSYM'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	external/io_int/diffwrf.dSYM
	external/io_int/test_io_idx.dSYM
	external/io_netcdf/diffwrf.dSYM
	main/ndown.exe.dSYM
	main/real.exe.dSYM
	main/tc.exe.dSYM
	main/wrf.exe.dSYM
	makeem.csh
	tools/registry.dSYM
	tools/standard.exe.dSYM

nothing added to commit but untracked files present (use "git add" to track)
```
Then issue `clean` command, and look at the status:
```
> clean
> git status
On branch clean_dSYM
Your branch is up to date with 'dave/clean_dSYM'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	makeem.csh

nothing added to commit but untracked files present (use "git add" to track)
```

