### PR TITLE
Generalize new Goddard radiation and MP schemes to partner with other schemes

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2772,7 +2772,6 @@ package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc
 package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg;scalar:qndrop,qnr,qni,qns,qng,qvolg;state:re_cloud,re_ice,re_snow
 package   wsm7scheme      mp_physics==24               -             moist:qv,qc,qr,qi,qs,qg,qh;state:re_cloud,re_ice,re_snow
 package   wdm7scheme      mp_physics==26               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
-package   nuwrf3icescheme mp_physics==27             -               moist:qv,qc,qr,qi,qs,qg;state:phys_tot,physc,physe,physd,physs,physm,physf,acphys_tot,acphysc,acphyse,acphysd,acphyss,acphysm,acphysf,preci3d,precs3d,precg3d,precr3d,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc
 package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa;state:re_cloud,re_ice,re_snow,qnwfa2d,qnifa2d,taod5503d,taod5502d
 package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;scalar:qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
 package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;scalar:qnc,qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
@@ -2808,7 +2807,6 @@ package   nssl_1mom_dfi     mp_physics_dfi==19       -             dfi_moist:dfi
 package   nssl_1momlfo_dfi  mp_physics_dfi==21       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
 package   wsm7scheme_dfi    mp_physics_dfi==24       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   wdm7scheme_dfi    mp_physics_dfi==26       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
-package   nuwrf3icescheme_dfi mp_physics_dfi==27     -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;state:dfi_re_cloud_gsfc,dfi_re_rain_gsfc,dfi_re_ice_gsfc,dfi_re_snow_gsfc,dfi_re_graupel_gsfc
 package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   p3_1category_dfi  mp_physics_dfi==50       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
 package   p3_1category_nc_dfi  mp_physics_dfi==51    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2756,7 +2756,7 @@ package   wsm5scheme      mp_physics==4                -             moist:qv,qc
 package   fer_mp_hires    mp_physics==5                -             moist:qv,qc,qr,qi;scalar:qt;state:f_ice_phy,f_rain_phy,f_rimef_phy
 package   fer_mp_hires_advect  mp_physics==15          -             moist:qv,qc,qr,qi;scalar:qrimef
 package   wsm6scheme      mp_physics==6                -             moist:qv,qc,qr,qi,qs,qg;state:re_cloud,re_ice,re_snow
-package   nuwrf4icescheme mp_physics==7              -               moist:qv,qc,qr,qi,qs,qg,qh;state:phys_tot,physc,physe,physd,physs,physm,physf,acphys_tot,acphysc,acphyse,acphysd,acphyss,acphysm,acphysf,preci3d,precs3d,precg3d,precr3d,prech3d,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc
+package   nuwrf4icescheme mp_physics==7              -               moist:qv,qc,qr,qi,qs,qg,qh;state:phys_tot,physc,physe,physd,physs,physm,physf,acphys_tot,acphysc,acphyse,acphysd,acphyss,acphysm,acphysf,preci3d,precs3d,precg3d,precr3d,prech3d,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,re_cloud,re_ice,re_snow
 package   thompson        mp_physics==8                -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr;state:re_cloud,re_ice,re_snow
 package   milbrandt2mom   mp_physics==9                -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnc,qnr,qni,qns,qng,qnh
 package   morr_two_moment mp_physics==10               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qns,qnr,qng;state:rqrcuten,rqscuten,rqicuten
@@ -2772,6 +2772,7 @@ package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc
 package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg;scalar:qndrop,qnr,qni,qns,qng,qvolg;state:re_cloud,re_ice,re_snow
 package   wsm7scheme      mp_physics==24               -             moist:qv,qc,qr,qi,qs,qg,qh;state:re_cloud,re_ice,re_snow
 package   wdm7scheme      mp_physics==26               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
+package   nuwrf3icescheme mp_physics==27             -               moist:qv,qc,qr,qi,qs,qg;state:phys_tot,physc,physe,physd,physs,physm,physf,acphys_tot,acphysc,acphyse,acphysd,acphyss,acphysm,acphysf,preci3d,precs3d,precg3d,precr3d,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc
 package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa;state:re_cloud,re_ice,re_snow,qnwfa2d,qnifa2d,taod5503d,taod5502d
 package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;scalar:qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
 package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;scalar:qnc,qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
@@ -2793,7 +2794,7 @@ package   wsm3scheme_dfi    mp_physics_dfi==3        -             dfi_moist:dfi
 package   wsm5scheme_dfi    mp_physics_dfi==4        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   fer_mp_hires_dfi  mp_physics_dfi==5        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qt
 package   wsm6scheme_dfi    mp_physics_dfi==6        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
-package   nuwrf4icescheme_dfi mp_physics_dfi==7      -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud_gsfc,dfi_re_rain_gsfc,dfi_re_ice_gsfc,dfi_re_snow_gsfc,dfi_re_graupel_gsfc,dfi_re_hail_gsfc
+package   nuwrf4icescheme_dfi mp_physics_dfi==7      -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud_gsfc,dfi_re_rain_gsfc,dfi_re_ice_gsfc,dfi_re_snow_gsfc,dfi_re_graupel_gsfc,dfi_re_hail_gsfc,dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   thompson_dfi      mp_physics_dfi==8        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   milbrandt2mom_dfi mp_physics_dfi==9        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnc,dfi_qnr,dfi_qni,dfi_qns,dfi_qng,dfi_qnh
 package   morr_two_moment_dfi  mp_physics_dfi==10    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qns,dfi_qnr,dfi_qng
@@ -2807,6 +2808,7 @@ package   nssl_1mom_dfi     mp_physics_dfi==19       -             dfi_moist:dfi
 package   nssl_1momlfo_dfi  mp_physics_dfi==21       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
 package   wsm7scheme_dfi    mp_physics_dfi==24       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   wdm7scheme_dfi    mp_physics_dfi==26       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   nuwrf3icescheme_dfi mp_physics_dfi==27     -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;state:dfi_re_cloud_gsfc,dfi_re_rain_gsfc,dfi_re_ice_gsfc,dfi_re_snow_gsfc,dfi_re_graupel_gsfc
 package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   p3_1category_dfi  mp_physics_dfi==50       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
 package   p3_1category_nc_dfi  mp_physics_dfi==51    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
@@ -2826,7 +2828,7 @@ package   camlwscheme      ra_lw_physics==3          -             ozmixm:mth01,
 package   rrtmg_lwscheme   ra_lw_physics==4          -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,o3rad
 package   rrtmk_lwscheme   ra_lw_physics==14          -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,o3rad
 package   rrtmg_lwscheme_fast  ra_lw_physics==24     -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,o3rad
-package   goddardlwscheme  ra_lw_physics==5          -             state:tlwdn,tlwup,slwdn,slwup,taucldc,taucldi,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,cod2d_out,ctop2d_out
+package   goddardlwscheme  ra_lw_physics==5          -             state:tlwdn,tlwup,slwdn,slwup,taucldc,taucldi,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,cod2d_out,ctop2d_out,re_cloud,re_ice,re_snow
 package   flglwscheme      ra_lw_physics==7          -             -
 package   heldsuarez       ra_lw_physics==31         -             -
 package   gfdllwscheme     ra_lw_physics==99         -             -
@@ -2837,7 +2839,7 @@ package   camswscheme     ra_sw_physics==3           -             ozmixm:mth01,
 package   rrtmg_swscheme  ra_sw_physics==4           -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,o3rad;aerod:ocarbon,seasalt,dust,bcarbon,sulfate,upperaer
 package   rrtmk_swscheme  ra_sw_physics==14           -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,o3rad;aerod:ocarbon,seasalt,dust,bcarbon,sulfate,upperaer
 package   rrtmg_swscheme_fast  ra_sw_physics==24     -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,o3rad;aerod:ocarbon,seasalt,dust,bcarbon,sulfate,upperaer
-package   goddardswscheme ra_sw_physics==5           -             state:tswdn,tswup,sswdn,sswup,taucldc,taucldi,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,cod2d_out,ctop2d_out
+package   goddardswscheme ra_sw_physics==5           -             state:tswdn,tswup,sswdn,sswup,taucldc,taucldi,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,cod2d_out,ctop2d_out,re_cloud,re_ice,re_snow
 package   flgswscheme     ra_sw_physics==7           -             -
 package   gfdlswscheme    ra_sw_physics==99          -             -
 

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2772,6 +2772,7 @@ package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc
 package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg;scalar:qndrop,qnr,qni,qns,qng,qvolg;state:re_cloud,re_ice,re_snow
 package   wsm7scheme      mp_physics==24               -             moist:qv,qc,qr,qi,qs,qg,qh;state:re_cloud,re_ice,re_snow
 package   wdm7scheme      mp_physics==26               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
+package   nuwrf3icescheme mp_physics==27             -               moist:qv,qc,qr,qi,qs,qg;state:phys_tot,physc,physe,physd,physs,physm,physf,acphys_tot,acphysc,acphyse,acphysd,acphyss,acphysm,acphysf,preci3d,precs3d,precg3d,precr3d,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc
 package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa;state:re_cloud,re_ice,re_snow,qnwfa2d,qnifa2d,taod5503d,taod5502d
 package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;scalar:qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
 package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;scalar:qnc,qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
@@ -2807,6 +2808,7 @@ package   nssl_1mom_dfi     mp_physics_dfi==19       -             dfi_moist:dfi
 package   nssl_1momlfo_dfi  mp_physics_dfi==21       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
 package   wsm7scheme_dfi    mp_physics_dfi==24       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   wdm7scheme_dfi    mp_physics_dfi==26       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   nuwrf3icescheme_dfi mp_physics_dfi==27     -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;state:dfi_re_cloud_gsfc,dfi_re_rain_gsfc,dfi_re_ice_gsfc,dfi_re_snow_gsfc,dfi_re_graupel_gsfc
 package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   p3_1category_dfi  mp_physics_dfi==50       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
 package   p3_1category_nc_dfi  mp_physics_dfi==51    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice

--- a/phys/module_mp_gsfcgce_4ice_nuwrf.F
+++ b/phys/module_mp_gsfcgce_4ice_nuwrf.F
@@ -676,18 +676,18 @@ CONTAINS
   REAL                          :: t_del_tv, del_tv, flux, fluxin, fluxout
   LOGICAL                       :: notlast
 
-  if (itimestep.eq.1) then
-     write(6, *) 'GSFCGCE 4ice scheme inside fall_flux'
-     write(6, *) 'improve = ', improve
-    
-     write(6, *) 'ims=', ims, '  ime=', ime
-     write(6, *) 'jms=', jms, '  jme=', jme
-     write(6, *) 'kms=', kms, '  kme=', kme
-     write(6, *) 'its=', its, '  ite=', ite
-     write(6, *) 'jts=', jts, '  jte=', jte
-     write(6, *) 'kts=', kts, '  kte=', kte
-     write(6, *) 'dt=', dt
-  endif 
+! if (itimestep.eq.1) then
+!    write(6, *) 'GSFCGCE 4ice scheme inside fall_flux'
+!    write(6, *) 'improve = ', improve
+!   
+!    write(6, *) 'ims=', ims, '  ime=', ime
+!    write(6, *) 'jms=', jms, '  jme=', jme
+!    write(6, *) 'kms=', kms, '  kme=', kme
+!    write(6, *) 'its=', its, '  ite=', ite
+!    write(6, *) 'jts=', jts, '  jte=', jte
+!    write(6, *) 'kts=', kts, '  kte=', kte
+!    write(6, *) 'dt=', dt
+! endif 
 
 !-----------------------------------------------------------------------
 !  This program calculates precipitation fluxes due to terminal velocities.

--- a/phys/module_mp_gsfcgce_4ice_nuwrf.F
+++ b/phys/module_mp_gsfcgce_4ice_nuwrf.F
@@ -676,19 +676,6 @@ CONTAINS
   REAL                          :: t_del_tv, del_tv, flux, fluxin, fluxout
   LOGICAL                       :: notlast
 
-! if (itimestep.eq.1) then
-!    write(6, *) 'GSFCGCE 4ice scheme inside fall_flux'
-!    write(6, *) 'improve = ', improve
-!   
-!    write(6, *) 'ims=', ims, '  ime=', ime
-!    write(6, *) 'jms=', jms, '  jme=', jme
-!    write(6, *) 'kms=', kms, '  kme=', kme
-!    write(6, *) 'its=', its, '  ite=', ite
-!    write(6, *) 'jts=', jts, '  jte=', jte
-!    write(6, *) 'kts=', kts, '  kte=', kte
-!    write(6, *) 'dt=', dt
-! endif 
-
 !-----------------------------------------------------------------------
 !  This program calculates precipitation fluxes due to terminal velocities.
 !-----------------------------------------------------------------------

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1539,12 +1539,11 @@ CONTAINS
 #endif
 
 !  Initialize cloud droplet effective radius for Goddard MP and Radiation
-!  Must be (Goddard LW and SW) AND must be (Goddard 3ice OR 4ice)
+!  Must be (Goddard LW and SW) AND must be (Goddard 4ice)
 #if ( EM_CORE == 1 )
     
    if ( ( ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME )   .AND. &
           ( config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME ) ) .AND. &
-        ( ( config_flags%mp_physics    .EQ. NUWRF3ICESCHEME )   .OR.  &
           ( config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) ) ) THEN
       do j=jts,jtf
          do k=kts,ktf

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1539,11 +1539,12 @@ CONTAINS
 #endif
 
 !  Initialize cloud droplet effective radius for Goddard MP and Radiation
-!  Must be (Goddard LW and SW) AND must be (Goddard 4ice)
+!  Must be (Goddard LW and SW) AND must be (Goddard 3ice OR 4ice)
 #if ( EM_CORE == 1 )
     
    if ( ( ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME )   .AND. &
           ( config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME ) ) .AND. &
+        ( ( config_flags%mp_physics    .EQ. NUWRF3ICESCHEME )   .OR.  &
           ( config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) ) ) THEN
       do j=jts,jtf
          do k=kts,ktf

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1538,13 +1538,12 @@ CONTAINS
    end if
 #endif
 
-!  Initialize cloud droplet effective radius for Goddard MP and Radiation
-!  Must be (Goddard LW and SW) AND must be (Goddard 4ice)
+!  Initialize cloud droplet effective radii for Goddard MP and/or Radiation
 #if ( EM_CORE == 1 )
     
-   if ( ( ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME )   .AND. &
-          ( config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME ) ) .AND. &
-          ( config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) ) ) THEN
+   if ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME .OR. &
+        config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME .OR. &
+        config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) THEN
       do j=jts,jtf
          do k=kts,ktf
             do i=its,itf

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1146,6 +1146,27 @@ CONTAINS
        end do
     endif
 
+!  Initialize cloud droplet effective radii for Goddard MP and/or Radiation
+#if ( EM_CORE == 1 )
+
+   if ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME .OR. &
+        config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME .OR. &
+        config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) THEN
+      do j=jts,jtf
+         do k=kts,ktf
+            do i=its,itf
+               re_cloud_gsfc(i,k,j)   = 0.
+               re_rain_gsfc(i,k,j)    = 0.
+               re_snow_gsfc(i,k,j)    = 0.
+               re_ice_gsfc(i,k,j)     = 0.
+               re_graupel_gsfc(i,k,j) = 0.
+               re_hail_gsfc(i,k,j)    = 0.
+            end do
+         end do
+      end do
+   end if
+#endif
+
    CALL wrf_debug ( 200 , 'module_start: phy_init: Before call to landuse_init' )
 
    IF(mminlu_loc .ne. '    ')THEN
@@ -1535,27 +1556,6 @@ CONTAINS
         config_flags%gsfcgce_gocart_coupling == 1) then
       CALL wrf_debug(200 , 'phy_init: Before call to makelut_ccn_icn')
       call makelut_ccn_icn
-   end if
-#endif
-
-!  Initialize cloud droplet effective radii for Goddard MP and/or Radiation
-#if ( EM_CORE == 1 )
-    
-   if ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME .OR. &
-        config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME .OR. &
-        config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) THEN
-      do j=jts,jtf
-         do k=kts,ktf
-            do i=its,itf
-               re_cloud_gsfc(i,k,j)   = 0.
-               re_rain_gsfc(i,k,j)    = 0.
-               re_snow_gsfc(i,k,j)    = 0.
-               re_ice_gsfc(i,k,j)     = 0.
-               re_graupel_gsfc(i,k,j) = 0.
-               re_hail_gsfc(i,k,j)    = 0.
-            end do
-         end do
-      end do
    end if
 #endif
 

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -869,11 +869,13 @@ CONTAINS
 #if( BUILD_RRTMG_FAST == 1)
          (config_flags%ra_lw_physics .eq. RRTMG_LWSCHEME_FAST ) .or. &
 #endif
+         (config_flags%ra_lw_physics .eq. goddardlwscheme ) .or. &
          (config_flags%ra_lw_physics .eq. RRTMK_LWSCHEME  ) ) .and. &
        ( (config_flags%ra_sw_physics .eq. RRTMG_SWSCHEME ) .or. &
 #if( BUILD_RRTMG_FAST == 1)
          (config_flags%ra_sw_physics .eq. RRTMG_SWSCHEME_FAST ) .or. &
 #endif
+         (config_flags%ra_sw_physics .eq. goddardswscheme ) .or. &
          (config_flags%ra_sw_physics .eq. RRTMK_SWSCHEME ) ) .and. &
         (config_flags%mp_physics  .eq. THOMPSON .or.        &
          config_flags%mp_physics  .eq. THOMPSONAERO .or.    &
@@ -886,8 +888,9 @@ CONTAINS
          config_flags%mp_physics  .eq. WSM7SCHEME .or.      &
          config_flags%mp_physics  .eq. WDM5SCHEME .or.      &
          config_flags%mp_physics  .eq. WDM6SCHEME .or.      &
-         config_flags%mp_physics  .eq. JENSEN_ISHMAEL .or.  &
          config_flags%mp_physics  .eq. WDM7SCHEME .or.      &
+         config_flags%mp_physics  .eq. nuwrf4icescheme .or. &
+         config_flags%mp_physics  .eq. JENSEN_ISHMAEL .or.  &
          config_flags%mp_physics  .eq. P3_1CATEGORY .or.    &
          config_flags%mp_physics  .eq. P3_1CATEGORY_NC .or. &
          config_flags%mp_physics  .eq. P3_2CATEGORY    ) ) then    ! P3
@@ -1536,12 +1539,13 @@ CONTAINS
 #endif
 
 !  Initialize cloud droplet effective radius for Goddard MP and Radiation
-!  Must be (Goddard LW and SW) AND must be (Goddard 4ice)
+!  Must be (Goddard LW and SW) AND must be (Goddard 3ice OR 4ice)
 #if ( EM_CORE == 1 )
     
    if ( ( ( config_flags%ra_lw_physics .EQ. GODDARDLWSCHEME )   .AND. &
           ( config_flags%ra_sw_physics .EQ. GODDARDSWSCHEME ) ) .AND. &
-          ( config_flags%mp_physics    .EQ. NUWRF4ICESCHEME )   ) THEN
+        ( ( config_flags%mp_physics    .EQ. NUWRF3ICESCHEME )   .OR.  &
+          ( config_flags%mp_physics    .EQ. NUWRF4ICESCHEME ) ) ) THEN
       do j=jts,jtf
          do k=kts,ktf
             do i=its,itf

--- a/phys/module_ra_goddard.F
+++ b/phys/module_ra_goddard.F
@@ -1380,21 +1380,6 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
 !--------------------       PROGRAM START        ---------------------------------------
 
   i24h=nint(86400./dt_in)
-!  if (mod(itimestep,i24h).eq.1) then
-!if ( wrf_dm_on_monitor() .and. mod(itimestep,i24h).eq.1 ) then
-!   print *, 'in goddardrad1014 ', sw_or_lw
-!   print *, '   kts, kte = ', kts, kte
-!   print *, '   kms, kme = ', kms, kme
-!   print *, '   kds, kde = ', kds, kde
-!endif
-
-! if ( kme .ne. kte+1 ) then
-!    print *,'Something is strange, kde, kme, kte = ', kde, kme, kte 
-!    print *,'                      kds, kms, kts = ', kds, kms, kts 
-!    print *,' at timestep = ', itimestep
-!    print *,' at gmt, julday, xtime = ', gmt,julday,xtime
-! endif
-
 !
 ! Make sure there is no negative value in qv and cloud species
 ! Negative value happen through dynamic core (advection).

--- a/phys/module_ra_goddard.F
+++ b/phys/module_ra_goddard.F
@@ -1381,19 +1381,19 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
 
   i24h=nint(86400./dt_in)
 !  if (mod(itimestep,i24h).eq.1) then
- if ( wrf_dm_on_monitor() .and. mod(itimestep,i24h).eq.1 ) then
-    print *, 'in goddardrad1014 ', sw_or_lw
-    print *, '   kts, kte = ', kts, kte
-    print *, '   kms, kme = ', kms, kme
-    print *, '   kds, kde = ', kds, kde
- endif
+!if ( wrf_dm_on_monitor() .and. mod(itimestep,i24h).eq.1 ) then
+!   print *, 'in goddardrad1014 ', sw_or_lw
+!   print *, '   kts, kte = ', kts, kte
+!   print *, '   kms, kme = ', kms, kme
+!   print *, '   kds, kde = ', kds, kde
+!endif
 
-  if ( kme .ne. kte+1 ) then
-     print *,'Something is strange, kde, kme, kte = ', kde, kme, kte 
-     print *,'                      kds, kms, kts = ', kds, kms, kts 
-     print *,' at timestep = ', itimestep
-     print *,' at gmt, julday, xtime = ', gmt,julday,xtime
-  endif
+! if ( kme .ne. kte+1 ) then
+!    print *,'Something is strange, kde, kme, kte = ', kde, kme, kte 
+!    print *,'                      kds, kms, kts = ', kds, kms, kts 
+!    print *,' at timestep = ', itimestep
+!    print *,' at gmt, julday, xtime = ', gmt,julday,xtime
+! endif
 
 !
 ! Make sure there is no negative value in qv and cloud species

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1656,6 +1656,7 @@ CONTAINS
                       re_cloud_gsfc(i,k,j) = re_cloud(i,k,j) * 1.E+6
                       re_ice_gsfc(i,k,j) = re_ice(i,k,j) * 1.E+6
                       re_snow_gsfc(i,k,j) = re_snow(i,k,j) * 1.E+6
+                      re_rain_gsfc(i,k,j) = 0.
                       re_graupel_gsfc(i,k,j) = 0.
                       re_hail_gsfc(i,k,j) = 0.
                    ENDDO
@@ -2053,6 +2054,7 @@ CONTAINS
            tlwup(i,j) = erbe_out(i,j,2)    ! TOA LW upwelling flux [W/m2]
            slwdn(i,j) = erbe_out(i,j,3)    ! surface LW downwelling flux [W/m2]
            slwup(i,j) = erbe_out(i,j,4)    ! surface LW upwelling flux [W/m2]
+           olr(i,j)   = erbe_out(i,j,2)
         ENDDO    
         ENDDO    
           ENDIF
@@ -2187,6 +2189,7 @@ CONTAINS
                       re_cloud_gsfc(i,k,j) = re_cloud(i,k,j) * 1.E+6
                       re_ice_gsfc(i,k,j) = re_ice(i,k,j) * 1.E+6
                       re_snow_gsfc(i,k,j) = re_snow(i,k,j) * 1.E+6
+                      re_rain_gsfc(i,k,j) = 0.
                       re_graupel_gsfc(i,k,j) = 0.
                       re_hail_gsfc(i,k,j) = 0.
                    ENDDO

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1663,7 +1663,7 @@ CONTAINS
                    ENDDO
                    ENDDO
                 ELSE
-                   WRITE ( wrf_err_message , * ) 'must choose one of the microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
+                   WRITE ( wrf_err_message , * ) 'Must choose a microphysics that provides effective radii.'
                    CALL wrf_debug (0, wrf_err_message)
                 END IF
              END IF
@@ -2196,7 +2196,7 @@ CONTAINS
                    ENDDO
                    ENDDO
                 ELSE
-                   WRITE ( wrf_err_message , * ) 'must choose a diff microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
+                   WRITE ( wrf_err_message , * ) 'Must choose a microphysics that provides effective radii.'
                    CALL wrf_debug (0, wrf_err_message)
                 END IF
              END IF

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1663,7 +1663,7 @@ CONTAINS
                    ENDDO
                    ENDDO
                 ELSE
-                   WRITE ( wrf_err_message , * ) 'must choose one of the microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
+                   WRITE ( wrf_err_message , * ) 'Must choose a microphysics that provides effective radii.'
                    CALL wrf_debug (0, wrf_err_message)
                 END IF
              END IF
@@ -2196,7 +2196,7 @@ CONTAINS
                    ENDDO
                    ENDDO
                 ELSE
-                   WRITE ( wrf_err_message , * ) 'must choose a diff microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
+                   WRITE ( wrf_err_message , * ) 'Must choose a a microphysics that provides effective radii.'
                    CALL wrf_debug (0, wrf_err_message)
                 END IF
              END IF

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2054,7 +2054,7 @@ CONTAINS
            tlwup(i,j) = erbe_out(i,j,2)    ! TOA LW upwelling flux [W/m2]
            slwdn(i,j) = erbe_out(i,j,3)    ! surface LW downwelling flux [W/m2]
            slwup(i,j) = erbe_out(i,j,4)    ! surface LW upwelling flux [W/m2]
-           olr(i,j)   = erbe_out(i,j,2)
+           olr(i,j)   = -erbe_out(i,j,2)
         ENDDO    
         ENDDO    
           ENDIF

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1663,7 +1663,7 @@ CONTAINS
                    ENDDO
                    ENDDO
                 ELSE
-                   WRITE ( wrf_err_message , * ) 'Must choose a microphysics that provides effective radii.'
+                   WRITE ( wrf_err_message , * ) 'must choose one of the microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
                    CALL wrf_debug (0, wrf_err_message)
                 END IF
              END IF
@@ -2196,7 +2196,7 @@ CONTAINS
                    ENDDO
                    ENDDO
                 ELSE
-                   WRITE ( wrf_err_message , * ) 'Must choose a a microphysics that provides effective radii.'
+                   WRITE ( wrf_err_message , * ) 'must choose a diff microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
                    CALL wrf_debug (0, wrf_err_message)
                 END IF
              END IF

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -211,6 +211,7 @@ CONTAINS
 #ifndef HWRF
    USE module_wrf_error , ONLY : wrf_err_message
 #endif
+   USE module_state_description, ONLY : nuwrf4icescheme
 
 ! *** add new modules of schemes here
 
@@ -1647,6 +1648,25 @@ CONTAINS
 
              CALL wrf_debug(100, 'CALL NUWRF goddard longwave radiation scheme 2017')
 
+            IF ( mp_physics .NE. nuwrf4icescheme ) THEN
+                IF ( has_reqc .EQ. 1 ) THEN
+                   DO j=jts,jte
+                   DO k=kts,kte
+                   DO i=its,ite
+                      re_cloud_gsfc(i,k,j) = re_cloud(i,k,j) * 1.E+6
+                      re_ice_gsfc(i,k,j) = re_ice(i,k,j) * 1.E+6
+                      re_snow_gsfc(i,k,j) = re_snow(i,k,j) * 1.E+6
+                      re_graupel_gsfc(i,k,j) = 0.
+                      re_hail_gsfc(i,k,j) = 0.
+                   ENDDO
+                   ENDDO
+                   ENDDO
+                ELSE
+                   WRITE ( wrf_err_message , * ) 'must choose one of the microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
+                   CALL wrf_debug (0, wrf_err_message)
+                END IF
+             END IF
+
              CALL goddardrad(sw_or_lw='lw',dx=dx                  &
                     ,rthraten=rthraten,gsf=glw,xlat=xlat,xlong=xlong   &
                     ,alb=albedo,t3d=t,p3d=p,p8w3d=p8w,pi3d=pi          &
@@ -1801,7 +1821,20 @@ CONTAINS
              ENDIF
 
         CASE (RRTMG_LWSCHEME)
+
              CALL wrf_debug (100, 'CALL rrtmg_lw')
+             IF ( mp_physics .EQ. nuwrf4icescheme ) THEN
+                DO j=jts,jte
+                DO k=kts,kte
+                DO i=its,ite
+                   re_cloud(i,k,j) = re_cloud_gsfc(i,k,j) * 1.E-6
+                   re_ice(i,k,j) = re_ice_gsfc(i,k,j) * 1.E-6
+                   re_snow(i,k,j) = re_snow_gsfc(i,k,j) * 1.E-6
+                ENDDO
+                ENDDO
+                ENDDO
+             END IF
+
              CALL RRTMG_LWRAD(                                      &
                   RTHRATENLW=RTHRATEN,                              &
                   LWUPT=LWUPT,LWUPTC=LWUPTC,LWUPTCLN=LWUPTCLN,      &
@@ -2146,6 +2179,25 @@ CONTAINS
 
              CALL wrf_debug(100, 'CALL NUWRF goddard shortwave radiation scheme 2017')
 
+             IF ( mp_physics .NE. nuwrf4icescheme ) THEN
+                IF ( has_reqc .EQ. 1 ) THEN
+                   DO j=jts,jte
+                   DO k=kts,kte
+                   DO i=its,ite
+                      re_cloud_gsfc(i,k,j) = re_cloud(i,k,j) * 1.E+6
+                      re_ice_gsfc(i,k,j) = re_ice(i,k,j) * 1.E+6
+                      re_snow_gsfc(i,k,j) = re_snow(i,k,j) * 1.E+6
+                      re_graupel_gsfc(i,k,j) = 0.
+                      re_hail_gsfc(i,k,j) = 0.
+                   ENDDO
+                   ENDDO
+                   ENDDO
+                ELSE
+                   WRITE ( wrf_err_message , * ) 'must choose a diff microphysics: 3,4,6,8,14,16,17-21,28,51,or 52'
+                   CALL wrf_debug (0, wrf_err_message)
+                END IF
+             END IF
+
              CALL goddardrad(sw_or_lw='sw',dx=dx                  &
                     ,rthraten=rthraten,gsf=gsw,xlat=xlat,xlong=xlong   &
                     ,alb=albedo,t3d=t,p3d=p,p8w3d=p8w,pi3d=pi          &
@@ -2249,7 +2301,20 @@ CONTAINS
              ENDDO
 
         CASE (RRTMG_SWSCHEME)
+
              CALL wrf_debug(100, 'CALL rrtmg_sw')
+             IF ( mp_physics .EQ. nuwrf4icescheme ) THEN
+                DO j=jts,jte
+                DO k=kts,kte
+                DO i=its,ite
+                   re_cloud(i,k,j) = re_cloud_gsfc(i,k,j) * 1.E-6
+                   re_ice(i,k,j) = re_ice_gsfc(i,k,j) * 1.E-6
+                   re_snow(i,k,j) = re_snow_gsfc(i,k,j) * 1.E-6
+                ENDDO
+                ENDDO
+                ENDDO
+             END IF
+
              CALL RRTMG_SWRAD(                                         &
                      RTHRATENSW=RTHRATENSW,                            &
                      SWUPT=SWUPT,SWUPTC=SWUPTC,SWUPTCLN=SWUPTCLN,      &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -237,6 +237,22 @@
       ENDDO god_r8
 
 # endif
+#
+# Print a warning message for not using a combination of radiation and microphysics from Goddard
+#
+      DO i = 1, model_config_rec % max_dom
+         IF ( (model_config_rec % ra_lw_physics(i) == goddardlwscheme .OR. &
+               model_config_rec % ra_sw_physics(i) == goddardswscheme) .AND. &
+               model_config_rec % mp_physics(i) /= nuwrf4icescheme .OR. &
+               model_config_rec % mp_physics(i) == nuwrf4icescheme .AND. &
+              (model_config_rec % ra_lw_physics(i) /= goddardlwscheme .AND. &
+               model_config_rec % ra_sw_physics(i) /= goddardswscheme) ) THEN
+            wrf_err_message = '--- WARNING: Goddard radiation and Goddard 4ice microphysics are not used together'
+            CALL wrf_message ( wrf_err_message )
+            wrf_err_message = '--- WARNING: These options may be best to use together.'
+            CALL wrf_message ( wrf_err_message )
+         END IF
+      ENDDO
 #endif
 
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -237,24 +237,25 @@
       ENDDO god_r8
 
 # endif
-#
-# Print a warning message for not using a combination of radiation and microphysics from Goddard
-#
+
+!-----------------------------------------------------------------------
+! Print a warning message for not using a combination of radiation and microphysics from Goddard
+!-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
-         IF ( (model_config_rec % ra_lw_physics(i) == goddardlwscheme .OR. &
-               model_config_rec % ra_sw_physics(i) == goddardswscheme) .AND. &
-               model_config_rec % mp_physics(i) /= nuwrf4icescheme .OR. &
-               model_config_rec % mp_physics(i) == nuwrf4icescheme .AND. &
-              (model_config_rec % ra_lw_physics(i) /= goddardlwscheme .AND. &
-               model_config_rec % ra_sw_physics(i) /= goddardswscheme) ) THEN
+         IF ( ( (model_config_rec % ra_lw_physics(i) == goddardlwscheme .OR. &
+                 model_config_rec % ra_sw_physics(i) == goddardswscheme) .AND. &
+                 model_config_rec % mp_physics(i) /= nuwrf4icescheme ) .OR. &
+              (  model_config_rec % mp_physics(i) == nuwrf4icescheme .AND. &
+                (model_config_rec % ra_lw_physics(i) /= goddardlwscheme .AND. &
+                 model_config_rec % ra_sw_physics(i) /= goddardswscheme) ) ) THEN
             wrf_err_message = '--- WARNING: Goddard radiation and Goddard 4ice microphysics are not used together'
             CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- WARNING: These options may be best to use together.'
             CALL wrf_message ( wrf_err_message )
          END IF
       ENDDO
-#endif
 
+#endif
 
 !-----------------------------------------------------------------------
 ! Check that some microphysics is not allowed for WRF-NMM run


### PR DESCRIPTION
TYPE: bug fix, enhancement

KEYWORDS: Goddard radiation, microphysics, effective radii

SOURCE: internal

DESCRIPTION OF CHANGES: 
This PR is related to the recently added Goddard radiation (ra_lw_physics=5 and ra_sw_physics=5), and Goddard microphysics (mp_physics=7) schemes. The newly added Goddard radiation and microphysics options are general enough to work with other microphysics and radiation options. The Goddard radiation must have effective radii from microphysics, and Goddard microphysics always provides effective radii for cloud, ice, snow, graupel, hail and rain. 

   - If one uses Goddard radiation, but not Goddard microphysics, the radiation output (e.g. SWDOWN) is wrong because there is no cloud effect. 
   - If one uses Goddard microphysics with radiation options that don't use effective radii, the code should be ok. 
   - If one uses Goddard microphysics with RRTMG radiation, the code should be ok too, as it treats it as if effective radii isn't available (this is determined in module_physics_init.F). 

This PR makes the physics choices more general. 

   - If RRTMG radiation is used with Goddard microphysics, we transfer effective radii from Goddard to general arrays of re_cloud, re_ice and re_snow, and we ignore the equivalent parts for re_rain, re_graupel, and re_hail. 
   - If Goddard radiation is used with a microphysics that provides effective radii, we transfer the general arrays to what are used by Goddard radiation, but we set equivalent re_rain, re_graupel and re_hail to 0. 

This may not be perfect, and that's why a warning message is added to suggest to users that the new Goddard schemes (radiation LW and SW, and microphysics) are best used together.

Other minor changes:
- Fix restart
- Remove prints from Goddard radiation and microphysics modules
- Add a warning message that it is best to use these schemes together
- Fill OLR array from negative values of tlwup

LIST OF MODIFIED FILES: list of changed files 
M       Registry/Registry.EM_COMMON (package Goddard schemes to include other effective radii)
M       phys/module_mp_gsfcgce_4ice_nuwrf.F (remove prints)
M       phys/module_physics_init.F
M       phys/module_ra_goddard.F (remove prints)
M       phys/module_radiation_driver.F
M       share/module_check_a_mundo.F (add warning message)

TESTS CONDUCTED: 
The code compiles and runs as expected. No reg test yet.

RELEASE NOTE: 
The new Goddard radiation (ra_lw_physics=5 and ra_sw_physics=5)  and microphysics (mp_physics=7) schemes are best used together. However, they can be used with other microphysics or radiation options, respectively.
