### PR TITLE
Added check for cv_option=3 and ensdim_alpha>0

### DIFF
--- a/var/da/da_main/da_solve.inc
+++ b/var/da/da_main/da_solve.inc
@@ -209,7 +209,7 @@
          write(unit=message(1),fmt='(A)') &
             'Alpha control variables are not implemented for cv_options = 3'
          write(unit=message(2),fmt='(A)') &
-            'Please use a different value for cv_options or set ensdim_alpha = 0'
+            'Please set cv_options=5 or 7, or ensdim_alpha=0'
          call da_error(__FILE__,__LINE__,message(1:2))
       end if
    end if

--- a/var/da/da_main/da_solve.inc
+++ b/var/da/da_main/da_solve.inc
@@ -196,13 +196,22 @@
          ' Resetting ntmax = 0 for analysis_type = randomcv' 
    end if
 
-   if ( cv_options == 3 .and. cloud_cv_options > 0 ) then
-      write(unit=message(1),fmt='(A)') &
-         'Cloud control variables are not implemented for cv_options = 3'
-      write(unit=message(2),fmt='(A)') &
-         'Resetting cloud_cv_options = 0 for cv_options = 3'
-      cloud_cv_options = 0
-      call da_warning(__FILE__,__LINE__,message(1:2))
+   if ( cv_options == 3 ) then
+      if ( cloud_cv_options > 0 ) then
+         write(unit=message(1),fmt='(A)') &
+            'Cloud control variables are not implemented for cv_options = 3'
+         write(unit=message(2),fmt='(A)') &
+            'Resetting cloud_cv_options = 0 for cv_options = 3'
+         cloud_cv_options = 0
+         call da_warning(__FILE__,__LINE__,message(1:2))
+      end if
+      if ( ensdim_alpha > 0 ) then
+         write(unit=message(1),fmt='(A)') &
+            'Alpha control variables are not implemented for cv_options = 3'
+         write(unit=message(2),fmt='(A)') &
+            'Please use a different value for cv_options or set ensdim_alpha = 0'
+         call da_error(__FILE__,__LINE__,message(1:2))
+      end if
    end if
 
    if ( use_radarobs ) then


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: WRFDA, EnVar, cv_options, alpha_cv

SOURCE: JJ Guerrette

DESCRIPTION OF CHANGES: WRFDA throws an error for this unsupported set of namelist variables

ISSUE:
```
Fixes #867 
```

LIST OF MODIFIED FILES: 
M       var/da/da_main/da_solve.inc

TESTS CONDUCTED: WRFDA compiles successfully.  No impact to results.
