### PR TITLE
Remove one unnecessary DA print introduced in a recent commit

### DIFF
--- a/var/da/da_main/da_update_firstguess.inc
+++ b/var/da/da_main/da_update_firstguess.inc
@@ -157,7 +157,7 @@ subroutine da_update_firstguess(grid, out_filename)
      nlat_regional=end_index1(2)
      nsig_regional=end_index1(3)
 
-     write(6,*)' nlon,nlat,nsig_regional=',nlon_regional,nlat_regional,nsig_regional
+     !write(6,*)' nlon,nlat,nsig_regional=',nlon_regional,nlat_regional,nsig_regional
      allocate(field2(nlon_regional,nlat_regional),field3(nlon_regional,nlat_regional,nsig_regional))
      allocate(field3u(nlon_regional+1,nlat_regional,nsig_regional))
      allocate(field3v(nlon_regional,nlat_regional+1,nsig_regional))


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: WRFDA, print

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Remove one unnecessary print added in commit 1a93c9.

The last 4 lines of the log file after commit 1a93c9.
```
  nlon,nlat,nsig_regional=         414         324          50
THM = T when use_theta_m =  0
  
*** WRF-Var completed successfully ***
```
The nlon,nlat line should not have been added.

LIST OF MODIFIED FILES:
M       var/da/da_main/da_update_firstguess.inc

TESTS CONDUCTED:

RELEASE NOTE: not needed