### PR TITLE
A fix for the cloud detection scheme based on Particle Filter and MMR

### DIFF
--- a/var/da/da_radiance/da_cloud_detect.inc
+++ b/var/da/da_radiance/da_cloud_detect.inc
@@ -180,12 +180,13 @@ else if (ahi) then
       Bands(1:Band_Size(1),1) = &
 &   (/7,8,9,10/)	 
 end if
-    jo=0
+
     allocate(ppx(ndim*11,ndim))  
     allocate(wx(ndim*11))    
     allocate(jo(ndim*11))
     wx=1.0
-	px(1:ndim-1) = 1.0/ndim
+    jo=0.0
+    px(1:ndim-1) = 1.0/ndim
     px(ndim)     = 1.0 - SUM(px(1:ndim-1))
     ichan        = iv%instid(isensor)%ichan(1:nchannels)
     rad_clr      = iv%instid(isensor)%rad_xb(1:nchannels,n)              !iv%instid(isensor)%tb_xb(1:nchan,n)
@@ -319,12 +320,14 @@ if (use_clddet==1) then
 !    call inria_n2qn1(da_cloud_sim,NDIM,px,ZF,ZG,(/(ZDXMIN,jlev=1,NDIM)/),ZDF1, &
 !                ZEPSG,impres,io,IMODE,nit,NSIM,binf,bsup,IZ,ZRZ,izs,RZS,DZS)
   
-      IF (ALLOCATED(IZ))  DEALLOCATE(IZ)       
-      IF (ALLOCATED(ZRZ)) DEALLOCATE(ZRZ)       
-      IF (ALLOCATED(DZS)) DEALLOCATE(DZS)       
+      if (allocated(iz))  deallocate(iz)       
+      if (allocated(zrz)) deallocate(zrz)       
+      if (allocated(dzs)) deallocate(dzs)       
       if (allocated(rzs)) deallocate(rzs)                 
 end if !mmr
-        
+      deallocate(ppx)
+      deallocate(wx)
+      deallocate(jo)         
       !-----------------!
       ! Cloudy radiance !
       !-----------------!


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, Infrared Radiance Data Assimilation, Cloud detection

SOURCE: Dongmei Xu (NUIST/NCAR)

DESCRIPTION OF CHANGES:
Three arrays are not deallocated in cloud detection subroutine, which caused segmentation fault with gnu-compiler compiled code for two WRFDA regression test cases related to AIRS and IASI DA (now by default cloud detection is on with particle filter) even though ifort-compiled code ran Ok.

LIST OF MODIFIED FILES:
M var/da/da_radiance/da_cloud_detect.inc

TESTS CONDUCTED: WRFDA regression tests ran successfully with gnu/ifort+mpt on Cheyenne.
