### PR TITLE
In top-level Makefile, put required run dir file links to test/em_real

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -556,11 +556,13 @@ em_real : wrf
                ln -sf ../../run/aerosol_lon.formatted . ;              \
                ln -sf ../../run/aerosol_plev.formatted . ;             \
                ln -sf ../../run/CCN_ACTIVATE.BIN . ;                   \
-               ln -sf ../../run/p3_lookup_table_1.dat-v2.8.2 . ;              \
-               ln -sf ../../run/p3_lookup_table_2.dat-v2.8.2 . ;              \
-               ln -sf ../../run/ishmael-gamma-tab.bin . ;             \
-               ln -sf ../../run/ishmael-qi-qc.bin . ;             \
-               ln -sf ../../run/ishmael-qi-qr.bin . ;             \
+               ln -sf ../../run/p3_lookup_table_1.dat-v4.1 . ;         \
+               ln -sf ../../run/p3_lookup_table_2.dat-v4.1 . ;         \
+               ln -sf ../../run/HLC.TBL . ;                            \
+               ln -sf ../../run/wind-turbine-1.tbl . ;                 \
+               ln -sf ../../run/ishmael-gamma-tab.bin . ;              \
+               ln -sf ../../run/ishmael-qi-qc.bin . ;                  \
+               ln -sf ../../run/ishmael-qi-qr.bin . ;                  \
                ln -sf ../../run/BROADBAND_CLOUD_GODDARD.bin . ;        \
                if [ $(RWORDSIZE) -eq 8 ] ; then                        \
                   ln -sf ../../run/ETAMPNEW_DATA_DBL ETAMPNEW_DATA ;   \
@@ -614,23 +616,25 @@ em_real : wrf
              ln -sf ../../run/aerosol_lat.formatted . ;             \
              ln -sf ../../run/aerosol_lon.formatted . ;             \
              ln -sf ../../run/aerosol_plev.formatted . ;            \
-             ln -sf ../../run/capacity.asc . ;            \
-             ln -sf ../../run/coeff_p.asc . ;            \
-             ln -sf ../../run/coeff_q.asc . ;            \
-             ln -sf ../../run/constants.asc . ;            \
-             ln -sf ../../run/masses.asc . ;            \
-             ln -sf ../../run/termvels.asc . ;            \
+             ln -sf ../../run/capacity.asc . ;                      \
+             ln -sf ../../run/coeff_p.asc . ;                       \
+             ln -sf ../../run/coeff_q.asc . ;                       \
+             ln -sf ../../run/constants.asc . ;                     \
+             ln -sf ../../run/masses.asc . ;                        \
+             ln -sf ../../run/termvels.asc . ;                      \
              ln -sf ../../run/kernels.asc_s_0_03_0_9 . ;            \
-             ln -sf ../../run/kernels_z.asc . ;            \
-             ln -sf ../../run/bulkdens.asc_s_0_03_0_9 . ;            \
-             ln -sf ../../run/bulkradii.asc_s_0_03_0_9 . ;            \
-             ln -sf ../../run/CCN_ACTIVATE.BIN . ;                   \
-             ln -sf ../../run/p3_lookup_table_1.dat-v2.8.2 . ;                   \
-             ln -sf ../../run/p3_lookup_table_2.dat-v2.8.2 . ;                   \
+             ln -sf ../../run/kernels_z.asc . ;                     \
+             ln -sf ../../run/bulkdens.asc_s_0_03_0_9 . ;           \
+             ln -sf ../../run/bulkradii.asc_s_0_03_0_9 . ;          \
+             ln -sf ../../run/CCN_ACTIVATE.BIN . ;                  \
+             ln -sf ../../run/p3_lookup_table_1.dat-v4.1 . ;        \
+             ln -sf ../../run/p3_lookup_table_2.dat-v4.1 . ;        \
+             ln -sf ../../run/HLC.TBL . ;                           \
+             ln -sf ../../run/wind-turbine-1.tbl . ;                \
              ln -sf ../../run/ishmael-gamma-tab.bin . ;             \
-             ln -sf ../../run/ishmael-qi-qc.bin . ;             \
-             ln -sf ../../run/ishmael-qi-qr.bin . ;             \
-             ln -sf ../../run/BROADBAND_CLOUD_GODDARD.bin . ;        \
+             ln -sf ../../run/ishmael-qi-qc.bin . ;                 \
+             ln -sf ../../run/ishmael-qi-qr.bin . ;                 \
+             ln -sf ../../run/BROADBAND_CLOUD_GODDARD.bin . ;       \
              if [ $(RWORDSIZE) -eq 8 ] ; then                       \
                 ln -sf ../../run/ETAMPNEW_DATA_DBL ETAMPNEW_DATA ;  \
                 ln -sf ../../run/ETAMPNEW_DATA.expanded_rain_DBL ETAMPNEW_DATA.expanded_rain ;   \


### PR DESCRIPTION
TYPE: bug fixKEYWORDS: Makefile, link, ln, run

SOURCE: internal

DESCRIPTION OF CHANGES: 
For the data files in the run directory, they need to be explicitly linked into the test/em_real 
directory (by the top-level Makefile). A few files were missing, a couple have been recently
renamed.

Also, I lined up all of the `ln -sf` commands as best as could be done. So tidy now.

LIST OF MODIFIED FILES: l
M Makefile

TESTS CONDUCTED: 
 - [x] Regtest failed with wrong p3_* files. 
 - [x] Regtest works with correct p3_* files in the Makefile
 - [x] Did a grep for each data file in the run directory, and found a couple more that were missing.
