### PR TITLE
RRTMG bug fix for o3input option 2

### DIFF
--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -4292,7 +4292,7 @@ SUBROUTINE ozn_time_int(julday,julian,ozmixm,ozmixt,levsiz,num_months,  &
       do j=jts,jte
       do k=1,levsiz
       do i=its,ite
-            ozmixt(i,k,j) = ozmixm(i,k,j,nm)*fact1 + ozmixm(i,k,j,np)*fact2
+            ozmixt(i,k,j) = ozmixm(i,k,j,nm+1)*fact1 + ozmixm(i,k,j,np+1)*fact2
       end do
       end do
       end do


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RRTMG, CAM Ozone, o3input, wrf, mpas, unify

SOURCE: Takahiro Benno 

DESCRIPTION OF CHANGES: When RRTMG is turned on with CAM ozone as input (o3input=2), the variable ozmixm has 13 elements in time dimension, and monthly ozone data is stored in the 2nd through 13th elements, corresponding to 1-12 months. In the subroutine "ozn_time_int", however, the time dimension for "ozmixm" is not specified accordingly. More details are as follows. With a fix to the radiation driver, monthly ozone data are correctly set to correspond to the 2nd-13th elements of the 4th dimension of ozmixm. While the bug fix is already implemented in the v4.1 release branch,  it is also necessary for the WRF/MPAS comparison tests, and is therefore now being placed in the unified_physics branch. Additional details regarding the original commit can be found here: [214e3606](https://github.com/wrf-model/WRF/commit/214e3606).

LIST OF MODIFIED FILES:
M phys/module_radiation_driver.F

TESTS CONDUCTED: No additional testing was conducted, regarding comparisons before/after the fix. Verified that this compiles okay for this version.
