### PR TITLE
Fix dependencies for AFWA diagnostics

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -786,8 +786,6 @@ module_diag_pld.o: \
 module_diag_zld.o: \
 		../share/module_model_constants.o
 
-module_diag_afwa_hail.o:
-
 module_diag_afwa.o: \
 		module_diag_trad_fields.o		\
 		../frame/module_domain.o 		\
@@ -796,8 +794,7 @@ module_diag_afwa.o: \
 		../frame/module_configure.o 		\
 		../frame/module_streams.o		\
 		../external/esmf_time_f90/module_utility.o \
-	        ../share/module_model_constants.o       \
-	        module_diag_afwa_hail.o
+	        ../share/module_model_constants.o
 
 module_diag_hailcast.o: \
 		../frame/module_configure.o 		\


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: AFWA diagnostics dependency

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
The file `phys/module_diag_afwa.o` was always re-compiled, even when there were no updated
dependencies.

Solution:
The `depend.common` file incorrectly listed a file, `module_diag_afwa_hail.o`, as one of the 
required files to produce `module_diag_afwa.o`. The file `module_diag_afwa_hail.o` does not 
exist. 
1. The file `module_diag_afwa_hail.o` is removed as a target in `depend.common`.
2. This file is removed from the list of dependencies for `module_diag_afwa.o`.

LIST OF MODIFIED FILES:
M main/depend.common

TESTS CONDUCTED: 
 - [x] Without mod, the file `module_diag_afwa.o` is ALWAYS re-compiled.
 - [x] With mod, the file is not unnecessarily re-compiled