### PR TITLE
Multiple LBC files for ARW, run-time option

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2711,6 +2711,7 @@ rconfig   integer spec_bdy_final_mu       namelist,bdy_control	        1     1  
 rconfig   integer real_data_init_type     namelist,bdy_control		1                 1    irh   "real_data_init_type"   "REAL DATA INITIALIZATION OPTIONS: 1=SI, 2=MM5, 3=GENERIC" "PRE-PROCESSOR TYPES"
 rconfig   logical have_bcs_moist          namelist,bdy_control  max_domains    .false. rh    "have_bcs_moist"           ""      ""
 rconfig   logical have_bcs_scalar         namelist,bdy_control  max_domains    .false. rh    "have_bcs_scalar"          ""      ""
+rconfig   logical multi_bdy_files         namelist,bdy_control          1      .false. rh    "multi_bdy_files"          ""      ""
 
 rconfig   integer background_proc_id      namelist,grib2 	        1     255    rh    "background_proc_id"    "Background processing id for grib2"  ""
 rconfig   integer forecast_proc_id        namelist,grib2 	        1     255    rh    "forecast_proc_id"      "Analysis and forecast processing id for grib2"  ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1682,6 +1682,7 @@ rconfig   logical open_ye                 namelist,bdy_control	max_domains    .f
 rconfig   logical polar                   namelist,bdy_control  max_domains    .false. rh    "polar"                 ""      ""
 rconfig   logical nested                  namelist,bdy_control	max_domains    .false. rh    "nested"                ""      ""
 rconfig   integer real_data_init_type     namelist,bdy_control		1                 1    irh   "real_data_init_type"   "REAL DATA INITIALIZATION OPTIONS: 1=SI, 2=MM5, 3=GENERIC" "PRE-PROCESSOR TYPES"
+rconfig   logical multi_bdy_files         namelist,bdy_control          1      .false. rh    "multi_bdy_files"       ""      ""
 
 rconfig   integer background_proc_id      namelist,grib2 	        1     255    rh    "background_proc_id"    "Background processing id for grib2"  ""
 rconfig   integer forecast_proc_id        namelist,grib2 	        1     255    rh    "forecast_proc_id"      "Analysis and forecast processing id for grib2"  ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1682,7 +1682,7 @@ rconfig   logical open_ye                 namelist,bdy_control	max_domains    .f
 rconfig   logical polar                   namelist,bdy_control  max_domains    .false. rh    "polar"                 ""      ""
 rconfig   logical nested                  namelist,bdy_control	max_domains    .false. rh    "nested"                ""      ""
 rconfig   integer real_data_init_type     namelist,bdy_control		1                 1    irh   "real_data_init_type"   "REAL DATA INITIALIZATION OPTIONS: 1=SI, 2=MM5, 3=GENERIC" "PRE-PROCESSOR TYPES"
-rconfig   logical multi_bdy_files         namelist,bdy_control          1      .false. rh    "multi_bdy_files"       ""      ""
+rconfig   logical multi_bdy_files         namelist,bdy_control          1    .false. rh    "multi_bdy_files"       ""      ""
 
 rconfig   integer background_proc_id      namelist,grib2 	        1     255    rh    "background_proc_id"    "Background processing id for grib2"  ""
 rconfig   integer forecast_proc_id        namelist,grib2 	        1     255    rh    "forecast_proc_id"      "Analysis and forecast processing id for grib2"  ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1682,7 +1682,7 @@ rconfig   logical open_ye                 namelist,bdy_control	max_domains    .f
 rconfig   logical polar                   namelist,bdy_control  max_domains    .false. rh    "polar"                 ""      ""
 rconfig   logical nested                  namelist,bdy_control	max_domains    .false. rh    "nested"                ""      ""
 rconfig   integer real_data_init_type     namelist,bdy_control		1                 1    irh   "real_data_init_type"   "REAL DATA INITIALIZATION OPTIONS: 1=SI, 2=MM5, 3=GENERIC" "PRE-PROCESSOR TYPES"
-rconfig   logical multi_bdy_files         namelist,bdy_control          1    .false. rh    "multi_bdy_files"       ""      ""
+rconfig   logical multi_bdy_files         namelist,bdy_control      1    .false. rh    "multi_bdy_files"       ""      ""
 
 rconfig   integer background_proc_id      namelist,grib2 	        1     255    rh    "background_proc_id"    "Background processing id for grib2"  ""
 rconfig   integer forecast_proc_id        namelist,grib2 	        1     255    rh    "forecast_proc_id"      "Analysis and forecast processing id for grib2"  ""

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -333,7 +333,8 @@ SUBROUTINE med_sidata_input ( grid , config_flags )
    CHARACTER (LEN=256)     :: si_inpname
    CHARACTER (LEN=80)      :: message
 
-   CHARACTER(LEN=19) :: start_date_char , end_date_char , current_date_char , next_date_char
+   CHARACTER(LEN=19) :: start_date_char , end_date_char , current_date_char , next_date_char , &
+                        prev_date_char
 
    INTEGER :: time_loop_max , loop, rc
    INTEGER :: julyr , julday 
@@ -377,6 +378,7 @@ real::t1,t2,t3,t4
    !  Here we define the initial time to process, for later use by the code.
    
    current_date_char = start_date_char
+   prev_date_char = start_date_char
    start_date = start_date_char // '.0000'
    current_date = start_date
 
@@ -576,7 +578,8 @@ real::t1,t2,t3,t4
 #endif
 
       CALL cpu_time ( t3 )
-      CALL assemble_output ( grid , config_flags , loop , time_loop_max )
+      CALL assemble_output ( grid , config_flags , loop , time_loop_max, current_date_char , prev_date_char )
+      prev_date_char = current_date_char
       CALL cpu_time ( t4 )
       WRITE ( wrf_err_message , FMT='(A,I10,A)' ) 'Timing for output ',NINT(t4-t3) ,' s.'
       CALL wrf_debug( 0, wrf_err_message )
@@ -668,7 +671,7 @@ SUBROUTINE compute_si_start_and_end (  &
    END DO loop_count
 END SUBROUTINE compute_si_start_and_end
 
-SUBROUTINE assemble_output ( grid , config_flags , loop , time_loop_max )
+SUBROUTINE assemble_output ( grid , config_flags , loop , time_loop_max , current_date_char , prev_date_char )
 
    USE module_big_step_utilities_em
    USE module_domain
@@ -693,6 +696,7 @@ SUBROUTINE assemble_output ( grid , config_flags , loop , time_loop_max )
    CHARACTER (LEN=256) :: inpname , bdyname
    CHARACTER(LEN= 4) :: loop_char
    CHARACTER (LEN=256) :: message
+   CHARACTER (LEN=19) , INTENT(IN) :: current_date_char, prev_date_char
 character *19 :: temp19
 character *24 :: temp24 , temp24b
 
@@ -702,6 +706,10 @@ character *24 :: temp24 , temp24b
    REAL , DIMENSION(:,:,:) , ALLOCATABLE , SAVE :: mbdy2dtemp2
    REAL , DIMENSION(:,:,:) , ALLOCATABLE , SAVE :: qn1bdy3dtemp1, qn1bdy3dtemp2, qn2bdy3dtemp1, qn2bdy3dtemp2
 real::t1,t2
+
+   INTEGER                                :: open_status
+
+#include "wrf_io_flags.h"
 
    !  Various sizes that we need to be concerned about.
 
@@ -957,10 +965,12 @@ real::t1,t2
 
       IF ( loop .eq. 2 ) THEN
          IF ( (grid%id .eq. 1) .and. ( .NOT. config_flags%polar ) ) THEN
-            CALL construct_filename1( bdyname , 'wrfbdy' , grid%id , 2 )
-            CALL open_w_dataset ( id, TRIM(bdyname) , grid , config_flags , output_boundary , "DATASET=BOUNDARY", ierr )
-            IF ( ierr .NE. 0 ) THEN
-               CALL wrf_error_fatal( 'real: error opening wrfbdy for writing' )
+            IF      ( .NOT. config_flags%multi_bdy_files ) THEN
+               CALL construct_filename2a( bdyname , TRIM(config_flags%bdy_inname) , grid%id , 2 , " " )
+               CALL open_w_dataset ( id, TRIM(bdyname) , grid , config_flags , output_boundary , "DATASET=BOUNDARY", ierr )
+               IF ( ierr .NE. 0 ) THEN
+                  CALL wrf_error_fatal( 'real: error opening ' // TRIM(bdyname) // ' for writing' )
+               END IF
             END IF
          END IF
          IF(grid_fdda .GE. 1)THEN
@@ -971,10 +981,31 @@ real::t1,t2
             END IF
          END IF
       ELSE
+         
+         !  Advance the clock to the next time period.
+
          IF ( .NOT. domain_clockisstoptime(grid) ) THEN
             CALL domain_clockadvance( grid )
             CALL domain_clockprint ( 150, grid, &
                    'DEBUG assemble_output:  clock after ClockAdvance,' )
+         END IF
+      END IF
+
+      !  If the lateral boundary conditions are split into single times per file, then
+      !  open the file with a date string. Also, if is easier to CLOSE the file just 
+      !  before we need it OPENed.
+
+      IF ( config_flags%multi_bdy_files ) THEN
+         CALL construct_filename2a( bdyname , TRIM(config_flags%bdy_inname) , grid%id , 2 , prev_date_char )
+
+         CALL wrf_inquire_opened(id , TRIM(bdyname) , open_status , ierr )
+         IF ( open_status .EQ. WRF_FILE_OPENED_FOR_WRITE ) THEN
+            CALL close_dataset ( id , config_flags , "DATASET=BOUNDARY" )
+         END IF
+
+         CALL open_w_dataset ( id, TRIM(bdyname) , grid , config_flags , output_boundary , "DATASET=BOUNDARY", ierr )
+         IF ( ierr .NE. 0 ) THEN
+            CALL wrf_error_fatal( 'real: error opening ' // TRIM(bdyname) // ' for writing' )
          END IF
       END IF
 
@@ -1160,7 +1191,7 @@ real::t1,t2
          !  Output boundary file.
    
          IF(grid%id .EQ. 1)THEN
-           print *,'LBC valid between these times ',current_date, ' ',start_date
+           print *,'LBC valid between these times ',prev_date_char, ' and ',current_date_char
            CALL output_boundary ( id, grid , config_flags , ierr )
          END IF
 

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -1006,7 +1006,7 @@ real::t1,t2
 
          CALL open_w_dataset ( id, TRIM(bdyname) , grid , config_flags , output_boundary , "DATASET=BOUNDARY", ierr )
          IF ( ierr .NE. 0 ) THEN
-            CALL wrf_error_fatal( 'real: error opening ' // TRIM(bdyname) // ' for writing' )
+            CALL wrf_error_fatal( 'REAL: error opening ' // TRIM(bdyname) // ' for writing' )
          END IF
       END IF
 

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -991,9 +991,10 @@ real::t1,t2
          END IF
       END IF
 
-      !  If the lateral boundary conditions are split into single times per file, then
-      !  open the file with a date string. Also, it is easier to CLOSE the file just 
-      !  before we need it OPENed.
+      !  If the lateral boundary conditions are split, then open the file with a 
+      !  date string. Only single time periods are allowed in a lateral BC file
+      !  when the files are split into multiple pieces. Also, it is easier to 
+      !  CLOSE the file just before we need it OPENed.
 
       IF ( config_flags%multi_bdy_files ) THEN
          CALL construct_filename2a( bdyname , TRIM(config_flags%bdy_inname) , grid%id , 2 , prev_date_char )

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -969,7 +969,7 @@ real::t1,t2
                CALL construct_filename2a( bdyname , TRIM(config_flags%bdy_inname) , grid%id , 2 , " " )
                CALL open_w_dataset ( id, TRIM(bdyname) , grid , config_flags , output_boundary , "DATASET=BOUNDARY", ierr )
                IF ( ierr .NE. 0 ) THEN
-                  CALL wrf_error_fatal( 'real: error opening ' // TRIM(bdyname) // ' for writing' )
+                  CALL wrf_error_fatal( 'REAL: error opening ' // TRIM(bdyname) // ' for writing' )
                END IF
             END IF
          END IF
@@ -977,7 +977,7 @@ real::t1,t2
             CALL construct_filename1( inpname , 'wrffdda' , grid%id , 2 )
             CALL open_w_dataset ( id2, TRIM(inpname) , grid , config_flags , output_auxinput10 , "DATASET=AUXINPUT10", ierr )
             IF ( ierr .NE. 0 ) THEN
-               CALL wrf_error_fatal( 'real: error opening wrffdda for writing' )
+               CALL wrf_error_fatal( 'REAL: error opening wrffdda for writing' )
             END IF
          END IF
       ELSE

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -992,7 +992,7 @@ real::t1,t2
       END IF
 
       !  If the lateral boundary conditions are split into single times per file, then
-      !  open the file with a date string. Also, if is easier to CLOSE the file just 
+      !  open the file with a date string. Also, it is easier to CLOSE the file just 
       !  before we need it OPENed.
 
       IF ( config_flags%multi_bdy_files ) THEN

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -993,7 +993,7 @@ real::t1,t2
 
       !  If the lateral boundary conditions are split, then open the file with a 
       !  date string. Only single time periods are allowed in a lateral BC file
-      !  when the files are split into multiple pieces. Also, it is easier to 
+      !  when the files are split into multiple pieces. Also, we choose to 
       !  CLOSE the file just before we need it OPENed.
 
       IF ( config_flags%multi_bdy_files ) THEN

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -815,7 +815,7 @@ real::t1,t2
       CALL construct_filename1( inpname , 'wrfinput' , grid%id , 2 )
       CALL open_w_dataset ( id1, TRIM(inpname) , grid , config_flags , output_input , "DATASET=INPUT", ierr )
       IF ( ierr .NE. 0 ) THEN
-         CALL wrf_error_fatal( 'real: error opening wrfinput for writing' )
+         CALL wrf_error_fatal( 'REAL: error opening wrfinput for writing' )
       END IF
       CALL output_input ( id1, grid , config_flags , ierr )
       CALL close_dataset ( id1 , config_flags , "DATASET=INPUT" )
@@ -825,7 +825,7 @@ real::t1,t2
            CALL construct_filename1( inpname , 'wrflowinp' , grid%id , 2 )
            CALL open_w_dataset ( id4, TRIM(inpname) , grid , config_flags , output_auxinput4 , "DATASET=AUXINPUT4", ierr )
            IF ( ierr .NE. 0 ) THEN
-              CALL wrf_error_fatal( 'real: error opening wrflowinp for writing' )
+              CALL wrf_error_fatal( 'REAL: error opening wrflowinp for writing' )
            END IF
            CALL output_auxinput4 ( id4, grid , config_flags , ierr )
          END IF

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1562,6 +1562,7 @@ The following are for observation nudging:
                                      = .true. , ! use microphysics variables in bdy file
  have_bcs_scalar (max_dom)           = .false., ! model run after ndown only: do not use scalar variables in bdy file
                                      = .true. , ! use scalar variables in bdy file
+ multi_bdy_files                     = .false., ! F=default; T=model will run with split and individually named LBC files
 
  euler_adv                           = .false., ! conservative Eulerian passive advection (NMM only)
  idtadt                              = 1,       ! fundamental timesteps between calls to Euler advection, dynamics (NMM only)

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1563,6 +1563,9 @@ The following are for observation nudging:
  have_bcs_scalar (max_dom)           = .false., ! model run after ndown only: do not use scalar variables in bdy file
                                      = .true. , ! use scalar variables in bdy file
  multi_bdy_files                     = .false., ! F=default; T=model will run with split and individually named LBC files
+                                                  requires usage of bdy_inname = "wrfbdy_d<domain>_<date>"
+                                                  the real program can generate all LBC files in a single run
+                                                  only a single time period is in each separate LBC file
 
  euler_adv                           = .false., ! conservative Eulerian passive advection (NMM only)
  idtadt                              = 1,       ! fundamental timesteps between calls to Euler advection, dynamics (NMM only)

--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -2104,9 +2104,7 @@ SUBROUTINE med_latbound_in ( grid , config_flags )
    Type (WRFU_Time )                      :: startTime, stopTime, currentTime
    Type (WRFU_TimeInterval )              :: stepTime
 integer myproc,i,j,k
-#ifdef _MULTI_BDY_FILES_
    CHARACTER(LEN=80)                      :: timestr
-#endif
 
 #include "wrf_io_flags.h"
 
@@ -2142,14 +2140,16 @@ integer myproc,i,j,k
        CALL WRFU_AlarmRingerOff( grid%alarms( BOUNDARY_ALARM ), rc=rc )
        IF ( wrf_dm_on_monitor() ) CALL start_timing
 
-#ifdef _MULTI_BDY_FILES_
        ! Possibility to have a <date> as part of the bdy_inname.
-       CALL domain_clock_get( grid, current_timestr=timestr )
-       CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , timestr )
-#else
-! typically a <date> wouldn't be part of the bdy_inname, so just pass a dummy
-       CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , " " )
-#endif
+       IF ( config_flags%multi_bdy_files ) THEN
+         CALL domain_clock_get( grid, current_timestr=timestr )
+         CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , timestr )
+
+       ! typically a <date> wouldn't be part of the bdy_inname, so just pass a dummy
+       ELSE
+         CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , " " )
+
+       END IF
 
        CALL wrf_inquire_opened(grid%lbc_fid , TRIM(bdyname) , open_status , ierr ) 
        IF ( open_status .EQ. WRF_FILE_OPENED_FOR_READ ) THEN
@@ -2159,11 +2159,11 @@ integer myproc,i,j,k
        ENDIF
        CALL wrf_dm_bcast_bytes ( lbc_opened , LWORDSIZE )
        IF ( .NOT. lbc_opened ) THEN
-#ifdef _MULTI_BDY_FILES_
-         CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , timestr )
-#else
-         CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , " " )
-#endif
+          IF ( config_flags%multi_bdy_files ) THEN
+           CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , timestr )
+          ELSE
+           CALL construct_filename2a ( bdyname , config_flags%bdy_inname , grid%id , 2 , " " )
+          END IF
           WRITE(message,*)'Opening: ',TRIM(bdyname)
           CALL wrf_debug(100,TRIM(message))
           CALL open_r_dataset ( grid%lbc_fid, TRIM(bdyname) , grid , config_flags , "DATASET=BOUNDARY", ierr )
@@ -2203,10 +2203,10 @@ integer myproc,i,j,k
          CALL input_boundary ( grid%lbc_fid, grid , config_flags , ierr )
        ENDDO
 #endif
-#ifdef _MULTI_BDY_FILES_
        ! Close the bdy file so that next time around, we'll open it again.
-       CALL close_dataset ( grid%lbc_fid , config_flags , "DATASET=BOUNDARY" )
-#endif
+       IF ( config_flags%multi_bdy_files ) THEN
+         CALL close_dataset ( grid%lbc_fid , config_flags , "DATASET=BOUNDARY" )
+       END IF
 #if ( WRFPLUS == 1 )
        IF ( config_flags%dyn_opt .NE. dyn_em_ad ) THEN
           CALL WRFU_AlarmSet( grid%alarms( BOUNDARY_ALARM ), RingTime=grid%next_bdy_time, rc=rc )

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -936,6 +936,18 @@
          model_config_rec%num_traj = 0
    END IF
 
+!-----------------------------------------------------------------------
+! Catch old method for using multi-file LBCs. Let folks know the 
+! new way to get the same functionality with run-time options.
+!-----------------------------------------------------------------------
+#if _MULTI_BDY_FILES_
+   wrf_err_message = '--- ERROR: Do not use the compile-time -D_MULTI_BDY_FILES_ option for multi-file LBCs.'
+   CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+   wrf_err_message = '--- ERROR: Use the run-time namelist option multi_bdy_files in nml record bdy_control.'
+   CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+   count_fatal_error = count_fatal_error + 1
+#endif
+
 #elif( NMM_CORE == 1 )
 !----------------------------------------------------------------------------
 ! If NMM core and trajectories are on then halt.

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -66,6 +66,7 @@
 !END FASDAS
 !
       INTEGER :: count_fatal_error
+      INTEGER :: len1, len2, len_loop
 
       !  These functions are located with in the Urban Physics files, but
       !  not within the confines of the modules. Since we are in the share
@@ -947,6 +948,37 @@
    CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
    count_fatal_error = count_fatal_error + 1
 #endif
+
+!----------------------------------------------------------------------------
+! If using multi_bdy_files option or not, make the lateral bdy file root name
+! correct. For example, we want "wrfbdy_d01" for NON multi_bdy_files and we
+! want "wrfbdy_d01_SOME_DATE" when using the multi_bdy_files option.
+!----------------------------------------------------------------------------
+   IF      ( model_config_rec%multi_bdy_files ) THEN
+      IF ( INDEX ( TRIM(model_config_rec%bdy_inname) , "_<date>" ) .GT. 0 ) THEN
+         ! No op, all OK
+      ELSE
+         wrf_err_message = '--- ERROR: Need bdy_inname = "wrfbdy_d<domain>_<date>"'
+         CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+         count_fatal_error = count_fatal_error + 1
+!        len1 = LEN_TRIM(model_config_rec%bdy_inname)
+!        len2 = "_<date>"
+!        model_config_rec%bdy_inname(1:len1+len2) = TRIM(model_config_rec%bdy_inname) // "_<date>"
+      END IF
+   ELSE IF ( .NOT. model_config_rec%multi_bdy_files ) THEN
+      IF ( INDEX ( TRIM(model_config_rec%bdy_inname) , "_<date>" ) .EQ. 0 ) THEN
+         ! No op, all OK
+      ELSE
+         wrf_err_message = '--- ERROR: Remove bdy_inname = "wrfbdy_d<domain>_<date>"'
+         CALL wrf_debug ( 0, TRIM(wrf_err_message) )
+         count_fatal_error = count_fatal_error + 1
+!        len1 = LEN_TRIM(model_config_rec%bdy_inname)
+!        len2 = "_<date>"
+!        DO len_loop len1-len2+1 , len1
+!           model_config_rec%bdy_inname(len_loop:len_loop) = " "
+!        END DO 
+      END IF
+   END IF
 
 #elif( NMM_CORE == 1 )
 !----------------------------------------------------------------------------

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -322,6 +322,7 @@ Switching off latent heating from a microphysics scheme (must also set cu_physic
     spec_zone is ALWAYS = 1 
     relax_zone is ALWAYS = spec_bdy_width - spec_zone
 
+&bdy_control
  spec_bdy_width                      = 10,
  specified                           = .true.,
  spec_exp                            = 0.33
@@ -330,6 +331,17 @@ For a tropical channel configuration, set the following:
 
  specified                           = .true.,
  periodic_x                          = .true.,
+
+** Using split lateral boundary files
+     The run-time flag multi_bdy_files must be set to TRUE (default is false), and the
+     lateral boundary files must have a date associated. When using the split LBC option,
+     there is ALWAYS and ONLY a single time LBC time in each file.
+
+ multi_bdy_files                     = .true.
+
+Also requires
+&time_control
+ bdy_inname                          = "wrfbdy_d<domain>_<date>"
 
 ** using io quilting option to improve output efficiency for large domain runs
     (note that this is a separate namelist record):


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: LBC files

SOURCE: Kevin Manning and Jim Bresch (MMM/NCAR), internal

DESCRIPTION OF CHANGES:
For real-time users, the ability to start the WRF model before the
GFS model finishes allows the WRF model to complete a regional 
simulation earlier (because of not delaying the model start). However, this 
only works if the lateral boundary files from subsequent times are able to be 
ingested by the model. As a compile-time option, this split LBC capability has 
existed for years. Now that capability from the compile-time option is run-time 
selectable from the namelist.

1. WRF model

Modify the compile-time option in WRF that provides the capability for split
LBC files, and now make that capability a namelist-driven run-time option.
By default, the multi_bdy_files option is FALSE.

2. real program

The user may now set the namelist.input file as follows in real:
```
 &time_control
 start_year                          = 2000, 2000, 2000,
 start_month                         = 01,   01,   01,
 start_day                           = 24,   24,   24,
 start_hour                          = 12,   12,   12,
 end_year                            = 2000, 2000, 2000,
 end_month                           = 01,   01,   01,
 end_day                             = 25,   25,   25,
 end_hour                            = 12,   12,   12,
 interval_seconds                    = 21600
 bdy_inname                          = "wrfbdy_d<domain>_<date>"
 /

 &bdy_control
 multi_bdy_files                     = .true.
 /
```
and receive the following files with a single run of the real program.
```
wrfbdy_d01_2000-01-24_12:00:00
wrfbdy_d01_2000-01-24_18:00:00
wrfbdy_d01_2000-01-25_00:00:00
wrfbdy_d01_2000-01-25_06:00:00
```

ISSUE:
Fixes #656 "Multi-file lateral boundary conditions"

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON
modified:   main/real_em.F
modified:   run/README.namelist
modified:   share/mediation_integrate.F
modified:   share/module_check_a_mundo.F
modified:   test/em_real/examples.namelist

TESTS CONDUCTED:
1. Checked 24-h Jan 2000 simulation with SPLIT LBC vs traditional LBC: bit-for-bit results.
2. The lateral boundary files and the initial condition files are bit-wise identical whether the 
the original two-time-levels of multiple runs of the real program were used or if the new 
single-run of the real program is used.
3. Tried inconsistent namelist settings. They are detected:
```
 &time_control
 blah 
 /
 bdy_inname = "wrfbdy_d<domain>_<date>"

 &bdy_control
 multi_bdy_files = .true.
 /
```
Yields:
```
  --- ERROR: Need bdy_inname = "wrfbdy_d<domain>_<date>"
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2035
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
And the other way:
```
 &time_control
 bdy_inname = "wrfbdy_d<domain>_<date>"
 /

 &bdy_control
 blah
 /
 multi_bdy_files = .true.
```
Yields:
```
  --- ERROR: Remove bdy_inname = "wrfbdy_d<domain>_<date>"
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2035
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
4. Code benignly builds with NMM.

RELEASE NOTE: A run-time capability for multiple LBC files is now available. This supersedes and replaces the compile-time option. This is run-time option is accessed through &bdy_control namelist logical variable multi_bdy_files. This option requires that the lateral boundary file names in &time_control include a date: `bdy_inname = "wrfbdy_d<domain>_<date>"`. All other functionality of the capability is identical to the compile-time option.