### PR TITLE
Identify which auxiliary file is missing - stop incorrectly blaming failures on wrfout metadata

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -106,6 +106,9 @@
 
     LOGICAL :: yes_use_this_data
 
+    CHARACTER(10) :: check_which_switch 
+    CHARACTER(10) :: my_string
+
 
 
 !<DESCRIPTION>
@@ -159,20 +162,25 @@
 
 #if ( NMM_CORE != 1 )
     IF ( .NOT. dryrun ) THEN
+   
+       !  Does this file exist?
+   
+       CALL wrf_inquire_filename ( fid , fname , filestate , ierr )
+       IF ( ( filestate .EQ. WRF_FILE_NOT_OPENED       ) .OR. &
+            ( filestate .EQ. WRF_FILE_OPENED_FOR_WRITE ) ) THEN
+          my_string = check_which_switch(switch)
+          CALL wrf_error_fatal( 'Possibly missing file for = ' // TRIM(my_string) )
+       END IF
 
        !  Determine is the input file we are reading is acceptable given the
        !  assumptions about the current version of the modeling system.
-   
+
        CALL is_this_data_ok_to_use ( fid , yes_use_this_data )
-   
-       CALL wrf_inquire_filename ( fid , fname , filestate , ierr )
        IF ( ( yes_use_this_data ) .OR. ( config_flags%force_use_old_data ) ) THEN
           WRITE(wrf_err_message,*)'Input data is acceptable to use: ' // TRIM(fname) 
           CALL wrf_debug( 0 , wrf_err_message )
        ELSE
           CALL wrf_debug( 0 , 'File name that is causing troubles = ' // TRIM(fname) )
-          CALL wrf_debug( 0 , TRIM(fname) )
-          CALL wrf_debug( 0 , TRIM(wrf_err_message) )
           WRITE(wrf_err_message,*)'You can try 1) ensure that the input file was created with WRF v4 pre-processors, or '
           CALL wrf_debug( 0 , TRIM(wrf_err_message) )
           WRITE(wrf_err_message,*)'2) use force_use_old_data=T in the time_control record of the namelist.input file'
@@ -1929,4 +1937,32 @@
     END IF
     
   END SUBROUTINE is_this_data_ok_to_use
+
+  FUNCTION check_which_switch (switch) RESULT (aux_thing)
+    IMPLICIT NONE
+    INTEGER, INTENT(IN) :: switch
+    CHARACTER(10) :: aux_thing
+  
+    CHARACTER(LEN=80) :: joe_message
+    INTEGER :: switch_loop, start, end, count
+  
+    aux_thing = 'auxinputxx'
+  
+    start =   MAX_HISTORY + 1
+    end   = 2*MAX_HISTORY
+    count = 0
+    DO switch_loop = start, end
+      IF ( switch .EQ. switch_loop ) THEN
+        IF ( count .EQ. 0 ) THEN
+          WRITE(aux_thing,FMT='(a      )') 'wrfinput '
+        ELSE IF ( count .LT. 10 ) THEN
+          WRITE(aux_thing,FMT='(a,i1   )') 'auxinput',count
+        ELSE 
+          WRITE(aux_thing,FMT='(a,i2.2 )') 'auxinput',count
+        END IF
+      END IF
+      count = count +1
+    END DO
+  END FUNCTION check_which_switch
+
 #endif

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -110,7 +110,6 @@
     CHARACTER(10) :: my_string
 
 
-
 !<DESCRIPTION>
 !
 ! Core wrf input routine for all input data streams. Part of mediation layer.
@@ -174,7 +173,7 @@
 
        !  Determine is the input file we are reading is acceptable given the
        !  assumptions about the current version of the modeling system.
-
+   
        CALL is_this_data_ok_to_use ( fid , yes_use_this_data )
        IF ( ( yes_use_this_data ) .OR. ( config_flags%force_use_old_data ) ) THEN
           WRITE(wrf_err_message,*)'Input data is acceptable to use: ' // TRIM(fname) 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: missing files, input_wrf

SOURCE: identified by Michael Duda (NCAR/MMM), fixed internally

DESCRIPTION OF CHANGES: 
Problem:
The user was given an incorrect diagnostic print when an auxiliary file was missing (such as for
SST update or FDDA). The user was ALWAYS told that the WRF model could not read the 
metadata from the wrfout file. 
```
d01 2000-01-24_12:00:00  Error trying to read metadata
d01 2000-01-24_12:00:00 File name that is causing troubles = wrfout_d01_2000-01-24_12:00:00
d01 2000-01-24_12:00:00 wrfout_d01_2000-01-24_12:00:00
d01 2000-01-24_12:00:00  Error trying to read metadata
d01 2000-01-24_12:00:00  You can try 1) ensure that the input file was created with WRF v4 pre-processors, or
d01 2000-01-24_12:00:00  2) use force_use_old_data=T in the time_control record of the namelist.input file
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     324
 ---- ERROR: The input file appears to be from a pre-v4 version of WRF initialization routines
-------------------------------------------
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     324
 ---- ERROR: The input file appears to be from a pre-v4 version of WRF initialization routines
-------------------------------------------
```

Solution:
If the _filestate_ is either "unopened" or "open for write", we flag the attempt to read the file as
a fatal error. If the file is "unopened", then the file name was wrong or missing. If the _filestate_ is 
"open for write", then the WRF I/O is using the old data from the previous write of the WRF model.
In either case, a print out is issued that maps the _switch_ (stream number) to a more recognizable
WRF namelist identifier (for example, stream 30 is mapped to auxinput4).

ISSUE: 
Fixes #770 "Misleading error message when wrflowinp_d01 file is missing"

LIST OF MODIFIED FILES:
M share/input_wrf.F

TESTS CONDUCTED: 
1. With no missing files, and with FDDA and SST update, bit-wise identical results with a restart.
2. With sst_update activated, and no wrflowinp file
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     315
Possibly missing file for = auxinput4
-------------------------------------------
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     315
Possibly missing file for = auxinput4
-------------------------------------------
```
3. With fdda active, and no wrffdda file
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     315
Possibly missing file for = auxinput10
-------------------------------------------
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     315
Possibly missing file for = auxinput10
-------------------------------------------
```
4. For the standard WRF Chem case, things behave as expected:
```
Timing for Writing wrfout_d01_2006-04-06_00:00:00 for domain        1:    0.21654 elapsed seconds
d01 2006-04-06_00:00:00  Yes, this special data is acceptable to use:  OUTPUT FROM EMISSIONS V1.0 PREPROCESSOR for WRF version 2.03.1
d01 2006-04-06_00:00:00  Input data is acceptable to use: wrfchemi_d01_2006-04-06_00:00:00
**WARNING** Time in input file not being checked **WARNING**
d01 2006-04-06_00:00:00 Input data processed for aux input   5 for domain   1
d01 2006-04-06_00:00:00  Input data is acceptable to use: wrfbdy_d01
Timing for processing lateral boundary for domain        1:    0.05871 elapsed seconds
 Tile Strategy is not specified. Assuming 1D-Y
WRF TILE   1 IS      1 IE     40 JS      1 JE     40
WRF NUMBER OF TILES =   1
Timing for main: time 2006-04-06_00:04:00 on domain   1:    1.42039 elapsed seconds
Timing for main: time 2006-04-06_00:08:00 on domain   1:    0.45995 elapsed seconds
```

5. For the Chem case, when we remove a file `wrfchemi_d01_2006-04-06_00:00:00`:
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     314
Possibly missing file for = auxinput5
-------------------------------------------
```
Then you look in the namelist to find:
```
 &time_control
 auxinput5_inname     = "wrfchemi_d<domain>_<date>"
 /
```

MMM Classroom regtest; em_real, nmm, em_chem; GNU only

Individual tests:
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11
SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_33_em_real_10
SUCCESS_RUN_WRF_d01_em_real_33_em_real_11
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5
SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_34_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_34_em_real_10
SUCCESS_RUN_WRF_d01_em_real_34_em_real_11
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_01
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_03
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_04a
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_06
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_01
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_03
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_04a
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_06

Comparison tests:
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD status = 0
Files SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE and SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE differ
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE status = 1
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_07NE status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_01 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_01 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_03 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_03 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_04a vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_04a status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_06 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_06 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5 status = 0
