### PR TITLE
Support for compiling on cygwin

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -604,9 +604,9 @@ while ( <CONFIGURE_DEFAULTS> )
                  $_ .= " \$\(NETCDF4_IO_OPTS\)\n" ; 
                }
              if (/^LIB.*=/) 
-               { $_  =~ s/\r|\n//g ;
-                 $_ .=" \$\(NETCDF4_DEP_LIB\)\n" ;
-               }
+	     {
+		 $_ =~ s/(\\?)[\r\n]/ \$\(NETCDF4_DEP_LIB\)\1\n/g ;
+	     }
            }
        }
 

--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -526,7 +526,7 @@ while ( <CONFIGURE_DEFAULTS> )
 
       { $_ =~ s/CONFIGURE_WRFIO_PHDF5/wrfio_phdf5/g ;
 	$_ =~ s:CONFIGURE_PHDF5_FLAG:-DPHDF5: ;
-	$_ =~ s:CONFIGURE_PHDF5_LIB_PATH:-L\$\(WRF_SRC_ROOT_DIR\)/external/io_phdf5 -lwrfio_phdf5 -L$sw_phdf5_path/lib -lhdf5_fortran -lhdf5 -lm -lz -L$sw_phdf5_path/lib -lsz: ;
+	$_ =~ s:CONFIGURE_PHDF5_LIB_PATH:-L\$\(WRF_SRC_ROOT_DIR\)/external/io_phdf5 -lwrfio_phdf5 -L$sw_phdf5_path/lib -lhdf5_hl -lhdf5 -lm -lz -L$sw_phdf5_path/lib -lsz: ;
 	 }
     else                   
       { $_ =~ s/CONFIGURE_WRFIO_PHDF5//g ;

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1597,8 +1597,7 @@ RLFLAGS		=
 CC_TOOLS        =       $(SCC) 
 
 LIB_EXTERNAL    = \
-                     ../external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.lib \
-                     ../external/wavelet/libWavelet.a ../external/wavelet/lib_wavelet.a
+                     ../external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.lib
 ESMF_IO_LIB     =    ../external/esmf_time_f90/libesmf_time.a
 LIB_BUNDLED     = \
                      ../external/fftpack/fftpack5/libfftpack.a \

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1556,7 +1556,7 @@ CC_TOOLS        =      $(SCC)
 ###########################################################
 #ARCH    CYGWIN_NT i686, PGI compiler on Windows # serial smpar dmpar dm+sm
 #
-DESCRIPTION     =       PGI ($SFC/$SCC): Windows
+DESCRIPTION     =       PGI ($SFC/$SCC): Windows native
 DMPARALLEL      =       # 1
 OMPCPP          =       # -D_OPENMP
 OMP             =       # -mp -Minfo=mp
@@ -1915,6 +1915,124 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+
+###########################################################
+#ARCH    CYGWIN_NT i686 x86_64, gfortran compiler with gcc  #serial smpar dmpar dm+sm
+#
+DESCRIPTION     =       GNU ($SFC/$SCC)
+DMPARALLEL      =       # 1
+OMPCPP          =       # -D_OPENMP
+OMP             =       # -fopenmp
+OMPCC           =       # -fopenmp
+SFC             =       gfortran
+SCC             =       gcc
+CCOMP           =       gcc
+DM_FC           =       mpif90 -f90=$(SFC)
+DM_CC           =       mpicc -cc=$(SCC)
+FC              =       CONFIGURE_FC
+CC              =       CONFIGURE_CC
+LD              =       $(FC)
+RWORDSIZE       =       CONFIGURE_RWORDSIZE
+PROMOTION       =       #-fdefault-real-8
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
+CFLAGS_LOCAL    =       -w -O3 -c
+LDFLAGS_LOCAL   =       
+CPLUSPLUSLIB    =       
+ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
+FCOPTIM         =       -O2 -ftree-vectorize -funroll-loops
+FCREDUCEDOPT	=       $(FCOPTIM)
+FCNOOPT		=       -O0
+FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
+FORMAT_FIXED    =       -ffixed-form
+FORMAT_FREE     =       -ffree-form -ffree-line-length-none
+FCSUFFIX        =       
+BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
+MODULE_SRCH_FLAG =     
+TRADFLAG        =      -traditional
+CPP             =      /lib/cpp -P
+AR              =      ar
+ARFLAGS         =      ru
+M4              =      m4 -G
+RANLIB          =      ranlib
+RLFLAGS		=	
+CC_TOOLS        =      $(SCC)
+
+LIB_EXTERNAL    = \
+                     $(WRF_SRC_ROOT_DIR)/external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.dll.a \
+		     -L CONFIGURE_NETCDF_PATH -lnetcdff -lnetcdf -lnetcdf -ltirpc -lhdf5_hl -lhdf5 -lm -lz \
+		     $(WRF_SRC_ROOT_DIR)/external/io_grib2/libio_grib2.a
+ESMF_IO_LIB     =    $(WRF_SRC_ROOT_DIR)/external/esmf_time_f90/libesmf_time.a
+LIB_BUNDLED     = \
+                     $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
+                     $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
+		     $(WRF_SRC_ROOT_DIR)/external/io_grib2/libio_grib2.a \
+                     $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
+                     $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
+                     $(ESMF_IO_LIB) \
+                     CONFIGURE_COMMS_LIB \
+                     $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
+                     $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
+
+###########################################################
+#ARCH    Mingw64 i686 x86_64, gfortran compiler with gcc  #serial smpar dmpar dm+sm
+#
+DESCRIPTION     =       GNU ($SFC/$SCC)
+DMPARALLEL      =       # 1
+OMPCPP          =       # -D_OPENMP
+OMP             =       # -fopenmp
+OMPCC           =       # -fopenmp
+SFC             =       gfortran
+SCC             =       gcc
+CCOMP           =       gcc
+DM_FC           =       mpif90 -f90=$(SFC)
+DM_CC           =       mpicc -cc=$(SCC)
+FC              =       CONFIGURE_FC
+CC              =       CONFIGURE_CC
+LD              =       $(FC)
+RWORDSIZE       =       CONFIGURE_RWORDSIZE
+PROMOTION       =       #-fdefault-real-8
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
+CFLAGS_LOCAL    =       -w -O3 -c
+LDFLAGS_LOCAL   =       
+CPLUSPLUSLIB    =       
+ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
+FCOPTIM         =       -O2 -ftree-vectorize -funroll-loops
+FCREDUCEDOPT	=       $(FCOPTIM)
+FCNOOPT		=       -O0
+FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
+FORMAT_FIXED    =       -ffixed-form
+FORMAT_FREE     =       -ffree-form -ffree-line-length-none
+FCSUFFIX        =       
+BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
+MODULE_SRCH_FLAG =     
+TRADFLAG        =      -traditional
+CPP             =      /lib/cpp -P
+AR              =      ar
+ARFLAGS         =      ru
+M4              =      m4 -G
+RANLIB          =      ranlib
+RLFLAGS		=	
+CC_TOOLS        =      $(SCC)
+
+LIB_EXTERNAL    = \
+                     $(WRF_SRC_ROOT_DIR)/external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.dll.a \
+		     -L CONFIGURE_NETCDF_PATH -lnetcdff -lnetcdf -lnetcdf -lhdf5_hl -lhdf5 -lm -lz \
+		     $(WRF_SRC_ROOT_DIR)/external/io_grib2/libio_grib2.a
+ESMF_IO_LIB     =    $(WRF_SRC_ROOT_DIR)/external/esmf_time_f90/libesmf_time.a
+LIB_BUNDLED     = \
+                     $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
+                     $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
+		     $(WRF_SRC_ROOT_DIR)/external/io_grib2/libio_grib2.a \
+                     $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
+                     $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
+                     $(ESMF_IO_LIB) \
+                     CONFIGURE_COMMS_LIB \
+                     $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
+                     $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
 
 #insert new stanza here
 

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1974,65 +1974,6 @@ LIB_BUNDLED     = \
                      $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
 
-###########################################################
-#ARCH    Mingw64 i686 x86_64, gfortran compiler with gcc  #serial smpar dmpar dm+sm
-#
-DESCRIPTION     =       GNU ($SFC/$SCC)
-DMPARALLEL      =       # 1
-OMPCPP          =       # -D_OPENMP
-OMP             =       # -fopenmp
-OMPCC           =       # -fopenmp
-SFC             =       gfortran
-SCC             =       gcc
-CCOMP           =       gcc
-DM_FC           =       mpif90 -f90=$(SFC)
-DM_CC           =       mpicc -cc=$(SCC)
-FC              =       CONFIGURE_FC
-CC              =       CONFIGURE_CC
-LD              =       $(FC)
-RWORDSIZE       =       CONFIGURE_RWORDSIZE
-PROMOTION       =       #-fdefault-real-8
-ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
-CFLAGS_LOCAL    =       -w -O3 -c
-LDFLAGS_LOCAL   =       
-CPLUSPLUSLIB    =       
-ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-FCOPTIM         =       -O2 -ftree-vectorize -funroll-loops
-FCREDUCEDOPT	=       $(FCOPTIM)
-FCNOOPT		=       -O0
-FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
-FORMAT_FIXED    =       -ffixed-form
-FORMAT_FREE     =       -ffree-form -ffree-line-length-none
-FCSUFFIX        =       
-BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
-FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
-MODULE_SRCH_FLAG =     
-TRADFLAG        =      -traditional
-CPP             =      /lib/cpp -P
-AR              =      ar
-ARFLAGS         =      ru
-M4              =      m4 -G
-RANLIB          =      ranlib
-RLFLAGS		=	
-CC_TOOLS        =      $(SCC)
-
-LIB_EXTERNAL    = \
-                     $(WRF_SRC_ROOT_DIR)/external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.dll.a \
-		     -L CONFIGURE_NETCDF_PATH -lnetcdff -lnetcdf -lnetcdf -lhdf5_hl -lhdf5 -lm -lz \
-		     $(WRF_SRC_ROOT_DIR)/external/io_grib2/libio_grib2.a
-ESMF_IO_LIB     =    $(WRF_SRC_ROOT_DIR)/external/esmf_time_f90/libesmf_time.a
-LIB_BUNDLED     = \
-                     $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
-                     $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
-		     $(WRF_SRC_ROOT_DIR)/external/io_grib2/libio_grib2.a \
-                     $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
-                     $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
-                     $(ESMF_IO_LIB) \
-                     CONFIGURE_COMMS_LIB \
-                     $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
-                     $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
-
 #insert new stanza here
 
 ###########################################################

--- a/arch/postamble
+++ b/arch/postamble
@@ -55,19 +55,6 @@ INCLUDE_MODULES =    $(MODULE_SRCH_FLAG) \
 REGISTRY        =    Registry
 CC_TOOLS_CFLAGS = CONFIGURE_NMM_CORE
 
-#NOWIN LIB_BUNDLED     = \
-#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
-#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
-#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
-#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
-#NOWIN                      $(ESMF_IO_LIB) \
-#NOWIN                      CONFIGURE_COMMS_LIB \
-#NOWIN                      $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
-#NOWIN                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o 
-
-#NOWIN LIB_EXTERNAL    = \
-#NOWIN                      CONFIGURE_NETCDF_LIB_PATH CONFIGURE_PNETCDF_LIB_PATH CONFIGURE_GRIB2_LIB CONFIGURE_ATMOCN_LIB CONFIGURE_HDF5_LIB_PATH
-
 LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO)
 LDFLAGS         =    $(OMP) $(FCFLAGS) $(LDFLAGS_LOCAL) CONFIGURE_LDFLAGS
 ENVCOMPDEFS     =    CONFIGURE_COMPILEFLAGS

--- a/arch/preamble
+++ b/arch/preamble
@@ -105,6 +105,19 @@ NETCDF4_DEP_LIB = $(DEP_LIB_PATH) $(HDF5) $(ZLIB) $(GPFS) $(CURL)
 
 LIBWRFLIB = libwrflib.a
 
+#NOWIN LIB_BUNDLED     = \
+#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
+#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
+#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
+#NOWIN                      $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
+#NOWIN                      $(ESMF_IO_LIB) \
+#NOWIN                      CONFIGURE_COMMS_LIB \
+#NOWIN                      $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
+#NOWIN                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
+
+#NOWIN LIB_EXTERNAL    = \
+#NOWIN                      CONFIGURE_NETCDF_LIB_PATH CONFIGURE_PNETCDF_LIB_PATH CONFIGURE_GRIB2_LIB CONFIGURE_ATMOCN_LIB CONFIGURE_HDF5_LIB_PATH
+
 
 #### Architecture specific settings ####
 

--- a/configure
+++ b/configure
@@ -180,12 +180,12 @@ USENETCDF=""
 if [ -n "$NETCDF" ] ; then
   echo "Will use NETCDF in dir: $NETCDF"
 # Oh UNIDATA, why make it so hard ...
-  if [ -f "$NETCDF/lib/libnetcdff.a" -o -f "$NETCDF/lib/libnetcdff.so" ] ; then
+  if [ -f "$NETCDF/lib/libnetcdff.a" -o -f "$NETCDF/lib/libnetcdff.so" -o -f "${NETCDF}/lib/libnetcdff.dll.a" ] ; then
     USENETCDFF="-lnetcdff"
   else
     USENETCDFF=" "
   fi
-  if [ -f "$NETCDF/lib/libnetcdf.a" -o -f "$NETCDF/lib/libnetcdf.so" ] ; then
+  if [ -f "$NETCDF/lib/libnetcdf.a" -o -f "$NETCDF/lib/libnetcdf.so" -o -f "${NETCDF}/lib/libnetcdf.dll.a" ] ; then
     USENETCDF="-lnetcdf"
   else
     USENETCDF=" "
@@ -204,7 +204,7 @@ fi
 
 # If the user asked for classic netcdf, acquiesce to the request.
 
-if [ "`uname`" = "Linux" ] ; then
+if [ "`uname`" = "Linux" -o "`uname -o`" = "Cygwin" ] ; then
   ans="`whereis nf-config`"
 elif [ "`uname`" = "Darwin" ] ; then
   ans="`which nf-config`"

--- a/external/io_netcdf/makefile
+++ b/external/io_netcdf/makefile
@@ -50,7 +50,7 @@ diffwrf:                diffwrf.F90
 	$(FC) -c $(FFLAGS) diffwrf.f
 	@if [ \( -f ../../frame/wrf_debug.o \) -a \( -f ../../frame/module_wrf_error.o \) -a \( -f $(ESMF_MOD_DEPENDENCE) \) -a \( -f ../../frame/clog.o \) ] ; then \
 	  echo "diffwrf io_netcdf is being built now. " ; \
-          if [ \( -f $(NETCDFPATH)/lib/libnetcdff.a -o $(NETCDFPATH)/lib/libnetcdff.dll.a -o -f $(NETCDFPATH)/lib/libnetcdff.so \) ] ; then \
+          if [ \( -f $(NETCDFPATH)/lib/libnetcdff.a -o -f $(NETCDFPATH)/lib/libnetcdff.dll.a -o -f $(NETCDFPATH)/lib/libnetcdff.so \) ] ; then \
             $(FC) $(FFLAGS) $(LDFLAGS) -o diffwrf diffwrf.o $(OBJSL) ../../frame/wrf_debug.o ../../frame/module_wrf_error.o ../../frame/clog.o $(ESMF_IO_LIB_EXT) $(LIBFFS) ;\
           else \
             $(FC) $(FFLAGS) $(LDFLAGS) -o diffwrf diffwrf.o $(OBJSL) ../../frame/wrf_debug.o ../../frame/module_wrf_error.o ../../frame/clog.o $(ESMF_IO_LIB_EXT) $(LIBS) ;\

--- a/external/io_netcdf/makefile
+++ b/external/io_netcdf/makefile
@@ -50,7 +50,7 @@ diffwrf:                diffwrf.F90
 	$(FC) -c $(FFLAGS) diffwrf.f
 	@if [ \( -f ../../frame/wrf_debug.o \) -a \( -f ../../frame/module_wrf_error.o \) -a \( -f $(ESMF_MOD_DEPENDENCE) \) -a \( -f ../../frame/clog.o \) ] ; then \
 	  echo "diffwrf io_netcdf is being built now. " ; \
-          if [ \( -f $(NETCDFPATH)/lib/libnetcdff.a -o -f $(NETCDFPATH)/lib/libnetcdff.so \) ] ; then \
+          if [ \( -f $(NETCDFPATH)/lib/libnetcdff.a -o $(NETCDFPATH)/lib/libnetcdff.dll.a -o -f $(NETCDFPATH)/lib/libnetcdff.so \) ] ; then \
             $(FC) $(FFLAGS) $(LDFLAGS) -o diffwrf diffwrf.o $(OBJSL) ../../frame/wrf_debug.o ../../frame/module_wrf_error.o ../../frame/clog.o $(ESMF_IO_LIB_EXT) $(LIBFFS) ;\
           else \
             $(FC) $(FFLAGS) $(LDFLAGS) -o diffwrf diffwrf.o $(OBJSL) ../../frame/wrf_debug.o ../../frame/module_wrf_error.o ../../frame/clog.o $(ESMF_IO_LIB_EXT) $(LIBS) ;\

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -12,6 +12,7 @@ OBJ = registry.o my_strtok.o reg_parse.o data.o type.o misc.o \
 
 registry : $(OBJ) standard.exe
 	$(CC_TOOLS) -o registry $(DEBUG) $(LDFLAGS) $(OBJ)
+	if which peflags; then peflags --stack-reserve=33554432 registry; fi
 
 standard.exe : standard.o
 	$(CC_TOOLS) -o standard.exe $(DEBUG) $(LDFLAGS) standard.o

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -12,7 +12,7 @@ OBJ = registry.o my_strtok.o reg_parse.o data.o type.o misc.o \
 
 registry : $(OBJ) standard.exe
 	$(CC_TOOLS) -o registry $(DEBUG) $(LDFLAGS) $(OBJ)
-	if which peflags; then peflags --stack-reserve=33554432 registry; fi
+	if [ -x /usr/bin/peflags.exe ] ; then /usr/bin/peflags.exe --stack-reserve=33554432 registry; fi
 
 standard.exe : standard.o
 	$(CC_TOOLS) -o standard.exe $(DEBUG) $(LDFLAGS) standard.o


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cygwin, compiler, configure, library search path

SOURCE: DWesl (PSU)

DESCRIPTION OF CHANGES: 

The build configury did not understand the cygwin platform.  Since the platform is similar to Linux and BSD, it was relatively straightforward to add support.

I had to move some settings from the postamble to the preamble for the settings in configure.defaults to be honored.  I also had to allow a larger stack in the registry for that program not to crash.

Some libraries appear to have different names on Cygwin and on Linux, in particular, I cannot find a libhdf5_fortran, but libhdf5_hl appears to work just fine.  I have no idea if these are fully interchangeable on Linux.

I could not find code for libwavelet, so I removed that library from LIB_EXTERNAL

LIST OF MODIFIED FILES: 
arch/Config.pl
arch/configure.defaults
arch/postamble
arch/preamble
configure
external/io_netcdf/makefile
tools/Makefile

TESTS CONDUCTED: 
I succeeded in compiling and running the em_scm_xy case on Cygwin.
