### PR TITLE
TSLIST: add pressure field to vertical profile output files

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -735,13 +735,15 @@ state    real   ts_clw          ?!       misc      -         -      -        "TS
 state    real   ts_rainc        ?!       misc      -         -      -        "TS_RAINC"       "Cumulus precip"
 state    real   ts_rainnc       ?!       misc      -         -      -        "TS_RAINNC"      "Grid-scale precip"
 
-# Time series of vertical profile of U, V, GHT, THETA and QVAPOR
-state    real   ts_u_profile   ?!k       misc      -         -      -        "TS_U_PROFILE"   "Wind u-Component, earth relative, vertical profile"
-state    real   ts_v_profile   ?!k       misc      -         -      -        "TS_V_PROFILE"   "Wind v-Component, earth relative, vertical profile"
-state    real   ts_w_profile   ?!k       misc      -         -      -        "TS_W_PROFILE"   "Wind w-Component, earth relative, vertical profile"
-state    real   ts_gph_profile ?!k       misc      -         -      -        "TS_GPH_PROFILE" "Total geopotential height, vertical profile"
-state    real   ts_th_profile  ?!k       misc      -         -      -        "TS_TH_PROFILE"  "Total potential temperature, vertical profile"
-state    real   ts_qv_profile  ?!k       misc      -         -      -        "TS_QV_PROFILE"  "Water vapor mixing ratio, vertical profile"
+# Time series of vertical profile of U, V, GHT, THETA, QVAPOR, PRESSURE
+state    real   ts_u_profile   ?!k       misc      -         -      -        "TS_U_PROFILE"   "Wind u-Component, earth relative, vertical profile" "m/s"
+state    real   ts_v_profile   ?!k       misc      -         -      -        "TS_V_PROFILE"   "Wind v-Component, earth relative, vertical profile" "m/s"
+state    real   ts_w_profile   ?!k       misc      -         -      -        "TS_W_PROFILE"   "Wind w-Component, earth relative, vertical profile" "m/s"
+state    real   ts_gph_profile ?!k       misc      -         -      -        "TS_GPH_PROFILE" "Total geopotential height, vertical profile" "m"
+state    real   ts_th_profile  ?!k       misc      -         -      -        "TS_TH_PROFILE"  "Total potential temperature, vertical profile" "K"
+state    real   ts_qv_profile  ?!k       misc      -         -      -        "TS_QV_PROFILE"  "Water vapor mixing ratio, vertical profile" "kg/kg"
+state    real   ts_p_profile   ?!k       misc      -         -      -        "TS_P_PROFILE"   "Pressure, vertical profile" "Pa"
+
 
 # urban model variables
 state    real   DZR             l        em      -         Z     r        "DZR"            "THICKNESSES OF ROOF LAYERS"                      "m"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -738,7 +738,7 @@ state    real   ts_rainnc       ?!       misc      -         -      -        "TS
 # Time series of vertical profile of U, V, GHT, THETA, QVAPOR, PRESSURE
 state    real   ts_u_profile   ?!k       misc      -         -      -        "TS_U_PROFILE"   "Wind u-Component, earth relative, vertical profile" "m/s"
 state    real   ts_v_profile   ?!k       misc      -         -      -        "TS_V_PROFILE"   "Wind v-Component, earth relative, vertical profile" "m/s"
-state    real   ts_w_profile   ?!k       misc      -         -      -        "TS_W_PROFILE"   "Wind w-Component, earth relative, vertical profile" "m/s"
+state    real   ts_w_profile   ?!k       misc      -         -      -        "TS_W_PROFILE"   "Wind w-Component, vertical profile" "m/s"
 state    real   ts_gph_profile ?!k       misc      -         -      -        "TS_GPH_PROFILE" "Total geopotential height, vertical profile" "m"
 state    real   ts_th_profile  ?!k       misc      -         -      -        "TS_TH_PROFILE"  "Total potential temperature, vertical profile" "K"
 state    real   ts_qv_profile  ?!k       misc      -         -      -        "TS_QV_PROFILE"  "Water vapor mixing ratio, vertical profile" "kg/kg"

--- a/run/README.tslist
+++ b/run/README.tslist
@@ -34,11 +34,13 @@ or nested), the following files are created:
 3. pfx.dNN.VV containing a vertical profile of v wind component for each time step
 4. pfx.dNN.WW containing a vertical profile of w wind component for each time step
 5. pfx.dNN.TH containing a vertical profile of potential temperature for time step
-6. pfx.dNN.PH containing a vertical profile of geopotential height in time step
-7. pfx.dNN.QV containing a vertical profile of water vapor mixing ratio time step
+6. pfx.dNN.PH containing a vertical profile of geopotential height for each time step
+7. pfx.dNN.QV containing a vertical profile of water vapor mixing ratio for each time step
+8. pfx.dNN.PR containing a vertical profile of pressure for each time step
 
 
-Where pfx is the specified prefix for the dd location in the tslist file, and NN is the domain ID, as given in 
+Where pfx is the specified prefix for the dd location in the tslist file, 
+and NN is the domain ID, as given in 
 namelist.input. If locations not in any model domain are specified in the 
 tslist file, they will be simply ignored by the time series capability.
 
@@ -51,8 +53,8 @@ however, smaller buffers will need to be flushed to disk more often than
 larger buffers. Thus, it is recommended that the size of the buffer be set 
 to the maximum number of time steps for any domain in a model run. 
 
-By default, the u, v, and w component winds are output on the staggered grid. To unstagger them,
-the namelist variable tslist_unstagger_winds can be set to true.
+By default, the u, v, and w component winds are output on the staggered grid. 
+To unstagger them, the namelist variable tslist_unstagger_winds can be set to true.
 
 Namelist.input variables related to to this new capability:
 
@@ -96,4 +98,5 @@ Example:
 
 
 Format of the files of vertical  profile:
-each line starting with the model time in hours, followed by the variable at model level 1,2,3, ... up to the highest model level of interest 
+each line starting with the model time in hours, followed by the variable 
+at model level 1,2,3, ... up to the highest model level of interest 

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -33,7 +33,8 @@ SUBROUTINE calc_ts_locations( grid )
    REAL :: known_lat, known_lon
    CHARACTER (LEN=132) :: message
    CHARACTER (LEN=24) :: ts_profile_filename
-   CHARACTER (LEN=2), DIMENSION(6) :: ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' ,'WW'/) 
+   INTEGER, PARAMETER :: TS_FIELDS = 7
+   CHARACTER (LEN=2), DIMENSION(6) :: ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' ,'WW', 'PR'/) 
    TYPE (PROJ_INFO) :: ts_proj
    TYPE (grid_config_rec_type) :: config_flags
 
@@ -411,6 +412,7 @@ SUBROUTINE calc_ts( grid )
                grid%ts_th_profile(n,i,k)  =  grid%t_2(ix,k,iy) + T0
             END IF
             grid%ts_qv_profile(n,i,k)  = grid%moist(ix,k,iy,P_QV)
+            grid%ts_p_profile(n,i,k)   = grid%pb(ix,k,iy)+grid%p(ix,k,iy)
             END DO
 #endif
          grid%ts_u(n,i)    = earth_u
@@ -441,6 +443,7 @@ SUBROUTINE calc_ts( grid )
          grid%ts_gph_profile(n,i,k)   = 1.E30
          grid%ts_th_profile(n,i,k)    = 1.E30
          grid%ts_qv_profile(n,i,k)    = 1.E30
+         grid%ts_p_profile(n,i,k)     = 1.E30
          END DO
 #endif   
          grid%ts_hour(n,i) = 1.E30
@@ -536,6 +539,11 @@ SUBROUTINE write_ts( grid )
    DO k=1,grid%max_ts_level
    ts_buf(:,:) = grid%ts_qv_profile(:,:,k)
    CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_qv_profile(:,:,k),grid%ts_buf_size*grid%max_ts_locs)
+   END DO
+
+   DO k=1,grid%max_ts_level
+   ts_buf(:,:) = grid%ts_p_profile(:,:,k)
+   CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_p_profile(:,:,k),grid%ts_buf_size*grid%max_ts_locs)
    END DO
 #endif         
    ts_buf(:,:) = grid%ts_u(:,:)
@@ -753,6 +761,26 @@ SUBROUTINE write_ts( grid )
                               grid%ts_qv_profile(n,i,1:grid%max_ts_level)                                       
          END DO
          CLOSE(UNIT=iunit)
+       
+         !Write pressure profile to separate file
+         iunit = get_unused_unit()
+            IF ( iunit <= 0 ) THEN
+            CALL wrf_error_fatal('Error in write_ts: could not find a free Fortran unit.')
+            END IF
+         !Recreate filename for pressure profiles
+         k = LEN_TRIM(ts_profile_filename)
+         WRITE(ts_profile_filename(k-1:k),'(A2)') 'PR'
+         
+         OPEN(UNIT=iunit, FILE=TRIM(ts_profile_filename), STATUS='unknown', POSITION='append', FORM='formatted')
+
+         DO n=1,grid%next_ts_time - 1
+
+            WRITE(UNIT=iunit,FMT=profile_format)  &
+                              grid%ts_hour(n,i),             &
+                              grid%ts_p_profile(n,i,1:grid%max_ts_level)                                       
+         END DO
+         CLOSE(UNIT=iunit)
+
 #endif   
 
       END DO

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -34,7 +34,8 @@ SUBROUTINE calc_ts_locations( grid )
    CHARACTER (LEN=132) :: message
    CHARACTER (LEN=24) :: ts_profile_filename
    INTEGER, PARAMETER :: TS_FIELDS = 7
-   CHARACTER (LEN=2), DIMENSION(6) :: ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' ,'WW', 'PR'/) 
+   CHARACTER (LEN=2), DIMENSION(TS_FIELDS) :: &
+      ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' ,'WW', 'PR'/) 
    TYPE (PROJ_INFO) :: ts_proj
    TYPE (grid_config_rec_type) :: config_flags
 
@@ -220,14 +221,25 @@ SUBROUTINE calc_ts_locations( grid )
                WRITE(grid%ts_filename(k)(i-4:i-3),'(I2.2)') grid%id
                OPEN(UNIT=iunit, FILE=TRIM(grid%ts_filename(k)), FORM='FORMATTED', STATUS='REPLACE')
 #if (EM_CORE == 1)
-               WRITE(UNIT=iunit, &
-                     FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
-                     grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
-                     ' '//grid%nametsloc(grid%id_tsloc(k)), &
-                     ' (', grid%lattsloc(grid%id_tsloc(k)), ',', grid%lontsloc(grid%id_tsloc(k)), ') (', &
-                     grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
-                     ts_xlat, ',', ts_xlong, ') ', &
-                     ts_hgt,' meters'
+               IF ( .NOT. grid%tslist_ij ) THEN 
+                  WRITE(UNIT=iunit, &
+                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                        grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
+                        ' '//grid%nametsloc(grid%id_tsloc(k)), &
+                        ' (', grid%lattsloc(grid%id_tsloc(k)), ',', grid%lontsloc(grid%id_tsloc(k)), ') (', &
+                        grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
+                        ts_xlat, ',', ts_xlong, ') ', &
+                        ts_hgt,' meters'
+               ELSE
+                  WRITE(UNIT=iunit, &
+                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                        grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
+                        ' '//grid%nametsloc(grid%id_tsloc(k)), &
+                        ' (', ts_xlat, ',', ts_xlong, ') (', &
+                        grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
+                        ts_xlat, ',', ts_xlong, ') ', &
+                        ts_hgt,' meters'
+               END IF
 #else
                WRITE(UNIT=iunit, &
                      FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2)') &
@@ -250,14 +262,25 @@ SUBROUTINE calc_ts_locations( grid )
                   WRITE(ts_profile_filename(i-1:i),'(A2)') ts_file_endings(j)
                   OPEN(UNIT=iunit, FILE=TRIM(ts_profile_filename), FORM='FORMATTED', STATUS='REPLACE')
 #if (EM_CORE == 1)
-                  WRITE(UNIT=iunit, &
-                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
-                        grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
-                        ' '//grid%nametsloc(grid%id_tsloc(k)), &
-                        ' (', grid%lattsloc(grid%id_tsloc(k)), ',', grid%lontsloc(grid%id_tsloc(k)), ') (', &
-                        grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
-                        ts_xlat, ',', ts_xlong, ') ', &
-                        ts_hgt,' meters'
+                  IF ( .NOT. grid%tslist_ij ) THEN 
+                     WRITE(UNIT=iunit, &
+                           FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                           grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
+                           ' '//grid%nametsloc(grid%id_tsloc(k)), &
+                           ' (', grid%lattsloc(grid%id_tsloc(k)), ',', grid%lontsloc(grid%id_tsloc(k)), ') (', &
+                           grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
+                           ts_xlat, ',', ts_xlong, ') ', &
+                           ts_hgt,' meters'
+                  ELSE
+                     WRITE(UNIT=iunit, &
+                           FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                           grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
+                           ' '//grid%nametsloc(grid%id_tsloc(k)), &
+                           ' (', ts_xlat, ',', ts_xlong, ') (', &
+                           grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
+                           ts_xlat, ',', ts_xlong, ') ', &
+                           ts_hgt,' meters'
+                 END IF
 #else
                   WRITE(UNIT=iunit, &
                         FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2)') &


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: tslist, pressure, profile

SOURCE: Suggested by Gokhan Sever, implemented internal

DESCRIPTION OF CHANGES: 
1. Add the pressure field to those that are included in the vertical profiles.
2. Fixed the printout for the (i,j) case, where (lat,lon) was printed as (0.000,0.000)
3. The Registry.EM_COMMON description for W said "earth relative", but not any more

LIST OF MODIFIED FILES:
M Registry/Registry.EM_COMMON
M run/README.tslist
M share/wrf_timeseries.F

TESTS CONDUCTED: 
1. Pressure field looks reasonable.
2. Bit-wise identical results when using (i,j) vs (lat,lon)
3. For the (i,j) case, the (lat,lon) print out is correct (tested Lambert)

RELEASE NOTES: Add "pressure" to list of profile fields that are available (release notes from SHA 43ac4e93fb29, PR #712 "new tslist options: add W; cell-centered u,v; (i,j) and (lat,lon) locations")
