### PR TITLE
logical "specified" should be defined before use in diff_6th_opt

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -6306,6 +6306,8 @@ END SUBROUTINE set_tend
 ! Also modified to work with idealized boundary conditions.
 
     ktf = MIN( kte, kde-1 )
+    specified = .false.
+    if(config_flags%specified .or. config_flags%nested) specified = .true.
 
     IF ( name .EQ. 'u' ) THEN
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: diff_6th_opt, specified

SOURCE: Robert Rozumalski (COMET)

DESCRIPTION OF CHANGES: 
When a restart problem was fixed in 4.0.3 (Dec 18, 2018), an error was introduced. It used a logical 
variable 'specified' in subroutine sixth_order_diffusion, but it was not defined before it was used. This 
caused model failure in the case reported by Rob. This PR fixes the problem.

ISSUE:
Fixes #895 "module_big_step_utilities_em.F - logical variable "specified" not assigned"

LIST OF MODIFIED FILES: 
M   dyn_em/module_big_step_utilities_em.F

TESTS CONDUCTED: 
Compiled and verified it fixed the user's problem.

RELEASE NOTE: 
Fixed a bug associated with option diff_6th_opt. When a restart problem was fixed in 4.0.3 (Dec 18, 2018), an error was introduced. It used a logical variable 'specified' in subroutine sixth_order_diffusion, but it was not defined before it was used. This caused model failure in the user's case.
