### PR TITLE
Enforce conditional use of IEEE Fortran 2003 capabilities in v4.1 Goddard schemes

### DIFF
--- a/configure
+++ b/configure
@@ -879,7 +879,7 @@ EOF
   rm -f ${foo} ${foo}.[cfo] 2> /dev/null
 fi
 
-# testing for Fortran 2003 IEEE signaling features
+# testing for Fortran 2003 IEEE features
 make fortran_2003_ieee_test > tools/fortran_2003_ieee_test.log 2>&1
 rm -f tools/fortran_2003_ieee_test.log
 retval=-1
@@ -893,8 +893,8 @@ if [ $retval -ne 0 ] ; then
   echo " "
   echo "************************** W A R N I N G ************************************"
   echo " "
-  echo "There are some Fortran 2003 features in WRF that your compiler does not recognize"
-  echo "The IEEE signaling call has been removed.  That may not be enough."
+  echo "There are some IEEE Fortran 2003 features in WRF that your compiler does not"
+  echo "recognize. The IEEE function calls have been removed."
   echo " "
   echo "*****************************************************************************"
 fi

--- a/phys/module_checkerror.F
+++ b/phys/module_checkerror.F
@@ -70,7 +70,9 @@
 !SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU 
 
  subroutine checkerror_single(subroutine_name, param_id,i,k,j,input_real)
+#ifndef NO_IEEE_MODULE
  use, intrinsic :: ieee_arithmetic
+#endif
  implicit none
  character*(*),intent(in) :: subroutine_name
  character*(*),intent(in) :: param_id
@@ -217,12 +219,14 @@
     call wrf_error_fatal('Terminate run.')
  end if
 
+#ifndef NO_IEEE_MODULE
  if (ieee_is_nan(input_real)) then
     write(string,*) 'MSG '//trim(subroutine_name)//': '//trim(param_id)//' =',input_real,&
                ' NaN at grid(i,k,j) =',i,k,j
     call wrf_message(string)
     call wrf_error_fatal('Terminate run.')
  end if
+#endif
 
  end subroutine checkerror_single
 
@@ -230,7 +234,9 @@
 !SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU SDSU 
 
  subroutine checkerror_double(subroutine_name, param_id,i,k,j,input_real)
+#ifndef NO_IEEE_MODULE
  use, intrinsic :: ieee_arithmetic
+#endif
  implicit none
  character*(*),intent(in) :: subroutine_name
  character*(*),intent(in) :: param_id
@@ -377,12 +383,14 @@
     call wrf_error_fatal('Terminate run.')
  end if
 
+#ifndef NO_IEEE_MODULE
  if (ieee_is_nan(input_real)) then
     write(string,*) 'MSG '//trim(subroutine_name)//': '//trim(param_id)//' =',input_real,&
                ' NaN at grid(i,k,j) =',i,k,j
     call wrf_message(string)
     call wrf_error_fatal('Terminate run.')
  end if
+#endif
 
  end subroutine checkerror_double
 

--- a/phys/module_gocart_coupling.F
+++ b/phys/module_gocart_coupling.F
@@ -8845,7 +8845,9 @@
 !GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD 
 
  subroutine mass2icn(p_air,t_air,aero,icn_out,ii,jj,kk)
+#ifndef NO_IEEE_MODULE
  use, intrinsic :: ieee_arithmetic
+#endif
  implicit none
 !------------------------------------------------------------------------
 ! Comments: Convert GOCART aerosol mass concentrations into IN number conc 
@@ -8929,6 +8931,7 @@
 !
  icn_estimate = icn_std * (p_air*t_std) / (p_std*t_air)  ! [#/std L] --> [#/L]
 
+#ifndef NO_IEEE_MODULE
          if( ieee_is_nan( icn_estimate ) ) then
             print*, 'NAN in mass2icn, i,j,k, icn_estimate = ', ii, jj, kk, icn_estimate
             print*, 'icn_std, t_std, p_std, p_air, t_air =', icn_std, t_std, p_std, p_air, t_air
@@ -8939,6 +8942,7 @@
             print*, 'icn_std, t_std, p_std, p_air, t_air =', icn_std, t_std, p_std, p_air, t_air
             print*, 'aero = ', aero
          endif
+#endif
 
 !
 ! IN conc ranges from 100 ~ 1000000 per litter based on DeMott et al. 2010 PNAS.

--- a/phys/module_mp_gsfcgce_4ice_nuwrf.F
+++ b/phys/module_mp_gsfcgce_4ice_nuwrf.F
@@ -4955,7 +4955,9 @@ CONTAINS
 ! Calculate cloud droplet effective radius
    real function eff_rad(lambda)
 
+#ifndef NO_IEEE_MODULE
       use, intrinsic :: ieee_arithmetic
+#endif
       implicit none
 
 !---------------------------------------------------------------------------------------------------
@@ -4972,7 +4974,11 @@ CONTAINS
 !
 ! for no particles.
 !
+#ifndef NO_IEEE_MODULE
        if ( lambda <= 0.e0  .or. ieee_is_nan(lambda) ) then
+#else
+       if ( lambda <= 0.e0                           ) then
+#endif
           eff_rad = 0.e0
           return
        endif

--- a/phys/module_ra_goddard.F
+++ b/phys/module_ra_goddard.F
@@ -1041,7 +1041,9 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
                    ,gsfcrad_gocart_coupling                       &
 #endif
                     )
+#ifndef NO_IEEE_MODULE
  use, intrinsic :: ieee_arithmetic
+#endif
  implicit none
 !----------------------------------------------------------------------
 !
@@ -2093,6 +2095,7 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
          i = ii+ic -1
          tten1d(ic,kt) = - fac * (flx(ic,kt-1) - flx(ic,kt)) / (p8w1d(ic,kt-1)-p8w1d(ic,kt))
 
+#ifndef NO_IEEE_MODULE
          ! check error
          if( ieee_is_nan( tten1d(ic,kt) ) ) then
             print*,'MSG goddardrad SW: Found NaN in tten1d(k)',i,j,kt
@@ -2108,6 +2111,7 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
             print*,'asyal_sw',asyal_sw(ic,:,:)
             tten1d(ic,kt) = 0.  !brute force correction
          endif
+#endif
         endif
         ENDDO
       enddo
@@ -2329,6 +2333,7 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
         i = ii+ic -1
         tten1d(ic,kt) = - fac * (flx(ic,kt-1) - flx(ic,kt)) / (p8w1d(ic,kt-1)-p8w1d(ic,kt))
 
+#ifndef NO_IEEE_MODULE
         if( ieee_is_nan( tten1d(ic,kt) ) ) then
             print*,'MSG goddardrad LW: Found NaN in tten1d(k)',i,j,kt
             print*,'tsfc',tsfc(ic)
@@ -2345,6 +2350,7 @@ data ((mcdat(ilev,10,ifld),ifld=1,6),ilev=12,22)/  &
             print*,'asyal_lw',asyal_lw(ic,:,:)
             tten1d(ic,k) = 0.  !brute force correction
         endif
+#endif
        ENDDO
      enddo
 
@@ -12407,7 +12413,9 @@ subroutine delta_eddington(tau,ssc,g0,cza,rr,tt,td)
 !GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD GODDARD 
 
  subroutine check_reff(spc,q,re,i,j,k)
+#ifndef NO_IEEE_MODULE
  use, intrinsic :: ieee_arithmetic
+#endif
  implicit none
  character(len=*) :: spc  !species 
  real,intent(inout) :: q !mass concentration [g/m2]
@@ -12415,6 +12423,7 @@ subroutine delta_eddington(tau,ssc,g0,cza,rr,tt,td)
  integer,intent(in) :: i,j,k !array index
 
 
+#ifndef NO_IEEE_MODULE
 !
 ! Check NaN
 !
@@ -12422,6 +12431,7 @@ subroutine delta_eddington(tau,ssc,g0,cza,rr,tt,td)
   print*,'MSG check_reff: Warning '//trim(spc)//' re is NaN at (i,j,k)=',i,j,k
   re = 0.e0
  endif
+#endif
 !
 ! Check  too large (100m)
 !


### PR DESCRIPTION
TYPE: bug fix
    
KEYWORDS: IEEE, GNU
    
SOURCE: reported by Maik Reichert, fixed internally
    
DESCRIPTION OF CHANGES:
Problem:
With the introduction of the Goddard MP and radiation schemes in release-v4.1, there
are locations where the IEEE capability for Fortran 2003 is unconditionally used. With the 
default GNU compiler on Linux, the WRF code will not build. Updating the compiler, while
free, does require that the user then rebuild libraries from scratch.
    
Solution:
The WRF code has had tests for using IEEE for a number of years (with the svn releases,
starting with v3.6). Since that release, during the `configure` step, if a small test code fails 
to build or run successfully, the `configure.wrf` file sets a cpp compile-time flag. This ifdef
infrastructure is now added to the new Goddard-related files that were recently included in 
the WRF repository (b60a5b9e7729).
    
ISSUE:
Fixes #905 "ieee_arithmetic usage"
    
LIST OF MODIFIED FILES:
M ./configure
M ./phys/module_checkerror.F
M ./phys/module_gocart_coupling.F
M ./phys/module_mp_gsfcgce_4ice_nuwrf.F
M ./phys/module_ra_goddard.F
    
TESTS CONDUCTED:
1. No harm - the code performs as expected with newer GNU compilers.
2. Code builds with an older GNU compiler (4.9.2), with this warning during the `configure` step:
```
************************** W A R N I N G ************************************
There are some IEEE Fortran 2003 features in WRF that your compiler does not
recognize. The IEEE function calls have been removed.
*****************************************************************************
```
    
RELEASE NOTE: The WRF code added unprotected IEEE functions in the source code with release-v4.1. Using existing infrastructure, those declarations and functions are now ifdef'ed out automatically. Note that this does remove some default error checking in the Goddard MP and radiation schemes.
