### PR TITLE
Correct some instructions in README.namelist

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -656,7 +656,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 0, no surface-layer
                                      = 1, Revised MM5 Monin-Obukhov scheme (Jimenez, renamed in v3.6)
                                      = 2, Monin-Obukhov (Janjic) scheme
-                                     = 3, NCEP Global Forecast System scheme (NMM only)
+                                     = 3, NCEP Global Forecast System scheme (works for both ARW and NMM )
                                      = 4, QNSE surface layer
                                      = 5, MYNN surface layer
                                      = 7, Pleim-Xiu surface layer (ARW only)
@@ -695,7 +695,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 0, no boundary-layer 
                                      = 1, YSU scheme
                                      = 2, Mellor-Yamada-Janjic TKE scheme
-                                     = 3, Hybrid EDMF GFS scheme (NMM only)
+                                     = 3, Hybrid EDMF GFS scheme (works for both ARW and NMM)
                                      = 4, Eddy-diffusivity Mass Flux, Quasi-Normal Scale Elimination PBL
                                      = 5, MYNN 2.5 level TKE scheme, works with
                                           sf_sfclay_physics=1 or 2 as well as 5

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -656,7 +656,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 0, no surface-layer
                                      = 1, Revised MM5 Monin-Obukhov scheme (Jimenez, renamed in v3.6)
                                      = 2, Monin-Obukhov (Janjic) scheme
-                                     = 3, NCEP Global Forecast System scheme (works for both ARW and NMM )
+                                     = 3, NCEP Global Forecast System scheme 
                                      = 4, QNSE surface layer
                                      = 5, MYNN surface layer
                                      = 7, Pleim-Xiu surface layer (ARW only)
@@ -695,7 +695,7 @@ Namelist variables for controlling the adaptive time step option:
                                      = 0, no boundary-layer 
                                      = 1, YSU scheme
                                      = 2, Mellor-Yamada-Janjic TKE scheme
-                                     = 3, Hybrid EDMF GFS scheme (works for both ARW and NMM)
+                                     = 3, Hybrid EDMF GFS scheme 
                                      = 4, Eddy-diffusivity Mass Flux, Quasi-Normal Scale Elimination PBL
                                      = 5, MYNN 2.5 level TKE scheme, works with
                                           sf_sfclay_physics=1 or 2 as well as 5


### PR DESCRIPTION
TYPE: text only

KEYWORDS:  README.namelist, NMM

SOURCE: internal

DESCRIPTION OF CHANGES: 
A few physics options are declared as "NMM only" in README.namelist, whereas they actually work 
for both ARW and NMM. 
Surface Layer: NCEP GFS (`sf_sfclay_physics=3`)
PBL: Hybrid EDMF GFS (`bl_pbl_physics=3`)
This PR corrects the information. 

LIST OF MODIFIED FILES: 
M    run/README.namelist

TESTS CONDUCTED: 
A single ARW case is successfully done with the options of sf_sfclay_physics=3 and bl_pbl_physics=3. Results look fine.