### PR TITLE
Additional Mods to Unify WRF and MPAS Noah LSM Scheme

### DIFF
--- a/phys/module_sf_bem.F
+++ b/phys/module_sf_bem.F
@@ -2,6 +2,13 @@ MODULE module_sf_bem
 ! -----------------------------------------------------------------------
 !  Variables and constants used in the BEM module
 ! -----------------------------------------------------------------------
+
+#ifdef mpas
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+#define FATAL_ERROR(M) write(0,*) M ; stop
+#endif
          
         real emins		!emissivity of the internal walls
         parameter (emins=0.9) 
@@ -2220,7 +2227,7 @@ MODULE module_sf_bem
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     CALL wrf_error_fatal('singular matrix in gaussjbem')
+                     FATAL_ERROR('singular matrix in gaussjbem')
                   endif
                enddo
             endif
@@ -2241,7 +2248,7 @@ MODULE module_sf_bem
           
          endif
          
-         if(a(icol,icol).eq.0) CALL wrf_error_fatal('singular matrix in gaussjbem')
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussjbem')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1

--- a/phys/module_sf_bep.F
+++ b/phys/module_sf_bep.F
@@ -1,6 +1,12 @@
 MODULE module_sf_bep
-
+#if defined(mpas)
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M)
 !USE module_model_constants
+#endif
  USE module_sf_urban
 
 ! SGClarke 09/11/2008
@@ -2245,7 +2251,7 @@ MODULE module_sf_bep
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     CALL wrf_error_fatal('singular matrix in gaussj')
+                     FATAL_ERROR('singular matrix in gaussj')
                   endif
                enddo
             endif
@@ -2266,7 +2272,7 @@ MODULE module_sf_bep
           
          endif
          
-         if(a(icol,icol).eq.0) CALL wrf_error_fatal('singular matrix in gaussj')
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussj')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1

--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -1,6 +1,12 @@
 MODULE module_sf_bep_bem
-
+#if defined(mpas)
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
 !USE module_model_constants
+#endif
  USE module_sf_urban
  USE module_sf_bem
 
@@ -3280,7 +3286,7 @@ MODULE module_sf_bep_bem
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     CALL wrf_error_fatal('singular matrix in gaussj')
+                     FATAL_ERROR('singular matrix in gaussj')
                   endif
                enddo
             endif
@@ -3301,8 +3307,8 @@ MODULE module_sf_bep_bem
           
          endif
          
-         if(a(icol,icol).eq.0) CALL wrf_error_fatal('singular matrix in gaussj')
-         
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussj')
+ 
          pivinv=1./a(icol,icol)
          a(icol,icol)=1
          

--- a/phys/module_sf_noah_seaice.F
+++ b/phys/module_sf_noah_seaice.F
@@ -1,5 +1,13 @@
 MODULE module_sf_noah_seaice
-  USE module_model_constants, only : CP, R_D, XLF, XLV, RHOWATER, STBOLT
+#if defined(mpas)
+use mpas_atmphys_constants,only: cp,R_D=>R_d,XLF,XLV,RHOWATER=>rho_w,STBOLT
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+use module_model_constants, only : CP, R_D, XLF, XLV, RHOWATER, STBOLT
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#endif
   use module_sf_noahlsm, only : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, &
        &                        HSTEP
 
@@ -281,7 +289,7 @@ CONTAINS
 
       SNDENS = SNEQV / SNOWH
       IF(SNDENS > 1.0) THEN
-         CALL wrf_error_fatal ( 'Physical snow depth is less than snow water equiv.' )
+         FATAL_ERROR( 'Physical snow depth is less than snow water equiv.' )
       ENDIF
       CALL CSNOW (SNCOND,SNDENS)
 

--- a/phys/module_sf_noah_seaice_drv.F
+++ b/phys/module_sf_noah_seaice_drv.F
@@ -1,4 +1,13 @@
 module module_sf_noah_seaice_drv
+#if defined(mpas)
+use mpas_atmphys_utilities, only: physics_message,physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#define WRITE_MESSAGE(M) call physics_message( M )
+#else
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#define WRITE_MESSAGE(M) call wrf_message( M )
+#endif
   use module_sf_noah_seaice
   implicit none
 contains
@@ -16,10 +25,12 @@ contains
        &                  IDS, IDE, JDS, JDE, KDS, KDE,                                 &
        &                  IMS, IME, JMS, JME, KMS, KME,                                 &
        &                  ITS, ITE, JTS, JTE, KTS, KTE  )
+#if defined(wrfmodel)
 #if (NMM_CORE != 1)
     USE module_state_description, ONLY : NOAHUCMSCHEME
     USE module_state_description, ONLY : BEPSCHEME
     USE module_state_description, ONLY : BEP_BEMSCHEME
+#endif
 #endif
     implicit none
 
@@ -113,7 +124,7 @@ contains
     REAL,    OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme )  , &
          &   INTENT (INOUT)   ::                        B_Q_BEP, &
          &                                              B_T_BEP
-    REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+    REAL,    OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme )  , &
          &   INTENT (IN)      ::                            RHO
 
     INTEGER :: I
@@ -206,7 +217,7 @@ contains
           SELECT CASE ( SEAICE_THICKNESS_OPT )
           CASE DEFAULT
               WRITE(message,'("Namelist value for SEAICE_THICKNESS_OPT not recognized: ",I6)') SEAICE_THICKNESS_OPT
-              CALL wrf_error_fatal(message)
+              FATAL_ERROR(message)
           CASE (0)
               ! Use uniform sea-ice thickness.
               SITHICK = SEAICE_THICKNESS_DEFAULT
@@ -214,10 +225,10 @@ contains
               ! Use the sea-ice as read in from the input files.
               ! Limit the to between 0.10 and 10.0 m.
               IF ( ICEDEPTH(I,J) < -1.E6 ) THEN
-                  call wrf_message("Field ICEDEPTH not found in input files.")
-                  call wrf_message(".... Namelist SEAICE_THICKNESS_OPT=1 requires ICEDEPTH field.")
-                  call wrf_message(".... Try namelist option SEAICE_THICKNESS_OPT=0.")
-                  call wrf_error_fatal("SEAICE_THICKNESS_OPT")
+                  WRITE_MESSAGE("Field ICEDEPTH not found in input files.")
+                  WRITE_MESSAGE(".... Namelist SEAICE_THICKNESS_OPT=1 requires ICEDEPTH field.")
+                  WRITE_MESSAGE(".... Try namelist option SEAICE_THICKNESS_OPT=0.")
+                  FATAL_ERROR("SEAICE_THICKNESS_OPT")
               ENDIF
               SITHICK = MIN ( MAX ( 0.10 , ICEDEPTH(I,J) ) , 10.0 )
               ICEDEPTH(I,J) = SITHICK
@@ -227,7 +238,7 @@ contains
           T1     = TSK(I,J)
           IF ( SEAICE_ALBEDO_OPT == 2 ) THEN
               IF ( ALBSI(I,J) < -1.E6 ) THEN
-                  call wrf_error_fatal("Field ALBSI not found in input.  Field ALBSI is required if SEAICE_ALBEDO_OPT=2")
+                  FATAL_ERROR("Field ALBSI not found in input.  Field ALBSI is required if SEAICE_ALBEDO_OPT=2")
               ENDIF
               SNOALB = ALBSI(I,J)
               ALBEDO(I,J) = ALBSI(I,J)
@@ -274,7 +285,7 @@ contains
           CASE DEFAULT
               
               WRITE(message,'("Namelist value for SEAICE_SNOWDEPTH_OPT not recognized: ",I6)') SEAICE_SNOWDEPTH_OPT
-              CALL wrf_error_fatal(message)
+              FATAL_ERROR(message)
 
           CASE ( 0 )
 
@@ -468,6 +479,7 @@ contains
                &         - SHEAT + SSOIL - ETA &
                &         - ( EMISSI * STBOLT * (T1**4) ) &
                &         - FLX1 - FLX2 - FLX3
+#if defined(wrfmodel)
 #if (NMM_CORE != 1)
           IF ( ( SF_URBAN_PHYSICS == NOAHUCMSCHEME ) .OR. &
                (SF_URBAN_PHYSICS == BEPSCHEME )      .OR. &
@@ -479,6 +491,7 @@ contains
                 B_Q_BEP(I,1,J)=qfx(i,j)/dz8w(i,1,j)/rho(i,1,j)
              endif
           ENDIF
+#endif
 #endif
 
        enddo SEAICE_ILOOP

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -16,7 +16,15 @@ MODULE module_sf_noahdrv
   USE module_sf_noahlsm_glacial_only, only: sflx_glacial
   USE module_sf_bep,      only: bep
   USE module_sf_bep_bem,  only: bep_bem
-  USE module_ra_gfdleta,  only: cal_mon_day
+#if defined(mpas)
+use mpas_atmphys_date_time, only: cal_mon_day
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+ use module_ra_gfdleta,  only: cal_mon_day
+ use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#endif
 #if ( WRF_CHEM == 1 )
   USE module_data_gocart_dust
 #endif
@@ -342,7 +350,7 @@ CONTAINS
                INTENT(OUT)    ::                        CHKLOWQ
    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LAI
    REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) ::        QZ0
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(OUT) ::  RC2, XLAI2
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) ::  RC2, XLAI2
 
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMR_SFCDIF
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHR_SFCDIF
@@ -943,10 +951,10 @@ CONTAINS
 
 	  IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
           IF(AOASIS > 1.0) THEN
-          CALL wrf_error_fatal('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
+          FATAL_ERROR('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
           ENDIF
           IF(IRIOPTION == 1) THEN
-          CALL wrf_error_fatal('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
+          FATAL_ERROR('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
           ENDIF
           ENDIF
 
@@ -1089,8 +1097,10 @@ CONTAINS
     ENDIF
 
        lai(i,j) = xlai
+       if (present(rc2) .and. present(xlai2)) then
        rc2(I,J) = RC                                              ! for output
        xlai2(I,J) = XLAI
+       endif
 
 #if 0
           IF(IPRINT) THEN
@@ -1149,9 +1159,11 @@ CONTAINS
 !
           TSK(I,J)=T1
           TSK_RURAL(I,J)=T1
-          IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
-            TSK_RURAL_BEP(I,J)=T1
-          END IF
+          if (present(tsk_rural_bep)) then
+             IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
+               TSK_RURAL_BEP(I,J)=T1
+             END IF
+          endif
           HFX(I,J)=SHEAT
           HFX_RURAL(I,J)=SHEAT
 ! MEk Jul07 add potential evap accum
@@ -1673,6 +1685,12 @@ CONTAINS
    END SUBROUTINE lsm
 !------------------------------------------------------
 
+!For MPAS, the below section of the module is moved to module_physics_lsm_noahinit.F in
+!./../core_physics to accomodate differences in the mpi calls between WRF and MPAS.I thought
+!that it would be cleaner to do this instead of adding a lot of #ifdef statements throughout
+!the initialization subroutine.
+
+#if defined(wrfmodel)
   SUBROUTINE LSMINIT(VEGFRA,SNOW,SNOWC,SNOWH,CANWAT,SMSTAV,    &
                      SMSTOT, SFCRUNOFF,UDRUNOFF,ACSNOW,        &
                      ACSNOM,IVGTYP,ISLTYP,TSLB,SMOIS,SH2O,ZS,DZS, &
@@ -5062,5 +5080,6 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 !--------------------------------      
   END SUBROUTINE lsm_mosaic_init  
 !--------------------------------  
+#endif
 
 END MODULE module_sf_noahdrv

--- a/phys/module_sf_noahlsm.F
+++ b/phys/module_sf_noahlsm.F
@@ -322,7 +322,7 @@ CONTAINS
 
       REAL, INTENT(IN)   :: SHDMIN,SHDMAX,DT,DQSDT2,LWDN,PRCP,PRCPRAIN,     &
                             Q2,Q2SAT,SFCPRS,SFCSPD,SFCTMP, SNOALB,          &
-                            SOLDN,SOLNET,TBOT,TH2,ZLVL,                            &
+                            SOLDN,SOLNET,TBOT,TH2,ZLVL,                     &
                             FFROZP,AOASIS
       REAL, INTENT(OUT)  :: EMBRD
       REAL, INTENT(OUT)  :: ALBEDO

--- a/phys/module_sf_noahlsm_glacial_only.F
+++ b/phys/module_sf_noahlsm_glacial_only.F
@@ -1,5 +1,14 @@
 MODULE module_sf_noahlsm_glacial_only
-  USE module_model_constants
+#if defined(mpas)
+use mpas_atmphys_constants
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+use module_model_constants
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#endif
+
   USE module_sf_noahlsm, ONLY : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, ROSR12
   USE module_sf_noahlsm, ONLY : LVCOEF_DATA
 
@@ -215,7 +224,7 @@ CONTAINS
 ! ----------------------------------------------------------------------
     SNDENS = SNEQV / SNOWH
     IF(SNDENS > 1.0) THEN
-       CALL wrf_error_fatal ( 'Physical snow depth is less than snow water equiv.' )
+       FATAL_ERROR( 'Physical snow depth is less than snow water equiv.' )
     ENDIF
 
     CALL CSNOW (SNCOND,SNDENS)

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1,4 +1,13 @@
 MODULE module_sf_urban
+#if defined(mpas)
+use mpas_atmphys_utilities, only: physics_message,physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#define WRITE_MESSAGE(M) call physics_message( M )
+#else
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#define WRITE_MESSAGE(M) call wrf_message( M )
+#endif
 
 !===============================================================================
 !     Single-Layer Urban Canopy Model for WRF Noah-LSM
@@ -612,48 +621,48 @@ MODULE module_sf_urban
 
  if(mh_urb.gt.0.0)THEN 
   !write(mesg,*) 'Mean Height NUDAPT',mh_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'Mean Height Table',ZR
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   if(zo_check.eq.1)THEN
    write(mesg,*) 'Mean Height NUDAPT',mh_urb
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Mean Height Table',ZR
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Roughness Length Table',Z0C
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Roof Roughness Length Table',Z0R
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Sky View Factor Table',SVF
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Normalized Height Table',HGT
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Plan Area Fraction', lp_urb
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
    write(mesg,*) 'Plan Area Fraction table', R
-   call wrf_message(mesg)
+   WRITE_MESSAGE(mesg)
   end if
   !write(mesg,*) 'Area Weighted Mean Height',hgt_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'Plan Area Fraction', lp_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'STD Height', stdh_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'Frontal Area Index',lf_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'Urban Fraction',frc_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'Building Surf Ratio',lb_urb
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
  
  !Calculate Building Width and Street Width Based on BEP formulation
  if(lb_urb.gt.lp_urb)THEN
   BW=2.*hgt_urb*lp_urb/(lb_urb-lp_urb)
   SW=2.*hgt_urb*lp_urb*((frc_urb/lp_urb)-1.)/(lb_urb-lp_urb)
   !write(mesg,*) 'Building Width',BW
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
   !write(mesg,*) 'Street Width',SW
-  !call wrf_message(mesg)
+  !WRITE_MESSAGE(mesg)
  elseif (SW.lt.0.0.or.BW.lt.0.0)then
   BW=BUILDING_WIDTH(1)
   SW=STREET_WIDTH(1)
@@ -709,7 +718,7 @@ MODULE module_sf_urban
      
       if(zo_check.eq.1)THEN
         write(mesg,*) 'Roughness Length NUDAPT',Z0C
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
       end if
 
       lambda_fr  = stdh_urb/(SW + BW)
@@ -741,11 +750,11 @@ MODULE module_sf_urban
 
     if(zo_check.eq.1)THEN
       write(mesg,*) 'Roof Roughness Length NUDAPT',Z0R
-      call wrf_message(mesg)
+      WRITE_MESSAGE(mesg)
       write(mesg,*) 'Sky View Factor NUDAPT',SVF
-      call wrf_message(mesg)
+      WRITE_MESSAGE(mesg)
       write(mesg,*) 'normalized Height NUDAPT', HGT
-      call wrf_message(mesg)
+      WRITE_MESSAGE(mesg)
     end if
 
 
@@ -768,8 +777,7 @@ MODULE module_sf_urban
    if(alhoption==1) ALH = ALH*alhdiuprf(tloc2)*alhseason(Kalh)
 
    IF( ZDC+Z0C+2. >= ZA) THEN
-    CALL wrf_error_fatal ("ZDC + Z0C + 2m is larger than the 1st WRF level "// &
-                           "Stop in subroutine urban - change ZDC and Z0C" ) 
+    FATAL_ERROR("ZDC + Z0C + 2m is larger than the 1st WRF level - Stop in subroutine urban - change ZDC and Z0C" ) 
    END IF
 
    IF(.NOT.LSOLAR) THEN
@@ -1152,7 +1160,7 @@ MODULE module_sf_urban
      END DO
        ! Update temperature in soil layer
        CALL SHFLX (SSOILR,TGRL,SMR,SMCMAX,NGR,TGRP,DELT,YY,ZZ1,ZSOILR,       &
-                  TRLEND,ZBOT,SMCWLT,DF1,QUARTZ,CSOIL,CAPR)     
+                   TRLEND,ZBOT,SMCWLT,DF1,QUARTZ,CSOIL,CAPR)
    FLXTHGR=HGR/RHO/CP/100.
    FLXHUMGR=ELEGR/RHO/EL/100.
 ELSE
@@ -1992,7 +2000,7 @@ ENDIF
          IOSTAT=IOSTATUS)
 
    IF (IOSTATUS > 0) THEN
-   CALL wrf_error_fatal('ERROR OPEN URBPARM.TBL')
+   FATAL_ERROR('ERROR OPEN URBPARM.TBL')
    ENDIF
 
    READLOOP : do 
@@ -2009,120 +2017,120 @@ ENDIF
          read(string(indx+1:),*) icate
          IF (.not. ALLOCATED(ZR_TBL)) then
             ALLOCATE( ZR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ZR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating ZR_TBL in urban_param_init')
             ALLOCATE( SIGMA_ZED_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0)CALL wrf_error_fatal('Error allocating SIGMA_ZED_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating SIGMA_ZED_TBL in urban_param_init')
             ALLOCATE( Z0C_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0C_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0C_TBL in urban_param_init')
             ALLOCATE( Z0HC_TBL(ICATE), stat=allocate_status ) 
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0HC_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0HC_TBL in urban_param_init')
             ALLOCATE( ZDC_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ZDC_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating ZDC_TBL in urban_param_init')
             ALLOCATE( SVF_TBL(ICATE), stat=allocate_status ) 
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating SVF_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating SVF_TBL in urban_param_init')
             ALLOCATE( R_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating R_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating R_TBL in urban_param_init')
             ALLOCATE( RW_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating RW_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating RW_TBL in urban_param_init')
             ALLOCATE( HGT_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating HGT_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating HGT_TBL in urban_param_init')
             ALLOCATE( AH_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating AH_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating AH_TBL in urban_param_init')
             ALLOCATE( ALH_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ALH_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating ALH_TBL in urban_param_init')
             ALLOCATE( BETR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating BETR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating BETR_TBL in urban_param_init')
             ALLOCATE( BETB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating BETB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating BETB_TBL in urban_param_init')
             ALLOCATE( BETG_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating BETG_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating BETG_TBL in urban_param_init')
             ALLOCATE( CAPR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating CAPR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating CAPR_TBL in urban_param_init')
             ALLOCATE( CAPB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating CAPB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating CAPB_TBL in urban_param_init')
             ALLOCATE( CAPG_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating CAPG_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating CAPG_TBL in urban_param_init')
             ALLOCATE( AKSR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating AKSR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating AKSR_TBL in urban_param_init')
             ALLOCATE( AKSB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating AKSB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating AKSB_TBL in urban_param_init')
             ALLOCATE( AKSG_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating AKSG_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating AKSG_TBL in urban_param_init')
             ALLOCATE( ALBR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ALBR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating ALBR_TBL in urban_param_init')
             ALLOCATE( ALBB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ALBB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating ALBB_TBL in urban_param_init')
             ALLOCATE( ALBG_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ALBG_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating ALBG_TBL in urban_param_init')
             ALLOCATE( EPSR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating EPSR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating EPSR_TBL in urban_param_init')
             ALLOCATE( EPSB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating EPSB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating EPSB_TBL in urban_param_init')
             ALLOCATE( EPSG_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating EPSG_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating EPSG_TBL in urban_param_init')
             ALLOCATE( Z0R_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0R_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0R_TBL in urban_param_init')
             ALLOCATE( Z0B_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0B_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0B_TBL in urban_param_init')
             ALLOCATE( Z0G_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0G_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0G_TBL in urban_param_init')
             ALLOCATE( AKANDA_URBAN_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating AKANDA_URBAN_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating AKANDA_URBAN_TBL in urban_param_init')
             ALLOCATE( Z0HB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0HB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0HB_TBL in urban_param_init')
             ALLOCATE( Z0HG_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0HG_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating Z0HG_TBL in urban_param_init')
             ALLOCATE( TRLEND_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TRLEND_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TRLEND_TBL in urban_param_init')
             ALLOCATE( TBLEND_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TBLEND_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TBLEND_TBL in urban_param_init')
             ALLOCATE( TGLEND_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TGLEND_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TGLEND_TBL in urban_param_init')
             ALLOCATE( FRC_URB_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating FRC_URB_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating FRC_URB_TBL in urban_param_init')
             ! ALLOCATE( ROOF_WIDTH(ICATE), stat=allocate_status )
-            ! if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ROOF_WIDTH in urban_param_init')
+            ! if(allocate_status /= 0) FATAL_ERROR('Error allocating ROOF_WIDTH in urban_param_init')
             ! ALLOCATE( ROAD_WIDTH(ICATE), stat=allocate_status )
-            ! if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ROAD_WIDTH in urban_param_init')
+            ! if(allocate_status /= 0) FATAL_ERROR('Error allocating ROAD_WIDTH in urban_param_init')
             !for BEP
             ALLOCATE( NUMDIR_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating NUMDIR_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating NUMDIR_TBL in urban_param_init')
             ALLOCATE( STREET_DIRECTION_TBL(MAXDIRS , ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating STREET_DIRECTION_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating STREET_DIRECTION_TBL in urban_param_init')
             ALLOCATE( STREET_WIDTH_TBL(MAXDIRS , ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating STREET_WIDTH_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating STREET_WIDTH_TBL in urban_param_init')
             ALLOCATE( BUILDING_WIDTH_TBL(MAXDIRS , ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating BUILDING_WIDTH_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating BUILDING_WIDTH_TBL in urban_param_init')
             ALLOCATE( NUMHGT_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating NUMHGT_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating NUMHGT_TBL in urban_param_init')
             ALLOCATE( HEIGHT_BIN_TBL(MAXHGTS , ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating HEIGHT_BIN_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating HEIGHT_BIN_TBL in urban_param_init')
             ALLOCATE( HPERCENT_BIN_TBL(MAXHGTS , ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating HPERCENT_BIN_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating HPERCENT_BIN_TBL in urban_param_init')
             ALLOCATE( COP_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating COP_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating COP_TBL in urban_param_init')
             ALLOCATE( PWIN_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating PWIN_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating PWIN_TBL in urban_param_init')
             ALLOCATE( BETA_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating BETA_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating BETA_TBL in urban_param_init')
             ALLOCATE( SW_COND_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating SW_COND_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating SW_COND_TBL in urban_param_init')
             ALLOCATE( TIME_ON_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TIME_ON_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TIME_ON_TBL in urban_param_init')
             ALLOCATE( TIME_OFF_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TIME_OFF_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TIME_OFF_TBL in urban_param_init')
             ALLOCATE( TARGTEMP_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TARGTEMP_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TARGTEMP_TBL in urban_param_init')
             ALLOCATE( GAPTEMP_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating GAPTEMP_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating GAPTEMP_TBL in urban_param_init')
             ALLOCATE( TARGHUM_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating TARGHUM_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating TARGHUM_TBL in urban_param_init')
             ALLOCATE( GAPHUM_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating GAPHUM_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating GAPHUM_TBL in urban_param_init')
             ALLOCATE( PERFLO_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating PERFLO_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating PERFLO_TBL in urban_param_init')
             ALLOCATE( HSESF_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating HSESF_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating HSESF_TBL in urban_param_init')
          endif
          numdir_tbl = 0
          street_direction_tbl = -1.E36
@@ -2139,12 +2147,12 @@ ENDIF
          read(string(indx+1:),*) sigma_zed_tbl(1:icate)
       else if (name == "ROOF_WIDTH") then
          ALLOCATE( ROOF_WIDTH(ICATE), stat=allocate_status )
-         if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ROOF_WIDTH in urban_param_init')
+         if(allocate_status /= 0) FATAL_ERROR('Error allocating ROOF_WIDTH in urban_param_init')
 
          read(string(indx+1:),*) roof_width(1:icate)
       else if (name == "ROAD_WIDTH") then
          ALLOCATE( ROAD_WIDTH(ICATE), stat=allocate_status )
-         if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ROAD_WIDTH in urban_param_init')
+         if(allocate_status /= 0) FATAL_ERROR('Error allocating ROAD_WIDTH in urban_param_init')
          read(string(indx+1:),*) road_width(1:icate)
       else if (name == "AH") then
          read(string(indx+1:),*) ah_tbl(1:icate)
@@ -2281,7 +2289,7 @@ ENDIF
          if ( pctsum /= 100.) then
             write (*,'(//,"Building height percentages for category ", I2, " must sum to 100.0")') k
             write (*,'("Currently, they sum to ", F6.2,/)') pctsum
-            CALL wrf_error_fatal('pctsum is not equal to 100.') 
+            FATAL_ERROR('pctsum is not equal to 100.') 
          endif
       else if ( name == "Z0R") then
          read(string(indx+1:),*) Z0R_tbl(1:icate)
@@ -2313,7 +2321,7 @@ ENDIF
          read(string(indx+1:),*) hsesf_tbl(1:icate)
 !end BEP         
       else
-         CALL wrf_error_fatal('URBPARM.TBL: Unrecognized NAME = "'//trim(name)//'" in Subr URBAN_PARAM_INIT')
+         FATAL_ERROR('URBPARM.TBL: Unrecognized NAME = "'//trim(name)//'" in Subr URBAN_PARAM_INIT')
       endif
    enddo READLOOP
 
@@ -2561,7 +2569,8 @@ ENDIF
                IF (HGT_URB2D(I,J)>0.) THEN
                   CONTINUE
                ELSE
-                  CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
+                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
+                  WRITE_MESSAGE(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2581,9 +2590,9 @@ ENDIF
                   CONTINUE
                 ELSE
                   WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
                 ENDIF           
                SWITCH_URB=1
@@ -2595,7 +2604,8 @@ ENDIF
                IF (HGT_URB2D(I,J)>0.) THEN
                   CONTINUE
                ELSE
-                  CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
+                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
+                  WRITE_MESSAGE(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2615,9 +2625,9 @@ ENDIF
                   CONTINUE
                 ELSE
                   WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
                 ENDIF         
               SWITCH_URB=1
@@ -2629,7 +2639,8 @@ ENDIF
               IF (HGT_URB2D(I,J)>0.) THEN
                   CONTINUE
                ELSE
-                  CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
+                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
+                  WRITE_MESSAGE(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2649,9 +2660,9 @@ ENDIF
                   CONTINUE
                 ELSE
                   WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
                 ENDIF
               SWITCH_URB=1
@@ -2663,7 +2674,8 @@ ENDIF
               IF (HGT_URB2D(I,J)>0.) THEN
                   CONTINUE
                ELSE
-                  CALL wrf_debug(100, 'USING DEFAULT URBAN MORPHOLOGY')
+                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
+                  WRITE_MESSAGE(mesg)
                   LP_URB2D(I,J)=0.
                   LB_URB2D(I,J)=0.
                   HGT_URB2D(I,J)=0.
@@ -2683,9 +2695,9 @@ ENDIF
                   CONTINUE
                 ELSE
                   WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  call wrf_message(mesg)
+                  WRITE_MESSAGE(mesg)
                   FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
                 ENDIF
                SWITCH_URB=1
@@ -2862,51 +2874,51 @@ ENDIF
       IF (CHECK.EQ.0)THEN
       IF(IVGTYP(I,J).EQ.1)THEN
         write(mesg,*) 'TSURFACE0_URB',TSURFACE0_URB(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TDEEP0_URB', TDEEP0_URB(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'IVGTYP',IVGTYP(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TR_URB2D',TR_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TB_URB2D',TB_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TG_URB2D',TG_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TC_URB2D',TC_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'QC_URB2D',QC_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'XXXR_URB2D',XXXR_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'SH_URB2D',SH_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'LH_URB2D',LH_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'G_URB2D',G_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'RN_URB2D',RN_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TS_URB2D',TS_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'LF_AC_URB3D', LF_AC_URB3D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'SF_AC_URB3D', SF_AC_URB3D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'CM_AC_URB3D', CM_AC_URB3D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'SFVENT_URB3D', SFVENT_URB3D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'LFVENT_URB3D', LFVENT_URB3D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'FRC_URB2D', FRC_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'UTYPE_URB2D', UTYPE_URB2D(I,J)
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'I',I,'J',J
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'num_urban_hi', num_urban_hi
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         CHECK = 1
        END IF
        END IF


### PR DESCRIPTION
TYPE: enhancement/no impact

KEYWORDS: noah, LSM, mpas, wrf, unify, seaice, urban, glacial

SOURCE: internal

DESCRIPTION OF CHANGES:
Identical to [PR #630 ](https://github.com/wrf-model/WRF/pull/630). Cherry-picked from that PR (going onto develop) and placed here (unified_physics). Also confirmed the modified files are identical to MPAS test:

commit 001589006b58952bd943a82facedbe6c3c4f7353
Merge: 5f67eb4 bfab9d1
Author: Michael Duda <duda@ucar.edu>
Date:   Wed Apr 3 13:49:42 2019 -0600

    Merge branch 'atmosphere/noah_mpas_wrf_unify' into test
    
    * atmosphere/noah_mpas_wrf_unify:
      Noah LSM physics unified with WRFV4.0
    
Toward the effort to unify physics schemes between MPAS and WRF, the Noah Scheme was updated again. Preliminary updates were previously pushed to the code prior to the V4.0 release, but additional modifications were necessary to allow MPAS to build and run without errors. These changes are based on WRFV4.0 and comparable to MPAS 2017 HWT code.

LIST OF MODIFIED FILES:
M phys/module_sf_bem.F
M phys/module_sf_bep.F
M phys/module_sf_bep_bem.F
M phys/module_sf_noah_seaice.F
M phys/module_sf_noah_seaice_drv.F
M phys/module_sf_noahdrv.F
M phys/module_sf_noahlsm.F
M phys/module_sf_noahlsm_glacial_only.F
M phys/module_sf_urban.F

TESTS CONDUCTED: Code compiles and runs. Bit-for-bit results before and after modifications.