### PR TITLE
Correct variable in the package of "do_trad_fields"

### DIFF
--- a/Registry/registry.trad_fields
+++ b/Registry/registry.trad_fields
@@ -25,4 +25,4 @@ state    real   rh            ikj   dyn_em    1  -   h1  "RH"           "relativ
 #  Package declarations
 
 package   skip_trad_fields   diag_nwp2==0  -   -
-package     do_trad_fields   diag_nwp2==1  -   state:sealevelp,temperature,pressure,geoheight,umet,vmet,speed,dir,rain,liqrain,tpw,theta,rh
+package     do_trad_fields   diag_nwp2==1  -   state:sealevelp,temperature,pressure,geoheight,umet,vmet,speed,dir,rain,liqrain,tpw,potential_t,rh


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: do_trad_fields, diag_nwp2, traditional fields

SOURCE: internal

DESCRIPTION OF CHANGES:  
Problem:
The variable `theta` is not a state variable, but it was incorrectly used as a variable in the package 
for "do_trad_fields". 

Solution:
This PR removes `theta` from the package list, and replaces `theta` with the correct variable 
`potential_t`.  

LIST OF MODIFIED FILES:
Registry/registry.trad_fields

TESTS CONDUCTED: 
A single case with the option `diag_nwp2=1` (the option to output the traditional fields) is 
conducted. The model runs fine and the results are reasonable. 
