### PR TITLE
check eta levels in ideal case

### DIFF
--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -631,19 +631,19 @@ CONTAINS
      DO k=1, kde
       grid%znw(k) = model_config_rec%eta_levels(k)
      ENDDO
-            !Check the value of the first and last eta level for our domain,
-            !then check that the vector of eta levels is only decreasing
-            IF (model_config_rec%eta_levels(1) .NE. 1.0) THEN
-               CALL wrf_error_fatal("--- ERROR: the first specified eta_level is not 1.0")
-            ENDIF
-            IF (model_config_rec%eta_levels(kde) .NE. 0.0) THEN
-               CALL wrf_error_fatal("--- ERROR: the last specified eta_level is not 0.0")
-            ENDIF
-            DO k=2,kde
-              IF (model_config_rec%eta_levels(k) .GT. model_config_rec%eta_levels(k-1)) THEN
-                 CALL wrf_error_fatal("--- ERROR: specified eta_levels are not uniformly decreasing from 1.0 to 0.0")
-              ENDIF
-            ENDDO
+ !Check the value of the first and last eta level for our domain,
+ !then check that the vector of eta levels is only decreasing
+     IF (model_config_rec%eta_levels(1) .NE. 1.0) THEN
+        CALL wrf_error_fatal("--- ERROR: the first specified eta_level is not 1.0")
+     ENDIF
+     IF (model_config_rec%eta_levels(kde) .NE. 0.0) THEN
+        CALL wrf_error_fatal("--- ERROR: the last specified eta_level is not 0.0")
+     ENDIF
+     DO k=2,kde
+       IF (model_config_rec%eta_levels(k) .GT. model_config_rec%eta_levels(k-1)) THEN
+          CALL wrf_error_fatal("--- ERROR: specified eta_levels are not uniformly decreasing from 1.0 to 0.0")
+       ENDIF
+     ENDDO
    ELSE
      DO k=1, kde
       grid%znw(k) = 1. - float(k-1)/float(kde-1)

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -631,6 +631,19 @@ CONTAINS
      DO k=1, kde
       grid%znw(k) = model_config_rec%eta_levels(k)
      ENDDO
+            !Check the value of the first and last eta level for our domain,
+            !then check that the vector of eta levels is only decreasing
+            IF (model_config_rec%eta_levels(1) .NE. 1.0) THEN
+               CALL wrf_error_fatal("--- ERROR: the first specified eta_level is not 1.0")
+            ENDIF
+            IF (model_config_rec%eta_levels(kde) .NE. 0.0) THEN
+               CALL wrf_error_fatal("--- ERROR: the last specified eta_level is not 0.0")
+            ENDIF
+            DO k=2,kde
+              IF (model_config_rec%eta_levels(k) .GT. model_config_rec%eta_levels(k-1)) THEN
+                 CALL wrf_error_fatal("--- ERROR: specified eta_levels are not uniformly decreasing from 1.0 to 0.0")
+              ENDIF
+            ENDDO
    ELSE
      DO k=1, kde
       grid%znw(k) = 1. - float(k-1)/float(kde-1)

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -631,8 +631,10 @@ CONTAINS
      DO k=1, kde
       grid%znw(k) = model_config_rec%eta_levels(k)
      ENDDO
- !Check the value of the first and last eta level for our domain,
- !then check that the vector of eta levels is only decreasing
+     
+ ! Check the value of the first and last eta level for our domain,
+ ! then check that the vector of eta levels is only decreasing
+ 
      IF (model_config_rec%eta_levels(1) .NE. 1.0) THEN
         CALL wrf_error_fatal("--- ERROR: the first specified eta_level is not 1.0")
      ENDIF


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: ideal, eta

SOURCE: internal

DESCRIPTION OF CHANGES: 
CPreviously, no check existed to detect invalid eta levels that a user specified in the `namelist.input`
file for an idealized case. A couple loops of code were copied from the file
`dyn_em/module_initialize-real.F`, which is used in the _real_ program.
1. Check that first and last level are 1.0 and 0.0, respectively.
2. Check that the eta levels are strictly monotonically decreasing (from surface to model lid).

LIST OF MODIFIED FILES: 
M dyn_em/module_initialize_ideal.F

TESTS CONDUCTED:  
 - [x] Code stops with incorrect eta-level settings
 - [x] Code still runs with correct eta-level settings

RELEASE NOTE:
If a user chooses to explicitly list the eta levels for an idealized case, a check has been added to verify that valid eta levels are supplied for idealized cases in the namelist.input file.