### PR TITLE
bug fix for deng shcu check-a-mundo

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -359,7 +359,7 @@
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
-              (model_config_rec % bl_pbl_physics(i) /= myjpblscheme .OR. &
+              (model_config_rec % bl_pbl_physics(i) /= myjpblscheme .AND. &
                model_config_rec % bl_pbl_physics(i) /= mynnpblscheme2 ) ) THEN
             wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL '
             CALL wrf_message ( wrf_err_message )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: deng, shcu, check-a-mundo, MYJ, MYNN

SOURCE: Internal 

DESCRIPTION OF CHANGES: When using the Deng shcu scheme, one must use either the MYJ or MYNN PBL scheme. There was a check in module_check_a_mundo.F for this, but the logic was incorrect, meaning that a user would always get a fatal error when using the Deng scheme. Modified logic to correct this.

LIST OF MODIFIED FILES: 
M     share/module_check_a_mundo.F

TESTS CONDUCTED: none

RELEASE NOTE: Bug fix for Deng shallow cumulus scheme (the scheme and the bug were introduced in release-v4.1). If using the Deng scheme, it is mandatory to use either the MYJ or MYNN PBL scheme. However, even when using one of these required PBL schemes, users would receive a fatal error due to incorrect logic in the check. This check has been corrected.
