### PR TITLE
Namelist checks only to be conducted on "allowed" grids

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Configuration Script for WRF prototype code
+# Configuration script for WRF prototype code
 # 
 # Be sure to run as ./configure (to avoid getting a system configure command by mistake)
 #

--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Configuration script for WRF prototype code
+# Configuration Script for WRF prototype code
 # 
 # Be sure to run as ./configure (to avoid getting a system configure command by mistake)
 #

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -320,6 +320,7 @@
 ! each of those respective modules.
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % sf_urban_physics(i) == bepscheme     ) THEN
            model_config_rec % num_urban_ndm  = bep_ndm()
            model_config_rec % num_urban_nz   = bep_nz_um()
@@ -341,6 +342,7 @@
 ! Check that mosiac option cannot turn on when sf_urban_physics = 2 and 3
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % sf_surface_mosaic .EQ. 1 .AND. &
               (model_config_rec % sf_urban_physics(i) .EQ. 2 .OR. &
                model_config_rec % sf_urban_physics(i) .EQ. 3 ) ) THEN
@@ -358,6 +360,7 @@
 ! Check that Deng Shallow Convection Must work with MYJ or MYNN PBL
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
               (model_config_rec % bl_pbl_physics(i) /= myjpblscheme .AND. &
                model_config_rec % bl_pbl_physics(i) /= mynnpblscheme2 ) ) THEN
@@ -377,6 +380,7 @@
 !-----------------------------------------------------------------------
 # if ( defined(PROMOTE_FLOAT) || ( RWORDSIZE == DWORDSIZE ) )
       god_r8 : DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % ra_lw_physics(i) == goddardlwscheme ) .OR. &
               ( model_config_rec % ra_sw_physics(i) == goddardswscheme ) ) THEN
             wrf_err_message = '--- ERROR: Goddard radiation scheme cannot run with real*8 floats'
@@ -394,6 +398,7 @@
 ! Print a warning message for not using a combination of radiation and microphysics from Goddard
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( (model_config_rec % ra_lw_physics(i) == goddardlwscheme .OR. &
                  model_config_rec % ra_sw_physics(i) == goddardswscheme) .AND. &
                  model_config_rec % mp_physics(i) /= nuwrf4icescheme ) .OR. &
@@ -414,6 +419,7 @@
 !-----------------------------------------------------------------------
 #if (NMM_CORE == 1) || (HWRF == 1)
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % mp_physics(i) == nuwrf4icescheme .OR. &
               model_config_rec % mp_physics(i) == nssl_2mom .OR. &
               model_config_rec % mp_physics(i) == nssl_2momccn .OR. &
@@ -434,6 +440,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % sf_surface_physics(i)     .NE. &
               model_config_rec % sf_surface_physics(1) ) THEN
             wrf_err_message = '--- ERROR: sf_surface_physics must be equal for all domains '
@@ -450,6 +457,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % sf_sfclay_physics(i)     .NE. &
               model_config_rec % sf_sfclay_physics(1) ) THEN
             wrf_err_message = '--- ERROR: sf_sfclay_physics must be equal for all domains '
@@ -466,6 +474,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % mp_physics(i)     .NE. &
               model_config_rec % mp_physics(1) ) THEN
             wrf_err_message = '--- NOTE: mp_physics must be equal for all domains '
@@ -510,6 +519,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % ra_lw_physics(i)     .NE. &
               model_config_rec % ra_lw_physics(1) ) THEN
             wrf_err_message = '--- ERROR: ra_lw_physics must be equal for all domains '
@@ -521,6 +531,7 @@
       ENDDO
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % ra_sw_physics(i)     .NE. &
               model_config_rec % ra_sw_physics(1) ) THEN
             wrf_err_message = '--- ERROR: ra_sw_physics must be equal for all domains '
@@ -550,6 +561,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % bl_pbl_physics(i) .NE. model_config_rec % bl_pbl_physics(1) ) .AND. &
               ( model_config_rec % bl_pbl_physics(i) .NE. 0                                    ) ) THEN
             wrf_err_message = '--- ERROR: bl_pbl_physics must be equal for all domains (or = zero)'
@@ -567,6 +579,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % cu_physics(i) .NE. model_config_rec % cu_physics(1) ) .AND. &
               ( model_config_rec % cu_physics(i) .NE. 0                                ) ) THEN
             wrf_err_message = '--- ERROR: cu_physics must be equal for all domains (or = zero)'
@@ -585,6 +598,7 @@
 !-----------------------------------------------------------------------
 
       GF_test : DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % cu_physics(i) .EQ. GFSCHEME ) THEN
             wrf_err_message = '--- ERROR: cu_physics GF uses an intrinsic gamma function that is not available with this compiler'
             CALL wrf_message ( TRIM( wrf_err_message ) )
@@ -613,6 +627,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%fine_input_stream(i) .NE. 0 ).AND. &
               ( model_config_rec%io_form_auxinput2 .EQ. 0 ) ) THEN
             wrf_err_message = '--- ERROR: If fine_input_stream /= 0, io_form_auxinput2 must be /= 0'
@@ -640,6 +655,7 @@
 
       d1_value = model_config_rec%sf_urban_physics(1)
       DO i = 2, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%sf_urban_physics(i) /= d1_value ) THEN
             wrf_err_message = '--- NOTE:   sf_urban_physics option must be identical in each domain'
             CALL wrf_debug ( 1, wrf_err_message )
@@ -649,6 +665,7 @@
       END DO
       d1_value = model_config_rec%sf_urban_physics(model_config_rec % max_dom)
       DO i = 1, model_config_rec % max_dom-1
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          model_config_rec%sf_urban_physics(i) = d1_value
       END DO
 
@@ -657,6 +674,7 @@
 !------------------------------------------------------------------------
       IF ( model_config_rec%seaice_albedo_opt == 1 ) THEN
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( ( model_config_rec%sf_surface_physics(i) /= LSMSCHEME ) .AND. &
                  ( model_config_rec%sf_surface_physics(i) /= NOAHMPSCHEME ) ) THEN
 
@@ -681,6 +699,7 @@
 !           Check that NOAH-MP LSM is not allowed for WRF-NMM run
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%sf_surface_physics(i) == NOAHMPSCHEME ) THEN
             WRITE(wrf_err_message, '(" --- ERROR:   Noah-MP LSM scheme (sf_surface_physics==", I2, ")")') NOAHMPSCHEME
             CALL wrf_message ( TRIM ( wrf_err_message ) )
@@ -697,6 +716,7 @@
 !           Check that NSAS shallow convection is not allowed to turn on simultaneously with NSAS
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%shcu_physics(i) == nscvshcuscheme .AND. model_config_rec%cu_physics(i) == nsasscheme) THEN
             WRITE(wrf_err_message, '(" --- ERROR: NSCV shallow convection scheme is already included in NSAS ")')
             CALL wrf_message ( TRIM ( wrf_err_message ) )
@@ -713,6 +733,7 @@
 !-----------------------------------------------------------------------
 
    DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % sppt(i) .ne. 0)  then
            model_config_rec % sppt_on=1
            IF (( model_config_rec%KMINFORCT .ne. 1) .or. (model_config_rec%KMAXFORCT .ne. 1000000) .or.   &
@@ -728,6 +749,7 @@
          endif
    ENDDO
    DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % rand_perturb(i) .ne. 0)  then
            model_config_rec % rand_perturb_on=1
            IF (( model_config_rec%KMINFORCT .ne. 1) .or. (model_config_rec%KMAXFORCT .ne. 1000000) .or.   &
@@ -743,6 +765,7 @@
          endif
    ENDDO
    DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF (( model_config_rec % spp_conv(i) .ne. 0).or.( model_config_rec % spp_pbl(i) .ne. 0).or. (model_config_rec % spp_lsm(i) .ne. 0)  &
            .or. ( model_config_rec % spp(i) .ne. 0))  then
            model_config_rec % spp_on=1
@@ -764,6 +787,7 @@
          endif
    ENDDO
    DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % stoch_vertstruc_opt(i) ==1 )  then
            model_config_rec % skebs_vertstruc=1       ! parameter stoch_vertstruc_opt is being replaced with skebs_vertstruc
                                                       ! stoch_vertstruc_opt is obsolete starting with V3.7
@@ -775,6 +799,7 @@
    ENDDO
 
    DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % stoch_force_opt(i) ==1 )  THEN
            model_config_rec % skebs(i)=1    ! parameter stoch_forc_opt is being replaced with skebs;
                                             ! stoch_vertstruc_opt is obsolete starting with V3.7
@@ -785,6 +810,7 @@
          ENDIF
    ENDDO
    DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % skebs(i) .ne. 0)  then
            model_config_rec % skebs_on=1
          endif
@@ -890,6 +916,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%bl_pbl_physics(i) .NE. YSUSCHEME ) .AND. &
               ( model_config_rec%cu_physics(i) .EQ. MSKFSCHEME ) ) THEN
             oops = oops + 1
@@ -904,6 +931,7 @@
       END IF
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%cu_physics(i) .EQ. MSKFSCHEME ) THEN
             wrf_err_message = '--- NOTE: cu_physics is 11, setting icloud = 1 and cu_rad_feedback = T'
             CALL wrf_debug ( 1, TRIM( wrf_err_message ) )
@@ -917,6 +945,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%aercu_opt .GT. 0 .AND.       &
               ( model_config_rec%cu_physics(i) .NE. MSKFSCHEME .OR. &
               model_config_rec%mp_physics(i) .NE. MORR_TM_AERO ) ) THEN
@@ -959,6 +988,7 @@
       IF ( model_config_rec%sst_update .EQ. 0 ) THEN
          model_config_rec%io_form_auxinput4 = 0
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             wrf_err_message = '--- NOTE: sst_update is 0, ' // &
                   'setting io_form_auxinput4 = 0 and auxinput4_interval = 0 for all domains'
             CALL wrf_debug ( 1, TRIM( wrf_err_message ) )
@@ -1031,6 +1061,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%grid_sfdda(i) .GT. 0 ).AND. &
               ( model_config_rec%grid_fdda (i) .NE. 1 ) ) THEN
             wrf_err_message = '--- ERROR: If grid_sfdda >= 1, then grid_fdda must also = 1 for that domain '
@@ -1050,6 +1081,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
 
          IF ( model_config_rec%grid_fdda(i) .EQ. 0 ) THEN
             WRITE (wrf_err_message, FMT='(A,I6,A)') '--- NOTE: grid_fdda is 0 for domain ', &
@@ -1116,6 +1148,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          model_config_rec%fasdas(i) = 0
          IF ( model_config_rec%grid_sfdda(i) .EQ. 2 ) THEN
             model_config_rec%fasdas(i) = 1
@@ -1127,8 +1160,10 @@
 !-----------------------------------------------------------------------
     rinblw_already_done = .FALSE.
     DO j = 1, model_config_rec%max_dom
+    IF ( .NOT. model_config_rec % grid_allowed(j) ) CYCLE
     IF (model_config_rec%grid_sfdda(j) .EQ. 1 ) THEN
       DO i = 2, model_config_rec%max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%rinblw(i) .EQ. -1 ) THEN
             model_config_rec%rinblw(i) = model_config_rec % rinblw(1)
             IF ( .NOT. rinblw_already_done ) THEN
@@ -1156,6 +1191,7 @@
 ! Check to see if FASDAS is active
 !------------------------------------------------------------------------
     DO i = 1, model_config_rec%max_dom
+     IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
      IF (model_config_rec%fasdas(i) .EQ. 1 ) THEN
         wrf_err_message = 'FASDAS is active. Mixed Layer fdda is inactive'
         CALL wrf_debug ( 1, TRIM( wrf_err_message ) )
@@ -1181,6 +1217,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%bl_pbl_physics(i) .NE. QNSEPBLSCHEME ) .AND. &
               ( model_config_rec%mfshconv(i) .NE. 0 ) ) THEN
             model_config_rec%mfshconv(i) = 0
@@ -1198,6 +1235,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%shcu_physics(i) .EQ. GRIMSSHCUSCHEME ) THEN
             IF ( (model_config_rec%bl_pbl_physics(i) .EQ. YSUSCHEME) .OR. &
                  (model_config_rec%bl_pbl_physics(i) .EQ. SHINHONGSCHEME) .OR. &
@@ -1221,6 +1259,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME2 ) .AND. &
               ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME3 ) ) THEN
               model_config_rec % bl_mynn_edmf(i) = 0
@@ -1252,6 +1291,7 @@
 
       model_config_rec%cu_used = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%cu_physics(i) .NE. NOCUSCHEME ) THEN
             model_config_rec%cu_used = 1
          END IF
@@ -1264,6 +1304,7 @@
 
       model_config_rec%shcu_used = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%shcu_physics(i) .NE. NOSHCUSCHEME ) THEN
             model_config_rec%shcu_used = 1
          END IF
@@ -1275,6 +1316,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%icloud_bl .eq. 1) THEN
            IF ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
                 model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) THEN
@@ -1296,6 +1338,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%icloud .eq. 3) THEN
            IF ( model_config_rec%mp_physics(i) .EQ. WSM3SCHEME .OR. &
                 model_config_rec%mp_physics(i) .EQ. KESSLERSCHEME ) THEN
@@ -1345,6 +1388,7 @@
 
       IF ( model_config_rec%p_lev_diags .EQ. 1 ) THEN
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( ( MAX ( model_config_rec%auxhist23_interval  (i) , &
                          model_config_rec%auxhist23_interval_d(i) , &
                          model_config_rec%auxhist23_interval_h(i) , &
@@ -1361,6 +1405,7 @@
             END IF
          END DO
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             model_config_rec%p_lev_interval(i) = model_config_rec%auxhist23_interval  (i)*   60 + &
                                                  model_config_rec%auxhist23_interval_d(i)*86400 + &
                                                  model_config_rec%auxhist23_interval_h(i)* 3600 + &
@@ -1376,6 +1421,7 @@
 
       IF ( model_config_rec%z_lev_diags .EQ. 1 ) THEN
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( ( MAX ( model_config_rec%auxhist22_interval  (i) , &
                          model_config_rec%auxhist22_interval_d(i) , &
                          model_config_rec%auxhist22_interval_h(i) , &
@@ -1392,6 +1438,7 @@
             END IF
          END DO
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             model_config_rec%z_lev_interval(i) = model_config_rec%auxhist22_interval  (i)*   60 + &
                                                  model_config_rec%auxhist22_interval_d(i)*86400 + &
                                                  model_config_rec%auxhist22_interval_h(i)* 3600 + &
@@ -1410,6 +1457,7 @@
 ! 1. Only one time interval type specified
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          count_opt = 0
          IF ( model_config_rec%mean_diag_interval_s (i) .GT. 0 ) THEN
             count_opt = count_opt + 1
@@ -1439,6 +1487,7 @@
 ! 2. Put canonical intervals into RASM expected form
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%mean_diag_interval_s (i) .GT. 0 ) THEN
             model_config_rec%mean_interval(i) = model_config_rec%mean_diag_interval_s (i)
             model_config_rec%mean_freq = 1
@@ -1470,6 +1519,7 @@
       IF ( model_config_rec%mean_diag .EQ. 1 ) THEN
          count_opt = 0
          DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( model_config_rec%mean_interval   (i) .GT. 0 ) THEN
                count_opt = count_opt + 1
             END IF
@@ -1508,6 +1558,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%hailcast_opt(i) .NE. 0 ) .AND. &
               (model_config_rec%cu_physics(i) .NE. 0) ) THEN
               wrf_err_message = '--- hailcast_opt and cu_physics cannot both be turned on for the same domain. You must turn one of them off (=0).'
@@ -1580,6 +1631,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%cu_rad_feedback(i) .EQV. .TRUE. )  .OR. &
               ( model_config_rec%cu_rad_feedback(i) .EQV. .true. ) ) THEN
             IF ( ( model_config_rec%cu_physics(1) .EQ. GFSCHEME     ) .OR. &
@@ -1600,6 +1652,7 @@
 !-----------------------------------------------------------------------
 
        DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%cu_diag(i) .EQ. G3TAVE ) THEN
           IF ( ( model_config_rec%cu_physics(i) .NE. GDSCHEME ) .AND. &
                ( model_config_rec%cu_physics(i) .NE. GFSCHEME ) .AND. &
@@ -1626,6 +1679,7 @@
 !-----------------------------------------------------------------------
 
        DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%kf_edrates(i) .EQ. KFEDRATES ) THEN
           IF ( ( model_config_rec%cu_physics(i) .NE. KFETASCHEME ) .AND. &
                ( model_config_rec%cu_physics(i) .NE. MSKFSCHEME ) .AND. &
@@ -1665,6 +1719,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%cu_physics(i) .EQ. GDSCHEME ) .OR. &
               ( model_config_rec%cu_physics(i) .EQ. GFSCHEME ) .OR. &
               ( model_config_rec%cu_physics(i) .EQ. KFCUPSCHEME ) .OR. &
@@ -1680,6 +1735,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%bl_pbl_physics(i) .EQ. TEMFPBLSCHEME ) .AND. &
               ( model_config_rec%sf_sfclay_physics(i) .NE. TEMFSFCSCHEME ) )  THEN
             wrf_err_message = '--- ERROR: Using bl_pbl_physics=10 requires sf_sfclay_physics=10 '
@@ -1709,6 +1765,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec%bl_pbl_physics(i) .EQ. TEMFPBLSCHEME ) .AND. &
               (model_config_rec%dfi_opt .NE. DFI_NODFI) )  THEN
             wrf_err_message = '--- ERROR: DFI not available for bl_pbl_physics=10 '
@@ -1733,6 +1790,7 @@
 #if !defined ( WRF_USE_CLM )
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%sf_surface_physics(i) .EQ. CLMSCHEME ) THEN
             oops = oops + 1
          END IF
@@ -1753,6 +1811,7 @@
 !-----------------------------------------------------------------------
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%mp_physics(i) .EQ. THOMPSONAERO ) THEN
             IF ( model_config_rec%grav_settling(i) .NE. FOGSETTLING0 ) THEN
                 model_config_rec%grav_settling(i) = 0
@@ -1770,6 +1829,7 @@
 !-----------------------------------------------------------------------
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%mp_physics(i) .EQ. THOMPSONAERO ) THEN
             IF ( model_config_rec%use_aero_icbc .AND. model_config_rec%scalar_pblmix(i) .NE. 1 ) THEN
                 model_config_rec%scalar_pblmix(i) = 1
@@ -1787,6 +1847,7 @@
       !NOW CHECK FOR MYNN
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ((model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2) .OR. &
              (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3) ) THEN
             IF ( model_config_rec%bl_mynn_mixscalars(i) .EQ. 1 ) THEN
@@ -1804,6 +1865,7 @@
 !  DJW Check that we're not using ndown and vertical nesting.
 !-----------------------------------------------------------------------
      DO i=1,model_config_rec%max_dom
+       IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
        IF ((model_config_rec%vert_refine_method(i) .NE. 0) .AND. (model_config_rec%vert_refine_fact .NE. 1)) THEN
          wrf_err_message = '--- ERROR: vert_refine_fact is ndown specific and cannot be used with vert_refine_method, and vice versa.'
          CALL wrf_debug ( 1, wrf_err_message )
@@ -1814,6 +1876,7 @@
 !  DJW Check that only one type of vertical nesting is enabled.
 !-----------------------------------------------------------------------
      DO i=1,model_config_rec%max_dom
+       IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
        IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
          DO j=1,model_config_rec%max_dom
            IF ((model_config_rec%vert_refine_method(i) .NE. model_config_rec%vert_refine_method(j)) .AND. (model_config_rec%vert_refine_method(j) .NE. 0)) THEN
@@ -1831,6 +1894,7 @@
 !-----------------------------------------------------------------------
       IF ((model_config_rec%max_dom .GT. 1) .AND. (model_config_rec%vert_refine_fact .EQ. 1)) THEN
         DO i=1,model_config_rec%max_dom
+          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
           IF (((model_config_rec%parent_id(i) .NE. 0) .AND. (model_config_rec%parent_id(i) .NE. model_config_rec%grid_id(i))) .AND. (model_config_rec%vert_refine_method(i) .EQ. 0)) THEN
             DO j=1,model_config_rec%max_dom
               IF ((i .NE. j) .AND. (model_config_rec%parent_id(i) .EQ. model_config_rec%grid_id(j))) THEN
@@ -1851,6 +1915,7 @@
 !  nesting enabled.
 !-----------------------------------------------------------------------
       DO i=1,model_config_rec%max_dom
+        IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
         IF ((model_config_rec%parent_id(i) .EQ. 0) .OR. (model_config_rec%parent_id(i) .EQ. model_config_rec%grid_id(i))) THEN
           IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
             write(wrf_err_message,'(A,I1,A,I2,A)') '--- ERROR: vert_refine_method=',model_config_rec%vert_refine_method(i),' for grid_id=',model_config_rec%grid_id(i),', must be 0 for a non-nested domain.'
@@ -1864,6 +1929,7 @@
 !  DJW Check that we've got appropriate e_vert for integer refinement.
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+        IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
         IF (model_config_rec%vert_refine_method(i) .EQ. 1) THEN
           j = model_config_rec%parent_id(i)
           IF (MOD(model_config_rec%e_vert(i)-1, model_config_rec%e_vert(j)-1) .NE. 0) THEN
@@ -1881,6 +1947,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
+        IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
         IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
           IF ( ( ( model_config_rec%ra_lw_physics(i) .EQ. 0                   ) .OR. &
                  ( model_config_rec%ra_lw_physics(i) .EQ. RRTMSCHEME          ) ) .AND. &
@@ -2037,6 +2104,7 @@
 ! Check for consistent chem_opt and irr_opt
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%irr_opt(i) > 0 .and. &
               (model_config_rec%chem_opt(i) /= mozcart_kpp .and. &
                model_config_rec%chem_opt(i) /= t1_mozcart_kpp .and. &
@@ -2061,6 +2129,7 @@
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % e_we(i) /  model_config_rec % nproc_x .LT. 10 ) .OR. &
               ( model_config_rec % e_sn(i) /  model_config_rec % nproc_y .LT. 10 ) ) THEN
             WRITE ( wrf_err_message , * ) 'For domain ',i,', the domain size is too small for this many processors, ', & 
@@ -2214,6 +2283,7 @@
       CASE ('conus')
          DO i = 1, max_dom
 
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( model_config_rec % cu_physics(i) == -1 ) model_config_rec % cu_physics(i) = TIEDTKESCHEME               ! Tiedtke
             IF ( model_config_rec % mp_physics(i) == -1 ) model_config_rec % mp_physics(i) = THOMPSON                    ! Thompson
             IF ( model_config_rec % ra_lw_physics(i) == -1 ) model_config_rec % ra_lw_physics(i) = RRTMG_LWSCHEME        ! RRTMG LW
@@ -2230,6 +2300,7 @@
       CASE ('tropical')
          DO i = 1, max_dom
 
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( model_config_rec % cu_physics(i) == -1 ) model_config_rec % cu_physics(i) = NTIEDTKESCHEME              ! New Tiedtke
             IF ( model_config_rec % mp_physics(i) == -1 ) model_config_rec % mp_physics(i) = WSM6SCHEME                  ! WSM6
             IF ( model_config_rec % ra_lw_physics(i) == -1 ) model_config_rec % ra_lw_physics(i) = RRTMG_LWSCHEME        ! RRTMG LW
@@ -2434,6 +2505,7 @@
 #if ( (EM_CORE == 1) && (WRF_CHEM != 1) )
       model_config_rec % cam_used = 0
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % mp_physics(i)     .EQ. CAMMGMPSCHEME   ) .OR. &
               ( model_config_rec % bl_pbl_physics(i) .EQ. CAMUWPBLSCHEME  ) .OR. &
               ( model_config_rec % shcu_physics(i)   .EQ. CAMUWSHCUSCHEME ) ) THEN
@@ -2473,6 +2545,7 @@
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % mp_physics(i) .EQ. MILBRANDT2MOM ) .OR. &
 #if (EM_CORE == 1)
               ( model_config_rec % mp_physics(i) .EQ. NSSL_2MOM     ) .OR. &
@@ -2493,6 +2566,7 @@
 
 #if (EM_CORE == 1)
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME2 ) .AND. &
               ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME3 ) ) THEN
             model_config_rec % bl_mynn_edmf = 0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: grid_allowed, check_a_mundo

SOURCE: Kevin Manning (NCAR/MMM), internal

DESCRIPTION OF CHANGES:

The WRF model has a construct to permit users to bypass specified nested domains (and all of that 
nest's children) using the `grid_allowed` option. In the example below, the 3-domain run is really
only a 2-domain run.
```
&domains
 grid_allowed = T, F, T
 parent_id    = 0, 1, 1,
 max_dom      = 3,
/
```
Problem:
If a user activated this option, the namelist checker in `module_check_a_mundo.F` previously did not consider whether a domain was active. For an unused domain, the WRF model would return a fatal error if, for example, the number of grid cells for the unused domain was too small for the decomposition.

Solution:
For each of the domain-indexed namelist checks in `module_check_a_mundo.F`, the DO loop 
block has been modified to include a Fortran `CYCLE` statement. If that domain is inactive, no 
domain-indexed namelist checks are conducted.

Original loop
```
DO i = 1, model_config_rec % max_dom
   IF ( ( model_config_rec % e_we(i) /  model_config_rec % nproc_x .LT. 10 ) .OR. &
        ( model_config_rec % e_sn(i) /  model_config_rec % nproc_y .LT. 10 ) ) THEN
      WRITE ( wrf_err_message , * ) 'For domain ',i,', the domain size is too small for this many processors, ', &
                                    'or the decomposition aspect ratio is poor.'
```

New loop
```
DO i = 1, model_config_rec % max_dom
   IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
   IF ( ( model_config_rec % e_we(i) /  model_config_rec % nproc_x .LT. 10 ) .OR. &
        ( model_config_rec % e_sn(i) /  model_config_rec % nproc_y .LT. 10 ) ) THEN
      WRITE ( wrf_err_message , * ) 'For domain ',i,', the domain size is too small for this many processors, ', &
                                    'or the decomposition aspect ratio is poor.'
```

ISSUE:
Closes issue #949 "domain decomposition check fails on an unused domain"

LIST OF MODIFIED FILES:
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. Kevin confirms that this has the expected behavior for the initially identified failure case.
    a. With `grid_allowed` set to `.false.` for the unused domain, the problematic checks are skipped 
for that grid, and the model runs as expected (correct behavior).
   b. With the older version of the code, without the fix, we get fatal error alerting to a grid too small for the decomposition (incorrect behavior).
    c. With the new version of the code, with `grid_allowed = 6*.true.`, we get fatal errors alerting 
to a grid too small for the decomposition (correct behavior).
2. Set up namelist with inconsistent physics for 3 domain run, with domain 2 not being run. The 
second domain has the wrong PBL (typically each domain has the same PBL scheme selected). 
Also, domain 2 has an incompatible request for using Deng shallow cu (given the PBL scheme).
```
&domains
max_dom        = 3,
grid_allowed   = T, F, T
/
```
```
&physics
bl_pbl_physics =  2,     1,     2,
shcu_physics    = 5,     5,     5,
/
```
- [x] Original code fails when inconsistent physics schemes are selected, even though the domain is 
not active.
```
*************************************
--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL
  --- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.
--- ERROR: bl_pbl_physics must be equal for all domains (or = zero)
  --- Fix bl_pbl_physics in namelist.input
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1986
NOTE:       2 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
 - [x] New code runs OK