### PR TITLE
Removed unused alarm and clock from microphysics schemes

### DIFF
--- a/phys/module_mp_gsfcgce.F
+++ b/phys/module_mp_gsfcgce.F
@@ -4,8 +4,6 @@
 MODULE module_mp_gsfcgce
 
    USE     module_wrf_error
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
    USE module_mp_radar
 
 !JJS 1/3/2008     vvvvv
@@ -342,7 +340,6 @@ CONTAINS
 !                   qiold, qsold, qgold,                         &
                    rho, pii, p, itimestep,                      & 
                    refl_10cm, diagflag, do_radar_ref,           & ! GT added for reflectivity calcs
-!                  refl_10cm, grid_clock, grid_alarms,          & ! GT added for reflectivity calcs
                    ids,ide, jds,jde, kds,kde,                   & ! domain dims
                    ims,ime, jms,jme, kms,kme,                   & ! memory dims
                    its,ite, jts,jte, kts,kte                    & ! tile   dims
@@ -1244,7 +1241,6 @@ CONTAINS
                        qiwrf, qswrf, qgwrf, &
                        rho_mks, pi_mks, p0_mks,itimestep, &
                        refl_10cm, diagflag, do_radar_ref,           & ! GT added for reflectivity calcs
-!                      refl_10cm, grid_clock, grid_alarms,          & ! GT added for reflectivity calcs
                        ids,ide, jds,jde, kds,kde, &
                        ims,ime, jms,jme, kms,kme, &
                        its,ite, jts,jte, kts,kte  &
@@ -1505,8 +1501,6 @@ CONTAINS
 
 !+---+-----------------------------------------------------------------+
   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT):: refl_10cm  ! GT
-! TYPE (WRFU_Clock):: grid_clock
-! TYPE (WRFU_Alarm), POINTER:: grid_alarms(:)
 
 
       REAL, DIMENSION(kts:kte):: qv1d, t1d, p1d, qr1d, qs1d, qg1d, dBZ

--- a/phys/module_mp_lin.F
+++ b/phys/module_mp_lin.F
@@ -4,8 +4,6 @@
 MODULE module_mp_lin
 
    USE     module_wrf_error
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
    USE module_mp_radar
 !
    REAL    , PARAMETER, PRIVATE ::       RH = 1.0

--- a/phys/module_mp_morr_two_moment.F
+++ b/phys/module_mp_morr_two_moment.F
@@ -84,8 +84,6 @@
 
 MODULE MODULE_MP_MORR_TWO_MOMENT
    USE     module_wrf_error
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm  ! GT
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep  ! GT
    USE module_mp_radar
 
 ! USE WRF PHYSICS CONSTANTS

--- a/phys/module_mp_morr_two_moment_aero.F
+++ b/phys/module_mp_morr_two_moment_aero.F
@@ -109,8 +109,6 @@
 
 MODULE MODULE_MP_MORR_TWO_MOMENT_AERO
    USE     module_wrf_error
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm  ! GT
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep  ! GT
    USE module_mp_radar
 
 ! USE WRF PHYSICS CONSTANTS

--- a/phys/module_mp_wdm5.F
+++ b/phys/module_mp_wdm5.F
@@ -9,8 +9,6 @@
 !Including inline expansion statistical function 
 MODULE module_mp_wdm5
 !
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
    USE module_mp_radar
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops

--- a/phys/module_mp_wdm6.F
+++ b/phys/module_mp_wdm6.F
@@ -9,8 +9,6 @@
    module module_mp_wdm6
 !-------------------------------------------------------------------------------
 !
-   use module_utility, only: WRFU_Clock, WRFU_Alarm
-   use module_domain, only: HISTORY_ALARM, Is_alarm_tstep
    use module_mp_radar
 !
 !

--- a/phys/module_mp_wdm7.F
+++ b/phys/module_mp_wdm7.F
@@ -8,8 +8,6 @@
 MODULE module_mp_wdm7
 !
 !
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
    USE module_mp_radar
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops

--- a/phys/module_mp_wsm5.F
+++ b/phys/module_mp_wsm5.F
@@ -12,8 +12,6 @@
 !Including inline expansion statistical function 
 MODULE module_mp_wsm5
 !
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
    USE module_mp_radar
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -8,10 +8,6 @@
 
 MODULE module_mp_wsm6
 !
-#if ( defined(wrfmodel) )
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
-#endif
    USE module_mp_radar
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops

--- a/phys/module_mp_wsm7.F
+++ b/phys/module_mp_wsm7.F
@@ -8,8 +8,6 @@
 
 MODULE module_mp_wsm7
 !
-   USE module_utility, ONLY: WRFU_Clock, WRFU_Alarm
-   USE module_domain, ONLY : HISTORY_ALARM, Is_alarm_tstep
    USE module_mp_radar
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: microphysics, mp, physics, unused, alarm, clock

SOURCE: internal

DESCRIPTION OF CHANGES:
Inside several of the microphysics modules were USE statements related to alarms and clocks. 
These are no longer needed, as they are no longer used for the radar reflectivity calculation
(which moved into the radiation driver). This PR simply removes the unnecessary code.

LIST OF MODIFIED FILES: 
M     phys/module_mp_gsfcgce.F
M     phys/module_mp_lin.F
M     phys/module_mp_morr_two_moment_aero.F
M     phys/module_mp_morr_two_moment.F
M     phys/module_mp_wdm5.F
M     phys/module_mp_wdm6.F
M     phys/module_mp_wdm7.F
M     phys/module_mp_wsm5.F
M     phys/module_mp_wsm6.F
M     phys/module_mp_wsm7.F

TESTS CONDUCTED: verified code builds with GNU/V8.1 after the modification.