### PR TITLE
Add diagnostic dry theta - t0 to restart file

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -231,7 +231,7 @@ i1       real   ph_tendf       ikj     dyn_em      1         Z
 i1       real   ph_save        ikj     dyn_em      1         Z 
 
 # Potential Temperature
-state    real   th_phy_m_t0    ikj      dyn_em      1         -     ihd "t"      "perturbation potential temperature theta-t0" "K"
+state    real   th_phy_m_t0    ikj      dyn_em      1         -     irhd      "t"      "perturbation potential temperature theta-t0" "K"
 state    real   t              ikjb     dyn_em      2         -     \
        i0rhusdf=(bdy_interp:dt)   "thm"      "either 1) pert moist pot temp=(1+Rv/Rd Qv)*(theta)-T0, or 2) pert dry pot temp=theta-T0; based on use_theta_m setting" "K"
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: restart, 0 h restart, dry potential temperature - t0, th_phy_m_t00

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
With a restart run, the history output at the end of the first run and the history output at the 
beginning of the second run (with write_hist_at_0h_rst=true) has a difference in the output field 
named "T". 

Solution:
The "T" field is diagnostic, and was not put into the restart file. However, a number of post-
processors rely on a valid value for dry theta form the model output. The easy solution is to put this 
field into the restart file, so it is correctly written out at the 0h of the model history file during a 
restart.

LIST OF MODIFIED FILES:
M Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
 - [x] Without the mod, the 0h history file has the "T" field as zero.
 - [x] With the mod, the 0h history file, after the restart, is bit-wise identical to the original wrfout file.
