### PR TITLE
"CHUNK = 16" -> "chunk = 16": avoids arch/configure.defaults -DCHUNK compiler flag confusion

### DIFF
--- a/phys/module_mp_gsfcgce_4ice_nuwrf.F
+++ b/phys/module_mp_gsfcgce_4ice_nuwrf.F
@@ -33,7 +33,7 @@ MODULE module_mp_gsfcgce_4ice_nuwrf
 #endif
    USE module_mp_radar
 
-   INTEGER, PARAMETER, PRIVATE:: CHUNK = 16
+   INTEGER, PARAMETER, PRIVATE:: chunk = 16
 
    LOGICAL, EXTERNAL :: wrf_dm_on_monitor
 

--- a/phys/module_ra_goddard.F
+++ b/phys/module_ra_goddard.F
@@ -127,7 +127,7 @@
 
  implicit none
 
-  INTEGER, PARAMETER, PRIVATE:: CHUNK = 16  !size of vector (16 is optimized number for Haswell/Broadwell CPUs.
+  INTEGER, PARAMETER, PRIVATE:: chunk = 16  !size of vector (16 is optimized number for Haswell/Broadwell CPUs.
 
 !
 ! encapsulation control


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Goddard, Intel, CHUNK

SOURCE: RCarpenter

DESCRIPTION OF CHANGES: 

Inside of frame/module_dm.F, there is an optimization effort for the Intel compiler:
```
#ifdef INTEL_ALIGN64
! align on 64 byte boundaries if -align array64byte
      ims = ips-CHUNK
      ime = ime + (CHUNK-mod(ime-ims+1,CHUNK))
#endif
```
This `CHUNK` variable is defined through a cpp directive in a couple of WRF build stanzas for
Intel: `Xeon Phi (MIC architecture)` and `Xeon (SNB with AVX mods)`, using the Intel compiler. 
For example:
```
ARCH_LOCAL  =   -DNONSTANDARD_SYSTEM_FUNC -DCHUNK=16 -DXEON_OPTIMIZED_WSM5
```
and
```
ARCH_LOCAL  =   -DNONSTANDARD_SYSTEM_FUNC -DCHUNK=64 -DXEON_OPTIMIZED_WSM5
```
[The switch `INTEL_ALIGN64` does not actually appear in any supported WRF build file.]

Therefore, for some selections of Intel compiler stanza in the `configure` step, there is a performance 
flag, `CHUNK`, that is automatically set that modifies Fortran files.

Problem:
Unfortunately, `CHUNK` is the same name that was used by the Goddard MP and radiation schemes 
(coincidentally, also for performance gains). 
Original:
```
INTEGER, PARAMETER, PRIVATE:: CHUNK = 16
```
The pre-processor (from `ARCH_LOCAL`) turns an OK line of Fortran into a syntactically incorrect 
line:
```
INTEGER, PARAMETER, PRIVATE:: 64 = 16
```

Solution:
As proposed on the WRF forum, http://forum.mmm.ucar.edu/phpBB3/viewtopic.php?f=37&t=5324,
since both of these `CHUNK` modifications are based on cpp directives, changing the case of 
`CHUNK` in the newly added Goddard schemes is sufficient to avoid multiple meanings for the 
same variable name.

LIST OF MODIFIED FILES: 
modified:   phys/module_mp_gsfcgce_4ice_nuwrf.F
modified:   phys/module_ra_goddard.F

TESTS CONDUCTED: 
1. For users on forum with this trouble, this was a good fix.
2. Since Fortran is case insensitive, there are no side effects to changing a variable's case.
3. Using Linux Intel build option 18 (AVX) on cheyenne, without this mod the code fails.
4.  Using Linux Intel build option 18 (AVX) on cheyenne, with this mod, the code builds.
