### PR TITLE
OML: fix out of bounds print

### DIFF
--- a/phys/module_sf_oml.F
+++ b/phys/module_sf_oml.F
@@ -217,7 +217,8 @@ CONTAINS
         ENDDO
         ENDDO
      ELSE IF (oml_hml0 .eq. 0.) THEN
-! initializing with climatological mixed layer depth only
+        WRITE(message,*)'Initializing OML with climatological mixed layer depth'
+        CALL wrf_debug (0, TRIM(message))
         DO J=jts,jtf
         DO I=its,itf
           HML(I,J)=H0ML(I,J)
@@ -227,9 +228,7 @@ CONTAINS
         ENDDO
         ENDDO
      ELSE
-        IF(I.EQ.1 .and. J.EQ.1) then
-          WRITE(message,*)'Initializing OML with 2d HML0, h0ml(1,1) = ', h0ml(1,1)
-        ENDIF
+        WRITE(message,*)'Initializing OML with 2d HML0'
         CALL wrf_debug (0, TRIM(message))
         DO J=jts,jtf
         DO I=its,itf

--- a/phys/module_sf_oml.F
+++ b/phys/module_sf_oml.F
@@ -227,7 +227,9 @@ CONTAINS
         ENDDO
         ENDDO
      ELSE
-        WRITE(message,*)'Initializing OML with real HML0, h(1,1) = ', h0ml(1,1)
+        IF(I.EQ.1 .and. J.EQ.1) then
+          WRITE(message,*)'Initializing OML with real HML0, h(1,1) = ', h0ml(1,1)
+        ENDIF
         CALL wrf_debug (0, TRIM(message))
         DO J=jts,jtf
         DO I=its,itf

--- a/phys/module_sf_oml.F
+++ b/phys/module_sf_oml.F
@@ -228,7 +228,7 @@ CONTAINS
         ENDDO
      ELSE
         IF(I.EQ.1 .and. J.EQ.1) then
-          WRITE(message,*)'Initializing OML with real HML0, h(1,1) = ', h0ml(1,1)
+          WRITE(message,*)'Initializing OML with 2d HML0, h0ml(1,1) = ', h0ml(1,1)
         ENDIF
         CALL wrf_debug (0, TRIM(message))
         DO J=jts,jtf


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: module_sf_oml, message

SOURCE: internal

DESCRIPTION OF CHANGES: 
When code is compiled with no optimization (configure -D) and distributed memory, and 
sf_ocean_physics = 1, the model stops when trying to write a message requesting the value of 
h0ml(1,1). This value will only be valid for MPI task 0, and therefore causes all other MPI tasks to 
stop with a bounds check error. This h0ml field is a 2d array, and the (1,1) location could be 
masked over land. Other than a simple indicator of which branch of the IF loop, no actual value 
is printed.

LIST OF MODIFIED FILES: 
M    phys/module_sf_oml.F

TESTS CONDUCTED: 
 - [x] Verified model builds (with optimization off) and runs to completion with fix. 
 - [x] Verified that a restart gives BFB results to a non-restart output file at the same time.

RELEASE NOTE: Corrected a problem that caused model to stop when using sf_ocean_physics = 1, with WRF code compiled for bounds checking. 