### PR TITLE
Fix to allow proper QVAPOR analysis when mp_physics is not set in namelist.input

### DIFF
--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -526,6 +526,7 @@ package   nomoist_ad   mp_physics_ad==98            -             -
 package   warmrain_ad  mp_physics_ad==99            -             -
 
 #do "grep package Registry/Registry.EM_COMMON | grep mp_physics==", then remove non-moist lists
+package   mpnotset        mp_physics==-1               -             moist:qv
 package   passiveqv       mp_physics==0                -             moist:qv
 package   kesslerscheme   mp_physics==1                -             moist:qv,qc,qr
 package   linscheme       mp_physics==2                -             moist:qv,qc,qr,qi,qs,qg
@@ -556,6 +557,7 @@ package   etampnew        mp_physics==95               -             moist:qv,qc
 package   lscondscheme    mp_physics==98               -             moist:qv
 package   mkesslerscheme  mp_physics==99               -             moist:qv,qc,qr
 #
+package   mpnotset_4dvar         mp_physics_4dvar==-1     -          g_moist:g_qv;a_moist:a_qv
 package   passiveqv_4dvar        mp_physics_4dvar==0      -          g_moist:g_qv;a_moist:a_qv
 package   kessler_4dvar          mp_physics_4dvar==1      -          g_moist:g_qv,g_qc,g_qr;a_moist:a_qv,a_qc,a_qr
 package   lins_4dvar             mp_physics_4dvar==2      -          g_moist:g_qv,g_qc,g_qr,g_qi,g_qs,g_qg;a_moist:a_qv,a_qc,a_qr


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, mp_physics, package, QVAPOR, physics_suite

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Add back the packaging for mp_physics=-1 (added in commit 93a17919, but dropped
unintentionally in commit 81ca2ff0) to allow WRFDA to allocate qv in the cases when
(1) physics_suite is set and mp_physics is not set,
(2) both physics_suite and mp_physics are not set.
Commit 7427eac9 contains some information about physics_suite in WRFDA.

When mp_physics is not set in the namelist.input, its default -1 leads to no moist variable
(even qv) being allocated. Even if the user is able to identify the incorrect QVAPOR analysis,
it is almost impossible for the user to figure out why and how to solve the problem.
The problem can be avoided by setting proper mp_physics. For dual-resolution EnVar, my_physics
in both column 1 and column 2 must be set.

NOTE that this PR handles qv only.
More other consideration and tests are needed for cloud variables.

LIST OF MODIFIED FILES:
M       Registry/registry.var

TESTS CONDUCTED:
(1) with missing mp_physics setting, the fixed code gets proper QVAPOR analysis for one simple test case.

RELEASE NOTE: Fix to allow proper QVAPOR analysis when mp_physics is not set in namelist.input.