### PR TITLE
Require user to specify BEP/BEM run-time dimensions

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -270,6 +270,73 @@
       END IF
 
 !-----------------------------------------------------------------------
+! Check that the dimensions are correctly secified when sf_urban_physics = 2 and 3
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( model_config_rec % sf_urban_physics(i) == bepscheme .OR. &
+              model_config_rec % sf_urban_physics(i) == bep_bemscheme )  THEN
+           IF ( model_config_rec % num_urban_ndm .NE. 2 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_ndm is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_ndm'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+           IF ( model_config_rec % num_urban_nz .NE. 18 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_nz is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nz'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+           IF ( model_config_rec % num_urban_ng .NE. 10 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_ng is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_ng'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+           IF ( model_config_rec % num_urban_nwr .NE. 10 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_nwr is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nwr'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+         END IF
+         IF ( model_config_rec % sf_urban_physics(i) == bep_bemscheme ) THEN 
+           IF ( model_config_rec % num_urban_nf .NE. 10 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_nf is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nf'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+           IF ( model_config_rec % num_urban_ngb .NE. 10 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_ngb is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_ngb'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+           IF ( model_config_rec % num_urban_nbui.NE. 15 ) THEN
+             wrf_err_message = '--- ERROR: num_urban_nbui is wrong'
+             CALL wrf_message ( wrf_err_message )
+             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nbui'
+             CALL wrf_message ( wrf_err_message )
+             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+             count_fatal_error = count_fatal_error + 1
+           END IF
+         END IF
+      ENDDO
+
+!-----------------------------------------------------------------------
 ! Check that mosiac option cannot turn on when sf_urban_physics = 2 and 3
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -275,60 +275,60 @@
       DO i = 1, model_config_rec % max_dom
          IF ( model_config_rec % sf_urban_physics(i) == bepscheme .OR. &
               model_config_rec % sf_urban_physics(i) == bep_bemscheme )  THEN
-           IF ( model_config_rec % num_urban_ndm .NE. 2 ) THEN
+           IF ( model_config_rec % num_urban_ndm .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_ndm is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_ndm'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_ndm'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1
            END IF
-           IF ( model_config_rec % num_urban_nz .NE. 18 ) THEN
+           IF ( model_config_rec % num_urban_nz .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_nz is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nz'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_nz'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1
            END IF
-           IF ( model_config_rec % num_urban_ng .NE. 10 ) THEN
+           IF ( model_config_rec % num_urban_ng .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_ng is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_ng'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_ng'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1
            END IF
-           IF ( model_config_rec % num_urban_nwr .NE. 10 ) THEN
+           IF ( model_config_rec % num_urban_nwr .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_nwr is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nwr'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_nwr'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1
            END IF
          END IF
          IF ( model_config_rec % sf_urban_physics(i) == bep_bemscheme ) THEN 
-           IF ( model_config_rec % num_urban_nf .NE. 10 ) THEN
+           IF ( model_config_rec % num_urban_nf .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_nf is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nf'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_nf'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1
            END IF
-           IF ( model_config_rec % num_urban_ngb .NE. 10 ) THEN
+           IF ( model_config_rec % num_urban_ngb .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_ngb is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_ngb'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_ngb'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1
            END IF
-           IF ( model_config_rec % num_urban_nbui.NE. 15 ) THEN
+           IF ( model_config_rec % num_urban_nbui .EQ. 1 ) THEN
              wrf_err_message = '--- ERROR: num_urban_nbui is wrong'
              CALL wrf_message ( wrf_err_message )
-             wrf_err_message = '--- Please refer to example.namelist for correct setting of num_urban_nbui'
+             wrf_err_message = '--- Please refer to examples.namelist for the correct setting of num_urban_nbui'
              CALL wrf_message ( wrf_err_message )
              CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
              count_fatal_error = count_fatal_error + 1

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -56,6 +56,23 @@ Note, this is not a namelist.input file. Find what interests you, and cut and pa
  opt_stc  = 1,
 /
 
+** Using BEP urban  model
+&physics
+ num_urban_ndm = 2
+ num_urban_nz = 18
+ num_urban_ng = 10
+ num_urban_nwr = 10
+
+** Using BEM urban  model
+&physics
+ num_urban_ndm = 2
+ num_urban_nz = 18
+ num_urban_ng = 10
+ num_urban_nwr = 10
+ num_urban_nf = 10
+ num_urban_ngb = 10
+ num_urban_nbui = 15
+
 ** Using lake model
 &physics
  sf_lake_physics                     = 1,      1,     1,

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -56,22 +56,28 @@ Note, this is not a namelist.input file. Find what interests you, and cut and pa
  opt_stc  = 1,
 /
 
+** Using UCM urban  model
+&physics
+ sf_urban_physics                    = 1, 1, 1,
+
 ** Using BEP urban  model
 &physics
- num_urban_ndm = 2
- num_urban_nz = 18
- num_urban_ng = 10
- num_urban_nwr = 10
+ sf_urban_physics                    = 2, 2, 2,
+ num_urban_ndm                       = 2
+ num_urban_nz                        = 18
+ num_urban_ng                        = 10
+ num_urban_nwr                       = 10
 
 ** Using BEM urban  model
 &physics
- num_urban_ndm = 2
- num_urban_nz = 18
- num_urban_ng = 10
- num_urban_nwr = 10
- num_urban_nf = 10
- num_urban_ngb = 10
- num_urban_nbui = 15
+ sf_urban_physics                    = 3, 3, 3,
+ num_urban_ndm                       = 2
+ num_urban_nz                        = 18
+ num_urban_ng                        = 10
+ num_urban_nwr                       = 10
+ num_urban_nf                        = 10
+ num_urban_ngb                       = 10
+ num_urban_nbui                      = 15
 
 ** Using lake model
 &physics


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: urban physics, BEP, BEM

SOURCE: internal

DESCRIPTION OF CHANGES: When BEP or BEM urban physics modules are turned on, values of 
several dimension variables need to be specified correctly in namelist.input. Their default values 
(set to 1) in the Registry only work for the UCM module. These values of these variables are checked 
in the check_a_mundo file when BEP/BEM options are turned on. If these variables are still the 
default values from the Registry (wrong), a fatal error informs the user to refer to 
test/em_real/examples.namelist for correct settings. 

These modifications are required with the commit SHA a500a27c, PR #745 "Improve memory usage 
for urban models".

LIST OF MODIFIED FILES:
M    share/module_check_a_mundo.F
M    test/em_real/examples.namelist

TESTS CONDUCTED: Three test cases have been done.

(1) BEP is turned on with incorrect values of the dimension variables. 

```
taskid: 0 hostname: r2i7n27
Quilting with   1 groups of   0 I/O tasks.
 Ntasks in X           12 , ntasks in Y           12
--- ERROR: num_urban_ndm is wrong
--- Please refer to example.namelist for correct setting of num_urban_ndm
  --- Please refer to example.namelist for correct setting of num_urban_ndm
--- ERROR: num_urban_nz is wrong
--- Please refer to example.namelist for correct setting of num_urban_nz
  --- Please refer to example.namelist for correct setting of num_urban_nz
--- ERROR: num_urban_ng is wrong
--- Please refer to example.namelist for correct setting of num_urban_ng
  --- Please refer to example.namelist for correct setting of num_urban_ng
--- ERROR: num_urban_nwr is wrong
--- Please refer to example.namelist for correct setting of num_urban_nwr
  --- Please refer to example.namelist for correct setting of num_urban_nwr
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1965
NOTE:       4 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```

(2) BEM is turned on with incorrect values:

```
taskid: 0 hostname: r1i4n0
Quilting with   1 groups of   0 I/O tasks.
 Ntasks in X           12 , ntasks in Y           12
--- ERROR: num_urban_ndm is wrong
--- Please refer to example.namelist for correct setting of num_urban_ndm
  --- Please refer to example.namelist for correct setting of num_urban_ndm
--- ERROR: num_urban_nz is wrong
--- Please refer to example.namelist for correct setting of num_urban_nz
  --- Please refer to example.namelist for correct setting of num_urban_nz
--- ERROR: num_urban_ng is wrong
--- Please refer to example.namelist for correct setting of num_urban_ng
  --- Please refer to example.namelist for correct setting of num_urban_ng
--- ERROR: num_urban_nwr is wrong
--- Please refer to example.namelist for correct setting of num_urban_nwr
  --- Please refer to example.namelist for correct setting of num_urban_nwr
--- ERROR: num_urban_nf is wrong
--- Please refer to example.namelist for correct setting of num_urban_nf
  --- Please refer to example.namelist for correct setting of num_urban_nf
--- ERROR: num_urban_ngb is wrong
--- Please refer to example.namelist for correct setting of num_urban_ngb
  --- Please refer to example.namelist for correct setting of num_urban_ngb
--- ERROR: num_urban_nbui is wrong
--- Please refer to example.namelist for correct setting of num_urban_nbui
  --- Please refer to example.namelist for correct setting of num_urban_nbui
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1965
NOTE:       7 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```

(3) BEM is turned on with correct settings in namelist, i.e.,

```
&physics
 num_urban_ndm = 2
 num_urban_nz = 18
 num_urban_ng = 10
 num_urban_nwr = 10
 num_urban_nf = 10
 num_urban_ngb = 10
 num_urban_nbui = 15
```

The case is run successfully for 12 hours. Results are reasonable.

RELEASE NOTE: When running with either of the BEP or BEM urban physics options, the values of several variables (used internally to allocate space) must be explicitly defined in namelist.input. The suggested values are provide in the test/em_real/examples.namelist file.