### PR TITLE
Handle lowest-level microphysics species in real.exe

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1898,7 +1898,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -1928,7 +1928,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -1958,7 +1958,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -1978,7 +1978,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -1998,7 +1998,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2018,7 +2018,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2038,7 +2038,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2058,7 +2058,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2078,7 +2078,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2098,7 +2098,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2118,7 +2118,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2138,7 +2138,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2163,7 +2163,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2179,7 +2179,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2216,7 +2216,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2231,7 +2231,7 @@ integer::oops1,oops2
                                      config_flags%maxw_above_this_level , &
                                      num_metgrid_levels , 'Q' , &
                                      interp_type , linear_interp , extrap_type , &
-                                     lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                                     .false. , use_levels_below_ground , use_surface , &
                                      zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                      ids , ide , jds , jde , kds , kde , &
                                      ims , ime , jms , jme , kms , kme , &
@@ -2325,7 +2325,7 @@ integer::oops1,oops2
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
                                interp_type , linear_interp , extrap_type , &
-                               lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                               .false. , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
                                ims , ime , jms , jme , kms , kme , &
@@ -2377,7 +2377,7 @@ integer::oops1,oops2
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
                                interp_type , linear_interp , extrap_type , &
-                               lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                               .false. , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
                                ims , ime , jms , jme , kms , kme , &
@@ -2429,7 +2429,7 @@ integer::oops1,oops2
                                config_flags%maxw_above_this_level , &
                                config_flags%num_gca_levels , 'Q' , &
                                interp_type , linear_interp , extrap_type , &
-                               lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                               .false. , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
                                ims , ime , jms , jme , kms , kme , &
@@ -2553,7 +2553,7 @@ integer::oops1,oops2
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
                                interp_type , linear_interp , extrap_type , &
-                               lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                               .false. , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
                                ims , ime , jms , jme , kms , kme , &
@@ -2614,7 +2614,7 @@ integer::oops1,oops2
                                config_flags%maxw_above_this_level , &
                                config_flags%num_wif_levels , 'Q' , &
                                interp_type , linear_interp , extrap_type , &
-                               lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
+                               .false. , use_levels_below_ground , use_surface , &
                                zap_close_levels , force_sfc_in_vinterp , grid%id , &
                                ids , ide , jds , jde , kds , kde , &
                                ims , ime , jms , jme , kms , kme , &


### PR DESCRIPTION
TYPE:  bug fix

KEYWORDS: real, vertical interpolation, microphysics, lowest level

SOURCE:  Greg Thompson (NCAR/RAL)

DESCRIPTION OF CHANGES:  For microphysical mixing ratios and number concentrations (and
chemical species) we do not actually have values at the so-called surface level, so do not try using 
surface level for vertical interpolation.  RH is *NOT* affected as we do wish the water vapor to 
continue using standard method, but we shall never have mixing ratios or number concentrations of 
microphysical species at the "surface" level per se.

ISSUE: Fixes #837 

LIST OF MODIFIED FILES:
 dyn_em/module_initialize_real.F

TESTS CONDUCTED:  
1. From met_em.d0X files to wrfinput_d0X, I confirmed that microphysics mass mixing ratios and number concentrations on WRF first model level (K=1) were previously zero and now get a proper value from interpolation procedure.  
2. New results with rain number concentrations, similar to the input data.
![Untitled](https://user-images.githubusercontent.com/35609171/55355601-03f13100-5486-11e9-9248-48f049fcc1cb.png)

