### PR TITLE
Bug fix for RRTMG shortwave radiation

### DIFF
--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -2575,6 +2575,7 @@
     
 ! Recompute original s.s.a. to test for conservative solution
             denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
+	    ! Code added to avoid 'divide by zero' error in zwo computation
             if (abs(denom).eq.0.0_rb) then
                denom = 1.0E-30_rb
             end if

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -2574,8 +2574,10 @@
             zgamma4= 1._rb - zgamma3
     
 ! Recompute original s.s.a. to test for conservative solution
-            !Balwinder.Singh@pnnl.gov: Code added to avoid 'divide by zero' error in zwo computation
-            denom = max((1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2),1.0E-30_rb)
+            denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
+            if (abs(denom).eq.0.0_rb) then
+               denom = 1.0E-30_rb
+            end if
             zwo= zw / denom
 
             if (zwo >= zwcrit) then

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -9438,6 +9438,7 @@ real gpu_device  :: zcd(tncol,ngptsw,nlayers+1)  , zcu(tncol,ngptsw,nlayers+1)
       real  :: zrk, zrk2, zrkg, zrm1, zrp, zrp1, zrpp
       real  :: zsr3, zt1, zt2, zt3, zt4, zt5, zto1
       real  :: zw, zwcrit, zwo, prmuz
+      real  :: denom
 
       real , parameter :: eps = 1.e-08 
 
@@ -9478,7 +9479,11 @@ real gpu_device  :: zcd(tncol,ngptsw,nlayers+1)  , zcu(tncol,ngptsw,nlayers+1)
     
 ! Recompute original s.s.a. to test for conservative solution
 
-               zwo= zw / (1.  - (1.  - zw) * (zg / (1.  - zg))**2)
+               denom = (1. - (1. - zw) * (zg / (1. - zg))**2)
+               if (abs(denom).eq.0.0) then
+                  denom = 1.0E-30
+               end if
+               zwo= zw / denom
     
                if (zwo >= zwcrit) then
 ! Conservative scattering

--- a/phys/module_ra_rrtmg_swk.F
+++ b/phys/module_ra_rrtmg_swk.F
@@ -2079,11 +2079,12 @@
        endif
 !
 ! Recompute original s.s.a. to test for conservative solution
-! Balwinder.Singh@pnnl.gov: Code added to avoid 'divide by zero' error 
-! in zwo computation
 !
-       denom = max((1._rb-(1._rb-zw)*(zg/(1._rb-zg))**2),1.0e-30_rb)
-       zwo = zw/denom
+       denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
+       if (abs(denom).eq.0.0_rb) then
+           denom = 1.0E-30_rb
+       end if
+       zwo= zw / denom
 !
        if (zwo >= zwcrit) then
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RRTMG shortwave radiation, dividing by zero

SOURCE: internal

DESCRIPTION OF CHANGES: 
In 3.5.1, a bug fix was introduced to fix possibility of dividing by zero in subroutine reftra_sw. The fix was to limit the denominator to a small positive number. However, this denominator can be both positive and negative. This fix is hence not correct, and introduced cold bias in areas of cloud. This PR fixes the problem in module_ra_rrtmg_sw.F. The same fix is also added to the other two versions of RRTMG shortwave code.

The attached figure shows temperature difference profiles from original 3.5.1 code and fixed 3.5.1 code compared to v3.4.1 over a Southeast Asia domain 6 h into the forecast. The rest of the difference is due to the introduction of eot, or 'equation of time' to improve the accuracy of zenith angle calculation.
![fix_rrtmg](https://user-images.githubusercontent.com/12705680/67112928-95f82700-f195-11e9-9850-01f797e9c391.png)

The following ncview plot shows the temperature differences at model level 31 6 h into the forecast:
![fix_rrtmg2](https://user-images.githubusercontent.com/12705680/67114451-22f0af80-f199-11e9-9c78-63c908cf478a.png)

LIST OF MODIFIED FILES: 
M       phys/module_ra_rrtmg_sw.F
M       phys/module_ra_rrtmg_swf.F
M       phys/module_ra_rrtmg_swk.F

TESTS CONDUCTED: 
Regression tests pass.

RELEASE NOTE: In 3.5.1, a bug fix was introduced to fix possibility of dividing by zero in subroutine reftra_sw. The fix was to limit the denominator to a small positive number. However, this denominator can be both positive and negative. This fix is hence not correct, and introduced cold bias in areas of cloud. This PR fixes the nearly identical problem in all three module_ra_rrtmg_sw*.F files. 