### PR TITLE
Fix to make restarts reproducible in nests when topo_shading is used

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1247,7 +1247,7 @@ state   real    ht_fine        ij      misc         1         -     -          "
 state   real    ht_int         ij      misc         1         -     -          "HGT_INT"          "Terrain Height Horizontally Interpolated"   "m"
 state   real    ht_input       ij      misc         1         -     -          "HGT_INPUT"        "Terrain Height from FG Input File"   "m"
 state   real    ht_smooth      ij      misc         1         -     -          "HGT_SMOOTH"       "Terrain Height Smoothed with External Model Topo (d1 only)"   "m"
-state   real    ht_shad        ijb     misc         1         -     df=(bdy_interp:dt)         "HGT_SHAD"        "Height of orographic shadow"   "m"
+state   real    ht_shad        ijb     misc         1         -     rdf=(bdy_interp:dt)         "HGT_SHAD"        "Height of orographic shadow"   "m"
 i1      real    ht_loc         ij      misc         1         -     - 
 state   integer  shadowmask    ij      misc         1         -     - 
 state   integer min_ptchsz     -       misc         1         -     r


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: topographic shading, radiation, restart runs, nested domains

SOURCE: Emily Collier (FAU Erlangen-Nürnberg)

DESCRIPTION OF CHANGES: 

1. Added ht_shad to the restart files

Restart runs aren't reproducible in nested domains when topographic shading is turned on, because ht_shad is not initialised in grid points adjacent to the lateral boundary of the nest.

Zero values for ht_shad at affected grid points (all located one grid point away from the eastern boundary in the same patch) lead to different values of shadowmask and swnorm. Here is a diff of swnorm in D2 in the first affected time step for a restart at 04 UTC:
![Screenshot 2019-06-14 at 15 59 08](https://user-images.githubusercontent.com/51397205/59514991-6a4ef280-8ebe-11e9-81a5-754391bd6a52.jpg)
![Screenshot 2019-06-14 at 15 59 30](https://user-images.githubusercontent.com/51397205/59514993-6a4ef280-8ebe-11e9-8768-8dfaf13cae8b.jpg)

Here is swdown for reference:
![Screenshot 2019-06-14 at 16 24 18](https://user-images.githubusercontent.com/51397205/59516140-f5c98300-8ec0-11e9-9797-861384fb8420.jpg)

Adding ht_shad to the restart files makes restart runs reproducible for all domains when topo_shading is used.

ISSUE: #922

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON

TESTS CONDUCTED: WRF 3.9.1.1 and 4.1 for two different configurations and study areas.