### PR TITLE
Add more developers to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,11 @@ README.md				@wrf-model/global_owner
 /phys/module_mp_jensen_ishmael.F	@graupely @wrf-model/physics
 /phys/module_mp_gsfcgce_4ice_nuwrf.F	@cacruz @wrf-model/physics
 /phys/module_sf_noahmp*			@barlage @wrf-model/physics
-/phys/module_fr_*			@wrf-model/physics
+/phys/module_fr_*			@pedro-jm @brankokosovic @domingom @wrf-model/physics
+/phys/module_bl_mynn.F			@joeolson42 @wrf-model/physics
+/phys/module_sf_mynn.F			@joeolson42 @wrf-model/physics
+/phys/module_sf_px*   			@coawstwx @wrf-model/physics
+/phys/module_bl_acm.F  			@coawstwx @wrf-model/physics
 
 #	Shared Physics Between MPAS and WRF
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,13 +4,18 @@
 
 *					@wrf-model/global_owner
 
-#	Next, generic top-level run dir and build files
+#	Generic top-level build files
 
-/run/					@wrf-model/infrastructure
 /configure				@wrf-model/infrastructure
 /compile				@wrf-model/infrastructure
 /clean					@wrf-model/infrastructure
 /Makefile				@wrf-model/infrastructure
+
+#	General use top-level files
+
+LICENSE.txt				@wrf-model/global_owner
+README					@wrf-model/global_owner
+README.md				@wrf-model/global_owner
 
 #	Architecture directories
 
@@ -19,10 +24,13 @@
 
 #	Common directories
 
-/share/					@wrf-model/infrastructure
+/doc/					@wrf-model/arw_dev @wrf-model/hwrf_dev @wrf-model/physics @wrf-model/infrastructure
 /frame/					@wrf-model/infrastructure
+/run/					@wrf-model/infrastructure
+/share/					@wrf-model/infrastructure @wrf-model/physics
 
 #	Chemistry
+
 /chem/					@wrf-model/chem
 
 #	Physics
@@ -30,6 +38,10 @@
 /phys/					@wrf-model/physics
 
 /phys/module_mp_thompson.F		@gthompsnWRF @wrf-model/physics
+/phys/module_mp_jensen_ishmael.F	@graupely @wrf-model/physics
+/phys/module_mp_gsfcgce_4ice_nuwrf.F	@cacruz @wrf-model/physics
+/phys/module_sf_noahmp*			@barlage @wrf-model/physics
+/phys/module_fr_*			@wrf-model/physics
 
 #	Shared Physics Between MPAS and WRF
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,12 +40,13 @@ README.md				@wrf-model/global_owner
 /phys/module_mp_thompson.F		@gthompsnWRF @wrf-model/physics
 /phys/module_mp_jensen_ishmael.F	@graupely @wrf-model/physics
 /phys/module_mp_gsfcgce_4ice_nuwrf.F	@cacruz @wrf-model/physics
-/phys/module_sf_noahmp*			@barlage @wrf-model/physics
+/phys/module_sf_noahmp*.F		@barlage @wrf-model/physics
 /phys/module_fr_*			@pedro-jm @brankokosovic @domingom @wrf-model/physics
 /phys/module_bl_mynn.F			@joeolson42 @wrf-model/physics
 /phys/module_sf_mynn.F			@joeolson42 @wrf-model/physics
-/phys/module_sf_px*   			@coawstwx @wrf-model/physics
+/phys/module_sf_px*.F 			@coawstwx @wrf-model/physics
 /phys/module_bl_acm.F  			@coawstwx @wrf-model/physics
+/phys/module_sf_ruclsm.F		@tanyasmirnova @wrf-model/physics
 
 #	Shared Physics Between MPAS and WRF
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: CODEOWNERS

SOURCE: internal

DESCRIPTION OF CHANGES: 
Add in a few more active developers

LIST OF MODIFIED FILES: 
M .github/CODEOWNERS

TESTS CONDUCTED: 
MMM Classroom regtest; em_real, nmm, em_chem; GNU only

Individual tests:
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11
SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_33_em_real_10
SUCCESS_RUN_WRF_d01_em_real_33_em_real_11
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2
SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5
SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD
SUCCESS_RUN_WRF_d01_em_real_34_em_real_07NE
SUCCESS_RUN_WRF_d01_em_real_34_em_real_10
SUCCESS_RUN_WRF_d01_em_real_34_em_real_11
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_01
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_03
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_04a
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_06
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_01
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_03
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_04a
SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_06

Comparison tests:
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD status = 0
Files SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE and SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE differ
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_07NE status = 1
SUCCESS_RUN_WRF_d01_em_real_32_em_real_07NE vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_07NE status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_01 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_01 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_03 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_03 status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_04a vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_04a status = 0
SUCCESS_RUN_WRF_d01_nmm_real_32_nmm_nest_06 vs SUCCESS_RUN_WRF_d01_nmm_real_34_nmm_nest_06 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5 status = 0

