### PR TITLE
Bug fix: diagnostics: in temperature computation, incorrectly remove moisture from DRY theta perturbation

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -2027,7 +2027,7 @@ DEALLOCATE(z_at_q)
                U=grid%u_2                                           &
                ,V=grid%v_2                                          &
                ,W=grid%w_2                                          &
-               ,t=grid%t_2                                          &
+               ,t=grid%th_phy_m_t0                                  &
                ,qv=moist(:,:,:,P_QV)                                &
                ,zp=grid%ph_2                                        &
                ,zb=grid%phb                                         &

--- a/phys/module_diag_trad_fields.F
+++ b/phys/module_diag_trad_fields.F
@@ -78,11 +78,7 @@ CONTAINS
    
                !  Temperature
 
-               IF ( use_theta_m .EQ. 1 ) THEN
-                  temperature(i,k,j) = ( ( t(i,k,j) + t0 ) * ( (pb(i,k,j)+pp(i,k,j)) / p1000mb ) ** rcp ) / ( 1. + (R_v/R_d) * qv(i,k,j) )
-               ELSE
-                  temperature(i,k,j) = ( ( t(i,k,j) + t0 ) * ( (pb(i,k,j)+pp(i,k,j)) / p1000mb ) ** rcp )
-               END IF
+               temperature(i,k,j) = ( ( t(i,k,j) + t0 ) * ( (pb(i,k,j)+pp(i,k,j)) / p1000mb ) ** rcp )
  
                !  Hydrostatic pressure
 
@@ -121,11 +117,7 @@ CONTAINS
 
                !  Potential Temperature  
 
-               IF ( use_theta_m .EQ. 1 ) THEN
-                  potential_t(i,k,j) =  ( t(i,k,j) + t0 )  / ( 1. + (R_v/R_d) * qv(i,k,j) )
-               ELSE
-                  potential_t(i,k,j) =   t(i,k,j) + t0  
-               END IF
+               potential_t(i,k,j) =   t(i,k,j) + t0  
 
 
                !  Relative humidity


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: diagnostics, temperature, moist theta

SOURCE: Nicolas Baldeck (OpenMeteoData), internal

DESCRIPTION OF CHANGES:
In the traditional fields diagnostics option, the moisture is removed from the (already) dry theta 
perturbation. The `trad_fields` is called in two locations. From the diagnostics driver, the input to the scheme is:
```
     CALL trad_fields ( &
        !  Input data for computing
        U=grid%u_2                                           &
        ,V=grid%v_2                                          &
        ,W=grid%w_2                                          &
        ,t=grid%th_phy_m_t0                                  &
```
From `start_em`, the call incorrectly and inconsistently uses `grid%t_2`, which is fixed in this PR 
to `grid%th_phy_m_t0`.

The name `th_phy_m_t0` means "theta from physics, minus t0", so this is a dry potential 
temperature perturbation. Therefore, since the input is dry potential temperature perturbation, 
attempting to remove the moisture results in a cooler temperature, as much as 8-10 K in locations 
near the surface with tropical moisture. This is how the error was spotted.

ISSUE:
Closes #935 "Bad Wind and Temperature values with diag_nwp2=1" (only the "temperature" portion)

LIST OF MODIFIED FILES:
modified: dyn_em/start_em.F
modified: physics/module_diag_trad_fields.F

TESTS CONDUCTED:
 - [x] With the new mods, the potential temperature fields are correct:
The `T` field from WRF is dry potential temperature perturbation.
The  `POTENTIAL_T` field from the diagnostics output is the total dry potential temperature.
The difference of these fields should be a constant 300 K (and, it is).
![Screen Shot 2019-06-25 at 2 52 13 PM](https://user-images.githubusercontent.com/12666234/60132496-d8b27100-9758-11e9-8b17-7f19f730b77d.png)
 - [x] With the new mods, the temperature fields are correct:
The `T2` field from WRF is 2m temperature.
The  `TEMPERATURE` field from the diagnostics output is the temperature.
At the initial time, these fields should be _similar_. They do not show the pre-mod large 6-10 K offset.
![Screen Shot 2019-06-25 at 4 08 35 PM](https://user-images.githubusercontent.com/12666234/60137282-a2c6ba00-9763-11e9-9455-4058d302d2f8.png)



RELEASE NOTE: <ADD THIS TO THE WIND FIX TO TRAD FIELDS> Also, the traditional fields diagnostics incorrectly removed the impact of moisture, but from an already dry potential temperature perturbation. Re-removing the moisture results in a cooler temperature, possibly 8-10 K at the surface in locations with tropical levels of moisture.