### PR TITLE
Fix DA EnVar unnecessary allocation to reduce memory requirement

### DIFF
--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -939,6 +939,8 @@ rconfig   integer var4d_cloudcv           derived               1            -1 
 rconfig   integer var4d_w_cv              derived               1             0       -     "var4d_w_cv"      "turn on if var4d=true and use_cv_w=true"
 rconfig   integer wpec_used               derived               1             0       -     "wpec_used"       "turn on if use_wpec=true"
 rconfig   integer alloc_xa_static         derived               1             0       -     "alloc_xa_static" "turn on if use_4denvar=true and num_fgat_time>1"
+rconfig   integer alloc_ep                derived               1             0       -     "alloc_ep"        "always 0, ep needs to be allocated outside alloc_and_configure_domain"
+rconfig   integer alloc_alphacv           derived               1             0       -     "alloc_alphacv"   "turn on if ensdim_alpha>0 and not hybrid_dual_res"
 
 #package derived types
 package   no_cloud_cv     cloud_cv_options==0         -             -
@@ -955,9 +957,13 @@ package   has_cv_w        cv_w_used==1                -             state:vp%v11
 package   no_var4d_cv_w   var4d_w_cv==0               -             -
 package   has_var4d_cv_w  var4d_w_cv==1               -             state:vp6%v11,vv6%v11
 package   no_ens          ens_used==0                 -             -
-package   has_ens         ens_used==1                 -             state:xa_ens%u,xa_ens%v,xa_ens%t,xa_ens%q,xa_ens%psfc,ep%v1,ep%v2,ep%v3,ep%v4,ep%v5,vp%alpha,vv%alpha
+package   has_ens         ens_used==1                 -             state:xa_ens%u,xa_ens%v,xa_ens%t,xa_ens%q,xa_ens%psfc
 package   no_ens_cloud    cloud_ens_used==0           -             -
-package   has_ens_cloud   cloud_ens_used==1           -             state:xa_ens%qrn,xa_ens%qcw,xa_ens%qci,xa_ens%qsn,xa_ens%qgr,ep%cw,ep%rn,ep%ci,ep%sn,ep%gr
+package   has_ens_cloud   cloud_ens_used==1           -             state:xa_ens%qrn,xa_ens%qcw,xa_ens%qci,xa_ens%qsn,xa_ens%qgr
+package   no_ep_alloc     alloc_ep==0                 -             -
+package   do_ep_alloc     alloc_ep==1                 -             state:ep%v1,ep%v2,ep%v3,ep%v4,ep%v5,ep%cw,ep%rn,ep%ci,ep%sn,ep%gr
+package   no_alphacv_alloc alloc_alphacv==0           -             -
+package   do_alphacv_alloc alloc_alphacv==1           -             state:vp%alpha,vv%alpha
 package   no_wpec         wpec_used==0                -             -
 package   has_wpec        wpec_used==1                -             state:xa%grad_p_x,xa%grad_p_y,xa%geoh,xa%mu,xb%xb_p_x,xb%xb_p_y
 package   no_xa_static    alloc_xa_static==0          -             -

--- a/var/da/da_main/da_wrfvar_init2.inc
+++ b/var/da/da_main/da_wrfvar_init2.inc
@@ -97,8 +97,17 @@ subroutine da_wrfvar_init2
    if ( use_cv_w ) then
       model_config_rec%cv_w_used = 1
    end if
+   model_config_rec%alloc_ep = 0
+   ! ep will be allocated in da_solve_init (not hybrid_dual_res) or
+   ! reallocate_analysis_grid (hybrid_dual_res)
    if ( ensdim_alpha > 0 ) then
       model_config_rec%ens_used = 1
+      if ( anal_type_hybrid_dual_res ) then
+         ! vp%alpha and vv%alpha will be allocated in reallocate_analysis_grid
+         model_config_rec%alloc_alphacv = 0
+      else
+         model_config_rec%alloc_alphacv = 1
+      end if
    end if
    if ( alpha_hydrometeors ) then
       model_config_rec%cloud_ens_used = 1


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, EnVar, ep

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

Avoid unused ep allocation in alloc_and_configure_domain for EnVar applications.
ep is allocated in subroutine da_solve_init (var/da/da_main/da_solve_init.inc) or
subroutine reallocate_analysis_grid (var/da/da_main/da_solve_dual_res_init.inc)
with desired dimensions.
The 4th dimension of ep should be ensdim_alpha*num_fgat_time instead of just ensdim_alpha
as defined in registry.
For dual-res EnVar, the ep is re-allocated with coarse intermediate grid dimensions.
Depending on domain/ensemble sizes, the memory reduction with the fix can
allow the job to run on regular nodes instead of large-memory nodes on NCAR/cheyenne.

LIST OF MODIFIED FILES:

modified:   Registry/registry.var
modified:   var/da/da_main/da_wrfvar_init2.inc

TESTS CONDUCTED: 

A dual-resolution EnVar case, before the fix:
 alloc_space_field: domain            1 ,            2088567208  bytes allocated
 alloc_space_field: domain            2 ,              47306336  bytes allocated
 alloc_space_field: domain            2 ,            2601652648  bytes allocated

A dual-resolution EnVar case, after the fix:
 alloc_space_field: domain            1 ,            1281764008  bytes allocated
 alloc_space_field: domain            2 ,              47306336  bytes allocated
 alloc_space_field: domain            2 ,            1594559848  bytes allocated

An EnVar case, on proc 0, before the fix:
 alloc_space_field: domain            1 ,            1705984056  bytes allocated

An EnVar case, on proc 0, after the fix:
 alloc_space_field: domain            1 ,             689084856  bytes allocated

RELEASE NOTE: Fix DA EnVar unnecessary allocation to reduce memory requirement.