### PR TITLE
Relocate derived bucket assignment to conventional location

### DIFF
--- a/dyn_em/namelist_remappings_em.h
+++ b/dyn_em/namelist_remappings_em.h
@@ -41,8 +41,6 @@
       model_config_rec%auxinput9_interval_s   =       model_config_rec%sgfdda_interval_s
       model_config_rec%auxinput9_interval_y   =       model_config_rec%sgfdda_interval_y
       model_config_rec%io_form_auxinput9      =       model_config_rec%io_form_sgfdda
-      IF (model_config_rec%prec_acc_dt(1) .gt. 0.) model_config_rec%prec_acc_opt = 1
-      IF (model_config_rec%bucket_mm .gt. 0.) model_config_rec%bucketr_opt = 1
 #ifdef PLANET
 !***************** special conversion for timesteps *********************
 ! 2004-12-07 ADT Notes

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -717,6 +717,15 @@
    END IF
 
 !-----------------------------------------------------------------------
+! Check if the bucket size for radiation is > 0. If so, then we need to activate
+! a derived namelist variable: bucketf_opt.
+!-----------------------------------------------------------------------
+
+   IF ( model_config_rec%bucket_J .GT. 0. ) THEN
+      model_config_rec%bucketf_opt = 1
+   END IF
+
+!-----------------------------------------------------------------------
 ! Check if the precip bucket reset time interval > 0. If so, then we need to 
 ! activate a derived namelist variable: prec_acc_opt
 !-----------------------------------------------------------------------
@@ -726,15 +735,6 @@
          model_config_rec%prec_acc_opt = 1
       END IF
    END DO
-
-!-----------------------------------------------------------------------
-! Check if the bucket size for radiation is > 0. If so, then we need to activate
-! a derived namelist variable: bucketf_opt.
-!-----------------------------------------------------------------------
-
-   IF ( model_config_rec%bucket_J .GT. 0. ) THEN
-      model_config_rec%bucketf_opt = 1
-   END IF
 
 !-----------------------------------------------------------------------
 ! Check if any stochastic perturbation scheme is turned on in any domain,

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -708,6 +708,35 @@
 #if (EM_CORE == 1)
 
 !-----------------------------------------------------------------------
+! Check if the bucket size for rain is > 0. If so, then we need to activate
+! a derived namelist variable: bucketr_opt.
+!-----------------------------------------------------------------------
+
+   IF ( model_config_rec%bucket_mm .GT. 0. ) THEN
+      model_config_rec%bucketr_opt = 1
+   END IF
+
+!-----------------------------------------------------------------------
+! Check if the precip bucket reset time interval > 0. If so, then we need to 
+! activate a derived namelist variable: prec_acc_opt
+!-----------------------------------------------------------------------
+
+   DO i = 1, model_config_rec % max_dom
+      IF ( model_config_rec%prec_acc_dt(i) .GT. 0. ) THEN
+         model_config_rec%prec_acc_opt = 1
+      END IF
+   END DO
+
+!-----------------------------------------------------------------------
+! Check if the bucket size for radiation is > 0. If so, then we need to activate
+! a derived namelist variable: bucketf_opt.
+!-----------------------------------------------------------------------
+
+   IF ( model_config_rec%bucket_J .GT. 0. ) THEN
+      model_config_rec%bucketf_opt = 1
+   END IF
+
+!-----------------------------------------------------------------------
 ! Check if any stochastic perturbation scheme is turned on in any domain,
 ! if so, set derived variable sppt_on=1 and/or rand_perturb_on and/or skebs_on=1
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: bucket

SOURCE: Chang Hai Liu (NCAR/RAL), internal

DESCRIPTION OF CHANGES: 

Problem:
This modification includes two types of changes dealing with the buckets used for longer-term 
simulations. The purpose of these buckets is to allow for an accurate accumulation of small values
over seasonal or regional climate time scales. These capabilities are both driven by derived namelist
options. Once a user defines a bucket size > 0, then the option is automatically activated.
 - [x] The derived option for the precip bucket was not handled in a standard way. 
 - [x] The radiation bucket was completely broken. The requested fields were not output.

Solution:
1. The bucket information for precipitation used to be buried in `dyn_em/namelist_remappings_em.h`,
which is not conventional and certainly not easy to find. This assignment of this derived variable is
moved into `module_check_a_mundo.F`, where it belongs.
2. More importantly, there was no assignment of the derived namelist variable for the radiation / flux /
energy bucket. If a user turned on the radiation bucket `bucket_J=1`, no additional output was
manufactured. With this modification, as with the precip bucket in check_a_mundo, there is now an 
assignment to the derived radiation / flux / energy bucket option.

LIST OF MODIFIED FILES: 
modified:   dyn_em/namelist_remappings_em.h
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED: 
 - [x] A segfault occurs instantly in the old code when requesting the bucket_J option because the 
fields are never allocated.
```
 &physics
 bucket_J = 10000.
```
 - [x] The results are identical for the rain buckets (original code vs the new code). This is expected
since the only change for the rain bucket is the location of the assignment of the derived namelist 
option (`module_check_a_mundo.F` vs `namelist_remappings_em.h`). This is a 12-h simulation of 
the Jan 2000 case.
```
 &physics
 bucket_mm = 1.0
```
![Screen Shot 2019-07-01 at 5 40 16 PM](https://user-images.githubusercontent.com/12666234/60472765-5ed22a00-9c27-11e9-87cb-de86ac4c569d.png)

 - [x] When comparing the code for the radiation flux buckets, we can see the impact of buckets on 
the original code (no buckets) and the new code (able to use buckets). The difference fields reflect 
the size of the bucket over two 6-h time periods. There are places with 0 difference (old vs new 
code), and places with +- 10000 W/m^2 and +-20000 W/m^2. For selected points, the differences 
between old code total ACLWDNB (left) and the new code bucketed ACLWDNB (middle), is 
identically the bucket size * the number of buckets at that grid point.
```
 &physics
 bucket_J = 10000.
```
![Screen Shot 2019-07-01 at 5 52 06 PM](https://user-images.githubusercontent.com/12666234/60473139-fab06580-9c28-11e9-833e-a6f348fd39c2.png)

 - [ ] waiting for confirmation from Chang Hai

RELEASE NOTE: Logic was added to include the buckets for accumulated radiation fields (i_acswupt, i_acswuptc, i_acswdnt, i_acswdntc, i_acswupb, i_acswupbc, i_acswdnb, i_acswdnbc, i_aclwupt, i_aclwuptc, i_aclwdnt, i_aclwdntc, i_aclwupb, i_aclwupbc, i_aclwdnb, i_aclwdnbc) when the user selects bucket_J > 0. Previously, when the user selected the bucket_J >0, no additional fields were computed or output.
