### PR TITLE
wrf/mpas unified 2d dx commits pushed to unified_physics branch

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -412,8 +412,10 @@ state    real   tratx           ij      misc        1         -      r          
 state    real   obs_savwt      hikj     dyn_em      1         X      -       "OBS_SAVWT"           "Internal space holding weights of each ob, for each i,j,k" "dimensionless"
 
 # Other
-state   real    rdx            -        misc      -         -     irh       "rdx"                   "INVERSE X GRID LENGTH"         ""      
-state   real    rdy            -        misc      -         -     irh       "rdy"                   "INVERSE Y GRID LENGTH"         ""      
+state   real    rdx            -        misc      -         -     irh       "rdx"                   "INVERSE X GRID LENGTH"         "m-1"      
+state   real    rdy            -        misc      -         -     irh       "rdy"                   "INVERSE Y GRID LENGTH"         "m-1"      
+state   real    dx2d           ij       misc      -         -     rh        "dx2d"                  "sqrt(dx*mf * dy*mf)"           "m"
+state   real    area2d         ij       misc      -         -     rh        "area2d"                "dx*mf * dy*mf"                 "m2"
 state   real    dts            -        misc      -         -     ir        "dts"                   "SMALL TIMESTEP"         ""      
 state   real    dtseps         -        misc      -         -     ir        "dtseps"                "TIME WEIGHT CONSTANT FOR SMALL STEPS"         ""      
 state   real    resm           -        misc      -         -     irh       "resm"                  "TIME WEIGHT CONSTANT FOR SMALL STEPS"         ""      

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -414,8 +414,8 @@ state    real   obs_savwt      hikj     dyn_em      1         X      -       "OB
 # Other
 state   real    rdx            -        misc      -         -     irh       "rdx"                   "INVERSE X GRID LENGTH"         "m-1"      
 state   real    rdy            -        misc      -         -     irh       "rdy"                   "INVERSE Y GRID LENGTH"         "m-1"      
-state   real    dx2d           ij       misc      -         -     rh        "dx2d"                  "sqrt(dx*mf * dy*mf)"           "m"
-state   real    area2d         ij       misc      -         -     rh        "area2d"                "dx*mf * dy*mf"                 "m2"
+state   real    area2d         ij       misc      -         -     rh        "area2d"                "Horizontal grid cell area, using dx, dy, and map factors" "m2"
+state   real    dx2d           ij       misc      -         -     rh        "dx2d"                  "Horizontal grid distance: sqrt(area2d)"   "m"
 state   real    dts            -        misc      -         -     ir        "dts"                   "SMALL TIMESTEP"         ""      
 state   real    dtseps         -        misc      -         -     ir        "dtseps"                "TIME WEIGHT CONSTANT FOR SMALL STEPS"         ""      
 state   real    resm           -        misc      -         -     irh       "resm"                  "TIME WEIGHT CONSTANT FOR SMALL STEPS"         ""      

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -453,7 +453,8 @@ BENCH_START(surf_driver_tim)
      &        ,AKMS=grid%akms          ,ALBBCK=grid%albbck      ,ALBEDO=grid%albedo      &
      &        ,EMBCK=grid%embck                                                          &
      &        ,BR=grid%br              ,CANWAT=grid%canwat      ,CHKLOWQ=chklowq    &
-     &        ,CT=grid%ct              ,DT=grid%dt         ,DX=grid%dx         &
+     &        ,CT=grid%ct              ,DT=grid%dt         ,DX=grid%dx              &
+     &        ,DX2D=grid%dx2d          ,AREA2d=grid%area2d                          &
      &        ,DZ8W=dz8w          ,DZS=grid%dzs            ,FLHC=grid%flhc          &
      &        ,FM=grid%fm         ,FHH=grid%fh                                      &
      &        ,FLQC=grid%flqc          ,GLW=grid%glw            ,GRDFLX=grid%grdflx      &
@@ -1091,6 +1092,7 @@ BENCH_START(cu_driver_tim)
      &             ,W=grid%w_2     ,P=grid%p_hyd   ,PI=pi_phy  ,RHO=grid%rho             &
                  ! Other arguments
      &             ,ITIMESTEP=grid%itimestep ,DT=grid%dt      ,DX=grid%dx              &
+     &             ,DX2D=grid%dx2d, AREA2D=grid%area2d                                 &
      &             ,CUDT=grid%cudt,CURR_SECS=curr_secs,ADAPT_STEP_FLAG=adapt_step_flag &
      &             ,CUDTACTTIME=grid%cudtacttime                                       & 
      &             ,RAINC=grid%rainc   ,RAINCV=grid%raincv   ,PRATEC=grid%pratec       &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1021,7 +1021,8 @@ endif
                       grid%acsnom,grid%ivgtyp,grid%isltyp, grid%sfcevp,grid%smois,     &
                       grid%sh2o, grid%snowh, grid%smfr3d,                    &
                       grid%snoalb,                 &
-                      grid%DX,grid%DY,grid%f_ice_phy,grid%f_rain_phy,grid%f_rimef_phy, &
+                      grid%DX,grid%DY,grid%dx2d,grid%area2d,              &
+                      grid%f_ice_phy,grid%f_rain_phy,grid%f_rimef_phy, &
                       grid%mp_restart_state,grid%tbpvs_state,grid%tbpvs0_state,&
                       allowed_to_read, grid%moved, start_of_simulation,               &
                       grid%LAGDAY, &

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -219,12 +219,8 @@ contains
 
       real,    intent(in) ::                                            &
                                         dt
-#if defined(mpas)
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         dx
-#elif defined(wrfmodel)
-      real,    intent(in) ::            dx
-#endif
 
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         xland
@@ -378,15 +374,9 @@ contains
         slimsk(i)=int(abs(xland(i,j)-2.))
       enddo
 
-#if defined(mpas)
       do i=its,ite
          dx2d(i) = dx(i,j)
       enddo
-#else
-      do i=its,ite
-         dx2d(i) = dx
-      enddo
-#endif
 
       do k=kts,kte
         kp=k+1

--- a/phys/module_cumulus_driver.F
+++ b/phys/module_cumulus_driver.F
@@ -14,7 +14,8 @@ CONTAINS
                      ,u,v,th,t,w                                      &
                      ,p,pi,rho                                        &
                  ! --Other arguments
-                     ,itimestep,dt,dx,cudt,curr_secs,adapt_step_flag  &
+                     ,itimestep,dt,dx,dx2d,area2d                     &
+                     ,cudt,curr_secs,adapt_step_flag                  &
                      ,cudtacttime                                     & 
                      ,rainc,raincv,pratec,nca                         &
                      ,cldfra_dp,cldfra_sh,w_up                        & !ckay for subgrid cloud
@@ -98,7 +99,7 @@ CONTAINS
                      ,ens_sasamp                                      &
                      ,shalconv,shal_pgcon                             &
                      ,HPBL2D,EVAP2D,HEAT2D                            &     !Kwon for SAS2010 shallow convection
-                     ,DX2D, DYNMM                                     & ! For scale-aware SAS
+                     ,DYNMM                                           & ! For scale-aware SAS
                      ,SCALEFUN,SCALEFUN1                              & !    scale functions 
                      ,SIGMU,SIGMU1                                    & !    updraft fraction
 
@@ -511,7 +512,9 @@ CONTAINS
    INTEGER, INTENT(IN   ), OPTIONAL        ::   nsas_dx_factor
 
    REAL,  INTENT(IN   ) :: DT, DX
-   INTEGER,      INTENT(IN   ),OPTIONAL    ::                             &
+   REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,               &    
+                    INTENT(IN) ::  DX2D, AREA2D
+   INTEGER,      INTENT(IN   ),OPTIONAL    ::                    &
                    ips,ipe, jps,jpe, kps,kpe,imomentum,ishallow
    REAL,  INTENT(IN   ),OPTIONAL :: CUDT
    REAL,  INTENT(IN   ),OPTIONAL :: CURR_SECS
@@ -526,8 +529,6 @@ CONTAINS
    REAL, OPTIONAL,  INTENT(INOUT) :: mommix
 
 
-   REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,               &    
-                    INTENT(IN) ::  DX2D                           ! For scale-aware SAS
    REAL, OPTIONAL,  INTENT(IN) ::  DYNMM                          ! For scale-aware SAS  
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,INTENT(INOUT) :: &
                                    SCALEFUN,SCALEFUN1,SIGMU,SIGMU1    
@@ -1400,7 +1401,7 @@ CONTAINS
                ,RAINCV=RAINCV,PRATEC=tmppratec,QFX=qfx          &
                ,U3D=u,V3D=v,W=w,T3D=t,PI3D=pi,RHO3D=rho         &
                ,QV3D=QV_CURR,QC3D=QC_CURR,QI3D=QI_CURR          &
-               ,DZ8W=dz8w,PCPS=p,P8W=p8w,XLAND=XLAND,DX=dx      &
+               ,DZ8W=dz8w,PCPS=p,P8W=p8w,XLAND=XLAND,DX=dx2d    &
                ,CU_ACT_FLAG=CU_ACT_FLAG                         &
                ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde &
                ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -71,7 +71,8 @@ CONTAINS
                          ACSNOM,IVGTYP,ISLTYP, SFCEVP, SMOIS,    &
                          SH2O, SNOWH, SMFR3D,                    &  ! temporary
                          SNOALB,                                 &
-                         DX,DY,F_ICE_PHY,F_RAIN_PHY,F_RIMEF_PHY, &
+                         DX,DY,DX2D,AREA2D,                      &
+                         F_ICE_PHY,F_RAIN_PHY,F_RIMEF_PHY,       &
                          mp_restart_state,tbpvs_state,tbpvs0_state,&
                          allowed_to_read, moved, start_of_simulation,&
                          LAGDAY,                                 &
@@ -263,6 +264,7 @@ CONTAINS
 
    LOGICAL,  INTENT(IN)        :: start_of_simulation
    REAL,     INTENT(IN)        :: DT, p_top, DX, DY
+   REAL, DIMENSION(ims:ime,jms:jme), INTENT(INOUT), OPTIONAL :: DX2D, AREA2D
    LOGICAL,  INTENT(IN)        :: restart
    REAL,     INTENT(IN)        :: RADT,BLDT,CUDT,MPDT
    REAL,     INTENT(IN)        :: swrad_scat
@@ -779,6 +781,22 @@ integer myproc
 !-------------------------------------------------  
    
 !-----------------------------------------------------------------
+
+#if ( EM_CORE == 1 )
+
+   !  Compute 2d grid distance and 2d grid cell area. For use with
+   !  physics schemes to make them compatible with models that have
+   !  a need for those 2d fields.
+
+   if ( .not. restart) then
+     if ( present(dx2d) .and. present(area2d) ) then
+        call compute_2d_dx_area(dx, dy, msftx, msfty, dx2d, area2d, &
+                              ids, ide, jds, jde, kds, kde,       &
+                              ims, ime, jms, jme, kms, kme,       &
+                              its, ite, jts, jte, kts, kte)
+      end if
+   end if
+#endif
 
    aercu_opt=config_flags%aercu_opt !PSH/TWG 06/10/16
    aercu_fct=config_flags%aercu_fct !PSH/TWG 06/10/16
@@ -4985,5 +5003,31 @@ subroutine interp_vec_cu(locvec,locwant,periodic,loc1,loc2,wght1,wght2)
   return
   end subroutine interp_vec_cu
 !---------------------END   PSH/TWG  CHANGES----------------
+
+  subroutine compute_2d_dx_area(dx, dy, msftx, msfty, dx2d, area2d, &
+                                ids, ide, jds, jde, kds, kde,       &
+                                ims, ime, jms, jme, kms, kme,       &
+                                its, ite, jts, jte, kts, kte)
+
+     implicit none
+
+     integer , intent(in) :: ids, ide, jds, jde, kds, kde,       &
+                             ims, ime, jms, jme, kms, kme,       &
+                             its, ite, jts, jte, kts, kte
+
+     real,                             intent(in)  :: dx, dy
+     real, dimension(ims:ime,jms:jme), intent(in)  :: msftx, msfty
+     real, dimension(ims:ime,jms:jme), intent(out) :: dx2d, area2d
+
+     integer :: i, j
+
+     do j = jts, min(jde-1,jte)
+        do i = its, min(ide-1,ite)
+           dx2d  (i,j) = sqrt ( dx/msftx(i,j) * dy/msfty(i,j) )
+           area2d(i,j) =        dx/msftx(i,j) * dy/msfty(i,j)
+        end do
+     end do
+
+  end subroutine compute_2d_dx_area
 
 END MODULE module_physics_init

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -5023,8 +5023,8 @@ subroutine interp_vec_cu(locvec,locwant,periodic,loc1,loc2,wght1,wght2)
 
      do j = jts, min(jde-1,jte)
         do i = its, min(ide-1,ite)
-           dx2d  (i,j) = sqrt ( dx/msftx(i,j) * dy/msfty(i,j) )
-           area2d(i,j) =        dx/msftx(i,j) * dy/msfty(i,j)
+           area2d(i,j) = dx/msftx(i,j) * dy/msfty(i,j)
+           dx2d  (i,j) = sqrt ( area2d(i,j) )
         end do
      end do
 

--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -173,14 +173,10 @@ CONTAINS
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)   ::                                 &
                                                               QGH
-#if defined(mpas)
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV
 
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(IN   )               ::                 DX
-#else
-      REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
-#endif
  
       REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
                 INTENT(OUT)     ::                  ck,cka,cd,cda
@@ -217,15 +213,9 @@ CONTAINS
 
       DO J=jts,jte
 
-#if defined(mpas)
         DO i=its,ite
            DX2D(i)=DX(i,j)
         ENDDO
-#else
-        DO i=its,ite
-           DX2D(i)=DX
-        ENDDo
-#endif
 
         DO i=its,ite
           dz8w1d(I) = dz8w(i,1,j)

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -7,7 +7,7 @@ CONTAINS
      &           HYDRO_dt,sfcheadrt,INFXSRT,soldrain,                 &
      &           acgrdflx,achfx,aclhf                                 &
      &          ,acsnom,acsnow,snowfallac,akhs,akms,albedo,br,canwat  &
-     &          ,chklowq,dt,dx,dz8w,dzs,glw                           &
+     &          ,chklowq,dt,dx,dx2d,area2d,dz8w,dzs,glw               &
      &          ,grdflx,gsw,swdown,gz1oz0,hfx,ht,ifsnow,isfflx        &
      &          ,fractional_seaice,seaice_albedo_opt                  &
      &          ,seaice_albedo_default,seaice_thickness_opt,          &
@@ -491,7 +491,9 @@ CONTAINS
 !-- t_phy         temperature (K)
 !-- dz8w          dz between full levels (m)
 !-- z             height above sea level (m)
-!-- DX            horizontal space interval (m)
+!-- DX            nominal horizontal space interval (m)
+!-- DX2D          horizontal space interval (m), sqrt(dx/mftx * dy/mfty)
+!-- AREA2D        horizontal cell area (m^2), (dx/mftx * dy/mfty)
 !-- DT            time step (second)
 !-- PSFC          pressure at the surface (Pa)
 !-- SST           sea-surface temperature (K)
@@ -831,6 +833,7 @@ CONTAINS
    REAL, DIMENSION(1:num_soil_layers), INTENT(IN)::   ZS
    REAL, INTENT(IN )::   DT
    REAL, INTENT(IN )::   DX
+   REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN ), OPTIONAL :: DX2D, AREA2D
    REAL,       INTENT(IN   ),OPTIONAL    ::     bldt
    REAL,       INTENT(IN   ),OPTIONAL    ::     curr_secs
    LOGICAL,    INTENT(IN   ),OPTIONAL    ::     adapt_step_flag
@@ -1884,7 +1887,7 @@ CONTAINS
                  znt,ust,pblh,mavail,zol,mol,regime,psim,psih,fm,fhh, &
                  xland,hfx,qfx,lh,tsk,flhc,flqc,qgh,qsfc,rmol,       &
                  u10,v10,th2,t2,q2,                                  &
-                 gz1oz0,wspd,br,isfflx,dx,                           &
+                 gz1oz0,wspd,br,isfflx,dx2d,                         &
                  svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,eomeg,stbolt, &
                  P1000mb,                                            &
                  XICE,SST,TSK_SEA,                                                  &
@@ -1902,7 +1905,7 @@ CONTAINS
                znt,ust,pblh,mavail,zol,mol,regime,psim,psih,fm,fhh, &
                xland,hfx,qfx,lh,tsk,flhc,flqc,qgh,qsfc,rmol,       &
                u10,v10,th2,t2,q2,                                  &
-               gz1oz0,wspd,br,isfflx,dx,                           &
+               gz1oz0,wspd,br,isfflx,dx2d,                         &
                svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,eomeg,stbolt, &
                P1000mb,                                            &
                ids,ide, jds,jde, kds,kde,                          &
@@ -5913,7 +5916,7 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                      GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
-                     P1000,                                      &
+                     P1000,                                        &
 XICE,SST,TSK_SEA,                                                  &
 CHS2_SEA,CHS_SEA,CPM_SEA,CQS2_SEA,FLHC_SEA,FLQC_SEA,               &
 HFX_SEA,LH_SEA,QFX_SEA,QGH_SEA,QSFC_SEA,ZNT_SEA,                   &
@@ -5990,7 +5993,9 @@ ITIMESTEP,TICE2TSK_IF2COLD,XICE_THRESHOLD,                         &
                INTENT(INOUT)   ::                                 &
                                                               QGH
 
-     REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
+     REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV
+     REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+               INTENT(IN) ::   DX
 
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
                INTENT(OUT)     ::                   ck,cka,cd,cda
@@ -6169,7 +6174,7 @@ ITIMESTEP,TICE2TSK_IF2COLD,XICE_THRESHOLD,                         &
                  GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                  SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                  KARMAN,EOMEG,STBOLT,                          &
-                 P1000,                                      &
+                 P1000,                                        &
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &


### PR DESCRIPTION
TYPE: enhancement (to get closer to MPAS spatially varying dx results)

KEYWORDS: dx 2d, wrf, mpas

SOURCE: internal

DESCRIPTION OF CHANGES: The unified_physics branch was created from the top of the master (which is the v4.0.3 release branch). These changes have already been approved for the develop branch, but I am adding them to the unified_physics branch for WRF/MPAS comparative testing purposes.

Similar to PR #831 "2d grid distance"
git cherry-pick 0031e002af857 3dae9791c47afc

LIST OF MODIFIED FILES:
	modified:   Registry/Registry.EM_COMMON
	modified:   dyn_em/module_first_rk_step_part1.F
	modified:   dyn_em/start_em.F
	modified:   phys/module_cu_ntiedtke.F
	modified:   phys/module_cumulus_driver.F
	modified:   phys/module_physics_init.F
	modified:   phys/module_sf_sfclay.F
	modified:   phys/module_surface_driver.F

TESTS CONDUCTED: 
1. Combined results look reasonable in a comparison with release-v4.0.3   
   - New: MM5 SFCLAY, NTeidtke, YSU, WSM6   
   - New: 2d dx in SFCLAY and NTiedtke   
   - New: bug fix for Noah LSM
2. Bit-wise identical to previous 12-h Jan 2000 run with the same bundled mods

