### PR TITLE
Fix conflict between obs nudging and Thompson microphysics

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -3611,7 +3611,7 @@
               ENDIF
             ENDIF
           ELSE
-            INQUIRE(63,opened=lopen)
+            INQUIRE(63,OPENED=lopen)
             IF (lopen) THEN
               CLOSE(63)
             ENDIF

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -3610,6 +3610,11 @@
                 CALL wrf_error_fatal("Error opening qr_acr_qg.dat. Aborting because force_read_thompson is .true.")
               ENDIF
             ENDIF
+          ELSE
+            INQUIRE(63,opened=lopen)
+            IF (lopen) THEN
+              CLOSE(63)
+            ENDIF
           ENDIF
         ELSE
           IF( force_read_thompson ) THEN
@@ -4082,6 +4087,11 @@
               IF( force_read_thompson ) THEN
                 CALL wrf_error_fatal("Error opening freezeH2O.dat. Aborting because force_read_thompson is .true.")
               ENDIF
+            ENDIF
+          ELSE
+            INQUIRE(63,opened=lopen)
+            IF (lopen) THEN
+              CLOSE(63)
             ENDIF
           ENDIF
         ELSE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: observation nudging, Thompson microphysics

SOURCE: Brian Reen (Army Research Lab)

DESCRIPTION OF CHANGES: 
When observation nudging was used on domain 3, Thompson microphysics was used, and the .dat files used by Thompson microphysics were already present WRF would crash.

The problem originates from the same unit (63) being used for the Thompson microphysics .dat files (qr_acr_qg.dat, qr_acr_qs.dat, and freezeH2O.dat) and the domain 3 observation nudging input file (OBS_DOMAIN301).  The Thompson microphysics code does not explicitly close qr_acr_qg.dat and freezeH2O.dat, and when observation nudging attempts to read from unit 63, it is freezeH2O.dat that is open rather than OBS_DOMAIN301.

This problem was earlier found and corrected in 80b22b316df5a24b13bf42e1d686d0b11e18dca0 but was reintroduced in 6cea5a0fd74af2abdd78551e68ca9f75ffd0d8dc.  The code earlier included to correct this problem by explicitly closing unit 63 for qr_acr_qg.dat and freezeH2O.dat was been reintroduced.

LIST OF MODIFIED FILES: 
M phys/module_mp_thompson.F

TESTS CONDUCTED: 
A 3-domain simulation with obs nudging and the *.dat files pre-existing using the unmodified code leads to the following messages in rsl.out:

<pre>
OBS NUDGING: Reading new obs for time window TBACK =   -1.500 TFORWD =    1.500 for grid =  3
 File open on obs nudging unit (          63 ) with wrong name
 File open on obs nudging unit is named freezeH2O.dat but it should be named OBS_DOMAIN301
 This likely means this unit number was opened elsewhere in WRF
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  wrf_fddaobs_in.b  LINE:     460
wrf_fddaobs_in: in4dob STOP Obs nudging file name mismatch
-------------------------------------------
</pre>

A 3-domain simulation with obs nudging and the *.dat files pre-existing using the modified code finishes without error.  This simulation creates bit-identical wrfout files to an experiment using the unmodified code in which the *.dat files do not exist. 

Tested 3-domain simulation without obs nudging with and without this modification and found bit-identical results.