### PR TITLE
Fix compile script to print model version, due to new version_decl format

### DIFF
--- a/compile
+++ b/compile
@@ -464,7 +464,7 @@ else
   echo " "
   echo "============================================================================================== "
   echo " "
-  cat inc/version_decl | cut -c 45-54
+  cat inc/version_decl | cut -d"'" -f2
   echo " "
   echo -n "Compiling: "
   if ( $WRF_DA_CORE ) echo -n "WRF_DA_CORE "


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compile, version_decl

SOURCE: internal

DESCRIPTION OF CHANGES:
The `compile` script has a line to inform users of the version of WRF that is being built, purely 
for informational purposes:
```
cat inc/version_decl | cut -c 45-54
```

While this could have been more general, it worked OK with the original syntax of the original
`inc/version_decl` file.

With the inclusion of modification 18c66c7eb99e in PR #918 "Prepare for WRF-v4.1.1 release", the 
string in the `inc/version_decl` file is no longer a fixed length, so the original character count
(grabbing 45 through 54), is no longer valid.

A modification to the `compile` script handles retrieving this information in a more robust fashion
from the `inc/version_decl` file.
The old version_decl file:
```
   CHARACTER (LEN=10) :: release_version = 'V4.1      '
```
The new `version_decl` file:
```
   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.1.1'
```
Basically, we modify the `compile` script to get the information between the single quotes:
```
cat inc/version_decl | cut -d"'" -f2
```
which gives the correct string, regardless of the style selected for the assignment:
```
V4.1.1
```

ISSUE:
Closes issue #938 "version_decl modification causes incorrect info in compile log"

LIST OF MODIFIED FILES:
M	compile

TESTS CONDUCTED:
 - [x] Without this mod, the top of the compile log has
```
ersion = '
Compiling: WRF_EM_CORE
```
 - [x] With this mod, the top of the compile log says
```
V4.1.1
Compiling: WRF_EM_CORE 
```

RELEASE NOTE: A modification was added to the compile script to print out the correct version number of the WRF model in the compile log.