### PR TITLE
BF: Remove extra comma in write statement inside Jensen MP

### DIFF
--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -4524,7 +4524,7 @@ contains
     
     if(x.lt.0.0.or.a.lt.0.0) then
        write(*,*) 'x or a is less than zero'
-       write(*,*), x, a
+       write(*,*) x, a
        return
     endif
     if(x.lt.(a + 1.0)) then

--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -4523,7 +4523,7 @@ contains
     REAL :: a, x, gammaser, gammacf, gln
     
     if(x.lt.0.0.or.a.lt.0.0) then
-       write(*,*) 'x or a is less than zero'
+       write(*,*) 'either x or a is less than zero'
        write(*,*) x, a
        return
     endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: comma, write, syntax, Cray, Ishmael

SOURCE: internal

DESCRIPTION OF CHANGES: 
A comma in a `write` statement following the closing ")" is a Fortran syntax error. Only the Cray
compiler picked this up.

LIST OF MODIFIED FILES:
modified:   phys/module_mp_jensen_ishmael.F

TESTS CONDUCTED: 
 - [x] On a Cray machine with Cray compiler, the WRF code fails to compile with a syntax error 
in the Jensen MP scheme.
 - [x] With this mod, the Jensen MP file compiles correctly.