### PR TITLE
MYNN PBL restart differences: add restart output stream for el_pbl

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1075,7 +1075,7 @@ state    real    dl_u_bep      ikj     misc        1         Z      -        "dl
 state    real    sf_bep        ikj     misc        1         Z      -        "sf_bep"                "surface grid"              "-"
 state    real    vl_bep        ikj     misc        1         Z      -        "vl_bep"                "volume grid"               "-"
 state    real   tke_pbl        ikj     misc        1         Z      rh       "tke_pbl"              "TKE from PBL"      "m2 s-2"
-state    real   el_pbl         ikj     misc        1         Z      h        "el_pbl"               "Length scale from PBL"      "m"
+state    real   el_pbl         ikj     misc        1         Z      rh        "el_pbl"               "Length scale from PBL"      "m"
 # Diagnostic BOULAC PBL variables
 state    real   wu_tur         ikj     misc        1         -      r        "wu_tur"               "Turbulent flux of momentum(x)"      "m2 s-2"
 state    real   wv_tur         ikj     misc        1         -      r        "wv_tur"               "Turbulent flux of momentum(y)"      "m2 s-2"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1075,7 +1075,7 @@ state    real    dl_u_bep      ikj     misc        1         Z      -        "dl
 state    real    sf_bep        ikj     misc        1         Z      -        "sf_bep"                "surface grid"              "-"
 state    real    vl_bep        ikj     misc        1         Z      -        "vl_bep"                "volume grid"               "-"
 state    real   tke_pbl        ikj     misc        1         Z      rh       "tke_pbl"              "TKE from PBL"      "m2 s-2"
-state    real   el_pbl         ikj     misc        1         Z      rh        "el_pbl"               "Length scale from PBL"      "m"
+state    real   el_pbl         ikj     misc        1         Z      rh       "el_pbl"               "Length scale from PBL"      "m"
 # Diagnostic BOULAC PBL variables
 state    real   wu_tur         ikj     misc        1         -      r        "wu_tur"               "Turbulent flux of momentum(x)"      "m2 s-2"
 state    real   wv_tur         ikj     misc        1         -      r        "wv_tur"               "Turbulent flux of momentum(y)"      "m2 s-2"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: bug, MYNN, registry, el_pbl, restart, differences

SOURCE: internal

DESCRIPTION OF CHANGES: When using the MYNN PBL scheme, restarts were not giving 
bit-for-bit results when comparing the output of a standard run with that of a restart run. This 
was thought to have been corrected in d944f1e, but was not. When using MYNN, the default 
setting for icloud_bl is 1 (on), but a variable that is used (el_pbl) was not put in the restart stream. 
Simply adding this variable to the restart stream in Registry.EM_COMMON corrects the problem.

LIST OF MODIFIED FILES: 
M Registry/Registry.EM_COMMON

TESTS CONDUCTED:
Confirmed that the code builds, and the change corrects the non-bit-for-bit restart problem.

RELEASE NOTE: When using the MYNN PBL scheme, with icloud_bl = 1 (which is default), restarts did not give bit-for-bit results when compared to a non-restart run. This has been a problem since the option was introduced in V3.8, but is now corrected.
