### PR TITLE
Allow Deng shcu to work with deep cu, remove prints, edit README

### DIFF
--- a/phys/module_shcu_deng.F
+++ b/phys/module_shcu_deng.F
@@ -614,8 +614,8 @@ CONTAINS
 !
       CALL get_wrf_debug_level( dbg_level )
 
-      ISTOP=0  !mchen
-      NT=0  !mchen
+      ISTOP= 0
+      NT   = 0
       ALIQ = SVP1*1000.
       BLIQ = SVP2
       CLIQ = SVP2*SVPT0
@@ -2095,14 +2095,12 @@ CONTAINS
 !&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 !     BEGINING OF CLOSURE ASSUMPTION SELECTIONS
 !&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
-!      print*, 'mchen, 2097 i,j==', i,j, ktau, NT, capei(i,j)
 !
       IF(CAPEI(I,J) .LT. 100.0) THEN    ! averaging KF number of clouds
         NT = NINT(15.0*60.0/(0.5*DT))-1 ! for 15 min.
       ELSE
         NT = 0
       ENDIF
-  !    if(i.eq.121.and.j.eq.75) print*, 'mchen, 2104, NT=', ktau, NT, capei(i,j)
 
   175 NCOUNT=NCOUNT+1
 !
@@ -2125,13 +2123,11 @@ CONTAINS
 !       KFLAG=3: CLOUD TOP HIGHER THAN LFC BUT LOWER THAN 4 KM
 !       KFLAG=4: CLOUD TOP HIGHER THAN 4 KM
 !
-  !    if(i.eq.121.and.j.eq.75) print*, 'mchen, 2127, KFLAG=', ktau, NT, KFLAG
       IF(KFLAG .EQ. 2) GO TO 176
 
       IF((CLDDPTH+ZLCL) .LE. ZLFC) THEN
         AINC=AINC2
         KFLAG=2
-    !  if(i.eq.121.and.j.eq.75) print*, 'mchen, 2130, KFLAG=', ktau, NT, KFLAG
         GO TO 255
       ENDIF
 
@@ -2425,9 +2421,6 @@ CONTAINS
             IF( ABS(C2) < 0.001 ) STOP 901
             C3=C1/C2
             VAL = 0.0
-    !  if(i.eq.121.and.j.eq.75) print*, 'mchen, 2423, before NT is used 1'
-    !  if(i.eq.121.and.j.eq.75) print*, 'mchen, 2424, NT=', ktau, NT
-       print*, 'mchen, 2423, before NT is used i,j=', i,j, ktau, NT
             DO II = 1, NT
               VAL = VAL + AINCKFSA(I,II,J)
             ENDDO
@@ -2454,7 +2447,6 @@ CONTAINS
           IF( ABS(C2) < 0.001 ) STOP 902
           C3=C1/C2
             VAL = 0.0
-       print*, 'mchen, 2451, before NT is used i,j=', i,j, ktau, NT
             DO II = 1, NT
               VAL = VAL + AINCKFSA(I,II,J)
             ENDDO

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -797,7 +797,9 @@ Namelist variables for controlling the adaptive time step option:
                                      = 1, Grell 3D ensemble scheme (use with cu_physics=93 or 5) (PLACEHOLDER: SWITCH NOT YET IMPLEMENTED--use ishallow)
                                      = 2, Park and Bretherton shallow cumulus from CAM5 (CESM 1_0_1)
                                      = 3, GRIMS shallow cumulus from YSU group
-                                     = 5, Deng cumulus scheme (including both shallow and deep convections) from PSU and WRF-Solar
+                                     = 5, Deng cumulus scheme (including both shallow and deep convections) from PSU and WRF-Solar.
+                                          However the deep part isn't very active. Not recommended to use along for deep convection 
+                                          case. Could work well for grid sizes 3-9 km.
                                           This scheme only works with MYJ or MYNN PBL schemes 
 
  ishallow                            = 0, !  = 1 turns on shallow convection, used with Grell 3D ensemble schemes (cu_physics = 3 or 5)

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -798,7 +798,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 2, Park and Bretherton shallow cumulus from CAM5 (CESM 1_0_1)
                                      = 3, GRIMS shallow cumulus from YSU group
                                      = 5, Deng cumulus scheme (including both shallow and deep convections) from PSU and WRF-Solar.
-                                          However the deep part isn't very active. Not recommended to use along for deep convection 
+                                          However the deep part isn't very active. Not recommended to use alone for deep convection 
                                           case. Could work well for grid sizes 3-9 km.
                                           This scheme only works with MYJ or MYNN PBL schemes 
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -207,14 +207,6 @@
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
          END IF
-         IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
-              model_config_rec % cu_physics(i) /= nocuscheme  ) THEN
-            wrf_err_message = '--- ERROR: Deng shallow convection must run with cu_physics=0 '
-            CALL wrf_message ( wrf_err_message )
-            wrf_err_message = '--- ERROR: Fix shcu_physics or cu_physics in namelist.input.'
-         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-         count_fatal_error = count_fatal_error + 1
-         END IF
       ENDDO
 
 #endif

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -194,6 +194,7 @@
          count_fatal_error = count_fatal_error + 1
          END IF
       ENDDO
+
 !-----------------------------------------------------------------------
 ! Check that Deng Shallow Convection Must work with MYJ or MYNN PBL
 !-----------------------------------------------------------------------
@@ -204,8 +205,8 @@
             wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL '
             CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.'
-         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-         count_fatal_error = count_fatal_error + 1
+            CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+            count_fatal_error = count_fatal_error + 1
          END IF
       ENDDO
 


### PR DESCRIPTION
TYPE: no impact, and text only

KEYWORDS: Deng shallow cu, README

SOURCE: Internal

DESCRIPTION OF CHANGES: 
After some tests, we decided that we will remove the hard constraint against allowing the Deng 
scheme to run with another deep scheme (i.e., we WILL allow the Deng scheme to run with another 
deep convection scheme). This is in part because, even though there is a component in the scheme 
for deep convection, it isn't very active. Without another deep scheme, the Deng scheme could 
potentially generate grid-point storms by not removing enough instability. 

Other changes include removing prints from Deng's module, and adding some text for the 
README.namelist file.

LIST OF MODIFIED FILES: 
M       phys/module_shcu_deng.F - Only removing prints and debugging comments
M       run/README.namelist - Better description of Deng as shallow + deep
M       share/module_check_a_mundo.F - Remove requirement of cu_physics == 0

TESTS CONDUCTED: 
The compiles!