### PR TITLE
Obs nudging diagnostic print fix

### DIFF
--- a/phys/module_fddaobs_rtfdda.F
+++ b/phys/module_fddaobs_rtfdda.F
@@ -2834,7 +2834,7 @@ SUBROUTINE errob(inest, ub, vb, tb, t0, qvb, pbase, pp, rovcp,  &
   if(iprt) then
     if(prt_max.gt.0) then
 
-      ! If ANY of the obs are not missing, then execute these prints (which 
+      ! If ANY of the obs are NOT missing, then execute these prints (which 
       ! include the headers for the rows of data to be printed in the next 
       ! do loop)
       if(ANY(obs.ne.-999)) then

--- a/phys/module_fddaobs_rtfdda.F
+++ b/phys/module_fddaobs_rtfdda.F
@@ -2834,7 +2834,10 @@ SUBROUTINE errob(inest, ub, vb, tb, t0, qvb, pbase, pp, rovcp,  &
   if(iprt) then
     if(prt_max.gt.0) then
 
-      if(obs(1).ne.-999) then
+      ! If ANY of the obs are not missing then execute these prints which 
+      ! include the headers for the rows of data to be printed in the next 
+      ! do loop
+      if(ANY(obs.ne.-999)) then
 
         call wrf_message("")
         write(msg,fmt='(a,i4,a,f8.1,a)') 'REPORTING OBS MASS-PT LOCS FOR NEST ',  &

--- a/phys/module_fddaobs_rtfdda.F
+++ b/phys/module_fddaobs_rtfdda.F
@@ -2834,9 +2834,9 @@ SUBROUTINE errob(inest, ub, vb, tb, t0, qvb, pbase, pp, rovcp,  &
   if(iprt) then
     if(prt_max.gt.0) then
 
-      ! If ANY of the obs are not missing then execute these prints which 
+      ! If ANY of the obs are not missing, then execute these prints (which 
       ! include the headers for the rows of data to be printed in the next 
-      ! do loop
+      ! do loop)
       if(ANY(obs.ne.-999)) then
 
         call wrf_message("")

--- a/share/wrf_fddaobs_in.F
+++ b/share/wrf_fddaobs_in.F
@@ -308,6 +308,7 @@
   DATA NMOVE/0/,NVOLA/61/
   character*140 file_name_on_obs_unit, obs_domain_file_name
   integer :: obs_domain_file_unit
+  integer :: ndx
 
 ! if(ieof(inest).eq.2.and.fdob%nstat.eq.0)then
 !   IF (iprt) print *,'returning from in4dob'
@@ -945,9 +946,10 @@
 !======================================================================
 !======================================================================
 ! check if ob time is too early (only applies to beginning)
-      IF(RTIMOB.LT.TBACK-TWINDO)then
+      IF(RTIMOB.LT.TBACK)then
         IF (iprt) call wrf_message("ob too early")
-        n=n-1
+!       Adjust n to omit ALL levels of the current observation
+        n=n-meas_count
         GOTO 110
       ENDIF
 
@@ -1239,6 +1241,21 @@
         TIMEOB(N)=99999.
       ENDDO
     ENDIF
+
+    ! Update the indices of the observations to print
+    ! Since the old observations have been removed from the beginning
+    ! of the list, need to update the variable with the list of 
+    ! ob index numbers to be printed 
+    DO ndx = 1,prt_max
+     if (obs_prt(ndx)>ndum) THEN
+      ! If the ob was not one of the removed obs 
+      obs_prt(ndx)=obs_prt(ndx)-ndum
+     else
+      ! If the ob was one of the removed obs then mark it as not to be printed
+      obs_prt(ndx)=-999
+     endif
+    ENDDO
+
   ENDIF
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
   NSTA=0

--- a/share/wrf_fddaobs_in.F
+++ b/share/wrf_fddaobs_in.F
@@ -949,6 +949,7 @@
       IF(RTIMOB.LT.TBACK)then
         IF (iprt) call wrf_message("ob too early")
 !       Adjust n to omit ALL levels of the current observation
+!       since it is too early
         n=n-meas_count
         GOTO 110
       ENDIF


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: observation nudging, diagnostic prints, obs_prt_max

SOURCE: Brian Reen (Army Research Lab)

DESCRIPTION OF CHANGES: 
The observation nudging diagnostic prints controlled by obs_prt_max were sometimes incorrect.  Information from different observations were sometimes mixed together and sometimes missing values were printed when it tried to print observations that were not available for printing.  This bug did not influence the nudging itself, only the diagnostic prints regarding the nudging.

Observation nudging stores some information to be printed about the obs in arrays specifically for diagnostic prints.  However, some fields printed do not have diagnostic-print specific variables.  When old obs are removed from non-diagnostic-print variables and the placement of obs in the array shifts to fill in the portion of the array left blank by the removal of old obs, previously the diagnostic print code was not aware of this.  This resulted in it using the correct index to pull data from diagnostic-specific variables but the wrong index to pull data from non-diagnostic-specific variables.  Now, the diagnostic-print variable indicating the index of the corresponding non-diagnostic-print variable is updated to account for the shifts in the placement of data within the arrays.

When obs are determined to be too early when first read in, previously it would decrement the obs counter by one.  However, for multi-level obs the check occurs at the end of the ob and thus all but the final level in the ob would be initially retained.  Now, it decrements the ob counter by the number of levels in the current ob.

Each obs in the array of obs to be printed is printed if it is not marked as missing.  Previously, the headers for the obs prints were printed only if the first ob to be printed was not marked as missing, whereas now the headers are printed if any of the obs to be printed are not marked as missing.

When obs are read in from the file, previously it would mark any obs prior to twice the length of the obs nudging window in the past as too early but then later (correctly) additionally mark any obs prior to once the length of the obs nudging window in the past for removal for being too early.  After the changes described in the preceding paragraphs were made, while the obs printed had their information correctly printed, the number of obs printed could be much fewer than the user-specified maximum number of observations to print (obs_prt_max).  This was because obs that met the first time criteria but not the second time criteria were included in the array of obs to print, and thus took up entries in this array, but were ultimately not printed because they were too early.  Now, the first time criteria is changed to the correct time criteria, and thus the obs that are too early are not included in the list of obs to print and the number of obs printed can be more consistent with obs_prt_max.

LIST OF MODIFIED FILES: 
M       phys/module_fddaobs_rtfdda.F
M       share/wrf_fddaobs_in.F

TESTS CONDUCTED: 

Tested with obs nudging enabled and found diagnostic prints are corrected by the changes but wrfout* files are unchanged as expected.

1. In the first example, the observation file contained surface observations at three locations. 
Observations are in the file that are too early to be used as well as observations that are
not too early to use.

 - [x] Using the unmodified version of the code, the following prints result:
---Begin sample from rsl.out.0000 generated by UNmodified code using obs file 1----
```
REPORTING OBS MASS-PT LOCS FOR NEST    1 AT XTIME=     0.0 MINUTES
FREQ=   1, MAX=   50 LOCS, NEWLY READ OBS ONLY, -999 => OBS OFF PROC

    OBS#     I       J       K     OBS LAT  OBS LON   XLAT(I,J)  XLONG(I,J)  TIME(hrs)  OBS STATION ID
        1   8.277   7.851   1.000   39.080  -77.560     39.080    -77.560    -1.07       KJYO
        2   5.596   5.129   1.000   39.170  -77.170     39.170    -77.170    -1.05       KGAI
        3   4.541   6.736   1.000   38.950  -77.450     38.950    -77.450    -1.03       KIAD
        4   5.596   5.129   1.000   39.170  -77.170     39.170    -77.170    -0.15       KGAI
        5   8.277   7.851   1.000   38.950  -77.450     38.950    -77.450    -0.13       KIAD
        6   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560    -0.12       KJYO
        7   4.541   6.736   1.000   38.950  -77.450     38.950    -77.450     0.90       KIAD
        8   5.596   5.129   1.000   39.170  -77.170     39.170    -77.170     0.92       KGAI
        9   8.277   7.851   1.000   39.080  -77.560     39.080    -77.560     0.93       KJYO
       10   8.277   7.851   1.000   39.080  -77.560     39.080    -77.560     1.95       KJYO
       11  -0.500  -0.500   0.000   38.950  -77.450     38.950    -77.450   ******       KIAD
       12  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
       13  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
```
---End sample from rsl.out.0000 generated by UNmodified code using obs file 1----

In the above sample, a given I,J does not consistently correspond with a given station, and a given 
station has more than one I,J value.  For example, note that I=8.277, J=7.851
is listed for OBS# 1 as being the location for KJYO, but in OBS# 5 
as being the location for KIAD.  KJYO reports it is at I=8.277, J=7.851 in OBS# 1, but in OBS# 6
as being at I=4.541, J=6.736.  

Also, in the above sample, asterisks are printed under the TIME(hrs) column for OBS# 11-13 because
the code is not correctly dealing with excluding observations that are too early to be assimilated.


 - [x] Using the modified version of the code, the following prints result:
---Begin sample from rsl.out.0000 generated by modified code using obs file 1----
```
REPORTING OBS MASS-PT LOCS FOR NEST    1 AT XTIME=     0.0 MINUTES
FREQ=   1, MAX=   50 LOCS, NEWLY READ OBS ONLY, -999 => OBS OFF PROC

    OBS#     I       J       K     OBS LAT  OBS LON   XLAT(I,J)  XLONG(I,J)  TIME(hrs)  OBS STATION ID
        1   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170    -1.07       KGAI
        2   5.596   5.129   1.000   38.950  -77.450     38.950    -77.450    -1.05       KIAD
        3   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560    -1.03       KJYO
        4   5.596   5.129   1.000   38.950  -77.450     38.950    -77.450    -0.15       KIAD
        5   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170    -0.13       KGAI
        6   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560    -0.12       KJYO
        7   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560     0.90       KJYO
        8   5.596   5.129   1.000   38.950  -77.450     38.950    -77.450     0.92       KIAD
        9   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170     0.93       KGAI
       10   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170     1.95       KGAI
```
---End sample from rsl.out.0000 generated by modified code using obs file 1----

In the above sample generated using the modified code, the I/J pairs have a one-to-one
correspondence to stations as would be expected.  Additionally there are no lines with
asterisks listed for TIME(hrs) since the code is correctly dealing with observations that
are too early to be assimialted.

**********************************
2. In the second example, the observation file contained surface observations at three locations plus
a sounding. The sounding is too early to be used by obs nudging while some surface observations
are too early to use while others are not.


 - [x] Using the unmodified version of the code, the following prints result:
---Begin sample from rsl.out.0000 generated by UNmodified code using obs file 2----
```
REPORTING OBS MASS-PT LOCS FOR NEST    1 AT XTIME=     0.0 MINUTES
FREQ=   1, MAX=   50 LOCS, NEWLY READ OBS ONLY, -999 => OBS OFF PROC

    OBS#     I       J       K     OBS LAT  OBS LON   XLAT(I,J)  XLONG(I,J)  TIME(hrs)  OBS STATION ID
        1   8.277   7.851   1.000   39.080  -77.560     38.980    -77.490    -1.07       KJYO
        2   5.596   5.129   1.000   39.080  -77.560     38.980    -77.490    -1.05       KJYO
        3   4.541   6.736   1.000   39.080  -77.560     38.980    -77.490    -1.03       KJYO
        4   5.596   5.129   1.000   39.080  -77.560     38.980    -77.490    -0.15       KJYO
        5   8.277   7.851   1.000   39.080  -77.560     38.980    -77.490    -0.13       KJYO
        6   4.541   6.736   1.000   39.080  -77.560     38.980    -77.490    -0.12       KJYO
        7   4.541   6.736   1.000   39.080  -77.560     38.980    -77.490     0.90       KJYO
        8   5.596   5.129   1.000   39.080  -77.560     38.980    -77.490     0.92       KJYO
        9   8.277   7.851   1.000   39.080  -77.560     38.980    -77.490     0.93       KJYO
       10   8.277   7.851   1.000   39.080  -77.560     38.980    -77.490     1.95       KJYO
       11  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       12  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       13  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       14  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       15  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       16  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       17  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       18  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       19  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       20  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       21  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       22  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       23  -0.500  -0.500   0.000   39.080  -77.560     38.980    -77.490   ******       KJYO
       24  -0.500  -0.500   0.000   39.080  -77.560     39.080    -77.560   ******       KJYO
       25  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
       26  -0.500  -0.500   0.000   38.950  -77.450     38.950    -77.450   ******       KIAD
       27  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
       28  -0.500  -0.500   0.000   38.950  -77.450     38.950    -77.450   ******       KIAD
       29  -0.500  -0.500   0.000   39.080  -77.560     39.080    -77.560   ******       KJYO
       30  -0.500  -0.500   0.000   38.950  -77.450     38.950    -77.450   ******       KIAD
       31  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
       32  -0.500  -0.500   0.000   39.080  -77.560     39.080    -77.560   ******       KJYO
       33  -0.500  -0.500   0.000   39.080  -77.560     39.080    -77.560   ******       KJYO
       34  -0.500  -0.500   0.000   38.950  -77.450     38.950    -77.450   ******       KIAD
       35  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
       36  -0.500  -0.500   0.000   39.170  -77.170     39.170    -77.170   ******       KGAI
```
---End sample from rsl.out.0000 generated by UNmodified code using obs file 2----

Note that it claims OBS# 1-10 are all at OBS STATION ID KJYO, but lists various I/J pairs.  
Also, note that OBS# 11-36 have asterisks for the time since the code does not 
properly deal with excluding obs that are too early from printing.

 - [x] Using the modified version of the code, the following prints result:

---Begin sample from rsl.out.0000 generated by modified code using obs file 2----
```
REPORTING OBS MASS-PT LOCS FOR NEST    1 AT XTIME=     0.0 MINUTES
FREQ=   1, MAX=   50 LOCS, NEWLY READ OBS ONLY, -999 => OBS OFF PROC

    OBS#     I       J       K     OBS LAT  OBS LON   XLAT(I,J)  XLONG(I,J)  TIME(hrs)  OBS STATION ID
        1   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170    -1.07       KGAI
        2   5.596   5.129   1.000   38.950  -77.450     38.950    -77.450    -1.05       KIAD
        3   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560    -1.03       KJYO
        4   5.596   5.129   1.000   38.950  -77.450     38.950    -77.450    -0.15       KIAD
        5   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170    -0.13       KGAI
        6   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560    -0.12       KJYO
        7   4.541   6.736   1.000   39.080  -77.560     39.080    -77.560     0.90       KJYO
        8   5.596   5.129   1.000   38.950  -77.450     38.950    -77.450     0.92       KIAD
        9   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170     0.93       KGAI
       10   8.277   7.851   1.000   39.170  -77.170     39.170    -77.170     1.95       KGAI
```
---Begin sample from rsl.out.0000 generated by modified code using obs file 2----

The observations that are too early are no longer included in the print and the I/J values 
have a one-to-one correspondence with the OBS STATION ID as expected for surface obs.
