### PR TITLE
fixed calculation of the dust gravitational flux

### DIFF
--- a/chem/module_gocart_settling.F
+++ b/chem/module_gocart_settling.F
@@ -353,8 +353,8 @@ SUBROUTINE gocart_settling_driver(dt,config_flags,t_phy,moist,      &
             transfer_to_below_level = (temp_tc*vd_wk1)*((delz(i,j,l2)*airden(i,j,l))/(delz(i,j,l2+1)*airden(i,j,l-1))) ! [ug/kg]
 
              IF (l==1) THEN
-                graset(i,j,k)=graset(i,j,k)+vd_cor(l)*(temp_tc*vd_wk1)/ndt_settl(k) ! [ug/kg][m/s]
-                grasetvel(i,j,k)=vd_cor(l)                                     ! [m/s]
+                graset(i,j,k)=graset(i,j,k)+vd_cor(l)*temp_tc/ndt_settl(k) ! [ug/kg][m/s]
+                grasetvel(i,j,k)=vd_cor(l)                                 ! [m/s]
              ENDIF
           ENDDO                 !l, height
         ENDDO                   !n, time


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: GOCART, WRF-Chem, dust gravitational settling flux.

SOURCE: Alexander Ukhov, KAUST

DESCRIPTION OF CHANGES: I introduced a typo in #714. This typo affected only the diagnostic variables (GRASET_1,...,5). Dust mixing ratios were not affected. The derivation of the dust gravitational flux in the surface grid-cell is attached below. Multiplication by RHO_air is done in strings 158-162.

LIST OF MODIFIED FILES: 
chem/module_gocart_settling.F

TESTS CONDUCTED: After the changes model runs and outputs corrected dust flux.

![IMG_0847](https://user-images.githubusercontent.com/5716976/64732042-ede2a480-d4ea-11e9-9ce3-6e744c40ad17.JPG)
