### PR TITLE
nwp_diagnostics made compatible with adaptive time step

### DIFF
--- a/phys/module_diag_misc.F
+++ b/phys/module_diag_misc.F
@@ -56,9 +56,9 @@ CONTAINS
                      ,qg_curr                                         &
                      ,ng_curr,qh_curr,nh_curr,qr_curr,nr_curr         & !  Optional (gthompsn)
                      ,rho,ph,phb,g                                    &
+                     ,max_time_step,adaptive_ts                       &
                                                                       )
 !----------------------------------------------------------------------
-
   USE module_dm, ONLY: wrf_dm_sum_real, wrf_dm_maxval
   USE module_state_description, ONLY :                                  &
       KESSLERSCHEME, LINSCHEME, SBU_YLINSCHEME, WSM3SCHEME, WSM5SCHEME, &
@@ -263,6 +263,11 @@ CONTAINS
       REAL:: mvd_r, xslw1, ygra1, zans1
       INTEGER:: ng, n
 
+   REAL                                       :: time_from_output
+   INTEGER                                    :: max_time_step
+   LOGICAL                                    :: adaptive_ts
+   LOGICAL                                    :: reset_arrays = .FALSE.
+
 !-----------------------------------------------------------------
 ! Handle accumulations with buckets to prevent round-off truncation in long runs
 ! This is done every 360 minutes assuming time step fits exactly into 360 minutes
@@ -442,18 +447,41 @@ CONTAINS
    IF ( nwp_diagnostics .EQ. 1 ) THEN
 
      idump = (history_interval * 60.) / dt
-
-!   print *,' history_interval = ', history_interval
-!   print *,' itimestep        = ', itimestep
-!   print *,' idump            = ', idump
-!   print *,' xtime            = ', xtime
-
-
+     
 ! IF ( MOD(itimestep, idump) .eq. 0 ) THEN
 !    WRITE(outstring,*) 'Computing PH0 for this domain with curr_secs2 = ', curr_secs2
 !    CALL wrf_message ( TRIM(outstring) )
+   
+   time_from_output = mod( xtime, REAL(history_interval) )
 
-   IF ( MOD((itimestep - 1), idump) .eq. 0 ) THEN
+!   print *,' history_interval     = ', history_interval
+!   print *,' itimestep            = ', itimestep
+!   print *,' idump                = ', idump
+!   print *,' xtime                = ', xtime
+!   print *,' time_from_output     = ', time_from_output
+!   print *,' max_time_step        = ', max_time_step
+   
+   IF ( adaptive_ts .EQV. .TRUE. ) THEN
+!     if timestep is adaptive, use new resetting method;
+!     also, we are multiplying max_time_step with 1.05; because of rounding error, 
+!     the time_from_output can become slightly larger than max_time_step when
+!     adaptive time step is maximized, in which case the if condition below fails to detect
+!     that we just wrote an output
+       IF ( ( time_from_output .GT. 0 ) .AND. ( time_from_output .LE. ( ( max_time_step * 1.05 ) / 60. ) ) )  THEN 
+          reset_arrays = .TRUE.
+       ENDIF
+   ELSE
+!     if timestep is fixed, use original resetting method
+      IF ( MOD((itimestep - 1), idump) .eq. 0 )  THEN
+        reset_arrays = .TRUE.
+      ENDIF
+   ENDIF
+
+!   print *,' reset_arrays = ', reset_arrays
+   IF ( reset_arrays .EQV. .TRUE. ) THEN
+
+!   print *,' Resetting NWP max arrays '
+   
      WRITE(outstring,*) 'NSSL Diagnostics: Resetting max arrays for domain with dt = ', dt
      CALL wrf_debug ( 10,TRIM(outstring) )
 
@@ -475,6 +503,7 @@ CONTAINS
        ENDDO
      ENDDO
 !  !$OMP END PARALLEL DO
+     reset_arrays = .FALSE.
    ENDIF
 
 !  !$OMP PARALLEL DO   &

--- a/phys/module_diagnostics_driver.F
+++ b/phys/module_diagnostics_driver.F
@@ -419,6 +419,8 @@ CONTAINS
                 ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
                 ,KTS=k_start, KTE=min(k_end,kde-1)                   &
                 ,NUM_TILES=grid%num_tiles                            &
+                ,MAX_TIME_STEP=grid%max_time_step                    &
+                ,ADAPTIVE_TS=config_flags%use_adaptive_time_step     &                
                                                                     )
 
         CASE (THOMPSON, THOMPSONAERO)
@@ -496,6 +498,8 @@ CONTAINS
                 ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
                 ,KTS=k_start, KTE=min(k_end,kde-1)                   &
                 ,NUM_TILES=grid%num_tiles                            &
+                ,MAX_TIME_STEP=grid%max_time_step                    &                
+                ,ADAPTIVE_TS=config_flags%use_adaptive_time_step     &                                
                                                                     )
 
         CASE (MORR_TWO_MOMENT, MORR_TM_AERO)  ! TWG add
@@ -572,6 +576,8 @@ CONTAINS
                 ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
                 ,KTS=k_start, KTE=min(k_end,kde-1)                   &
                 ,NUM_TILES=grid%num_tiles                            &
+                ,MAX_TIME_STEP=grid%max_time_step                    &       
+                ,ADAPTIVE_TS=config_flags%use_adaptive_time_step     &                                         
                                                                     )
 
         CASE (NSSL_1MOM)
@@ -648,6 +654,8 @@ CONTAINS
                 ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
                 ,KTS=k_start, KTE=min(k_end,kde-1)                   &
                 ,NUM_TILES=grid%num_tiles                            &
+                ,MAX_TIME_STEP=grid%max_time_step                    &                
+                ,ADAPTIVE_TS=config_flags%use_adaptive_time_step     &                                
                                                                     )
 
         CASE (MILBRANDT2MOM, NSSL_2MOM, NSSL_2MOMCCN)
@@ -726,6 +734,8 @@ CONTAINS
                 ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
                 ,KTS=k_start, KTE=min(k_end,kde-1)                   &
                 ,NUM_TILES=grid%num_tiles                            &
+                ,MAX_TIME_STEP=grid%max_time_step                    &    
+                ,ADAPTIVE_TS=config_flags%use_adaptive_time_step     &                                            
                                                                     )
 
 
@@ -830,6 +840,8 @@ CONTAINS
                 ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
                 ,KTS=k_start, KTE=min(k_end,kde-1)                   &
                 ,NUM_TILES=grid%num_tiles                            &
+                ,MAX_TIME_STEP=grid%max_time_step                    &            
+                ,ADAPTIVE_TS=config_flags%use_adaptive_time_step     &                                    
                                                                     )
 
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: nwp_diagnostic, adaptive time step

SOURCE: Ivan Toman (University of Zadar, Croatia)

DESCRIPTION OF CHANGES: 
Previously, the nwp_diagnostics feature worked properly only if fixed time step was used. 
If the adaptive time step option was used, resetting max arrays after output time failed 
because the original code expected a fixed number of time steps between output times. 

For this enhancement, the tracking of time after the output is used to determine when the
reset time has been reached. Resetting max arrays is performed after the output at the next 
time step by checking if 0 < if time from output < max_time_step. The details are given in 
code comments.

LIST OF MODIFIED FILES:
M       phys/module_diag_misc.F
M       phys/module_diagnostics_driver.F

TESTS CONDUCTED: 
1. Code compiled fine and produces expected results with single domain and with nested 
domain.
2. Regression is done successfully.
3. A test case with nwp_diagnostics = 1 and adaptive time step option turning on works fine. The 
figure attached displays the maximum 10m wind speed as one example.
![WSPD10MAX](https://user-images.githubusercontent.com/17932265/73198252-f7faed80-40ef-11ea-9295-9e5f92678148.png)
 