### PR TITLE
fix compiler-sensitive looping for random seeds initialization in stochastic processing

### DIFF
--- a/dyn_em/module_stoch.F
+++ b/dyn_em/module_stoch.F
@@ -1343,12 +1343,18 @@ IF (grid%sppt_on==1) then
 
       one_big = 1
       iseedarr=0.0
-      do i = seed_start,seed_dim-3,4
-         iseedarr(i  )= iseed1+config_flags%nens*1000000
-         iseedarr(i+1)= mod(fctime+iseed1*config_flags%nens*1000000,19211*one_big)
-         iseedarr(i+2)= mod(fctime+iseed1*config_flags%nens*1000000,71209*one_big)
-         iseedarr(i+3)= mod(fctime+iseed1*config_flags%nens*1000000,11279*one_big)
-      enddo
+      if ( seed_dim-3 .lt. seed_start ) then
+         do i = seed_start,seed_dim
+            iseedarr(i  )= iseed1+config_flags%nens*1000000
+         enddo
+      else
+         do i = seed_start,seed_dim-3,4
+            iseedarr(i  )= iseed1+config_flags%nens*1000000
+            iseedarr(i+1)= mod(fctime+iseed1*config_flags%nens*1000000,19211*one_big)
+            iseedarr(i+2)= mod(fctime+iseed1*config_flags%nens*1000000,71209*one_big)
+            iseedarr(i+3)= mod(fctime+iseed1*config_flags%nens*1000000,11279*one_big)
+         enddo
+      end if
 
       end SUBROUTINE rand_seed
 !     ------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: stochastic, random, pattern, spread, error, seed, dimension

SOURCE: problem found by and solution proposed by Judith Berner (NCAR)

DESCRIPTION OF CHANGES: 
The assignment of seeds for random numbers is complicated by the fact that the standard does not
provide a fixed number of required seeds. What is provided is a function that returns the 
necessary dimension of a random seed. Two currently used compilers (Intel and GNU) have the
dimensions for the seeds as 2 and 33, respectively.

Problem:
When multiple ensembles were run with stochastic processing, there was error but no spread.

Solution:
Judith Berner found that the DO loop for the assignment of value for the random seeds was not
being entered, due to the loop bounds. An IF test now checks if a sufficiently large enough seed
dimension is available to use a preferred loop. If the seed dimension is too small, then another 
DO loop is now provided.

LIST OF MODIFIED FILES:
M dyn_em/module_stoch.F

TESTS CONDUCTED: 
1. Without the mod, the real-time HRRR cases had zero spread (intel compiler).
2. After the mod, their ensemble results look as expected.
3. Results with this mod are verified by Judith Berner.
