### PR TITLE
Fix to allow assimilation of SSMI TPW contained in prepbufr obs files

### DIFF
--- a/var/da/da_obs_io/da_read_obs_bufr.inc
+++ b/var/da/da_obs_io/da_read_obs_bufr.inc
@@ -759,8 +759,8 @@ bufrfile:  do ibufr=1,numbufr
             end if
          end if
       end if
-      ! assign tpw obs errors for gpspw
-      if ( t29 == 74 ) then
+      ! assign tpw obs errors for gpspw (t29=74) and SPSSMI retrieved TPW (t29=65)
+      if ( t29 == 74 .or. t29 == 65 ) then
          if ( pwq == 8 .or. pwq  == 9 .or. pwq  == 15) then
             if ( obs(7,1) > 0.0 .and. obs(7,1) < r8bfms ) then
             platform%loc%pw%inv   = obs(7,1) * 0.1    ! convert to cm


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, ob.bufr, use_ssmiretrievalobs, TPW

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

Even though SSM/I retrievals are no longer available after November 2009,
the fixed code can be useful for retrospective studies.

The SPSSMI (SSM/I superobed retrievals) TPW contained in the global prepbufr
files is assigned missing obs error.

To allow assimilation of SSM/I TPW when ob_format=1 and use_ssmiretrievalobs=.true.,
assign an obs error either from an external obs error table or a specified 0.2cm for
this obs type.

LIST OF MODIFIED FILES:
M       var/da/da_obs_io/da_read_obs_bufr.inc

TESTS CONDUCTED:
A 2009-Oct case is able to assimilate SPSSMI TPW after the fix.

RELEASE NOTE: Fix to allow assimilation of SSMI TPW contained (prior to Nov 2009) in prepbufr obs files when ob_format=1 and use_ssmiretrievalobs=.true.