### PR TITLE
bug fix for mynn PBL restarts - not giving bit-for-bit results

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1533,7 +1533,7 @@ state    real  RTHRATENLW      ikj      misc        1         -      r        "R
 state    real  RTHRATENSW      ikj      misc        1         -      r        "RTHRATSW"              "UNCOUPLED THETA TENDENCY DUE TO SHORT WAVE RADIATION"   "K s-1"
 state    real  CLDFRA          ikj      misc        1         -      rh       "CLDFRA"                "CLOUD FRACTION"                                       ""
 state    real  CLDFRA_OLD      ikj      misc        1         -      r        "CLDFRA_OLD"            "previous time level cldfra"                           ""
-state    real  CLDFRA_BL       ikj      misc        1         -      -        "CLDFRA_BL"             "CLOUD FRACTION pbl"                                   ""
+state    real  CLDFRA_BL       ikj      misc        1         -      r        "CLDFRA_BL"             "CLOUD FRACTION pbl"                                   ""
 state    real  CLDT             ij      misc        1         -      -        "CFRACT"                "TOTAL CLOUD FRACTION"                                 ""
 #state    real  CLDL             ij      misc        1         -      -        "CFRACL"                "LOW CLOUD FRACTION (ETA GREATER THAN 0.69)"           ""
 #state    real  LWP              ij      misc        1         -      -        "LWP"                   "LIQUID CLOUD WATER PATH"                              "kg m-2"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: bug, MYNN, PBL, cldfra_bl, icloud_bl, Registry

SOURCE: internal

DESCRIPTION OF CHANGES: When using the MYNN PBL scheme, restarts did not give bit-for-bit 
results. When using this scheme, the default setting for icloud_bl is 1 (on), but the variable used 
(cldfra_bl) was not put in the restart stream. Simply adding this variable to the restart stream in 
Registry.EM_COMMON corrects the problem.

LIST OF MODIFIED FILES:
M Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
Confirmed that the code builds, and the change corrects the non-bit-for-bit restart problem.

RELEASE NOTE: When using the MYNN PBL scheme, with icloud_bl = 1 (which is default), restarts did not give bit-for-bit results when compared to a non-restart run. This has been a problem since the option was introduced in V3.8, but is now corrected.