### PR TITLE
max_ts_level should be .LE. the number of half levels

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1075,7 +1075,7 @@ state    real    dl_u_bep      ikj     misc        1         Z      -        "dl
 state    real    sf_bep        ikj     misc        1         Z      -        "sf_bep"                "surface grid"              "-"
 state    real    vl_bep        ikj     misc        1         Z      -        "vl_bep"                "volume grid"               "-"
 state    real   tke_pbl        ikj     misc        1         Z      rh       "tke_pbl"              "TKE from PBL"      "m2 s-2"
-state    real   el_pbl         ikj     misc        1         Z      h        "el_pbl"               "Length scale from PBL"      "m"
+state    real   el_pbl         ikj     misc        1         Z      rh       "el_pbl"               "Length scale from PBL"      "m"
 # Diagnostic BOULAC PBL variables
 state    real   wu_tur         ikj     misc        1         -      r        "wu_tur"               "Turbulent flux of momentum(x)"      "m2 s-2"
 state    real   wv_tur         ikj     misc        1         -      r        "wv_tur"               "Turbulent flux of momentum(y)"      "m2 s-2"

--- a/run/README.tslist
+++ b/run/README.tslist
@@ -60,8 +60,8 @@ Namelist.input variables related to to this new capability:
 
  * max_ts_locs = maximum number of locations in 'tslist' ( default is 5)
  * ts_buf_size = buffer size for time series output (default is 200)
- * max_ts_level = number of model levels for time series vertical
-   profiles (default is 15)
+ * max_ts_level = number of model levels for time series vertical profiles, the default is 15. 
+                  The maximum number of max_ts_level is e_vert-1 (the number of half layers in the model run)
  * tslist_unstagger_winds = output the unstaggered u, v, and w component
    winds (default is false)
 

--- a/run/README.tslist
+++ b/run/README.tslist
@@ -61,7 +61,7 @@ Namelist.input variables related to to this new capability:
  * max_ts_locs = maximum number of locations in 'tslist' ( default is 5)
  * ts_buf_size = buffer size for time series output (default is 200)
  * max_ts_level = number of model levels for time series vertical profiles, the default is 15. 
-                  The maximum number of max_ts_level is e_vert-1 (the number of half layers in the model run)
+   The maximum number of max_ts_level is e_vert-1 (the number of half layers in the model run)
  * tslist_unstagger_winds = output the unstaggered u, v, and w component
    winds (default is false)
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1906,13 +1906,13 @@
 !-----------------------------------------------------------------------
 !   Check that max_ts_level should be smaller than the number of half levels
 !-----------------------------------------------------------------------
-   IF ( model_config_rec % max_ts_level .gt. model_config_rec %e_vert(1)-1 )  then
+      IF ( model_config_rec % max_ts_level .gt. model_config_rec %e_vert(1)-1 )  then
         wrf_err_message = ' max_ts_level must be <= number of znu half layers '
         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
         wrf_err_message = ' max_ts_level is reset to the number of znu half layers '
         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
         model_config_rec % max_ts_level = model_config_rec %e_vert(1)-1
-   ENDIF
+      ENDIF
 
 !-----------------------------------------------------------------------
 !  Consistency checks between vertical refinement and radiation

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1904,7 +1904,7 @@
       ENDDO
 
 !-----------------------------------------------------------------------
-!   Check that max_ts_level should be smaller than the number of half levels
+!   Check that max_ts_level is smaller than the number of half levels
 !-----------------------------------------------------------------------
       IF ( model_config_rec % max_ts_level .gt. model_config_rec %e_vert(1)-1 )  then
         wrf_err_message = ' max_ts_level must be <= number of znu half layers '

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1906,10 +1906,12 @@
 !-----------------------------------------------------------------------
 !   Check that max_ts_level should be smaller than the number of half levels
 !-----------------------------------------------------------------------
-   IF ( model_config_rec % max_ts_locs .gt. model_config_rec %e_vert(1)-1 )  then
+   IF ( model_config_rec % max_ts_level .gt. model_config_rec %e_vert(1)-1 )  then
         wrf_err_message = ' max_ts_level must be <= number of znu half layers '
         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-        count_fatal_error = count_fatal_error + 1
+        wrf_err_message = ' max_ts_level is reset to the number of znu half layers '
+        CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+        model_config_rec % max_ts_level = model_config_rec %e_vert(1)-1
    ENDIF
 
 !-----------------------------------------------------------------------

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1904,6 +1904,15 @@
       ENDDO
 
 !-----------------------------------------------------------------------
+!   Check that max_ts_level should be smaller than the number of half levels
+!-----------------------------------------------------------------------
+   IF ( model_config_rec % max_ts_locs .gt. model_config_rec %e_vert(1)-1 )  then
+        wrf_err_message = ' max_ts_level must be <= number of znu half layers '
+        CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+        count_fatal_error = count_fatal_error + 1
+   ENDIF
+
+!-----------------------------------------------------------------------
 !  Consistency checks between vertical refinement and radiation
 !  scheme selection.  For "choose any vertical levels" for the nest,
 !  only RRTM is eligible.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: max_ts_level

SOURCE: Pedro Jimenez Munoz (RAL/MMM), internal

DESCRIPTION OF CHANGES: 
The value of `max_ts_level` should be set less than or equal to the number of half levels. If 
`max_ts_level` is accidentally set to a larger value, the wrf_timeseries.F would try to access 
the vertical velocity (`w_2`) and other variables that are defined on full levels with an index 
outside of the variables' extent.  A check is added to check_a_mundo to ensure that if 
`max_ts_level` is  set up to a number larger than the number of half layers, then it is reset to 
the number of half layers.

ISSUE:
Fixes #976 "Need check_a_mundo test: max_ts_level must be <= number of znu half layers"

LIST OF MODIFIED FILES:
M    share/module_check_a_mundo.F
M    run/README.tslist 

TESTS CONDUCTED: 
1. A single test is run to ensure the check works as expected. Below is the output:

```
Quilting with   1 groups of   0 I/O tasks.
 Ntasks in X            6 , ntasks in Y            6
   max_ts_level must be <= number of znu half layers
   max_ts_level is reset to the number of znu half layers
```