### PR TITLE
Add missing unit conversion for inverse of specific humidity to mixing ratio [g/kg]

### DIFF
--- a/var/da/da_radiance/da_transform_xtoy_crtm.inc
+++ b/var/da/da_radiance/da_transform_xtoy_crtm.inc
@@ -240,6 +240,8 @@ subroutine da_transform_xtoy_crtm (cv_size, cv, grid, iv, y )
       do k=kts,kte ! from bottom to top
          call da_interp_2d_partial (grid%xa%t(:,:,k), iv%instid(inst)%info, k, iv%instid(inst)%info%n1, iv%instid(inst)%info%n2, &
             temperature(kte-k+1,:))
+
+         ! dq=xa%q and absorber both specific humidity (kg h2o / kg moist air)
          call da_interp_2d_partial (grid%xa%q(:,:,k), iv%instid(inst)%info, k, iv%instid(inst)%info%n1, iv%instid(inst)%info%n2, &
             absorber(kte-k+1,:))
 
@@ -295,6 +297,7 @@ subroutine da_transform_xtoy_crtm (cv_size, cv, grid, iv, y )
             Atmosphere(n)%level_pressure(k) = iv%instid(inst)%pf(k,n)
             Atmosphere(n)%temperature(k)    = iv%instid(inst)%tm(k,n)
             Atmosphere(n)%absorber(k,1)     = iv%instid(inst)%qm(k,n)
+            ! convert mixing ratio (g h2o / kg dry air) to specific humidity (kg h2o / kg moist air)
             xb_q(k,n) = 0.001*iv%instid(inst)%qm(k,n)/(1.0+0.001*iv%instid(inst)%qm(k,n)) ! specific humidity
          end do
          if (crtm_cloud) then
@@ -378,6 +381,7 @@ subroutine da_transform_xtoy_crtm (cv_size, cv, grid, iv, y )
         do k = kts, kte
           if ( iv%instid(inst)%pm(k,n) < 75.0 ) absorber(k,n) = 0.0
         end do
+        ! compute mixing ratio increment, dr, (g h2o / kg dry air) from xb_q and dq (both kg h2o / kg moist air)
         Atmosphere_TL(n)%Absorber(kts+1:kte,1)  = 1000.0 / (1.0-xb_q(kts+1:kte,n))**2  &
                                                   * absorber(kts+1:kte,n)
 

--- a/var/da/da_radiance/da_transform_xtoy_crtm.inc
+++ b/var/da/da_radiance/da_transform_xtoy_crtm.inc
@@ -295,7 +295,7 @@ subroutine da_transform_xtoy_crtm (cv_size, cv, grid, iv, y )
             Atmosphere(n)%level_pressure(k) = iv%instid(inst)%pf(k,n)
             Atmosphere(n)%temperature(k)    = iv%instid(inst)%tm(k,n)
             Atmosphere(n)%absorber(k,1)     = iv%instid(inst)%qm(k,n)
-            xb_q(k,n) = 0.001*iv%instid(inst)%qm(k,n)/(1.0+iv%instid(inst)%qm(k,n)) ! specific humidity
+            xb_q(k,n) = 0.001*iv%instid(inst)%qm(k,n)/(1.0+0.001*iv%instid(inst)%qm(k,n)) ! specific humidity
          end do
          if (crtm_cloud) then
             do k=1,Atmosphere(n)%n_layers

--- a/var/da/da_radiance/da_transform_xtoy_crtm_adj.inc
+++ b/var/da/da_radiance/da_transform_xtoy_crtm_adj.inc
@@ -279,7 +279,7 @@ subroutine da_transform_xtoy_crtm_adj ( cv_size, cv, iv, jo_grad_y, jo_grad_x )
             Atmosphere(n)%level_pressure(k) = iv%instid(inst)%pf(k,n)
             Atmosphere(n)%temperature(k) = iv%instid(inst)%tm(k,n)
             Atmosphere(n)%absorber(k,1) = iv%instid(inst)%qm(k,n)
-            xb_q(k,n) = 0.001*iv%instid(inst)%qm(k,n)/(1.0+iv%instid(inst)%qm(k,n)) ! specific humidity
+            xb_q(k,n) = 0.001*iv%instid(inst)%qm(k,n)/(1.0+0.001*iv%instid(inst)%qm(k,n)) ! specific humidity
          end do
 
          if (crtm_cloud) then

--- a/var/da/da_radiance/da_transform_xtoy_crtm_adj.inc
+++ b/var/da/da_radiance/da_transform_xtoy_crtm_adj.inc
@@ -279,6 +279,7 @@ subroutine da_transform_xtoy_crtm_adj ( cv_size, cv, iv, jo_grad_y, jo_grad_x )
             Atmosphere(n)%level_pressure(k) = iv%instid(inst)%pf(k,n)
             Atmosphere(n)%temperature(k) = iv%instid(inst)%tm(k,n)
             Atmosphere(n)%absorber(k,1) = iv%instid(inst)%qm(k,n)
+            ! convert mixing ratio (g h2o / kg dry air) to specific humidity (kg h2o / kg moist air)
             xb_q(k,n) = 0.001*iv%instid(inst)%qm(k,n)/(1.0+0.001*iv%instid(inst)%qm(k,n)) ! specific humidity
          end do
 
@@ -498,9 +499,11 @@ subroutine da_transform_xtoy_crtm_adj ( cv_size, cv, iv, jo_grad_y, jo_grad_x )
          end if
 
          do k=kts,kte-1 ! from bottom to top.  Zero Jacobian for top level
+            ! compute specific_humidity gradient, dY/dq (kg moist air / kg h2o), 
+            ! from xb_q (kg h2o / kg moist air) and mixing ratio gradient, dY/dr ( kg dry air / g h2o)
             if (atmosphere(n)%pressure(kte-k+1) >= 75.0) &        ! Zero Jacobian for top level(s)
                q_ad(k,n) = Atmosphere_AD(n)%Absorber(kte-k+1,1) * 1000.0 /  &
-                           (1.0-xb_q(kte-k+1,n))**2               ! in g/kg
+                           (1.0-xb_q(kte-k+1,n))**2
                t_ad(k,n) = Atmosphere_AD(n)%Temperature(kte-k+1)
          end do
 

--- a/var/da/da_transfer_model/da_transfer_wrftoxb.inc
+++ b/var/da/da_transfer_model/da_transfer_wrftoxb.inc
@@ -506,12 +506,13 @@ subroutine da_transfer_wrftoxb(xbx, grid, config_flags)
             if ( num_pseudo == 0 ) then
                grid%moist(i,j,k,P_QV) = max(grid%moist(i,j,k,P_QV), qlimit)
             end if
+            ! water vapor mixing ratio (kg h2o / kg dry air) from wrfinput file
             grid%xb%q(i,j,k) = grid%moist(i,j,k,P_QV)
 
             theta = t0 + grid%t_2(i,j,k)
             grid%xb%t(i,j,k) = theta*(grid%xb%p(i,j,k)/base_pres)**kappa
 
-            ! Convert to specific humidity from mixing ratio of water vapor:
+            ! Convert to specific humidity (kg h2o / kg moist air) from mixing ratio:
             grid%xb%q(i,j,k)=grid%xb%q(i,j,k)/(1.0+grid%xb%q(i,j,k))
    
             ! Background qrn needed for radar radial velocity assimilation:


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CRTM, radiance, DA, water vapor, humidity

SOURCE: JJ Guerrette (NCAR)

DESCRIPTION OF CHANGES: There is a missing unit conversion in the inverse of the specific humidity to mixing ratio [g/kg] conversion for the trajectory value of specific humidity.  The 1000 multiplier in the forward conversion needs to be divided out in both usages of `iv%instid(inst)%qm`.  This is an inverse equation, not a TL or AD equation.  Bug was originally introduced in commit 058491a786df6f2.

LIST OF MODIFIED FILES:
M       var/da/da_radiance/da_transform_xtoy_crtm.inc
M       var/da/da_radiance/da_transform_xtoy_crtm_adj.inc
M       var/da/da_transfer_model/da_transfer_wrftoxb.inc

TESTS CONDUCTED: I ran difference tests for convection-permitting clear-sky and all-sky GOES-ABI experiments that use a single water-vapor-sensitive channel (8).   The final quadratic cost function after two outer iterations (50 inner iterations each) for the clear-sky experiment decreases from 4.871D+04 to 4.795D+04.  The final cost function for the all-sky experiment changes in the 6th digit (little to no gross impact).  Both experiments additionally include conventional observations.  I have not looked at detailed results, but the bug is clear enough that it should be fixed.

RELEASE NOTE: A bug fix in the trajectory calculation of specific humidity for CRTM may slightly improve radiance DA results that use water-vapor-sensitive channels.  There is not expected to be a large impact.
