### PR TITLE
Fix 4DVAR compilation failure after commit 56d4bef4

### DIFF
--- a/var/build/da_name_space.pl
+++ b/var/build/da_name_space.pl
@@ -194,4 +194,5 @@ wrf_dm_nestexchange_init
 set_tiles
 wrf_get_dom_ti_integer
 is_this_data_ok_to_use
+check_which_switch
 ###########################################################################################


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, compile

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:

Following commit 56d4bef4, the new function name (check_which_switch) needs to be added
in da_name_space.pl to avoid name conflict for 4DVAR build.
The error message:
```
duplicate symbol _check_which_switch_ in:
    /Volumes/sysdisk1/hclin/WRFV4/wrfplus/main/libwrflib.a(input_wrf.o)
    ./libwrfvar.a(input_wrf.o)
ld: 1 duplicate symbol for architecture x86_64
collect2: error: ld returned 1 exit status
```

LIST OF MODIFIED FILES:
M       var/build/da_name_space.pl

TESTS CONDUCTED:
WRFDA 4DVAR builds after the fix.

RELEASE NOTE: Fix WRFDA 4DVAR V4.1.1 compilation failure.