### PR TITLE
Fix to allow RRTMG longwave radiation (ra_lw_physics=4) to be used with vertical nesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1058,8 +1058,9 @@ fseek_test :
 
 # rule used by configure to test if this will compile with netcdf4
 nc4_test:
-	@cd tools ; /bin/rm -f nc4_test.{exe,nc,o} ; $(SCC) -o nc4_test.exe nc4_test.c -I$(NETCDF)/include -L$(NETCDF)/lib $(USENETCDF) ; cd ..
-
+	@cd tools ; /bin/rm -f nc4_test.{exe,nc,o} ; $(SCC) -o nc4_test.exe nc4_test.c -I$(NETCDF)/include -L$(NETCDF)/lib -lnetcdff -lnetcdf ; cd ..
+	
+#KAL the above line is modified.  The variable $(USENETCDF) has been replaced with the library names
 # rule used by configure to test if Fortran 2003 IEEE signaling is available
 fortran_2003_ieee_test:
 	@cd tools ; /bin/rm -f fortran_2003_ieee_test.{exe,o} ; $(SFC) -o fortran_2003_ieee_test.exe fortran_2003_ieee_test.F ; cd ..

--- a/Makefile
+++ b/Makefile
@@ -1058,9 +1058,8 @@ fseek_test :
 
 # rule used by configure to test if this will compile with netcdf4
 nc4_test:
-	@cd tools ; /bin/rm -f nc4_test.{exe,nc,o} ; $(SCC) -o nc4_test.exe nc4_test.c -I$(NETCDF)/include -L$(NETCDF)/lib -lnetcdff -lnetcdf ; cd ..
-	
-#KAL the above line is modified.  The variable $(USENETCDF) has been replaced with the library names
+	@cd tools ; /bin/rm -f nc4_test.{exe,nc,o} ; $(SCC) -o nc4_test.exe nc4_test.c -I$(NETCDF)/include -L$(NETCDF)/lib $(USENETCDF) ; cd ..
+
 # rule used by configure to test if Fortran 2003 IEEE signaling is available
 fortran_2003_ieee_test:
 	@cd tools ; /bin/rm -f fortran_2003_ieee_test.{exe,o} ; $(SFC) -o fortran_2003_ieee_test.exe fortran_2003_ieee_test.F ; cd ..

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -218,7 +218,7 @@ CONTAINS
    USE module_ra_sw         , ONLY : swrad
    USE module_ra_gsfcsw     , ONLY : gsfcswrad
    USE module_ra_rrtm       , ONLY : rrtmlwrad
-   USE module_ra_rrtmg_lw   , ONLY : rrtmg_lwrad
+   USE module_ra_rrtmg_lw   , ONLY : rrtmg_lwrad, rrtmg_lwinit
    USE module_ra_rrtmg_sw   , ONLY : rrtmg_swrad
 #if( BUILD_RRTMG_FAST == 1)
    USE module_ra_rrtmg_lwf  , ONLY : rrtmg_lwrad_fast
@@ -1835,6 +1835,26 @@ CONTAINS
                 ENDDO
                 ENDDO
              END IF
+
+             !Need to reset NLAYERS if vertical nesting is used.
+             !This code follows that for case RRTMSCHEME within
+             !subroutine RRTMLWRAD.
+             IF ( PRESENT(p_top) ) THEN
+                p_top_dummy = p_top
+             ELSE
+                p_top_dummy = -1. ! not used by NMM
+             END IF
+             IF ( p_top .GT. 0 ) THEN ! flag value for NMM = -1
+                !NLAYERS is recalculated
+                !every time the radiation scheme is called. This is
+                !necessary if e_vert parent .NE. e_vert nest since
+                !NLAYERS could then be different for each domain.
+                CALL RRTMG_LWINIT(                             &
+                              p_top, .FALSE. ,                 &
+                              ids, ide, jds, jde, kds, kde,    &
+                              ims, ime, jms, jme, kms, kme,    &
+                              its, ite, jts, jte, kts, kte     )
+             ENDIF
 
              CALL RRTMG_LWRAD(                                      &
                   RTHRATENLW=RTHRATEN,                              &

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1844,7 +1844,7 @@ CONTAINS
              ELSE
                 p_top_dummy = -1. ! not used by NMM
              END IF
-             IF ( p_top .GT. 0 ) THEN ! flag value for NMM = -1
+             IF ( p_top_dummy .GT. 0 ) THEN ! flag value for NMM = -1
                 !NLAYERS is recalculated
                 !every time the radiation scheme is called. This is
                 !necessary if e_vert parent .NE. e_vert nest since

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1906,19 +1906,21 @@
 !-----------------------------------------------------------------------
 !  Consistency checks between vertical refinement and radiation
 !  scheme selection.  For "choose any vertical levels" for the nest,
-!  only RRTM is eligible.
+!  only option 1 (RRTM/Dudhia) or option 4 (RRTMG) are eligible.
 !-----------------------------------------------------------------------
 
       DO i = 2, model_config_rec % max_dom
         IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
           IF ( ( ( model_config_rec%ra_lw_physics(i) .EQ. 0                   ) .OR. &
-                 ( model_config_rec%ra_lw_physics(i) .EQ. RRTMSCHEME          ) ) .AND. &
+                 ( model_config_rec%ra_lw_physics(i) .EQ. RRTMSCHEME          ) .OR. &
+                 ( model_config_rec%ra_lw_physics(i) .EQ. RRTMG_LWSCHEME      ) ) .AND. &
                ( ( model_config_rec%ra_sw_physics(i) .EQ. 0                   ) .OR. &
-                 ( model_config_rec%ra_sw_physics(i) .EQ. SWRADSCHEME         ) ) ) THEN
+                 ( model_config_rec%ra_sw_physics(i) .EQ. SWRADSCHEME         ) .OR. &
+                 ( model_config_rec%ra_sw_physics(i) .EQ. RRTMG_SWSCHEME      ) ) ) THEN
              !  We are OK, I just hate writing backwards / negative / convoluted if tests
              !  that are not easily comprehensible.
           ELSE
-            wrf_err_message = '--- ERROR: vert_refine_method=2 only works with ra_lw_physics=1 (RRTM) and ra_sw_physics=1 (Dudhia)'
+            wrf_err_message = '--- ERROR: vert_refine_method=2 only works with ra_lw/sw_physics=1 (RRTM/Dudhia) or ra_lw/sw_physics=4 (RRTMG)'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
             count_fatal_error = count_fatal_error + 1
           END IF


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: vertical nesting, RRTMG, longwave radiation, ra_lw_physics

SOURCE: Robert Arthur (LLNL)

DESCRIPTION OF CHANGES: When the RRTMG longwave radiation scheme (ra_lw_physics=4) was 
used in combination with vertical nesting, the longwave radiation was incorrect because the 
variable NLAYERS was set incorrectly. To fix this, NLAYERS is recalculated based on the updated 
number of vertical levels. This fix follows what is done already in the code for ra_lw_physics=1.

LIST OF MODIFIED FILES: 
phys/module_radiation_driver.F
share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Regression test runs and gives bit-wise identical parallel solutions with RRTMG and vertical 
nesting (21VN), and is also able to run RRTMG without vertical nesting (case=tropical, 
case=conus):
```
SUCCESS_RUN_WRF_d01_em_real_32_em_real_21VN vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_21VN status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_21VN vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_21VN status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_conus vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_conus status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_conus vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_conus status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_tropical vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_tropical status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_tropical vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_tropical status = 0
```

2. A nested case was run with 4 setups, with ra_sw/lw_physics = 1 and 4, and vertical nesting 
on and off on the finest domain (see plot). The non-vertically nested case has 88 vertical levels 
and the nested case has 351. While there are differences in the longwave radiation (GLW) 
depending on whether vertical nesting is used or not, the differences when using option 4 are 
comparable (and slightly smaller) than those with option 1.

![glw_comparison](https://user-images.githubusercontent.com/46732079/65084297-b0a16b00-d95f-11e9-89fb-d787d972c889.png)

RELEASE NOTE: The vertical refinement option now works with the RRTMG radiation scheme.