### PR TITLE
Fix incorrect use of whereis and which to find nf-config command

### DIFF
--- a/configure
+++ b/configure
@@ -205,9 +205,9 @@ fi
 # If the user asked for classic netcdf, acquiesce to the request.
 
 if [ "`uname`" = "Linux" ] ; then
-  ans="`whereis nf-config`"
-elif [ "`uname`" = "Darwin" ] ; then
   ans="`which nf-config`"
+elif [ "`uname`" = "Darwin" ] ; then
+  ans="`whereis nf-config`"
 else
   ans=""
 # echo "Add in your architecture's uname and the command to find executables in the path"

--- a/configure
+++ b/configure
@@ -204,16 +204,9 @@ fi
 
 # If the user asked for classic netcdf, acquiesce to the request.
 
-if [ "`uname`" = "Linux" ] ; then
-  ans="`which nf-config`"
-elif [ "`uname`" = "Darwin" ] ; then
-  ans="`which nf-config`"
-else
-  ans=""
-# echo "Add in your architecture's uname and the command to find executables in the path"
-# exit 1
-fi
-if [ "$ans" = "nf-config:" -o "$ans" = "" ] ; then
+ans="`which nf-config`"
+status="$?"
+if [ "$ans" = "nf-config:" -o "$ans" = "" -o "$status" != "0" ] ; then
     export NETCDF_classic=1
     unset NETCDF4
 else

--- a/configure
+++ b/configure
@@ -207,7 +207,7 @@ fi
 if [ "`uname`" = "Linux" ] ; then
   ans="`which nf-config`"
 elif [ "`uname`" = "Darwin" ] ; then
-  ans="`whereis nf-config`"
+  ans="`which nf-config`"
 else
   ans=""
 # echo "Add in your architecture's uname and the command to find executables in the path"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Linux, Darwin, nc-config, configure

SOURCE: Yago Riveiro (Air Quality and Odor Management - AQOM), internal

DESCRIPTION OF CHANGES: 
This pull fixes the incorrect use of `whereis` when we try to locate `nc-config` 
command. 
 - Only the `which` command is valid. 
 - The return code is used, not the value of the `which nc-config` command.
 - There is no need to determine the OS prior to this test.

LIST OF MODIFIED FILES: 
M       configure

TESTS CONDUCTED: 
 - [x] Re-run configure script, the warning disappears
 - [x] Still works on Darwin (netcdf/3.6.3 and netcdf/4.5.0)
 - [x] Still works on Linux desktop Centos 7.6 (netcdf/4.7.0)
 - [x] Still works on Linux NCAR supercomputer SUSE 12 SP4 (netcdf/4.6.3)