### PR TITLE
Fix DA serial compilation failure introduced in commit dba34646

### DIFF
--- a/var/da/da_vtox_transforms/da_vtox_transforms.f90
+++ b/var/da/da_vtox_transforms/da_vtox_transforms.f90
@@ -12,6 +12,7 @@ module da_vtox_transforms
    use module_comm_dm, only : halo_psichi_uv_adj_sub,halo_ssmi_xa_sub,halo_sfc_xa_sub, &
       halo_radar_xa_w_sub, halo_xa_sub, halo_psichi_uv_sub, &
       halo_psichi_uv_sub, halo_xa_wpec_sub,halo_xb_wpec_sub
+   use da_par_util, only : true_mpi_real, mpi_sum, comm
 #endif
    use module_domain, only : xb_type, xpose_type, ep_type, vp_type, x_type, domain, get_ijk_from_grid
    use module_domain, only : x_subtype
@@ -62,7 +63,6 @@ module da_vtox_transforms
       da_transform_xtogpsref_adj, da_transform_xtowtq_adj, &
       da_transform_xtoztd_lin, da_transform_xtoztd_adj
    use da_par_util, only : da_vv_to_cv, da_cv_to_vv
-   use da_par_util, only : true_mpi_real, mpi_sum, comm
 
    use da_recursive_filter, only : da_transform_through_rf, &
       da_transform_through_rf_adj, da_apply_rf, da_apply_rf_adj, &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, serial, compile

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
The error message of serial build:
```
da_vtox_transforms.f:44:26:
    use da_par_util, only : true_mpi_real, mpi_sum, comm
                           1
Error: Symbol 'true_mpi_real' referenced at (1) not found in module 'da_par_util'
da_vtox_transforms.f:44:41:
    use da_par_util, only : true_mpi_real, mpi_sum, comm
                                          1
Error: Symbol 'mpi_sum' referenced at (1) not found in module 'da_par_util'
```
The fix is to move the line of code
use da_par_util, only : true_mpi_real, mpi_sum, comm
inside #ifdef DM_PARALLEL.

ISSUE:
Fixes #923

LIST OF MODIFIED FILES:
modified:   var/da/da_vtox_transforms/da_vtox_transforms.f90

TESTS CONDUCTED:
WRFDA builds for serial mode after the fix.

RELEASE NOTE: Fix WRFDA V4.1.1 serial compilation failure.