### PR TITLE
Add new option cldovrlp to README file

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -589,6 +589,8 @@ Namelist variables for controlling the adaptive time step option:
  radt (max_dom)                      = 30,  ! minutes between radiation physics calls
                                               recommend 1 min per km of dx (e.g. 10 for 10 km);
                                               use the same value for all nests.                      
+ cldovrlp                            = 2,   ! cloud overlapping option for RRTMG only. 1=random, 2=maximum-random (default), 
+                                              3=maximum, 4=exponential, 5=exponential-random
 
  nrads (max_dom)                     = FOR NMM: number of fundamental timesteps between 
                                                 calls to shortwave radiation; the value


### PR DESCRIPTION
TYPE: text only

KEYWORDS: RRTMG, cldovrlp

SOURCE: internal

DESCRIPTION OF CHANGES: 
New option, cldovrlp, an option to select cloud overlapping option for the original RRTMG scheme, 
is added to README.namelist file.

LIST OF MODIFIED FILES: 
M       run/README.namelist

TESTS CONDUCTED: 
Not needed.
