### PR TITLE
Fix vertical refinement, broken from v4.0 through v4.1

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1568,121 +1568,18 @@ integer::oops1,oops2
                                its , ite , jts , jte , kts , kte )
          END IF
 
-         !  For hybrid coord
+         !  For vertical coordinate, compute 1d arrays.
 
-         DO k=kts, kte
-            IF      ( config_flags%hybrid_opt .EQ. 0 ) THEN
-               grid%c3f(k) = grid%znw(k)
-            ELSE IF ( config_flags%hybrid_opt .EQ. 1 ) THEN
-               grid%c3f(k) = grid%znw(k)
-            ELSE IF ( config_flags%hybrid_opt .EQ. 2 ) THEN
-               B1 = 2. * grid%etac**2 * ( 1. - grid%etac )
-               B2 = -grid%etac * ( 4. - 3. * grid%etac - grid%etac**3 )
-               B3 = 2. * ( 1. - grid%etac**3 )
-               B4 = - ( 1. - grid%etac**2 )
-               B5 = (1.-grid%etac)**4
-               grid%c3f(k) = ( B1 + B2*grid%znw(k) + B3*grid%znw(k)**2 + B4*grid%znw(k)**3 ) / B5
-               IF ( grid%znw(k) .LT. grid%etac ) THEN
-                  grid%c3f(k) = 0.
-               END IF
-               IF ( k .EQ. kds ) THEN
-                  grid%c3f(k) = 1.
-               ELSE IF ( k .EQ. kde ) THEN
-                  grid%c3f(k) = 0.
-               END IF
-            ELSE IF ( config_flags%hybrid_opt .EQ. 3 ) THEN
-               grid%c3f(k) = grid%znw(k)*sin(0.5*3.14159*grid%znw(k))**2
-               IF      ( k .EQ. kds ) THEN
-                  grid%c3f(k) = 1.
-               ELSE IF ( k .EQ. kds ) THEN
-                  grid%c3f(kde) = 0.
-               END IF
-            ELSE
-               CALL wrf_message     ( 'ERROR: --- hybrid_opt' )
-               CALL wrf_message     ( 'ERROR: --- hybrid_opt=0    ==> Standard WRF terrain-following coordinate' )
-               CALL wrf_message     ( 'ERROR: --- hybrid_opt=1    ==> Standard WRF terrain-following coordinate, hybrid c1, c2, c3, c4' )
-               CALL wrf_message     ( 'ERROR: --- hybrid_opt=2    ==> Hybrid, Klemp polynomial' )
-               CALL wrf_message     ( 'ERROR: --- hybrid_opt=3    ==> Hybrid, sin^2' )
-               CALL wrf_error_fatal ( 'ERROR: --- Invalid option' )
-            END IF
-         END DO
-
-         !  c4 is a function of c3 and eta.
-
-         DO k=1, kde
-            grid%c4f(k) = ( grid%znw(k) - grid%c3f(k) ) * ( p1000mb - grid%p_top )
-         ENDDO
-      
-         !  Now on half levels, just add up and divide by 2 (for c3h).  Use (eta-c3)*(p00-pt) for c4 on half levels.
-      
-         DO k=1, kde-1
-            grid%znu(k) = ( grid%znw(k+1) + grid%znw(k) ) * 0.5
-            grid%c3h(k) = ( grid%c3f(k+1) + grid%c3f(k) ) * 0.5
-            grid%c4h(k) = ( grid%znu(k) - grid%c3h(k) ) * ( p1000mb - grid%p_top )
-         ENDDO
-      
-         !  c1 = d(B)/d(eta).  We define c1f as c1 on FULL levels.  For a vertical difference,
-         !  we need to use B and eta on half levels.  The k-loop ends up referring to the
-         !  full levels, neglecting the top and bottom.
-      
-         DO k=kds+1, kde-1
-            grid%c1f(k) = ( grid%c3h(k) - grid%c3h(k-1) ) / ( grid%znu(k) - grid%znu(k-1) )
-         ENDDO
-      
-         !  The boundary conditions to get the coefficients:
-         !  1) At k=kts: define d(B)/d(eta) = 1.  This gives us the same value of B and d(B)/d(eta)
-         !     when doing the sigma-only B=eta.
-         !  2) At k=kte: define d(B)/d(eta) = 0.  The curve B SMOOTHLY goes to zero, and at the very
-         !     top, B continues to SMOOTHLY go to zero.  Note that for almost all cases of non B=eta,
-         !     B is ALREADY=ZERO at the top, so this is a reasonable BC to assume.
-      
-         grid%c1f(kds) = 1.
-         IF ( ( config_flags%hybrid_opt .EQ. 0 ) .OR. ( config_flags%hybrid_opt .EQ. 1 ) ) THEN
-            grid%c1f(kde) = 1.
-         ELSE
-            grid%c1f(kde) = 0.
-         END IF
-      
-         !  c2 = ( 1. - c1(k) ) * (p00 - pt).  There is no vertical differencing, so we can do the
-         !  full kds to kde looping.
-      
-         DO k=kds, kde
-            grid%c2f(k) = ( 1. - grid%c1f(k) ) * ( p1000mb - grid%p_top )
-         ENDDO
-      
-         !  Now on half levels for c1 and c2.  The c1h will result from the full level c3 and full
-         !  level eta differences.  The c2 value use the half level c1(k).
-      
-         DO k=1, kde-1
-            grid%c1h(k) = ( grid%c3f(k+1) - grid%c3f(k) ) / ( grid%znw(k+1) - grid%znw(k) )
-            grid%c2h(k) = ( 1. - grid%c1h(k) ) * ( p1000mb - grid%p_top )
-         ENDDO
-
-         !  With c3 and c4 on full levels, we can verify that we are maintaining monotonically
-         !  decreasing reference pressure.
-         !  P_dry_ref(k)  = c3f(k) * ( psurf - p_top ) + c4f(k) + p_top
-
-         DO j = jts, MIN(jde-1,jte)
-            DO i = its, MIN(ide-1,ite)
-               p_surf = p00 * EXP ( -t00/a + ( (t00/a)**2 - 2.*g*grid%ht(i,j)/a/r_d ) **0.5 )
-               DO k=1, kde-1
-                  press_above = grid%c3f(k+1)*(p_surf-grid%p_top) + grid%c4f(k+1) + grid%p_top
-                  press_below = grid%c3f(k  )*(p_surf-grid%p_top) + grid%c4f(k  ) + grid%p_top
-                  IF ( press_below - press_above .LE. 0.0 ) THEN
-                     CALL wrf_message ( '----- ERROR: The reference pressure is not monotonically decreasing' )
-                     CALL wrf_message ( '             This tends to be caused by very high topography')
-                     WRITE (a_message,*) '(i,j) = ',i,j,', topography = ',grid%ht(i,j),' m'
-                     CALL wrf_message ( TRIM(a_message) )
-                     WRITE (a_message,*) 'k = ',k,', reference pressure = ',press_below,' Pa'
-                     CALL wrf_message ( TRIM(a_message) )
-                     WRITE (a_message,*) 'k = ',k+1,', reference pressure = ',press_above,' Pa'
-                     CALL wrf_message ( TRIM(a_message) )
-                     WRITE (a_message,*) 'In the dynamics namelist record, reduce etac from ',config_flags%etac
-                     CALL wrf_error_fatal ( TRIM(a_message) )
-                  END IF
-               ENDDO
-            ENDDO
-         ENDDO
+         CALL compute_vcoord_1d_coeffs ( grid%ht, grid%etac, grid%znw, &
+                                         config_flags%hybrid_opt, &
+                                         r_d, g, p1000mb, &
+                                         grid%p_top, grid%p00, grid%t00, grid%tlp, &
+                                         ids, ide, jds, jde, kds, kde, &
+                                         ims, ime, jms, jme, kms, kme, &
+                                         its, ite, jts, jte, kts, kte, &
+                                         grid%znu, &
+                                         grid%c1f, grid%c2f, grid%c3f, grid%c4f, &
+                                         grid%c1h, grid%c2h, grid%c3h, grid%c4h )
 
          IF ( config_flags%interp_theta ) THEN
 

--- a/dyn_em/nest_init_utils.F
+++ b/dyn_em/nest_init_utils.F
@@ -241,6 +241,23 @@ END SUBROUTINE init_domain_vert_nesting
       
       ! the variables dzs and zs are kept from the parent domain.  These are the depths and thickness of the soil layers, which are not included in vertical nesting.
 
+      !KAL 2019
+      IF (nest%hybrid_opt == 0) THEN
+	 DO k = 1, kde_n
+	 nest%c1f(k) = 1.
+	 nest%c2f(k) = 0.
+	 nest%c3f(k) = nest%znw(k)
+	 nest%c4f(k) = 0.
+	 nest%c1h(k) = 1.
+	 nest%c2h(k) = 0.
+	 nest%c3h(k) = nest%znu(k)
+	 nest%c4h(k) = 0.
+	 END DO
+      ELSE
+          write(wrf_err_message,'(A,I2,A)') "--- ERROR: vertical nesting only works with hybrid_opt 0"
+          CALL wrf_error_fatal( wrf_err_message )
+      ENDIF
+    
       END SUBROUTINE vert_cor_vertical_nesting_integer
 
 !-----------------------------------------------------------------------------------------
@@ -384,6 +401,25 @@ SUBROUTINE vert_cor_vertical_nesting_arbitrary(nest,znw_c,kde_c,use_baseparam_fr
     nest%cf3  = cof2
     nest%cfn  = (.5*nest%dnw(kde_n-1)+nest%dn(kde_n-1))/nest%dn(kde_n-1)
     nest%cfn1 = -.5*nest%dnw(kde_n-1)/nest%dn(kde_n-1)
+
+    
+    !KAL 2019
+    IF (nest%hybrid_opt == 0) THEN
+       DO k = 1, kde_n
+       nest%c1f(k) = 1.
+       nest%c2f(k) = 0.
+       nest%c3f(k) = nest%znw(k)
+       nest%c4f(k) = 0.
+       nest%c1h(k) = 1.
+       nest%c2h(k) = 0.
+       nest%c3h(k) = nest%znu(k)
+       nest%c4h(k) = 0.
+       END DO
+    ELSE
+        write(wrf_err_message,'(A,I2,A)') "--- ERROR: vertical nesting only works with hybrid_opt 0"
+        CALL wrf_error_fatal( wrf_err_message )
+    ENDIF
+    
 
 END SUBROUTINE vert_cor_vertical_nesting_arbitrary
 

--- a/dyn_em/nest_init_utils.F
+++ b/dyn_em/nest_init_utils.F
@@ -185,6 +185,7 @@ END SUBROUTINE init_domain_vert_nesting
 !so a dependecy on ndown will not work. Additionally, ndown is not compiled for ideal cases. The variable is named parent in ndown, but it is actually operating on the nest. It has been renamed to nest here.
       SUBROUTINE vert_cor_vertical_nesting_integer(nest,znw_c,k_dim_c)
          USE module_domain
+         USE module_model_constants
    IMPLICIT NONE
          TYPE(domain), POINTER :: nest
          integer , intent(in) :: k_dim_c
@@ -192,6 +193,11 @@ END SUBROUTINE init_domain_vert_nesting
 
        integer :: kde_c , kde_n ,n_refine,ii,kkk,k
        real :: dznw_m,cof1,cof2
+
+       INTEGER :: ids, ide, jds, jde, kds, kde, &
+                  ims, ime, jms, jme, kms, kme, &
+                  its, ite, jts, jte, kts, kte
+
 !KAL this subroutine recalculates the vertical coordinates for the nest when vertical nesting is used.  This routine is copied from ndown and allows integer refinement only.
 
 !KAL znw is eta values on full w levels
@@ -241,23 +247,22 @@ END SUBROUTINE init_domain_vert_nesting
       
       ! the variables dzs and zs are kept from the parent domain.  These are the depths and thickness of the soil layers, which are not included in vertical nesting.
 
-      !KAL 2019
-      IF (nest%hybrid_opt == 0) THEN
-	 DO k = 1, kde_n
-	 nest%c1f(k) = 1.
-	 nest%c2f(k) = 0.
-	 nest%c3f(k) = nest%znw(k)
-	 nest%c4f(k) = 0.
-	 nest%c1h(k) = 1.
-	 nest%c2h(k) = 0.
-	 nest%c3h(k) = nest%znu(k)
-	 nest%c4h(k) = 0.
-	 END DO
-      ELSE
-          write(wrf_err_message,'(A,I2,A)') "--- ERROR: vertical nesting only works with hybrid_opt 0"
-          CALL wrf_error_fatal( wrf_err_message )
-      ENDIF
-    
+    CALL get_ijk_from_grid( nest, &
+                            ids, ide, jds, jde, kds, kde, &
+                            ims, ime, jms, jme, kms, kme, &
+                            its, ite, jts, jte, kts, kte )
+
+    CALL compute_vcoord_1d_coeffs ( nest%ht, nest%etac, nest%znw, &
+                                    model_config_rec%hybrid_opt, &
+                                    r_d, g, p1000mb, &
+                                    nest%p_top, nest%p00, nest%t00, nest%tlp, &
+                                    ids, ide, jds, jde, kds, kde, &
+                                    ims, ime, jms, jme, kms, kme, &
+                                    its, ite, jts, jte, kts, kte, &
+                                    nest%znu, &
+                                    nest%c1f, nest%c2f, nest%c3f, nest%c4f, &
+                                    nest%c1h, nest%c2h, nest%c3h, nest%c4h )
+
       END SUBROUTINE vert_cor_vertical_nesting_integer
 
 !-----------------------------------------------------------------------------------------
@@ -402,25 +407,22 @@ SUBROUTINE vert_cor_vertical_nesting_arbitrary(nest,znw_c,kde_c,use_baseparam_fr
     nest%cfn  = (.5*nest%dnw(kde_n-1)+nest%dn(kde_n-1))/nest%dn(kde_n-1)
     nest%cfn1 = -.5*nest%dnw(kde_n-1)/nest%dn(kde_n-1)
 
-    
-    !KAL 2019
-    IF (nest%hybrid_opt == 0) THEN
-       DO k = 1, kde_n
-       nest%c1f(k) = 1.
-       nest%c2f(k) = 0.
-       nest%c3f(k) = nest%znw(k)
-       nest%c4f(k) = 0.
-       nest%c1h(k) = 1.
-       nest%c2h(k) = 0.
-       nest%c3h(k) = nest%znu(k)
-       nest%c4h(k) = 0.
-       END DO
-    ELSE
-        write(wrf_err_message,'(A,I2,A)') "--- ERROR: vertical nesting only works with hybrid_opt 0"
-        CALL wrf_error_fatal( wrf_err_message )
-    ENDIF
-    
+    CALL get_ijk_from_grid( nest, &
+                            ids, ide, jds, jde, kds, kde, &
+                            ims, ime, jms, jme, kms, kme, &
+                            its, ite, jts, jte, kts, kte )
 
+    CALL compute_vcoord_1d_coeffs ( nest%ht, nest%etac, nest%znw, &
+                                    model_config_rec%hybrid_opt, &
+                                    r_d, g, p1000mb, &
+                                    nest%p_top, nest%p00, nest%t00, nest%tlp, &
+                                    ids, ide, jds, jde, kds, kde, &
+                                    ims, ime, jms, jme, kms, kme, &
+                                    its, ite, jts, jte, kts, kte, &
+                                    nest%znu, &
+                                    nest%c1f, nest%c2f, nest%c3f, nest%c4f, &
+                                    nest%c1h, nest%c2h, nest%c3h, nest%c4h )
+    
 END SUBROUTINE vert_cor_vertical_nesting_arbitrary
 
 SUBROUTINE compute_eta ( znw , &
@@ -1027,3 +1029,155 @@ SUBROUTINE update_after_feedback_em ( grid  &
 
 END SUBROUTINE update_after_feedback_em
 
+SUBROUTINE compute_vcoord_1d_coeffs ( ht, etac, znw, &
+                                      hybrid_opt, &
+                                      r_d, g, p1000mb, &
+                                      p_top, p00, t00, a, &
+                                      ids, ide, jds, jde, kds, kde, &
+                                      ims, ime, jms, jme, kms, kme, &
+                                      its, ite, jts, jte, kts, kte, &
+                                      znu, &
+                                      c1f, c2f, c3f, c4f, &
+                                      c1h, c2h, c3h, c4h )
+
+   IMPLICIT NONE
+
+   !  Input 
+
+   INTEGER ,                      INTENT(IN ) :: hybrid_opt
+   REAL    ,                      INTENT(IN ) :: etac
+   REAL    ,                      INTENT(IN ) :: r_d, g, p1000mb, p_top, p00, t00, a
+   INTEGER ,                      INTENT(IN ) :: ids, ide, jds, jde, kds, kde, &
+                                                 ims, ime, jms, jme, kms, kme, &
+                                                 its, ite, jts, jte, kts, kte
+   REAL    , DIMENSION(kms:kme) ,           INTENT(IN ) :: znw
+   REAL    , DIMENSION(ims:ime , jms:jme) , INTENT(IN ) :: ht
+
+   !  Output
+
+   REAL    , DIMENSION(kms:kme) , INTENT(OUT) :: znu
+   REAL    , DIMENSION(kms:kme) , INTENT(OUT) :: c1f, c2f, c3f, c4f, &
+                                                 c1h, c2h, c3h, c4h
+
+   !  Local vars
+
+   INTEGER :: i, j, k
+   REAL    :: B1, B2, B3, B4, B5
+   REAL    :: p_surf, press_above, press_below
+   CHARACTER (LEN=256) :: a_message
+
+   DO k=kts, kte
+      IF      ( hybrid_opt .EQ. 0 ) THEN
+         c3f(k) = znw(k)
+      ELSE IF ( hybrid_opt .EQ. 1 ) THEN
+         c3f(k) = znw(k)
+      ELSE IF ( hybrid_opt .EQ. 2 ) THEN
+         B1 = 2. * etac**2 * ( 1. - etac )
+         B2 = -etac * ( 4. - 3. * etac - etac**3 )
+         B3 = 2. * ( 1. - etac**3 )
+         B4 = - ( 1. - etac**2 )
+         B5 = (1.-etac)**4
+         c3f(k) = ( B1 + B2*znw(k) + B3*znw(k)**2 + B4*znw(k)**3 ) / B5
+         IF ( znw(k) .LT. etac ) THEN
+            c3f(k) = 0.
+         END IF
+         IF ( k .EQ. kds ) THEN
+            c3f(k) = 1.
+         ELSE IF ( k .EQ. kde ) THEN
+            c3f(k) = 0.
+         END IF
+      ELSE IF ( hybrid_opt .EQ. 3 ) THEN
+         c3f(k) = znw(k)*sin(0.5*3.14159*znw(k))**2
+         IF      ( k .EQ. kds ) THEN
+            c3f(k) = 1.
+         ELSE IF ( k .EQ. kds ) THEN
+            c3f(kde) = 0.
+         END IF
+      ELSE
+         CALL wrf_message     ( 'ERROR: --- hybrid_opt' )
+         CALL wrf_message     ( 'ERROR: --- hybrid_opt=0    ==> Standard WRF terrain-following coordinate' )
+         CALL wrf_message     ( 'ERROR: --- hybrid_opt=1    ==> Standard WRF terrain-following coordinate, hybrid c1, c2, c3, c4' )
+         CALL wrf_message     ( 'ERROR: --- hybrid_opt=2    ==> Hybrid, Klemp polynomial' )
+         CALL wrf_message     ( 'ERROR: --- hybrid_opt=3    ==> Hybrid, sin^2' )
+         CALL wrf_error_fatal ( 'ERROR: --- Invalid option' )
+      END IF
+   END DO
+
+   !  c4 is a function of c3 and eta.
+
+   DO k=1, kde
+      c4f(k) = ( znw(k) - c3f(k) ) * ( p1000mb - p_top )
+   ENDDO
+
+   !  Now on half levels, just add up and divide by 2 (for c3h).  Use (eta-c3)*(p00-pt) for c4 on half levels.
+
+   DO k=1, kde-1
+      znu(k) = ( znw(k+1) + znw(k) ) * 0.5
+      c3h(k) = ( c3f(k+1) + c3f(k) ) * 0.5
+      c4h(k) = ( znu(k) - c3h(k) ) * ( p1000mb - p_top )
+   ENDDO
+
+   !  c1 = d(B)/d(eta).  We define c1f as c1 on FULL levels.  For a vertical difference,
+   !  we need to use B and eta on half levels.  The k-loop ends up referring to the
+   !  full levels, neglecting the top and bottom.
+
+   DO k=kds+1, kde-1
+      c1f(k) = ( c3h(k) - c3h(k-1) ) / ( znu(k) - znu(k-1) )
+   ENDDO
+
+   !  The boundary conditions to get the coefficients:
+   !  1) At k=kts: define d(B)/d(eta) = 1.  This gives us the same value of B and d(B)/d(eta)
+   !     when doing the sigma-only B=eta.
+   !  2) At k=kte: define d(B)/d(eta) = 0.  The curve B SMOOTHLY goes to zero, and at the very
+   !     top, B continues to SMOOTHLY go to zero.  Note that for almost all cases of non B=eta,
+   !     B is ALREADY=ZERO at the top, so this is a reasonable BC to assume.
+
+   c1f(kds) = 1.
+   IF ( ( hybrid_opt .EQ. 0 ) .OR. ( hybrid_opt .EQ. 1 ) ) THEN
+      c1f(kde) = 1.
+   ELSE
+      c1f(kde) = 0.
+   END IF
+
+   !  c2 = ( 1. - c1(k) ) * (p00 - pt).  There is no vertical differencing, so we can do the
+   !  full kds to kde looping.
+
+   DO k=kds, kde
+      c2f(k) = ( 1. - c1f(k) ) * ( p1000mb - p_top )
+   ENDDO
+
+   !  Now on half levels for c1 and c2.  The c1h will result from the full level c3 and full
+   !  level eta differences.  The c2 value use the half level c1(k).
+
+   DO k=1, kde-1
+      c1h(k) = ( c3f(k+1) - c3f(k) ) / ( znw(k+1) - znw(k) )
+      c2h(k) = ( 1. - c1h(k) ) * ( p1000mb - p_top )
+   ENDDO
+
+   !  With c3 and c4 on full levels, we can verify that we are maintaining monotonically
+   !  decreasing reference pressure.
+   !  P_dry_ref(k)  = c3f(k) * ( psurf - p_top ) + c4f(k) + p_top
+
+   DO j = jts, MIN(jde-1,jte)
+      DO i = its, MIN(ide-1,ite)
+         p_surf = p00 * EXP ( -t00/a + ( (t00/a)**2 - 2.*g*ht(i,j)/a/r_d ) **0.5 )
+         DO k=1, kde-1
+            press_above = c3f(k+1)*(p_surf-p_top) + c4f(k+1) + p_top
+            press_below = c3f(k  )*(p_surf-p_top) + c4f(k  ) + p_top
+            IF ( press_below - press_above .LE. 0.0 ) THEN
+               CALL wrf_message ( '----- ERROR: The reference pressure is not monotonically decreasing' )
+               CALL wrf_message ( '             This tends to be caused by very high topography')
+               WRITE (a_message,*) '(i,j) = ',i,j,', topography = ',ht(i,j),' m'
+               CALL wrf_message ( TRIM(a_message) )
+               WRITE (a_message,*) 'k = ',k,', reference pressure = ',press_below,' Pa'
+               CALL wrf_message ( TRIM(a_message) )
+               WRITE (a_message,*) 'k = ',k+1,', reference pressure = ',press_above,' Pa'
+               CALL wrf_message ( TRIM(a_message) )
+               WRITE (a_message,*) 'In the dynamics namelist record, reduce etac from ',etac
+               CALL wrf_error_fatal ( TRIM(a_message) )
+            END IF
+         ENDDO
+      ENDDO
+   ENDDO
+                                      
+END SUBROUTINE compute_vcoord_1d_coeffs

--- a/main/depend.common
+++ b/main/depend.common
@@ -1241,9 +1241,11 @@ ndown_em.o: \
 	../share/module_bc.o \
 	../share/module_io_domain.o \
 	../share/module_get_file_names.o \
+	../share/module_model_constants.o \
 	../share/module_soil_pre.o \
 	../dyn_em/module_initialize_$(IDEAL_CASE).o \
 	../dyn_em/module_big_step_utilities_em.o \
+	../dyn_em/nest_init_utils.o \
 	$(ESMF_MOD_DEPENDENCE)
 
 # this already built above :../dyn_em/module_initialize.real.o \

--- a/main/ndown_em.F
+++ b/main/ndown_em.F
@@ -1648,12 +1648,16 @@ END SUBROUTINE check_consistency2
 !!!!!!!!!!!!!!!!!!!!!!!!!!!11
       SUBROUTINE vert_cor(parent,znw_c,k_dim_c)
          USE module_domain
+         USE module_model_constants
    IMPLICIT NONE
          TYPE(domain), POINTER :: parent
          integer , intent(in) :: k_dim_c
          real , dimension(k_dim_c), INTENT(IN) :: znw_c
 
        integer :: kde_c , kde_n ,n_refine,ii,kkk,k
+       INTEGER :: ids, ide, jds, jde, kds, kde, &
+                  ims, ime, jms, jme, kms, kme, &
+                  ips, ipe, jps, jpe, kps, kpe
        real :: dznw_m,cof1,cof2
 
         kde_c = k_dim_c
@@ -1695,7 +1699,34 @@ END SUBROUTINE check_consistency2
       parent%cfn  = (.5*parent%dnw(kde_n-1)+parent%dn(kde_n-1))/parent%dn(kde_n-1)
       parent%cfn1 = -.5*parent%dnw(kde_n-1)/parent%dn(kde_n-1)
 
+      ids = parent%sd31
+      ide = parent%ed31
+      kds = parent%sd32
+      jds = parent%sd33
+      jde = parent%ed33
 
+      ims = parent%sm31
+      ime = parent%em31
+      kms = parent%sm32
+      jms = parent%sm33
+      jme = parent%em33
+
+      ips = parent%sp31
+      ipe = parent%ep31
+      kps = parent%sp32
+      jps = parent%sp33
+      jpe = parent%ep33
+
+      CALL compute_vcoord_1d_coeffs ( parent%ht, parent%etac, parent%znw, &
+                                      parent%hybrid_opt, &
+                                      r_d, g, p1000mb, &
+                                      parent%p_top, parent%p00, parent%t00, parent%tlp, &
+                                      ids, ide, jds, jde, kds, kde_n, &
+                                      ims, ime, jms, jme, kms, kde_n, &
+                                      ips, ipe, jps, jpe, kps, kde_n, &
+                                      parent%znu, &
+                                      parent%c1f, parent%c2f, parent%c3f, parent%c4f, &
+                                      parent%c1h, parent%c2h, parent%c3h, parent%c4h )
 
       END SUBROUTINE vert_cor
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1801,17 +1801,6 @@
       END IF
 
 !-----------------------------------------------------------------------
-!  The hybrid vertical coordinate does not work with vertical refinement.
-!-----------------------------------------------------------------------
-     DO i=1,model_config_rec%max_dom
-        IF ((model_config_rec%vert_refine_method(i) .EQ. 2) .AND. (model_config_rec%hybrid_opt .EQ. 2)) THEN
-           WRITE(wrf_err_message,'(A)') '--- ERROR: The hybrid vertical coordinate does not work with vertical refinement.'
-           CALL wrf_message( wrf_err_message )
-           count_fatal_error = count_fatal_error + 1
-        ENDIF
-     END DO
-
-!-----------------------------------------------------------------------
 !  DJW Check that we're not using ndown and vertical nesting.
 !-----------------------------------------------------------------------
      DO i=1,model_config_rec%max_dom


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: hybrid vertical coordinate, vertical refinement

SOURCE: Katie Lundquist (LLNL) and internal

DESCRIPTION OF CHANGES:
Problem:
Since the formal introduction of the hybrid vertical coordinate option in
WRF (with version v4.0), the vertical refinement option (also referred to
as vertical nesting) has been broken for both of the options when vert_refine_method
= 1 or 2 (ndown or WRF, respectively). The symptomology is that model 
dies in the first time step, whether in the dynamics, physics, or initialization.

Solution:
Katie discovered that the 1d arrays (c1, c2, c3, c4 which are used to
construct the pressure level of the vertical levels) were never set for
vertical refinement.

Editor's note: These values were set for traditional nests. Since the number of
vertical levels in the parent and child domains were the same, the already 
existing code was sufficient:
```
 nest%c1h(1:parent%e_vert) = parent%c1h(1:parent%e_vert)
 nest%c2h(1:parent%e_vert) = parent%c2h(1:parent%e_vert)
 nest%c3h(1:parent%e_vert) = parent%c3h(1:parent%e_vert)
 nest%c4h(1:parent%e_vert) = parent%c4h(1:parent%e_vert)
 nest%c1f(1:parent%e_vert) = parent%c1f(1:parent%e_vert)
 nest%c2f(1:parent%e_vert) = parent%c2f(1:parent%e_vert)
 nest%c3f(1:parent%e_vert) = parent%c3f(1:parent%e_vert)
 nest%c4f(1:parent%e_vert) = parent%c4f(1:parent%e_vert)
```
However, when the two domains have a different number of vertical levels these assignments 
are incorrect. When there is no input for the second domain, there is no opportunity inside of
the WRF model to correct these wrong assignments by overwriting the nest values of the 1d 
arrays with a subsequent _read_.

The source code that is required to compute the vertical 1d arrays already exists.
For the real program, the computation of the 1d arrays is handled in the 
`dyn_em/module_initialize_real.F` file. The entirety of those computations are now removed from 
the `module_initialize_real.F` subroutine and placed in `dyn_em/nest_init_utils.F`, as a new 
subroutine. This refactoring does two things:
1. The computations necessary for the vertical refinement are available and consistent with the
existing computations done elsewhere in the real program.
2. A single shared routine is in place instead of duplicated software.

Due to the existing makefile dependencies, locating the new subroutine inside of the 
`nest_init_utils.F` file required no mods to the makefiles or `depend.common` for the
case of the (online) vertical refinement. For the ndown (offline vertical refinement), the
`depend.common` file is updated to include the files `nest_init_utils.o` (where the new 
1d array computing routine is located) and `module_model_constants.o` (where the 
constants are located for R, CP, etc.

Lastly, a previously required test in `check_a_mundo.F` is now able to be removed. That test
did not allow users to use vertical nesting with the hybrid coordinate. As it turns outs, that test
was insufficient. Any use of the vertical refinement with `input_from_file=.true.,.false.` would
fail.

LIST OF MODIFIED FILES:
modified:   dyn_em/module_initialize_real.F
modified:   dyn_em/nest_init_utils.F
modified:   main/depend.common
modified:   main/ndown_em.F
modified:   share/module_check_a_mundo.F

ISSUE:
Fixes #917 "NDOWN v4.1: vertical refinement is broken"

TESTS CONDUCTED:
 - [x] With the original code, the WRF model dies in the first time step. 
 - [x] With the mods, the model runs a successful 12-h simulation

Here are the pieces to make the code fail for online vertical refinement (within WRF):
1. A nested domain, but only a single input file. The 1d arrays must be internally computed.
```
 &time_control
 input_from_file     = .true.,.false.,
 /
```
2. The vertical refinement option must be active, with different values of `e_vert` on each domain.
Whether the nested value of `vert_refine_method` is 1 or 2 does not matter - fail city.
```
 &domains
 max_dom             = 2,
 e_vert              = 35,    45,
 feedback            = 0,
 vert_refine_method  = 0,     2,
 /
```
3. Nothing special, other than radiation LW and SW must be 1 - just a friendly reminder.
```
 &physics
 ra_lw_physics       = 1,     1,
 ra_sw_physics       = 1,     1,
 /
```
4. Importantly, the setting of the hybrid option does not matter. The original code will fail with either:
```
 &dynamics
 hybrid_opt          = 0
 /
```
or 
```
 &dynamics
 hybrid_opt          = 2
 /
```
5. With this mod, using hybrid_opt=0 and use_theta_m=0, I was able to get bit-wise identical results 
with #891 "fix for vertical nesting without the hybrid coordinate - fix for use". I used a test case
provided by Katie Lundquist:
```
curl -O ftp://ftp.llnl.gov/outgoing/lundquist3/vertnesting_example.tgz
```
Per Katie:
> I ran two cases in v3.9.1.1 (unchanged) and 4.1 (my vert. nesting fix, not your nice refactoring) and they look the same. MU certainly has noticeable effects at the edges from vertical nesting. Effects are much more muted on the other prognostic variables, such as velocity. The causes of this are documented in the Daniels et al (2016) paper in MWR. Some of it is unavoidable and I think some could be fixed by modifying the smoothing behavior between nested domains. This commit should return the vertical nesting functionality to that before v4.0 when the hybrid coordinate was set as the default. I have only looked at the solutions for hybrid_opt = 0, not 2. 

6. I ran Katie's case with the hybrid vertical coordinate with metgrid data that was provided:
```
curl -O ftp://ftp.llnl.gov/outgoing/lundquist3/vertnesting_example_input.tgz
```
This namelist snippet is used:
```
&time_control
 run_seconds            = 60,
 input_from_file        = .true.,  .false.,  .false.,  .false.,
 history_interval_s     = 20,    20,    10,      10,       
/

&domains
 time_step              = 20,
 e_we                   = 196,     100,     100,     100,     
 e_sn                   = 196,     100,     100,     100,     
 e_vert                 = 88,      89,     90,      91,      
 vert_refine_method     = 0,       2,       2,       2,       
 dx                     = 27000,   3000,    333,    37,    
 dy                     = 27000,   3000,    333,    37,    
 grid_id                = 1,       2,       3,       4,       
 parent_id              = 1,       1,       2,       3,       
 parent_grid_ratio      = 1,       9,       9,       9,       
 parent_time_step_ratio = 1,       5,       4,       4,       
 feedback               = 0,
 rebalance              = 1,
 /

&dynamics
 use_theta_m            = 0,
 hybrid_opt             = 2,
 /
```
The figure shows domain 4, after 1 hour (240 d04 time steps), MU field
LEFT - differences between terrain following and hybrid vertical coordinate
CENTER - MU field terrain following coordinate (considered an exemplar)
RIGHT - MU field hybrid coordinate
![Screen Shot 2019-05-16 at 2 29 44 PM](https://user-images.githubusercontent.com/12666234/57888621-e0910400-77ef-11e9-9ef4-4f4b59a95920.png)

Here are the pieces to make the code fail (for the original code) for offline vertical refinement 
(using ndown):
1. A nested domain, requesting the same number of vertical levels, and turning on the hybrid option.
```
 &domains
 vert_refine_fact = 2
 e_vert           = 45,    45,    33,
 feedback         = 0,               
 /
```
```
 &dynamics
 hybrid_opt       = 2,               
 /
```

For ndown, cross section plots of geopotential perturbation of the generated wrfbdy_d02 file (the 
ranges are not the same, to show detail of the figures).
Left: new mods
Center: original code
Right: difference
![Screen Shot 2019-05-31 at 1 50 55 PM](https://user-images.githubusercontent.com/12666234/58731176-4f9f5880-83ab-11e9-94c3-9e8cfb4f13a7.png)


Recap: This PR provides results similar to v3.9.1.1 for hybrid_opt=0.

This error condition and fix are consistent with the required modification to fill in the 1d vertical 
coordinate arrays. Those arrays became mandatory with v4.0 (when the vertical refinement option 
was first broken). Those 1d arrays are mandatory for both the hybrid and terrain-following vertical 
coordinates.

RELEASE NOTE: From version 4.0 through 4.1, both vertical refinement options were broken. For online vertical refinement (within the WRF model) with only a single input domain, the incorrect WRF code had uninitialized arrays that defined the vertical coordinate in the child domain. However, any users with vertical refinement activated AND with input_from_file  = t,t were never impacted. For offline vertical refinement (using ndown with vert_refine_fact), the initial conditions also only had the lower portion of the 1d arrays initialized (and those were initialized incorrectly). Modifications were introduced to fix both refinement options, and the modifications support the hybrid and the terrain-following vertical coordinate.
