### PR TITLE
Do not reinitialise SOA_VBS or SORGAM aerosols on restart

### DIFF
--- a/chem/module_aerosols_soa_vbs.F
+++ b/chem/module_aerosols_soa_vbs.F
@@ -6769,7 +6769,7 @@ SUBROUTINE         aerosols_soa_vbs_init(chem,convfac,z_at_w,                   
 !
 !  IF USING OLD SIMULATION, DO NOT REINITIALIZE!
 !
-        if(chem_in_opt == 1 ) return
+        if(chem_in_opt == 1  .OR. config_flags%restart) return
         do l=p_so4aj,num_chem
            chem(ims:ime,kms:kme,jms:jme,l)=epsilc
         enddo

--- a/chem/module_aerosols_sorgam.F
+++ b/chem/module_aerosols_sorgam.F
@@ -7522,7 +7522,7 @@ END SUBROUTINE VDVG_2
 !  IF USING OLD SIMULATION, DO NOT REINITIALIZE!
 !
 !
-        if(chem_in_opt == 1 ) return
+        if(chem_in_opt == 1 .OR. config_flags%restart) return
         do l=p_so4aj,num_chem
          chem(ims:ime,kms:kme,jms:jme,l)=epsilc
         enddo


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: aerosols, SOA, VBS, SORGAM, restart

SOURCE: Theodoros Christoudias (Cyprus Institute)

DESCRIPTION OF CHANGES: 
Problem:
If using an existing simulation, aerosols (SOA_VBS and SORGAM) should not be reinitialized 
on restart. 

Solution:
This modification checks the restart configuration flag. If this is a restart run, then do not set 
all aerosols to epsilc.

LIST OF MODIFIED FILES:  
WRF/chem/module_aerosols_soa_vbs.F 
WRF/chem/module_aerosols_sorgam.F

TESTS CONDUCTED: 
 - [x] Test conducted without change: aerosols are reinitialized and not recycled at 
simulation restart. 
 - [x] Test conducted with change: fixes problem.

Below are consecutive history outputs before and after the restart point. It's clear that PM 
concentrations are reinitialized and there's no continuity with previous concentrations:

![PM2_5_DRY in test_full_d02_00841](https://user-images.githubusercontent.com/91646/69728611-a8626a80-111c-11ea-8bdd-2c43cd743fd2.png)
![PM2_5_DRY in test_full_d02_00842](https://user-images.githubusercontent.com/91646/69728632-ae584b80-111c-11ea-8dfc-130cc3ab26f9.png)

