### PR TITLE
YSU fix for WSM3 and Kessler no-ice test

### DIFF
--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -229,7 +229,7 @@ contains
         do i = its,ite
           qv2d(i,k) = qv3d(i,k,j)
           qv2d(i,k+kte) = qc3d(i,k,j)
-          if(present(rqiblten)) qv2d(i,k+kte+kte) = qi3d(i,k,j)
+          if(flag_qi) qv2d(i,k+kte+kte) = qi3d(i,k,j)
         enddo
       enddo
 !

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -270,7 +270,7 @@ contains
          rthblten(i,k,j) = rthblten(i,k,j)/pi3d(i,k,j)
          rqvblten(i,k,j) = rqvbl2dt(i,k)
          rqcblten(i,k,j) = rqvbl2dt(i,k+kte)
-         if(present(rqiblten)) rqiblten(i,k,j) = rqvbl2dt(i,k+kte+kte)
+         if(flag_qi) rqiblten(i,k,j) = rqvbl2dt(i,k+kte+kte)
        enddo
      enddo
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: YSU, WSM3, Kessler, ice check

SOURCE: internal

DESCRIPTION OF CHANGES:
YSU checks on PRESENT(RQIBLTEN) to determine whether to fill local ice part of qv2d, but
RQIBLTEN is always present, so this does not avoid copy from ice array when WSM3/Kessler MP
is used. It is better to check flag_qi which is also available and true (except when using either
WSM3 and Kessler MP schemes).

LIST OF MODIFIED FILES:
phys/module_bl_ysu.F

TESTS CONDUCTED:
Check code runs and uses flag_qi for simple MP scheme.

RELEASE NOTE:
Using the YSU PBL scheme in combination with either the WSM3 or Kessler MP schemes (no ice) is now fixed to not use ice array.
