### PR TITLE
BF: Incorrect AFWA diagnostics packaging; symptom: model hangs on history output

### DIFF
--- a/Registry/registry.afwa
+++ b/Registry/registry.afwa
@@ -87,8 +87,8 @@ state    real   TORNADO_DUR      ij     misc        1         -      r          
 
 #  Package declaration for AFWA diagnostics
 
-package   afwa_diag      afwa_diag_opt==1            -             state:afwa_mslp,afwa_pwat,wspd10max
-package   afwa_ptype     afwa_ptype_opt==1           -             state:afwa_precip,afwa_totprecip,afwa_rain,afwa_snow,afwa_ice,afwa_fzra,afwa_snowfall
+package   afwa_diag      afwa_diag_opt==1            -             state:afwa_mslp,afwa_pwat,wspd10max,afwa_precip,afwa_totprecip
+package   afwa_ptype     afwa_ptype_opt==1           -             state:afwa_rain,afwa_snow,afwa_ice,afwa_fzra,afwa_snowfall
 package   afwa_vil       afwa_vil_opt==1             -             state:vil,radarvil
 package   afwa_radar     afwa_radar_opt==1           -             state:echotop,refd_com,refd
 package   afwa_severe    afwa_severe_opt==1          -             state:w_up_max,w_dn_max,tcoli_max,up_heli_max,grpl_flx_max,w_mean,afwa_hail,afwa_cape,afwa_zlfc,afwa_plfc,tornado_mask,tornado_dur,midrh_min,midrh_min_old,afwa_lidx,afwa_cin,afwa_tornado,afwa_llws

--- a/phys/module_diag_afwa.F
+++ b/phys/module_diag_afwa.F
@@ -253,7 +253,9 @@ CONTAINS
       DO j = jms, jme
         DO i = ims, ime
           grid % wspd10max(i,j) = 0.
+          IF ( config_flags % afwa_severe_opt == 1 ) THEN
           grid % afwa_llws(i,j) = 0.
+          ENDIF
         ENDDO
       ENDDO
     ENDIF 
@@ -312,6 +314,7 @@ CONTAINS
 
     ! Calculate 0-2000 foot (0 - 609.6 meter) shear.
     ! ----------------------------------------------
+    IF ( config_flags % afwa_severe_opt == 1 ) THEN
     DO j = jts, jte
       DO i = its, ite
         is_target_level=.false.
@@ -335,6 +338,7 @@ CONTAINS
         ENDDO
       ENDDO
     ENDDO
+    ENDIF
 
 #if ( WRF_CHEM == 1 )
     ! Surface dust concentration array (ug m-3)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: AFWA diagnostics, memory allocation

SOURCE: internal, reported by Abby Jaye (NCAR/MMM) and other users

DESCRIPTION OF CHANGES: 
Problem:
When AFWA diagnostics switch is turned on (`afwa_diag_opt = 1`), the model can behave badly,
usually by "hanging" when a history file is written. The problem is that some of the variables used 
in the diagnostic routine are not packaged correctly. Unless one turns on every afwa_* option,
essentially the union of all packages for AFWA diagnostic options, the WRF executable can fail.

Solution:
Identify variables that are ALWAYS assumed to be used, and include those in the basic option for
using the AFWA diagnostic capability.

Notes:
1. This error does not manifest in all situations (for example, the small January 2000 test case 
runs fine). 
2. This PR addresses just one of the memory problem related to AFWA diagnostics. The other part 
(assuming that graupel is always available) will be put in ISSUES, and will be addressed after the 
4.1 release.

LIST OF MODIFIED FILES: 
M       Registry/registry.afwa
M       phys/module_diag_afwa.F

TESTS CONDUCTED: 
 - [x] With this PR, the model completes and is able to correctly output diagnostic data.

RELEASE NOTE: 
Fixed a bug that causes AFWA diagnostics option to fail or hang at the time of writing output.
