### PR TITLE
Bug fix: traditional fields diags, u and v are 2x too large

### DIFF
--- a/phys/module_diag_trad_fields.F
+++ b/phys/module_diag_trad_fields.F
@@ -94,8 +94,8 @@ CONTAINS
    
                !  Earth relative winds
 
-               umet(i,k,j) = (u(i,k,j)+u(i+1,k,j))*cosa(i,j) - (v(i,k,j)+v(i,k,j+1))*sina(i,j)
-               vmet(i,k,j) = (u(i,k,j)+u(i+1,k,j))*sina(i,j) + (v(i,k,j)+v(i,k,j+1))*cosa(i,j)
+               umet(i,k,j) = 0.5 * ( (u(i,k,j)+u(i+1,k,j))*cosa(i,j) - (v(i,k,j)+v(i,k,j+1))*sina(i,j) )
+               vmet(i,k,j) = 0.5 * ( (u(i,k,j)+u(i+1,k,j))*sina(i,j) + (v(i,k,j)+v(i,k,j+1))*cosa(i,j) )
    
                !  Horizontal wind speed
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: diagnostics

SOURCE: Nicolas Baldeck (OpenMeteoData), internal

DESCRIPTION OF CHANGES:
When computing the earth-relative winds from the model's projection-relative winds, the resulting 
values of umet and vmet are correctly placed in the cell center. However, the averaging to the cell 
center from the momentum cell faces is missing a "divide by 2".

ISSUE:
Closes #935 "Bad Wind and Temperature values with diag_nwp2=1" (only the "wind" portion)

LIST OF MODIFIED FILES:
modified:   module_diag_trad_fields.F

TESTS CONDUCTED:
 - [x] Verified results for a single point

```
         +----- vt -----+        +--------------+
         |              |        |              |
         |              |        |              |
         |              |        |              |
         ul   ua,va     ur       |     um,vm    |
         |              |        |              |
         |              |        |              |
         |              |        |              |
         +----- vb -----+        +--------------+
```

The `ul`, `ur`, `vb`, `vt` points are the cell-faced, WRF-projection values for U and V.
The `ul` and `ur` points are averaged to `ua`
The `vb` and `vt` points are averaged to `va`
```
ul 9.646521
ur 9.88719
vb 5.692195
vt 6.119572
ua 9.7668555
va 5.9058835
```

The `um` and `vm` points are the mass-centered, earth-relative values for U and V.
```
um 11.25222
vm 1.912724
```


The speed computed with `ua` and `va` is `sa`.
The speed computed with `um` and `vm` is `sm`.
```
sa 11.41362897037802346311

sm 11.41363079955611670914
```
 - [x] With the old code, the results show a 2x factor in the earth-relative values of u, v, and speed.
```
ul 9.646521
ur 9.88719
vb 5.692195
vt 6.119572
ua 9.7668555
va 5.9058835
sa 11.41362897037802346311
um 22.50444
vm 3.825448
sm 22.82726159911223341829
```

RELEASE NOTE: One of the diagnostic options in WRF is called "traditional fields". One of the available fields is the earth-relative components of the horizontal wind. Those values were too large by a factor of two (due to averaging to the cell center, but neglecting to divide by 2).