### PR TITLE
Force positive definite with small mass and number from RRTMG K, avoids floating exception

### DIFF
--- a/phys/module_ra_effective_radius.F
+++ b/phys/module_ra_effective_radius.F
@@ -238,8 +238,8 @@
      enddo
 !
      do k = kts,kte_in
-       qsqg(k) = qs(k)+qg(k)
-       re_qs(k) = (re_qs(k)*qs(k)+re_qg(k)*qg(k))/qsqg(k)
+       qsqg(k) = max(r1,qs(k)+qg(k))
+       re_qs(k) = (re_qs(k)*max(0.,qs(k))+re_qg(k)*max(0.,qg(k)))/qsqg(k)
      enddo     
    endif
 !

--- a/phys/module_ra_effective_radius.F
+++ b/phys/module_ra_effective_radius.F
@@ -140,6 +140,7 @@
 !
 ! minimum microphys values
 !
+   real, parameter          :: r0 = 0.
    real, parameter          :: r1 = 1.e-12
    real, parameter          :: r2 = 1.e-6
 !
@@ -181,7 +182,7 @@
      qcmps(k)  = qc(k)-qccps(k)
      rqcmps(k) = max(r1,qcmps(k)*rho(k))
      if(f_qnc) then
-       lammps    = 2.*cdm2*(pidnc*MAX(r1,nc(k))/rqcmps(k))**obmr
+       lammps    = 2.*cdm2*(pidnc*MAX(r0,nc(k))/rqcmps(k))**obmr
      else
        lammps   = (pidnc*nc0/rqcmps(k))**obmr
      endif
@@ -208,7 +209,7 @@
    if (has_qc) then
      do k = kts,kte_in
        if (rqc(k).le.r1.or.rnc(k).le.r2) cycle
-       lamc = 2.*cdm2*(pidnc*(MAX(r1,nc(k))+nccps(k))/rqc(k))**obmr
+       lamc = 2.*cdm2*(pidnc*(MAX(r0,nc(k))+nccps(k))/rqc(k))**obmr
        re_qc(k) =  max(2.51e-6,min(sngl(3.0/lamc),50.e-6))
      enddo
    endif

--- a/phys/module_ra_effective_radius.F
+++ b/phys/module_ra_effective_radius.F
@@ -239,7 +239,7 @@
 !
      do k = kts,kte_in
        qsqg(k) = max(r1,qs(k)+qg(k))
-       re_qs(k) = (re_qs(k)*max(0.,qs(k))+re_qg(k)*max(0.,qg(k)))/qsqg(k)
+       re_qs(k) = (re_qs(k)*max(r0,qs(k))+re_qg(k)*max(r0,qg(k)))/qsqg(k)
      enddo     
    endif
 !

--- a/phys/module_ra_effective_radius.F
+++ b/phys/module_ra_effective_radius.F
@@ -179,9 +179,9 @@
 !
      rqc(k) = max(r1,qc(k)*rho(k))
      qcmps(k)  = qc(k)-qccps(k)
-     rqcmps(k) = qcmps(k)*rho(k)
+     rqcmps(k) = max(r1,qcmps(k)*rho(k))
      if(f_qnc) then
-       lammps    = 2.*cdm2*(pidnc*nc(k)/rqcmps(k))**obmr
+       lammps    = 2.*cdm2*(pidnc*MAX(r1,nc(k))/rqcmps(k))**obmr
      else
        lammps   = (pidnc*nc0/rqcmps(k))**obmr
      endif
@@ -208,7 +208,7 @@
    if (has_qc) then
      do k = kts,kte_in
        if (rqc(k).le.r1.or.rnc(k).le.r2) cycle
-       lamc = 2.*cdm2*(pidnc*(nc(k)+nccps(k))/rqc(k))**obmr
+       lamc = 2.*cdm2*(pidnc*(MAX(r1,nc(k))+nccps(k))/rqc(k))**obmr
        re_qc(k) =  max(2.51e-6,min(sngl(3.0/lamc),50.e-6))
      enddo
    endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: effective radius, radiation, exception

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
This subroutine computes an effective radius given the mass and the number for the cloud,
snow, and graupel. 
1. When a denominator is zero (in the first time step), this gives a divide-by-0 situation.
2. After a time step, (cloud number / cloud mass < 0) is a problem when using a real exponent.
3. The sum of snow and graupel is used as a denominator. Both can be zero.

Solution:
Use MAX function to make sure that positive definite values are >= zero, and make sure that 
denominators are >= a pre-defined small value.
1. Both the cloud mass and the cloud number now use a MAX function with a previously existing value
(r1 = 1.e-12). The `rqcmps` variable is local, so it is changed directly. The `nc` variable is INTENT(IN),
so the MAX function surrounds this variable (is used in-line) twice. 
2. The sum of qs and qg now has a minimum allowable value (r1 = 1.e-12). In the same loop, set the 
minimum allowable value for each qs and qg (both used in the numerator) to be 0.

LIST OF MODIFIED FILES: 
M module_ra_effective_radius.F

TESTS CONDUCTED: 
 - [x] Without mod, code failed in first time step, at (i,j) = (1,1).
 - [x] With mod, code runs through effective radius calculation OK.
 - [x] With mod, code completes the regression simulation (10 time steps) with full debugging.

MMM Classroom regtest; em_real, nmm, em_chem; GNU only

Individual tests:
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11
SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_33_em_real_10
SUCCESS_RUN_WRF_d01_em_real_33_em_real_11
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5
SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_34_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_34_em_real_10
SUCCESS_RUN_WRF_d01_em_real_34_em_real_11
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_01
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_03
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_04a
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_06
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_01
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_03
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_04a
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_06

Comparison tests:
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD status = 0
Files SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE and SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE differ
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE status = 1
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_07NE status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_01 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_01 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_03 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_03 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_04a vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_04a status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_06 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_06 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5 status = 0

