### PR TITLE
Fix to make DA namelist alpha_std_dev act as intended for tuning flow-dependent B

### DIFF
--- a/var/da/da_setup_structures/da_setup_background_errors.inc
+++ b/var/da/da_setup_structures/da_setup_background_errors.inc
@@ -19,8 +19,8 @@ subroutine da_setup_background_errors(grid, be)
    be % ne = ensdim_alpha                          ! Size of ensemble.
 
    if (be % ne > 0) then     ! Calculation to preserve total variance.
-      if ( je_factor > alpha_std_dev**2 ) then
-         jb_factor   = je_factor / ( je_factor - alpha_std_dev**2 )
+      if ( je_factor > 1.0 ) then
+         jb_factor   = je_factor / ( je_factor - 1.0 )
       else
          jb_factor   = -999.
          write(6,*) 'Full ensemble mode: deactivating Jb control variable'


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, namelist, alpha_std_dev

SOURCE: Jamie Bresch (NCAR/MMM)

DESCRIPTION OF CHANGES:

The current default of alpha_std_dev is 1.0, so the new code gives identical results.

The original code would be incorrect if users set namelist alpha_std_dev to values other than 1.0.
B = (1/Jb_factor)*Bb + (1/Je_factor)*Be where (1/Jb_factor)+(1/Je_factor) = 1.0
So that jb_factor = je_factor / ( je_factor - 1.0 ) as in the new da_setup_background_errors.inc.

Beyond the code diff can be seen in this PR,
alpha_std_dev value is assigned to variable sigma_alpha in da_setup_background_errors.inc.
sigma_alpha is then used in da_setup_be_regional.inc to inflate the localization covariance matrix.

LIST OF MODIFIED FILES:
modified:   var/da/da_setup_structures/da_setup_background_errors.inc

TESTS CONDUCTED:
New code acts as expected.

RELEASE NOTE: Fix WRFDA implementation of alpha_std_dev for tuning flow-dependent B. Current namelist alpha_std_dev can not be set to values other than 1.0 (default). After the fix, setting alpha_std_dev a value larger than 1.0 to inflate the spread, and a value smaller than 1.0 to deflate.