### PR TITLE
Local CPP includes should use quotes, not angle brackets

### DIFF
--- a/frame/module_alloc_space.h
+++ b/frame/module_alloc_space.h
@@ -149,6 +149,6 @@
 
       CALL nl_get_spec_bdy_width( 1, spec_bdy_width )
 
-# include <allocs.inc>
+# include "allocs.inc"
 
    END SUBROUTINE ROUTINENAME


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: include, cpp, quotes, angle brackets, ", >

SOURCE: Jamie Bresch (NCAR/MMM)

DESCRIPTION OF CHANGES: 
Problem:
When using CPP \#include, to access local include files, the correct syntax is to use quotes 
to surround the filename. Using angle brackets makes the search look in standard system
directories.

Solution:
Swap the single location of WRF-manufactured include file: `<filename.inc>` for `"filename.inc"`.

LIST OF MODIFIED FILES: 
modified:   frame/module_alloc_space.h

TESTS CONDUCTED: 
1. The code builds just fine.
2. The Jan 2000 test case looks as expected at 12-h.
