### PR TITLE
Dynamic lightning Scheme Implemented

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2417,6 +2417,15 @@ rconfig   integer tracer_pblmix           namelist,physics      max_domains  1  
 rconfig   logical use_aero_icbc           namelist,physics     	1              .false. rh    "use_aero_icbc"  "Use GOCART climo 3D aerosols IC/BC data in Thompson-MP-Aero"  "logical flag"
 rconfig   logical use_rap_aero_icbc       namelist,physics      1              .false. r     "use_rap_aero_icbc"  "Use GOCART climo 3D aerosols IC/BC data in Thompson-MP-Aero from RAP"  "logical flag"
 rconfig   integer use_mp_re               namelist,physics     	1              1       h     "use_mp_re"  "use effective radii computed in some mp schemes in RRTMG"  "flag"
+#dynamic lightning
+  rconfig   real     coul_pos            namelist,physics      max_domains  0.25E-4     rh       "Constant for Positive Charging of Clouds"  "Coulombs"      ""
+  rconfig   real     coul_neg            namelist,physics      max_domains  0.25E-4     rh       "Constant for Negative Charging of Clouds"  "Coulombs"      ""
+  rconfig   real     coul_neu            namelist,physics      max_domains  0.25E-4     rh       "Constant for Charging of Intracloud Lightning"  "Coulombs"      ""
+   rconfig   real     j_pos            namelist,physics      max_domains  5.E9     rh       "Threshold for Producing Positive Event"  "J"      ""
+   rconfig   real     j_neg            namelist,physics      max_domains  1.E9     rh       "Threshold for Producing Negative Event"  "J"      ""
+   rconfig   real     j_neu            namelist,physics      max_domains  1.E9     rh       "Threshold for Producing IC Event"  ""      "J"
+#  end dynamic lightning
+#
 
 # The following two options are hooked into various microphysics schemes to allow for ensemble perturbations of CCN and hail/graupel PSDs - GAC (AFWA)
 rconfig   real    ccn_conc                namelist,physics      1           1.0E8      h     "ccn_conc"                 "CCN concentration"                                                             "# m-3"
@@ -3055,6 +3064,18 @@ package	ltng_crm_PR92w      lightning_option==1            -       state:ic_flas
 package ltng_crm_PR92z      lightning_option==2            -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
 package	ltng_cpm_PR92z      lightning_option==11           -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
 package	ltng_lpi            lightning_option==3           -        state:lpi
+state   real    light_ne            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "LIGHTNING_NE"       "LIGHTNING NEG TOTAL ENERGY " "J"
+state   real    light_pe            ikjftb  scalar      1         -     \
+     i0rhusdf=(bdy_interp:dt)    "LIGHTNING_PE"       "LIGHTNING POS TOTAL ENERGY" "J"
+state   real    light_neu            ikjftb  scalar      1         -     \
+       i0rhusdf=(bdy_interp:dt)    "LIGHTNING_NEU"       "LIGHTNING NEU TOTAL ENERGY" "J"
+state    real   LPOS            ij     misc        1         -     irh05du      "LPOS"                   "Positive Cloud to Ground Lightning Density"       "# time-l"
+state    real   LNEG            ij     misc        1         -     irh05du      "LNEG"                   "Negative Cloud to Ground Lightning Density"       "# time-1"
+state    real   LNEU            ij     misc        1         -     irh05du      "LNEU"                   "Intra-Cloud Lightning Density"  "# time-1"
+state    real  l_obs          i{lp}j      misc        1         -      irh5       "L_OBS"                  "Lightning OBS"      " "
+package ltng_dyn_lightning      lightning_option==4   -   scalar:light_pe,light_ne,light_neu;state:lneu,lneg,lpos,l_obs
+#
 # only need to specify these once; not for every io_form* variable
 package   io_intio    io_form_restart==1                     -             -
 package   io_netcdf   io_form_restart==2                     -             -

--- a/Registry/Registry.EM_COMMON_add
+++ b/Registry/Registry.EM_COMMON_add
@@ -1,0 +1,3367 @@
+# At the present time this file is managed manually and edited by hand.                                         
+#                                               
+################################################################################
+# Dimension specifications
+#
+# This section of the Registry file is used to specify the dimensions
+# that will be used to define arrays. Dim is the one-letter name of the
+# dimension.  How defined can either be "standard_domain", which means
+# that the dimension (1) is one of the three spatial dimensions and (2)
+# it will be set using the standard namelist mechanism and domain data
+# structure dimension fields (e.g. sd31,ed31,sd32...).
+#
+# Order refers to which of the three sets of just-mentioned internal
+# dimension variables the dimension is referred to by in the driver.
+# That is, is it the first, second, or third dimension.  The registry
+# infers the mapping of its internal dimensions according to the
+# combination of Order and Coord-axis that are specified in this table.
+# Note that it is all right to more than one dimension name for, say, the
+# x dimension.  However, the Order and Coord-axis relationship must be
+# consistent throughout.
+# 
+# Note: these entries do not enforce storage order on a particular field.
+# That is determined by the dimension strings for each field. But it does
+# relate the dimspec to the internal data structures that the driver uses
+# to maintain the three physical domain dimensions.
+# 
+# "How defined" can also specify the name of a namelist variable from which
+# the definition for the dimension will come; this is specified as
+# "namelist=<variable name>".  The namelist variable must have been
+# defined as an integer and with only one entry in the rconfig table. Or
+# a constant can be specified.  The coordinate axis for the dimension is
+# either X, Y, Z, or C (for "not a spatial dimension").  The Dimname is
+# the descriptive name of the dimension that will be included in the
+# metadata in data sets.  Note that the b, f, and t modifiers that appear
+# as the last characters of dimension strings used # in state and # i1
+# registry definitions are not dimensions and do not need to be declared
+# here.
+#
+
+
+################################################################################
+################################################################################
+################################################################################
+
+# Lines that start with the word 'state' form a table that is
+# used by the script use_registry to generate module_state_descript.F
+# and other files.  Also see documentation in use_registry.
+#                                               
+# table entries are of the form
+#<Table> <Type> <Sym>         <Dims>   <Use>   <NumTLev> <Stagger> <IO>     <DNAME>             <DESCRIP>     <UNITS>
+#
+state    real  XLAT             ij      misc        1         -     i0123rh0156{22}{23}du=(copy_fcnm)      "XLAT"                "LATITUDE, SOUTH IS NEGATIVE"                                          "degree_north"
+state    real  XLONG            ij      misc        1         -     i0123rh0156{22}{23}d=(interp_fcn_blint_ll:xlat,input_from_file)u=(copy_fcnm)      "XLONG"               "LONGITUDE, WEST IS NEGATIVE"                                          "degree_east"
+
+# It is required that LU_INDEX appears before any variable that is
+# interpolated with a mask, as lu_index supplies that mask.
+# this next 1 is for the HFSoLE/PET demo; writing these to auxhist1 output over MCEL for coupling
+# with wave model, only if compiled with -DMCELIO, JM 2003/05/29
+state    real  LU_INDEX         ij      misc        1         -     i012rh01d=(interp_fcnm_lu:xlat,xlong,dx,grid_id)u=(copy_fcnm)   "LU_INDEX"              "LAND USE CATEGORY"         ""
+state    real  LU_MASK          ij      misc        1         -     i3h1     "LU_MASK"              "0 land 1 water"         ""
+
+# znw, znu, dzs, and zs must be listed before any 3-d fields
+# in order for the grib output module to work correctly.  The grib output
+# module retrieves the vertical levels from these parameters.  If znw, znu
+# dzs, and zs are not listed first, vertical level will not be encoded at 
+# time 0.
+
+state    real    znu            k       dyn_em      1         -     irh      "znu"  "eta values on half (mass) levels"  ""
+state    real    znw            k       dyn_em      1         Z     i0rh     "znw"  "eta values on full (w) levels"  ""
+state    real   ZS              l        misc      -         Z     irh       "ZS"                    "DEPTHS OF CENTERS OF SOIL LAYERS"         "m"
+state    real   DZS             l        misc      -         Z     irh       "DZS"                   "THICKNESSES OF SOIL LAYERS"               "m"
+# cyl : variables for trajectory calculation
+state    real  traj_i         {ntraj}       dyn_em      1         Z     irh     "traj_i" "grid number of trajectory " ""                                     
+state    real  traj_j         {ntraj}       dyn_em      1         Z     irh     "traj_j" "grid number of trajectory " ""                                     
+state    real  traj_k         {ntraj}       dyn_em      1         Z     irh     "traj_k" "vertical eta level of trajectory " ""                              
+state    real  traj_long      {ntraj}       dyn_em      1         Z     irh      "traj_long" "longitude of trajectory " ""                                   
+state    real  traj_lat       {ntraj}       dyn_em      1         Z     irh      "traj_lat" "latitude of trajectory " ""                                     
+
+#
+# Variables from WPS
+#
+
+state    real   u_gc           igj      dyn_em      1        XZ    i1  "UU"     "x-wind component"    "m s-1"
+state    real   v_gc           igj      dyn_em      1        YZ    i1  "VV"     "y-wind component"    "m s-1"
+state    real   t_gc           igj      dyn_em      1        Z     i1  "TT"     "temperature"         "K"
+state    real   rh_gc          igj      dyn_em      1        Z     i1  "RH"    "relative humidity"   "%"
+state    real   ght_gc         igj      dyn_em      1        Z     i1  "GHT"   "geopotential height" "m"
+state    real   p_gc           igj      dyn_em      1        Z     i1  "PRES"   "pressure"            "Pa"
+state    real   prho_gc        igj      dyn_em      1        Z     i1  "PRHO" "for UM data, pressure of U and V" "Pa"
+state    real   xlat_gc        ij       dyn_em      1        -     i1  "XLAT_M" "latitude, positive north" "degrees"
+state    real   xlong_gc       ij       dyn_em      1        -     i1  "XLONG_M" "longitude, positive east" "degrees"
+state    real   ht_gc          ij       dyn_em      1        -     i1  "HGT_M" "topography elevation" "m"
+state    real   var_sso        ij       dyn_em      1        -     i012hrd "var_sso" "variance of subgrid-scale orography" "m2"
+state    real   lap_hgt        ij       dyn_em      1        -     r    "lap_hgt" "Laplacian of orography" "m"
+state    real   tsk_gc         ij       dyn_em      1        -     i1  "SKINTEMP"  "skin temperature"  "K"
+state    real   tavgsfc        ij       dyn_em      1        -     i1  "TAVGSFC"  "daily mean of surface air temperature"  "K"
+state    real   tmn_gc         ij       dyn_em      1        -     i1  "SOILTEMP"  "annual mean deep soil temperature"  "K"
+state    real   pslv_gc        ij       dyn_em      1        -     i1  "PMSL"  "sea level pressure"  "Pa"
+state    real   sct_dom_gc     ij       dyn_em      1        -     i1  "SCT_DOM"  "Dominant soil (top) category from GEOGRID"  "cat"
+state    real   scb_dom_gc     ij       dyn_em      1        -     i1  "SCB_DOM"  "Dominant soil (bottom) category from GEOGRID"  "cat"
+state    real   greenfrac      imj      dyn_em      1        Z     i1  "GREENFRAC" "monthly greenness fraction" "0 - 1 fraction"
+state    real   albedo12m      imj      dyn_em      1        Z     i1  "ALBEDO12M" "background albedo" "0 - 1 fraction"
+state    real   lai12m         imj      dyn_em      1        Z     i1  "LAI12M" "monthly LAI" "m2/m2"
+state    real   pd_gc          igj      dyn_em      1        Z     -   "PD"    "dry pressure"        "Pa"
+state    real   pdrho_gc       igj      dyn_em      1        Z     -   "PDRHO"    "dry pressure for UM data for the variables U and V"   "Pa"
+state    real   psfc_gc        ij       dyn_em      1        -      -  "PSFC_GC"     "surface pressure"            "Pa"
+state    real   intq_gc        ij       dyn_em      1        -     -   "INTQ"  "integrated mixing ratio" "Pa"
+state    real   pdhs           ij       dyn_em      1        -     -   "PDHS"  "hydrostatic dry surface pressure" "Pa"
+state    real   qv_gc          igj      dyn_em      1        Z     i1  "QV"     "mixing ratio"        "kg kg-1"
+state    real   sh_gc          igj      dyn_em      1        Z     i1  "SPECHUMD"  "Specific humidity"        "kg kg-1"
+state    real   cl_gc          igj      dyn_em      1        Z     i1  "SPECCLDL"  "Cloud water content, liquid"    "kg kg-1"
+state    real   cf_gc          igj      dyn_em      1        Z     i1  "SPECCLDF"  "Cloud water content, frozen"    "kg kg-1"
+state    real   icefrac_gc     ij       dyn_em      1        -     i1  "ICEFRAC"  "Sea ice fraction"  "0 - 1 fraction"
+state    real   icepct         ij       dyn_em      1        -     i1  "ICEPCT"  "Sea ice percent"  "%"
+state    real   qr_gc          igj      dyn_em      1        Z     i1  "QR"    "rain water mixing ratio"   "kg kg-1"
+state    real   qc_gc          igj      dyn_em      1        Z     i1  "QC"    "cloud water mixing ratio"   "kg kg-1"
+state    real   qs_gc          igj      dyn_em      1        Z     i1  "QS"    "snow mixing ratio"   "kg kg-1"
+state    real   qi_gc          igj      dyn_em      1        Z     i1  "QI"    "cloud ice mixing ratio"   "kg kg-1"
+state    real   qg_gc          igj      dyn_em      1        Z     i1  "QG"    "graupel mixing ratio"   "kg kg-1"
+state    real   qh_gc          igj      dyn_em      1        Z     i1  "QH"    "hail mixing ratio"   "kg kg-1"
+state    real   qni_gc         igj      dyn_em      1        Z     i1  "QNI"   "ice num concentration"   "# kg-1"
+state    real   qnc_gc         igj      dyn_em      1        Z     i1  "QNC"   "cloud water num concentration"   "# kg-1"
+state    real   qnr_gc         igj      dyn_em      1        Z     i1  "QNR"   "rain num concentration"   "# kg-1"
+state    real   qns_gc         igj      dyn_em      1        Z     i1  "QNS"   "snow num concentration"   "# kg-1"
+state    real   qng_gc         igj      dyn_em      1        Z     i1  "QNG"   "graupel num concentration"   "# kg-1"
+state    real   qnh_gc         igj      dyn_em      1        Z     i1  "QNH"   "hail num concentration"   "# kg-1"
+state    real   qnwfa_gc       igj      dyn_em      1        Z     i1  "QNWFA"   "water-friendly aerosol  num concentration"   "# kg-1"
+state    real   qnifa_gc       igj      dyn_em      1        Z     i1  "QNIFA"   "water-friendly aerosol  num concentration"   "# kg-1"
+state    real   qnwfa_now      igj      dyn_em      1        Z     -   "QNWFA_NOW"   "num water-friendly aerosol Now"   "# kg-1"
+state    real   qnwfa_jan      igj      dyn_em      1        Z     i1  "QNWFA_JAN"   "num water-friendly aerosol Jan"   "# kg-1"
+state    real   qnwfa_feb      igj      dyn_em      1        Z     i1  "QNWFA_FEB"   "num water-friendly aerosol Feb"   "# kg-1"
+state    real   qnwfa_mar      igj      dyn_em      1        Z     i1  "QNWFA_MAR"   "num water-friendly aerosol Mar"   "# kg-1"
+state    real   qnwfa_apr      igj      dyn_em      1        Z     i1  "QNWFA_APR"   "num water-friendly aerosol Apr"   "# kg-1"
+state    real   qnwfa_may      igj      dyn_em      1        Z     i1  "QNWFA_MAY"   "num water-friendly aerosol May"   "# kg-1"
+state    real   qnwfa_jun      igj      dyn_em      1        Z     i1  "QNWFA_JUN"   "num water-friendly aerosol Jun"   "# kg-1"
+state    real   qnwfa_jul      igj      dyn_em      1        Z     i1  "QNWFA_JUL"   "num water-friendly aerosol Jul"   "# kg-1"
+state    real   qnwfa_aug      igj      dyn_em      1        Z     i1  "QNWFA_AUG"   "num water-friendly aerosol Aug"   "# kg-1"
+state    real   qnwfa_sep      igj      dyn_em      1        Z     i1  "QNWFA_SEP"   "num water-friendly aerosol Sep"   "# kg-1"
+state    real   qnwfa_oct      igj      dyn_em      1        Z     i1  "QNWFA_OCT"   "num water-friendly aerosol Oct"   "# kg-1"
+state    real   qnwfa_nov      igj      dyn_em      1        Z     i1  "QNWFA_NOV"   "num water-friendly aerosol Nov"   "# kg-1"
+state    real   qnwfa_dec      igj      dyn_em      1        Z     i1  "QNWFA_DEC"   "num water-friendly aerosol Dec"   "# kg-1"
+state    real   qnifa_now      igj      dyn_em      1        Z     -   "QNIFA_NOW"   "num ice-friendly aerosol Now"   "# kg-1"
+state    real   qnifa_jan      igj      dyn_em      1        Z     i1  "QNIFA_JAN"   "num ice-friendly aerosol Jan"   "# kg-1"
+state    real   qnifa_feb      igj      dyn_em      1        Z     i1  "QNIFA_FEB"   "num ice-friendly aerosol Feb"   "# kg-1"
+state    real   qnifa_mar      igj      dyn_em      1        Z     i1  "QNIFA_MAR"   "num ice-friendly aerosol Mar"   "# kg-1"
+state    real   qnifa_apr      igj      dyn_em      1        Z     i1  "QNIFA_APR"   "num ice-friendly aerosol Apr"   "# kg-1"
+state    real   qnifa_may      igj      dyn_em      1        Z     i1  "QNIFA_MAY"   "num ice-friendly aerosol May"   "# kg-1"
+state    real   qnifa_jun      igj      dyn_em      1        Z     i1  "QNIFA_JUN"   "num ice-friendly aerosol Jun"   "# kg-1"
+state    real   qnifa_jul      igj      dyn_em      1        Z     i1  "QNIFA_JUL"   "num ice-friendly aerosol Jul"   "# kg-1"
+state    real   qnifa_aug      igj      dyn_em      1        Z     i1  "QNIFA_AUG"   "num ice-friendly aerosol Aug"   "# kg-1"
+state    real   qnifa_sep      igj      dyn_em      1        Z     i1  "QNIFA_SEP"   "num ice-friendly aerosol Sep"   "# kg-1"
+state    real   qnifa_oct      igj      dyn_em      1        Z     i1  "QNIFA_OCT"   "num ice-friendly aerosol Oct"   "# kg-1"
+state    real   qnifa_nov      igj      dyn_em      1        Z     i1  "QNIFA_NOV"   "num ice-friendly aerosol Nov"   "# kg-1"
+state    real   qnifa_dec      igj      dyn_em      1        Z     i1  "QNIFA_DEC"   "num ice-friendly aerosol Dec"   "# kg-1"
+state    real   qntemp         imj      dyn_em      1        Z     -   "QNTEMP"     "temporary var for time interp"    ""
+state    real   qntemp2        ij       dyn_em      1        -     -   "QNTEMP2"    "temporary var2D for time interp"  ""
+state    real   t_max_p        ij       dyn_em      1        -     i0d  "T_MAX_P"   "temperature at max pressure"         "K"
+state    real   ght_max_p      ij       dyn_em      1        -     i0d  "GHT_MAX_P" "geopotential height at max pressure" "m"
+state    real   max_p          ij       dyn_em      1        -     i0d  "MAX_P"     "max pressure "                       "Pa"
+state    real   t_min_p        ij       dyn_em      1        -     i0d  "T_MIN_P"   "temperature at min pressure"         "K"
+state    real   ght_min_p      ij       dyn_em      1        -     i0d  "GHT_MIN_P" "geopotential height at min pressure" "m"
+state    real   min_p          ij       dyn_em      1        -     i0d  "MIN_P"     "min pressure "                       "Pa"
+state    real   hgtmaxw        ij       dyn_em      1        -     i1  "HGTMAXW"    "Height of the max wind speed"       "m"
+state    real   hgttrop        ij       dyn_em      1        -     i1  "HGTTROP"    "Height of the tropopause"           "m"
+state    real   pmaxw          ij       dyn_em      1        -     i1  "PMAXW"      "Pressure of the max wind speed"     "Pa"
+state    real   pmaxwnn        ij       dyn_em      1        -     i1  "PMAXWNN"    "PMAXW, nearest neighbor interp"     "Pa"
+state    real   ptrop          ij       dyn_em      1        -     i1  "PTROP"      "Pressure of the tropopause"         "Pa"
+state    real   ptropnn        ij       dyn_em      1        -     i1  "PTROPNN"    "PTROP, nearest neighbor interp"     "Pa"
+state    real   tmaxw          ij       dyn_em      1        -     i1  "TMAXW"      "Temperature of the max wind speed"  "K"
+state    real   ttrop          ij       dyn_em      1        -     i1  "TTROP"      "Temperature of the tropopause"      "K"
+state    real   umaxw          ij       dyn_em      1        X     i1  "UMAXW"      "U-component of the max wind speed"  "m s-1"
+state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"      "U-component of the tropopause wind" "m s-1"
+state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
+state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
+state    real   erod           ij.      misc        1        -     i012rd  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+#                                               
+# Variables for Eulerian mass coordinate dynamics                                            
+#                                               
+
+# Velocities
+#
+# U Vel
+state    real   u              ikjb     dyn_em      2         X     \
+     i0rhusdf=(bdy_interp:dt)       "U"                      "x-wind component"   "m s-1"
+state    real   ru             ikj     dyn_em      1         X      -        "MU_U"        "mu-coupled u"   "Pa m s-1"
+state    real   ru_m           ikj     dyn_em      1         X      -        "ru_m"        ""   ""
+state    real   ru_tend        ikj     dyn_em      1         X      -        "ru_tend"        ""   ""                                   
+i1       real   ru_tendf       ikj     dyn_em      1         X                                          
+state    real   u_save         ikj     dyn_em      1         X      -        "u_save"
+state    real   z_force        |       dyn_em      1         -      i3rh     "Z_FORCE" "height of forcing input" "m"
+state    real   z_force_tend   |       dyn_em      1         -      i3rh     "Z_FORCE_TEND" "tendency height of forcing input" "m"
+state    real   u_g            |       dyn_em      1         -      i3rh     "U_G" "x-direction geostrophic wind" "m s-1"
+state    real   u_g_tend       |       dyn_em      1         -      i3rh     "U_G_TEND" "tendency x-direction geostrophic wind" "m s-1"
+#                                               
+# V Vel
+state    real   v              ikjb     dyn_em      2         Y     \
+     i0rhusdf=(bdy_interp:dt)        "V"                     "y-wind component"   "m s-1"
+state    real   rv             ikj     dyn_em      1         Y      -        "MU_V"        "mu-coupled v"   "Pa m s-1"
+state    real   rv_m           ikj     dyn_em      1         Y      -        "rv_m"
+state    real   rv_tend        ikj     dyn_em      1         Y      -        "rv_tend"
+i1       real   rv_tendf       ikj     dyn_em      1         Y                                          
+state    real   v_save         ikj     dyn_em      1         Y      -        "v_save"                   
+state    real   v_g            |       dyn_em      1         -      i3rh     "V_G" "y-direction geostrophic wind" "m s-1"
+state    real   v_g_tend       |       dyn_em      1         -      i3rh     "V_G_TEND" "tendency y-direction geostrophic wind" "m s-1"
+#                                               
+# Vertical Vel                                          
+state    real   w              ikjb     dyn_em      2         Z     \
+        irhusdf=(bdy_interp:dt)  "w"                          "z-wind component"   "m s-1"
+state    real   ww             ikj     dyn_em      1         Z      r         "ww"   "mu-coupled eta-dot"    "Pa s-1"
+state    real   rw             ikj     dyn_em      1         Z      -         "rw"   "mu-coupled w"          "Pa m s-1"
+i1       real   ww1            ikj     dyn_em      1         Z                                          
+state    real   ww_m           ikj     dyn_em      1         Z      r         "ww_m"   "time-avg mu-coupled eta-dot"    "Pa s-1"
+i1       real   wwp            ikj     dyn_em      1         Z                                          
+i1       real   rw_tend        ikj     dyn_em      1         Z                                          
+i1       real   rw_tendf       ikj     dyn_em      1         Z                                          
+i1       real   w_save         ikj     dyn_em      1         Z                                          
+state    real   w_subs         |       dyn_em      1         -      i3rh      "W_SUBS" "large-scale vertical velocity" "m s-1"
+state    real   w_subs_tend    |       dyn_em      1         -      i3rh      "W_SUBS_TEND" "tendency large-scale vertical velocity" "m s-1"
+
+# Geopotential
+state    real   ph             ikjb     dyn_em      2         Z     \
+       irhusdf=(bdy_interp:dt)   "ph"   "perturbation geopotential"  "m2 s-2"
+state    real   phb            ikj     dyn_em      1         Z     irhdus "phb"  "base-state geopotential"  "m2 s-2"
+state    real   phb_fine       ikj     dyn_em      1         Z      -     "phb_fine"  "for nesting, temp holding interpolated coarse grid phb"  "m2 s-2"
+state    real   ph0            ikj     dyn_em      1         Z      r     "ph0"  "initial geopotential"     "m2 s-2"
+state    real   php            ikj     dyn_em      1         -      r     "php"  "geopotential"             "m2 s-2"
+i1       real   ph_tend        ikj     dyn_em      1         Z 
+i1       real   ph_tendf       ikj     dyn_em      1         Z 
+i1       real   ph_save        ikj     dyn_em      1         Z 
+
+# Potential Temperature
+state    real   th_phy_m_t0    ikj      dyn_em      1         -     irhd      "t"      "perturbation potential temperature theta-t0" "K"
+state    real   t              ikjb     dyn_em      2         -     \
+       i0rhusdf=(bdy_interp:dt)   "thm"      "either 1) pert moist pot temp=(1+Rv/Rd Qv)*(theta)-T0, or 2) pert dry pot temp=theta-T0; based on use_theta_m setting" "K"
+
+state    real   t_init         ikj     dyn_em      1         -      ird       "t_init" "initial potential temperature" "K"
+i1       real   t_tend         ikj     dyn_em      1         -  
+i1       real   t_tendf        ikj     dyn_em      1         -  
+i1       real   t_2save        ikj     dyn_em      1         -   
+state    real   t_save         ikj     dyn_em      1         -      -        "t_save"
+
+state    real   th_upstream_x       |     dyn_em      1      -      i3rh     "TH_UPSTREAM_X" "upstream theta x-advection" "K s-1"
+state    real   th_upstream_x_tend  |     dyn_em      1      -      i3rh     "TH_UPSTREAM_X_TEND" "tendency upstream theta x-advection" "K s-2"
+state    real   th_upstream_y       |     dyn_em      1      -      i3rh     "TH_UPSTREAM_Y" "upstream theta y-advection" "K s-1"
+state    real   th_upstream_y_tend  |     dyn_em      1      -      i3rh     "TH_UPSTREAM_Y_TEND" "tendency upstream theta y-advection" "K s-2"
+
+state    real   qv_upstream_x       |     dyn_em      1      -      i3rh     "QV_UPSTREAM_X" "upstream qv x-advection" "kg kg-1 s-1"
+state    real   qv_upstream_x_tend  |     dyn_em      1      -      i3rh     "QV_UPSTREAM_X_TEND" "tendency upstream qv x-advection" "kg kg-1 s-2"
+state    real   qv_upstream_y       |     dyn_em      1      -      i3rh     "QV_UPSTREAM_Y" "upstream qv y-advection" "kg kg-1 s-1"
+state    real   qv_upstream_y_tend  |     dyn_em      1      -      i3rh     "QV_UPSTREAM_Y_TEND" "tendency upstream qv y-advection" "kg kg-1 s-2"
+
+state    real   ql_upstream_x       |     dyn_em      1      -      i3rh     "QL_UPSTREAM_X" "upstream ql x-advection" "kg kg-1 s-1"
+state    real   ql_upstream_x_tend  |     dyn_em      1      -      i3rh     "QL_UPSTREAM_X_TEND" "tendency upstream ql x-advection" "kg kg-1 s-2"
+state    real   ql_upstream_y       |     dyn_em      1      -      i3rh     "QL_UPSTREAM_Y" "upstream ql y-advection" "kg kg-1 s-1"
+state    real   ql_upstream_y_tend  |     dyn_em      1      -      i3rh     "QL_UPSTREAM_Y_TEND" "tendency upstream ql y-advection" "kg kg-1 s-2"
+
+state    real   u_upstream_x        |     dyn_em      1      -      i3rh     "U_UPSTREAM_X" "upstream u x-advection" "m s-2"
+state    real   u_upstream_x_tend   |     dyn_em      1      -      i3rh     "U_UPSTREAM_X_TEND" "tendency upstream u x-advection" "m s-3"
+state    real   u_upstream_y        |     dyn_em      1      -      i3rh     "U_UPSTREAM_Y" "upstream u y-advection" "m s-2"
+state    real   u_upstream_y_tend   |     dyn_em      1      -      i3rh     "U_UPSTREAM_Y_TEND" "tendency upstream u y-advection" "m s-3"
+
+state    real   v_upstream_x        |     dyn_em      1      -      i3rh     "V_UPSTREAM_X" "upstream v x-advection" "m s-2"
+state    real   v_upstream_x_tend   |     dyn_em      1      -      i3rh     "V_UPSTREAM_X_TEND" "tendency upstream v x-advection" "m s-3"
+state    real   v_upstream_y        |     dyn_em      1      -      i3rh     "V_UPSTREAM_Y" "upstream v y-advection" "m s-2"
+state    real   v_upstream_y_tend   |     dyn_em      1      -      i3rh     "V_UPSTREAM_Y_TEND" "tendency upstream v y-advection" "m s-3"
+
+state    real   th_t_tend           |     dyn_em      1      -      i3rh     "TH_T_TEND" "tendency theta time" "K s-2"
+state    real   qv_t_tend           |     dyn_em      1      -      i3rh     "QV_T_TEND" "tendency qv time" "kg kg-1 s-1"
+
+state    real   th_largescale       |     dyn_em      1      -      i3rh     "TH_LARGESCALE" "SCM largescale theta" "K"
+state    real   th_largescale_tend  |     dyn_em      1      -      i3rh     "TH_LARGESCALE_TEND" "SCM tendency largescale theta" "K s-1"
+
+state    real   qv_largescale       |     dyn_em      1      -      i3rh     "QV_LARGESCALE" "SCM largescale qv" "kg kg-1 s-1"
+state    real   qv_largescale_tend  |     dyn_em      1      -      i3rh     "QV_LARGESCALE_TEND" "SCM tendency largescale qv" "kg kg-1 s-2"
+
+state    real   ql_largescale       |     dyn_em      1      -      i3rh     "QL_LARGESCALE" "SCM largescale ql" "kg kg-1 s-1"
+state    real   ql_largescale_tend  |     dyn_em      1      -      i3rh     "QL_LARGESCALE_TEND" "SCM tendency largescale ql" "kg kg-1 s-2"
+
+state    real   u_largescale        |     dyn_em      1      -      i3rh     "U_LARGESCALE" "SCM largescale u" "m s-2"
+state    real   u_largescale_tend   |     dyn_em      1      -      i3rh     "U_LARGESCALE_TEND" "SCM tendency largescale u" "m s-3"
+
+state    real   v_largescale        |     dyn_em      1      -      i3rh     "V_LARGESCALE" "SCM largescale v" "m s-2"
+state    real   v_largescale_tend   |     dyn_em      1      -      i3rh     "V_LARGESCALE_TEND" "SCM tendency largescale v" "m s-3"
+
+state    real   tau_largescale       |     dyn_em      1      -      i3rh     "TAU_LARGESCALE" "SCM largescale timescale" "s"
+state    real   tau_largescale_tend  |     dyn_em      1      -      i3rh     "TAU_LARGESCALE_TEND" "SCM tendency largescale timescale" ""
+
+state    real   tau_x               |     dyn_em      1      -      i3rh     "TAU_X" "X-direction advective timescale" "s"
+state    real   tau_x_tend          |     dyn_em      1      -      i3rh     "TAU_X_TEND" "tendency X-direction advective timescale" ""
+state    real   tau_y               |     dyn_em      1      -      i3rh     "TAU_Y" "Y-direction advective timescale" "s"
+state    real   tau_y_tend          |     dyn_em      1      -      i3rh     "TAU_Y_TEND" "tendency Y-direction advective timescale" ""
+
+dimspec  fslay  2     namelist=num_force_soil_layers    z     force_soil_layers
+state    real   t_soil_forcing_val  {fslay}     dyn_em      1      -      i3rh     "T_SOIL_FORCING_VAL" "Soil temp value for SCM forcing" "K"
+state    real   t_soil_forcing_tend {fslay}     dyn_em      1      -      i3rh     "T_SOIL_FORCING_TEND" "tendency soil temp for SCM forcing" "K s-1"
+state    real   q_soil_forcing_val  {fslay}     dyn_em      1      -      i3rh     "Q_SOIL_FORCING_VAL" "Soil moisture value for SCM forcing" "1"
+state    real   q_soil_forcing_tend {fslay}     dyn_em      1      -      i3rh     "Q_SOIL_FORCING_TEND" "tendency soil moisture for SCM forcing" "s-1"
+state    real   tau_soil            {fslay}     dyn_em      1      -      i3rh     "TAU_SOIL" "SCM soil forcing timescale" "s"
+state    real   soil_depth_force    {fslay}     dyn_em      1      -      i3rh     "SOIL_DEPTH_FORCE" "SCM depth at center of soil layers in forcing file" "1"
+
+state    real   hfx_force           -     dyn_em      1      -      i3rh     "HFX_FORCE" "SCM ideal surface sensible heat flux" "W m-2"
+state    real   lh_force            -     dyn_em      1      -      i3rh     "LH_FORCE" "SCM ideal surface latent heat flux" "W m-2"
+state    real   tsk_force           -     dyn_em      1      -      i3rh     "TSK_FORCE" "SCM ideal surface skin temperature" "W m-2"
+state    real   hfx_force_tend      -     dyn_em      1      -      i3rh     "HFX_FORCE_TEND" "SCM ideal surface sensible heat flux tendency" "W m-2 s-1"
+state    real   lh_force_tend       -     dyn_em      1      -      i3rh     "LH_FORCE_TEND" "SCM ideal surface latent heat flux tendency" "W m-2 s-1"
+state    real   tsk_force_tend      -     dyn_em      1      -      i3rh     "TSK_FORCE_TEND" "SCM ideal surface skin temperature tendency" "W m-2 s-1"
+
+
+# Mass
+state    real   mu              ijb     dyn_em      2         -     \
+     irh01usdf=(bdy_interp:dt) "mu"  "perturbation dry air mass in column" "Pa"
+state    real   mub             ij     dyn_em      1         -     irhdus       "mub" "base state dry air mass in column" "Pa"
+state    real   mub_fine        ij     dyn_em      1         -      -           "mub_fine" "nest temp, holds interpolated coarse grid mub" "Pa"
+state    real   mub_save        ij     dyn_em      1         -      -           "mub_save" "nest temp, holds orig fine grid mub" "Pa"
+state    real   mu0             ij     dyn_em      1         -      i1          "mu0" "initial dry mass in column" "Pa"
+state    real   mudf            ij     dyn_em      1         -      -           "mudf" "" ""
+state    real   muu             ij     dyn_em      1          X     -           "muu"
+state    real   muus            ij     dyn_em      1          X     -           "muus"
+state    real   muv             ij     dyn_em      1          Y     -           "muv"
+state    real   muvs            ij     dyn_em      1          Y     -           "muvs"
+state    real   mut             ij     dyn_em      1          -     -           "mut"
+state    real   muts            ij     dyn_em      1          -     -           "muts"
+i1       real   muave           ij     dyn_em      1          -     
+i1       real   mu_save         ij     dyn_em      1          -     
+i1       real   mu_tend         ij     dyn_em      1          -     
+i1       real   mu_tendf        ij     dyn_em      1          -     
+
+#diagnostic for looking at nest position in output. A mungy version of terrain height.
+state    real   nest_pos        ij     misc        1   -   rhu=(mark_domain)  "NEST_POS"
+state    real   nest_mask       ij     misc        1   -   ru=(mark_domain)   "NEST_MASK"     "LOCATION OF NEST IF ANY"
+state    real   ht_coarse       ij     misc        1   -     r                -              "STORAGE FOR LOW-RES TERRAIN"
+
+
+# TKE
+state    real   tke            ikj     dyn_em      2         -       r        "tke"          "TURBULENCE KINETIC ENERGY"     "m2 s-2"
+i1       real   tke_tend       ikj     dyn_em      1         -      
+
+# Pressure and Density
+state    real   p              ikj     dyn_em      1         -      irh       "p"           "perturbation pressure"         "Pa"
+state    real   al             ikj     dyn_em      1         -      ir        "al"          "inverse perturbation density"  "m3 kg-1"
+state    real   alt            ikj     dyn_em      1         -      r         "alt"         "inverse density"               "m3 kg-1"
+state    real   alb            ikj     dyn_em      1         -      irdus     "alb"         "inverse base density"          "m3 kg-1"
+state    real   zx             ikj     dyn_em      1         XZ     -         " "  " "  " "    
+state    real   zy             ikj     dyn_em      1         YZ     -         " "  " "  " "   
+state    real   rdz            ikj     dyn_em      1         Z      -         " "  " "  " "   
+state    real   rdzw           ikj     dyn_em      1         Z      -         " "  " "  " "   
+state    real   pb             ikj     dyn_em      1         -      irhdus    "pb"          "BASE STATE PRESSURE "          "Pa"
+
+#                                               
+# Other dyn                                             
+#                                               
+i1       real   advect_tend    ikj     dyn_em      1         -                                          
+i1       real   alpha          ikj     dyn_em      1         -                                                  
+i1       real   a              ikj     dyn_em      1         -                                                  
+i1       real   gamma          ikj     dyn_em      1         -                                                  
+i1       real   c2a            ikj     dyn_em      1         -     -
+state    real   rho            ikj      misc       1         -     r      "RHO"              "DENSITY"         "Kg m-3"
+i1       real   phm            ikj     dyn_em      1         -     -
+i1       real   cqu            ikj     dyn_em      1         -     -
+i1       real   cqv            ikj     dyn_em      1         -     -
+i1       real   cqw            ikj     dyn_em      1         -     -
+i1       real   pm1            ikj     dyn_em      1         -     -
+state    real    fnm            k       dyn_em      1         -     irh       "fnm"  "upper weight for vertical stretching"  ""
+state    real    fnp            k       dyn_em      1         -     irh       "fnp"  "lower weight for vertical stretching"  ""
+state    real    rdnw           k       dyn_em      1         -     irh       "rdnw"  "inverse d(eta) values between full (w) levels"   ""
+state    real    rdn            k       dyn_em      1         -     irh       "rdn"  "inverse d(eta) values between half (mass) levels"   ""
+state    real    dnw            k       dyn_em      1         -     irh       "dnw" "d(eta) values between full (w) levels"   ""
+state    real    dn             k       dyn_em      1         -     irh       "dn " "d(eta) values between half (mass) levels"   ""
+state    real    t_base         k       dyn_em      1         -     ir        "t_base"               "BASE STATE T IN IDEALIZED CASES"         "K"      
+state    real    z              ikj     dyn_em      1         -     -         " " " " " "
+state    real    z_at_w         ikj     dyn_em      1         Z 
+state    real    cfn            -       misc      -         -     irh       "cfn"    "extrapolation constant"  ""
+state    real    cfn1           -       misc      -         -     irh       "cfn1"   "extrapolation constant"  ""
+state    integer step_number    -       misc      -         -     ir        "step_number"  ""
+
+# Idealized run
+state    logical this_is_an_ideal_run   - misc    -         -     irh    "this_is_an_ideal_run"     "T/F flag: this is an ARW ideal simulation"
+
+# For the adaptive timestep restart
+state    logical stepping_to_time       - misc    -         -      r     "stepping_to_time"         ""
+state    integer last_step_updated      - misc    -         -      r     "last_step_updated"        ""
+state    logical adapt_step_using_child - misc    -         -      r     "adapt_step_using_child"   ""
+state    integer last_dt_sec            - misc    -         -      r     "last_dt_sec"              "Whole seconds for last timestep"  "sec"
+state    integer last_dt_sec_num        - misc    -         -      r     "last_dt_sec_num"          "Fractional secs, numerator"       "sec"
+state    integer last_dt_sec_den        - misc    -         -      r     "last_dt_sec_den"          "Fractional secs, denominator"     "sec"
+state    integer last_dt_yr             - misc    -         -      r     "last_dt_yr"               "Relative year"                    "years"
+state    integer last_dt_mm             - misc    -         -      r     "last_dt_mm"               "Relative month"                   "months"
+
+# hydrostatic pressure vars
+state    real   p_hyd           ikj     dyn_em      1         -      irh       "p_hyd"       "hydrostatic pressure"         "Pa"
+state    real   p_hyd_w         ikj     dyn_em      1         Z       r        "p_hyd_w"     "hydrostatic pressure at full levels"         "Pa"
+
+# 2m and 10m output diagnostics
+state    real   Q2               ij     misc        1         -     irh01{22}{23}du    "Q2"                   "QV at 2 M"         "kg kg-1"
+state    real   T2               ij     misc        1         -     i01rh01{22}{23}du  "T2"                   "TEMP at 2 M"       "K"
+state    real   TH2              ij     misc        1         -     irhdu     "TH2"                  "POT TEMP at 2 M"   "K"
+state    real   PSFC             ij     misc        1         -     i01rh01du   "PSFC"                 "SFC PRESSURE"      "Pa"
+
+# these next 2 are for the HFSoLE/PET demo; writing these to auxhist1 output over MCEL for coupling
+# with wave model, only if compiled with -DMCELIO, JM 2003/05/29
+state    real   U10              ij     misc        1         -     irh01{22}{23}du     "U10"                "U at 10 M"         "m s-1"
+state    real   V10              ij     misc        1         -     irh01{22}{23}du     "V10"                "V at 10 M"         "m s-1"
+# LPI
+state    real   LPI              ij     misc        1         -     rhdu   "LPI"                 "Lightning Potential Index"      "m^2 s-2"
+
+# these next 4 are for observational nudging
+state    real   uratx           ij      misc        1         -      r          "URATX"            "Ratio of U over U10 on mass points "         "dimensionless"
+state    real   vratx           ij      misc        1         -      r          "VRATX"            "Ratio of V over V10 on mass points "         "dimensionless"   
+state    real   tratx           ij      misc        1         -      r          "TRATX"            "Ratio of T over TH2 on mass points "         "dimensionless"   
+state    real   obs_savwt      hikj     dyn_em      1         X      -       "OBS_SAVWT"           "Internal space holding weights of each ob, for each i,j,k" "dimensionless"
+
+# Other
+state   real    rdx            -        misc      -         -     irh       "rdx"                   "INVERSE X GRID LENGTH"         ""      
+state   real    rdy            -        misc      -         -     irh       "rdy"                   "INVERSE Y GRID LENGTH"         ""      
+state   real    dts            -        misc      -         -     ir        "dts"                   "SMALL TIMESTEP"         ""      
+state   real    dtseps         -        misc      -         -     ir        "dtseps"                "TIME WEIGHT CONSTANT FOR SMALL STEPS"         ""      
+state   real    resm           -        misc      -         -     irh       "resm"                  "TIME WEIGHT CONSTANT FOR SMALL STEPS"         ""      
+state   real    zetatop        -        misc      -         -     irh       "zetatop"               "ZETA AT MODEL TOP"         ""      
+state   real    cf1            -        misc      -         -     irh       "cf1"                   "2nd order extrapolation constant"         ""      
+state   real    cf2            -        misc      -         -     irh       "cf2"                   "2nd order extrapolation constant"         ""      
+state   real    cf3            -        misc      -         -     irh       "cf3"                   "2nd order extrapolation constant"         ""      
+state   integer number_at_same_level    -         -         -     -          -        "number_at_same_level"  ""         ""      
+state   real    radtacttime    -        -         -         -     r         "radtacttime"              "RADTACTTIME"         "LW SW ACTIVATION TIME in s"
+state   real    bldtacttime    -        -         -         -     r         "bldtacttime"              "BLDTACTTIME"         "PBL   ACTIVATION TIME in s"
+state   real    cudtacttime    -        -         -         -     r         "cudtacttime"              "CUDTACTTIME"         "CPS   ACTIVATION TIME in s"
+state   real    ltngacttime    -        -         -         -     r         "ltngacttime"              "LTNGACTTIME"         "LTNG  ACTIVATION TIME in s"
+state   real    power          ij       misc      1         -     irh       "Power"                   "Power production"         "W"
+
+
+# State for derived time quantities.  
+state   integer itimestep      -        -          -         -     rh         "itimestep"             ""         ""      
+state   real    xtime          -        -          -         -     rh         "xtime"                 "minutes since YYYY-MM-DD hh:mm:ss"      "minutes since simulation start"
+state   real    julian         -        -          -         -     -          "julian"                "day of year, 0.0 at 0Z on 1 Jan."         "days"      
+
+# input file descriptor for lbcs on parent domain                                               
+state   integer lbc_fid        -        -          -         -     -         "lbc_fid"               ""         ""      
+# indicates if tiling has been computed                                         
+state   logical tiled          -        -          -         -     -         "tiled"                 ""         ""      
+# indicates if patches have been computed                                               
+state   logical patched        -        -          -         -     -         "patched"               ""         ""      
+# indicates whether to read input from file or generate                                         
+#state   logical input_from_file        -        -          -         -     -         "input_from_file"         ""         ""    
+# indicates whether to recompute mu                                                             
+state   logical press_adj      -        -          -         -     -         "press_adj"         "T/F flag adjust mu"         ""    
+
+# Mask for moving nest interpolations
+state    integer imask_nostag         ij      misc     1     -
+state    integer imask_xstag          ij      misc     1     X
+state    integer imask_ystag          ij      misc     1     Y
+state    integer imask_xystag         ij      misc     1     XY 
+# vortex center indices; need for restarts of moving nests
+state    real    xi                   -       misc     -     -    r
+state    real    xj                   -       misc     -     -    r
+state    real    vc_i                 -       misc     -     -    r
+state    real    vc_j                 -       misc     -     -    r
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+# Scalar (4D) arrays
+
+# Moist Scalars
+#                                               
+# The first line ensures that there will be identifiers named moist and                                         
+# moist_tend even if there are not any moist scalars (so the essentially                                                
+# dry code will will still link properly)                                               
+#                                               
+state   real    -              ikjftb   moist       1         -     -    -
+state   real    qv             ikjftb   moist       1         -     \
+  i0rh01usdf=(bdy_interp:dt) "QVAPOR"           "Water vapor mixing ratio"      "kg kg-1"
+state   real    qc             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QCLOUD"           "Cloud water mixing ratio"      "kg kg-1"
+state   real    qr             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QRAIN"            "Rain water mixing ratio"       "kg kg-1"
+state   real    qi             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QICE"             "Ice mixing ratio"              "kg kg-1"
+state   real    qi2             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QICE2"             "Ice mixing ratio cat 2"              "kg kg-1"
+state   real    qi3             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QICE3"             "Ice mixing ratio cat 3"              "kg kg-1"
+state   real    qs             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QSNOW"            "Snow mixing ratio"             "kg kg-1"
+state   real    qg             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QGRAUP"           "Graupel mixing ratio"          "kg kg-1"
+state   real    qh             ikjftb   moist       1         -     \
+  i0rhusdf=(bdy_interp:dt)   "QHAIL"            "Hail mixing ratio"             "kg kg-1"
+state   real    -              ikjftb   dfi_moist       1         -     -    -
+state   real    dfi_qv         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QVAPOR"       "Water vapor mixing ratio"      "kg kg-1"
+state   real    dfi_qc         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QCLOUD"       "Cloud water mixing ratio"      "kg kg-1"
+state   real    dfi_qr         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QRAIN"        "Rain water mixing ratio"       "kg kg-1"
+state   real    dfi_qi         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QICE"         "Ice mixing ratio"              "kg kg-1"
+state   real    dfi_qi2         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QICE2"         "Ice mixing ratio cat 2"              "kg kg-1"
+state   real    dfi_qi3         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QICE3"         "Ice mixing ratio cat 3"              "kg kg-1"
+state   real    dfi_qs         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QSNOW"        "Snow mixing ratio"             "kg kg-1"
+state   real    dfi_qg         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QGRAUP"       "Graupel mixing ratio"          "kg kg-1"
+state   real    dfi_qh         ikjftb   dfi_moist       1         -     \
+   rusdf=(bdy_interp:dt)  "DFI_QHAIL"        "Hail mixing ratio"             "kg kg-1"
+state    real   qvold            ikj    misc        1         -     rdu      "QVOLD"          "Water vapor mixing ratio, old time step"      "kg kg-1"
+state    real   rimi             ikj    misc        1         -     irh      "RIMI"           "riming intensity"  "fraction"
+state    real   qnwfa2d          ij     misc        1         -     i014rhdu "QNWFA2D"        "Surface aerosol number conc emission"  "kg-1 s-1"
+state    real   qnifa2d          ij     misc        1         -     i014rhdu "QNIFA2D"        "Surface dust number conc emission"  "kg-1 s-1"
+state    real   re_cloud         ikj    misc        1         -     r        "RE_CLOUD"       "Effective radius cloud water"  "m"
+state    real   re_ice           ikj    misc        1         -     r        "RE_ICE"         "Effective radius cloud ice"    "m"
+state    real   re_snow          ikj    misc        1         -     r        "RE_SNOW"        "Effective radius snow"         "m"
+state    real   re_cloud_gsfc    ikj    misc        1         -     rh       "RE_CLOUD_GSFC"  "Cloud Water effective radius"      "micron"
+state    real   re_rain_gsfc     ikj    misc        1         -     rh       "RE_RAIN_GSFC"   "Rain Water effective radius"       "micron"
+state    real   re_ice_gsfc      ikj    misc        1         -     rh       "RE_ICE_GSFC"    "Cloud Ice effective radius"        "micron"
+state    real   re_snow_gsfc     ikj    misc        1         -     rh       "RE_SNOW_GSFC"   "Snow effective radius"             "micron"
+state    real   re_graupel_gsfc  ikj    misc        1         -     rh       "RE_GRAUPEL_GSFC"  "Graupel Water effective radius"  "micron"
+state    real   re_hail_gsfc     ikj    misc        1         -     rh       "RE_HAIL_GSFC"   "Hail Water effective radius"       "micron"
+state    real   dfi_re_cloud     ikj    misc        1         -     -        "DFI_RE_CLOUD"   "DFI Effective radius cloud water"  "m"
+state    real   dfi_re_ice       ikj    misc        1         -     -        "DFI_RE_ICE"     "DFI Effective radius cloud ice"    "m"
+state    real   dfi_re_snow      ikj    misc        1         -     -        "DFI_RE_SNOW"    "DFI Effective radius snow"         "m"
+state    real   dfi_re_cloud_gsfc   ikj    misc        1         -      -       "DFI_RE_CLOUD_GSFC"  "DFI Cloud Water effective radius"      "micron"
+state    real   dfi_re_rain_gsfc    ikj    misc        1         -      -       "DFI_RE_RAIN_GSFC"   "DFI Rain Water effective radius"       "micron"
+state    real   dfi_re_ice_gsfc     ikj    misc        1         -      -       "DFI_RE_ICE_GSFC"    "DFI Cloud Ice effective radius"        "micron"
+state    real   dfi_re_snow_gsfc    ikj    misc        1         -      -       "DFI_RE_SNOW_GSFC"   "DFI Snow effective radius"             "micron"
+state    real   dfi_re_graupel_gsfc ikj    misc        1         -      -       "DFI_RE_GRAUPEL_GSFC"  "DFI Graupel Water effective radius"  "micron"
+state    real   dfi_re_hail_gsfc    ikj    misc        1         -      -       "DFI_RE_HAIL_GSFC"   "DFI Hail Water effective radius"       "micron"
+state  integer  has_reqc          -     misc        1         -     r        "has_reqc"       "Flag for having effective radius cloud water"  ""
+state  integer  has_reqi          -     misc        1         -     r        "has_reqi"       "Flag for having effective radius cloud ice"  ""
+state  integer  has_reqs          -     misc        1         -     r        "has_reqs"       "Flag for having effective radius snow"  ""
+
+# Other Scalars
+state   real    -              ikjftb  scalar      1         -     -   -
+state   real    qndrop         ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNDROP"        "Droplet number mixing ratio"        "# kg-1"
+state   real    qni            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNICE"         "Ice Number concentration" "# kg-1"
+state   real    qni2            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNICE2"         "Ice Number concentration cat 2" "# kg-1"
+state   real    qni3            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNICE3"         "Ice Number concentration cat 3" "# kg-1"
+state   real    qt             ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "CWM"           "Total condensate mixing ratio"      "kg kg-1"
+state   real    qns            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNSNOW"         "Snow Number concentration"   "# kg(-1)"
+state   real    qnr            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNRAIN"        "Rain Number concentration"   "# kg(-1)"
+state   real    qng            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNGRAUPEL"     "Graupel Number concentration" "# kg(-1)"
+state   real    qnh            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNHAIL"        "Hail Number concentration" "# kg(-1)"
+state   real    qnn            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNCCN"         "CCN Number concentration" "# kg(-1)"
+state   real    qnc            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QNCLOUD"       "cloud water Number concentration" "# kg(-1)"
+state   real    qvolg          ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QVGRAUPEL"     "Graupel Particle Volume" "m(3) kg(-1)"
+state   real    qvolh          ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QVHAIL"        "Hail Particle Volume" "m(3) kg(-1)"
+state   real    qrimef         ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QRIMEF"        "rime factor * qi" "kg kg-1"
+state   real    qir            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QIR"           "Rime ice mass-1 mixing ratio" "kg kg(-1)"
+state   real    qib            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QIB"           "Rime ice volume-1 mixing ratio" "m(3) kg(-1)"
+state   real    qir2            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QIR2"           "Rime ice mass-2 mixing ratio" "kg kg(-1)"
+state   real    qib2            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QIB2"           "Rime ice volume-2 mixing ratio" "m(3) kg(-1)"
+state   real    qvoli            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QVOLI"           "Ice volume-1 mixing ratio" "m(3) kg(-1)"
+state   real    qaoli            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QAOLI"           "Ice volume-1 times aspect ratio mixing ratio" "m(3) kg(-1)"
+state   real    qvoli2            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QVOLI2"           "Ice volume-2 mixing ratio" "m(3) kg(-1)"
+state   real    qaoli2            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QAOLI2"           "Ice volume-2 times aspect ratio mixing ratio" "m(3) kg(-1)"
+state   real    qvoli3            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QVOLI3"           "Ice volume-3 mixing ratio" "m(3) kg(-1)"
+state   real    qaoli3            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "QAOLI3"           "Ice volume-3 times aspect ratio mixing ratio" "m(3) kg(-1)"
+
+state   real    -              ikjftb  dfi_scalar      1         -     -   -
+state   real    dfi_qndrop     ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNDROP"    "DFI Droplet number mixing ratio"        "# kg-1"
+state   real    dfi_qni        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNICE"     "DFI Ice Number concentration" "# kg-1"
+state   real    dfi_qni2        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNICE2"     "DFI Ice Number concentration cat 2" "# kg-1"
+state   real    dfi_qni3        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNICE3"     "DFI Ice Number concentration cat 3" "# kg-1"
+state   real    dfi_qt         ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_CWM"       "DFI Total condensate mixing ratio"      "kg kg-1"
+state   real    dfi_qns        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNSNOW"    "DFI Snow Number concentration"   "# kg(-1)"
+state   real    dfi_qnr        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNRAIN"    "DFI Rain Number concentration"   "# kg(-1)"
+state   real    dfi_qng        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNGRAUPEL" "DFI Graupel Number concentration" "# kg(-1)"
+state   real    dfi_qnh        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNHAIL"    "DFI Hail Number concentration" "# kg(-1)"
+state   real    dfi_qnn        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNCC"      "DFI CNN Number concentration"   "# kg(-1)"
+state   real    dfi_qnc        ikjftb  dfi_scalar      1         -     \
+   rusdf=(bdy_interp:dt)    "DFI_QNCLOUD"   "DFI Cloud Number concentration" "# kg(-1)"
+state   real    dfi_qvolg      ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)   "DFI_QVGRAUPEL" "DFI Graupel Particle Volume" "m(3) kg(-1)"
+state   real    dfi_qvolh     ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)   "DFI_QVHAIL"    "DFI Hail Particle Volume" "m(3) kg(-1)"
+state   real    dfi_qir        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QIR"    "DFI Rime ice mass-1 mixing ratio" "kg kg(-1)"
+state   real    dfi_qib        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QIB"    "DFI Rime ice volume-1 mixing ratio" "m(3) kg(-1)"
+state   real    dfi_qir2        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QIR2"    "DFI Rime ice mass-2 mixing ratio" "kg kg(-1)"
+state   real    dfi_qib2        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QIB2"    "DFI Rime ice volume-2 mixing ratio" "m(3) kg(-1)"
+state   real    dfi_qvoli        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QVOLI"    "DFI Ice volume-1 mixing ratio" "kg kg(-1)"
+state   real    dfi_qaoli        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QAOLI"    "DFI Ice volume-1 times aspect ratio mixing ratio" "kg kg(-1)"
+state   real    dfi_qvoli2        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QVOLI2"    "DFI Ice volume-2 mixing ratio" "kg kg(-1)"
+state   real    dfi_qaoli2        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QAOLI2"    "DFI Ice volume-2 times aspect ratio mixing ratio" "kg kg(-1)"
+state   real    dfi_qvoli3        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QVOLI3"    "DFI Ice volume-3 mixing ratio" "kg kg(-1)"
+state   real    dfi_qaoli3        ikjftb  dfi_scalar      1         -     \
+   rhusdf=(bdy_interp:dt)    "DFI_QAOLI3"    "DFI Ice volume-3 times aspect ratio mixing ratio" "kg kg(-1)"
+
+state   real    dfi_qke_adv   ikjftb  dfi_scalar      1         -      \
+   rusdf=(bdy_interp:dt) "dfi_qke_adv"   "DFI twice TKE from MYNN"      "m2 s-2"
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+# Arrays for Specified LBCs  (lbc arrays REMOVED; Boundary arrays are now specified with the state array; see above, 20050413 JM )
+
+state    real   fcx            w         misc     -         -      ir       "fcx"                  "RELAXATION TERM FOR BOUNDARY ZONE"         ""
+state    real   gcx            w         misc     -         -      ir       "gcx"                  "2ND RELAXATION TERM FOR BOUNDARY ZONE"         ""
+state    real   dtbc            -        misc     -         -       r       "dtbc"                 "TIME SINCE BOUNDARY READ"         ""
+
+#-------------------------------------------------------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------------------------------------------------------
+# Physics Related State Varibles
+
+#-------------------------------------------------------------------------------------------------------------------------------------------
+# SI - start variables from netCDF format from Standard Initialization, most eventually for use in LSM schemes
+#-------------------------------------------------------------------------------------------------------------------------------------------
+
+state   real   soil_layers    i{lin}j    misc          1     Z     i1      "SOIL_LAYERS"   "SOIL LAYERS"         "cm"
+state   real   soil_levels    i{lin}j    misc          1     Z     i1      "SOIL_LEVELS"   "SOIL LEVELS"         "cm"
+state   real   st             i{lin}j    misc          1     Z     i1      "ST"            "SOIL TEMPERATURES"   "K"
+state   real   sm             i{lin}j    misc          1     Z     i1      "SM"            "SOIL MOISTURES"      "m3 m-3"
+state   real   sw             i{lin}j    misc          1     Z     i1      "SW"            "SOIL LIQUIDS"        "m3 m-3"
+state   real   soilt          i{lin}j    misc          1     Z     i1      "SOILT"         "RUC SOIL TEMPERATURES"  "K"
+state   real   soilm          i{lin}j    misc          1     Z     i1      "SOILM"         "RUC SOIL MOISTURES"  "m3 m-3"
+state   real   sm000007            ij    misc          1     -     i1      "SM000007"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm007028            ij    misc          1     -     i1      "SM007028"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm028100            ij    misc          1     -     i1      "SM028100"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm100255            ij    misc          1     -     i1      "SM100255"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   st000007            ij    misc          1     -     i1      "ST000007"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st007028            ij    misc          1     -     i1      "ST007028"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st028100            ij    misc          1     -     i1      "ST028100"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st100255            ij    misc          1     -     i1      "ST100255"      "LAYER SOIL TEMPERATURE" "K"
+state   real   sm000010            ij    misc          1     -     i1      "SM000010"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm010040            ij    misc          1     -     i1      "SM010040 "     "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm040100            ij    misc          1     -     i1      "SM040100 "     "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm100200            ij    misc          1     -     i1      "SM100200 "     "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sm010200            ij    misc          1     -     i1      "SM010200"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   soilm000            ij    misc          1     -     i1      "SOILM000"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   soilm005            ij    misc          1     -     i1      "SOILM005"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   soilm020            ij    misc          1     -     i1      "SOILM020"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   soilm040            ij    misc          1     -     i1      "SOILM040"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   soilm160            ij    misc          1     -     i1      "SOILM160"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   soilm300            ij    misc          1     -     i1      "SOILM300"      "LAYER SOIL MOISTURE" "m3 m-3"
+state   real   sw000010            ij    misc          1     -     i1      "SW000010"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   sw010040            ij    misc          1     -     i1      "SW010040"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   sw040100            ij    misc          1     -     i1      "SW040100"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   sw100200            ij    misc          1     -     i1      "SW100200"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   sw010200            ij    misc          1     -     i1      "SW010200"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   soilw000            ij    misc          1     -     i1      "SOILW000"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   soilw005            ij    misc          1     -     i1      "SOILW005"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   soilw020            ij    misc          1     -     i1      "SOILW020"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   soilw040            ij    misc          1     -     i1      "SOILW040"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   soilw160            ij    misc          1     -     i1      "SOILW160"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   soilw300            ij    misc          1     -     i1      "SOILW300"      "LAYER SOIL LIQUID" "m3 m-3"
+state   real   st000010            ij    misc          1     -     i1      "ST000010"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st010040            ij    misc          1     -     i1      "ST010040"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st040100            ij    misc          1     -     i1      "ST040100"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st100200            ij    misc          1     -     i1      "ST100200"      "LAYER SOIL TEMPERATURE" "K"
+state   real   st010200            ij    misc          1     -     i1      "ST010200"      "LAYER SOIL TEMPERATURE" "K"
+state   real   soilt000            ij    misc          1     -     i1      "SOILT000"      "LAYER SOIL TEMPERATURE" "K"
+state   real   soilt005            ij    misc          1     -     i1      "SOILT005"      "LAYER SOIL TEMPERATURE" "K"
+state   real   soilt020            ij    misc          1     -     i1      "SOILT020"      "LAYER SOIL TEMPERATURE" "K"
+state   real   soilt040            ij    misc          1     -     i1      "SOILT040"      "LAYER SOIL TEMPERATURE" "K"
+state   real   soilt160            ij    misc          1     -     i1      "SOILT160"      "LAYER SOIL TEMPERATURE" "K"
+state   real   soilt300            ij    misc          1     -     i1      "SOILT300"      "LAYER SOIL TEMPERATURE" "K"
+state   real   topostdv            ij    misc          1     -     i12     "TOPOSTDV"      "ELEVATION STD DEV"  "m"
+state   real   toposlpx            ij    misc          1     -     i012rdu "TOPOSLPX"      "ELEVATION X SLOPE"  ""
+state   real   toposlpy            ij    misc          1     -     i012rdu "TOPOSLPY"      "ELEVATION Y SLOPE"  ""
+state   real   slope               ij    misc          1     -     rdu     "SLOPE"         "ELEVATION SLOPE"  ""
+state   real   slp_azi             ij    misc          1     -     rdu     "SLP_AZI"       "ELEVATION SLOPE AZIMUTH"  "rad"
+state   real   shdmax              ij    misc          1     -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SHDMAX"        "ANNUAL MAX VEG FRACTION" ""
+state   real   shdmin              ij    misc          1     -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SHDMIN"        "ANNUAL MIN VEG FRACTION" ""
+state   real   snoalb              ij    misc          1     -     i012rhd  "SNOALB"        "ANNUAL MAX SNOW ALBEDO IN FRACTION" ""
+state   real   toposoil            ij    misc          1     -     i12     "SOILHGT"       "ELEVATION OF LSM DATA"  "m"
+state   real   landusef            iuj   misc          1     Z     i012rdu   "LANDUSEF"      "LANDUSE FRACTION BY CATEGORY"  ""
+state   real   soilctop            isj   misc          1     Z     i012rdu   "SOILCTOP"      "SOIL CAT FRACTION (TOP)"  ""
+state   real   soilcbot            isj   misc          1     Z     i012rdu   "SOILCBOT"      "SOIL CAT FRACTION (BOTTOM)"  ""
+state   real   soilcat             ij    misc          1     -     i12     "SOILCAT"       "SOIL CAT DOMINANT TYPE" ""
+state   real   vegcat              ij    misc          1     -     i12     "VEGCAT"        "VEGETATION CAT DOMINANT TYPE" ""
+
+#---------------------------------------------------------------------------------------------------------------------------------------
+# SI - end variables from netCDF format from Standard Initialization
+#---------------------------------------------------------------------------------------------------------------------------------------
+
+# soil model variables  (Note that they are marked as staggered in the vertical dimension
+# because they are "fully dimensioned" -- they use every element in that dim
+state    real   TSLB           ilj       misc      1         Z     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "TSLB"     "SOIL TEMPERATURE"   "K"
+
+# Time series variables
+state    real   ts_hour         ?!       misc      -         -      -        "TS_HOUR"        "Model integration time, hours"
+state    real   ts_u            ?!       misc      -         -      -        "TS_U"           "Surface wind U-component, earth-relative"
+state    real   ts_v            ?!       misc      -         -      -        "TS_V"           "Surface wind V-component, earth-relative"
+state    real   ts_q            ?!       misc      -         -      -        "TS_Q"           "Surface mixing ratio"
+state    real   ts_t            ?!       misc      -         -      -        "TS_T"           "Surface temperature"
+state    real   ts_psfc         ?!       misc      -         -      -        "TS_PSFC"        "Surface pressure"
+state    real   ts_glw          ?!       misc      -         -      -        "TS_GLW"         "Downward long wave flux at surface"
+state    real   ts_gsw          ?!       misc      -         -      -        "TS_GSW"         "Net short wave flux at surface"
+state    real   ts_hfx          ?!       misc      -         -      -        "TS_HFX"         "Upward heat flux at surface"
+state    real   ts_lh           ?!       misc      -         -      -        "TS_LH"          "Upward moisture flux at surface"
+state    real   ts_tsk          ?!       misc      -         -      -        "TS_TSK"         "Skin temperature"
+state    real   ts_tslb         ?!       misc      -         -      -        "TS_TSLB"        "Soil temperature"
+state    real   ts_clw          ?!       misc      -         -      -        "TS_CLW"         "Column integrated cloud water"
+state    real   ts_rainc        ?!       misc      -         -      -        "TS_RAINC"       "Cumulus precip"
+state    real   ts_rainnc       ?!       misc      -         -      -        "TS_RAINNC"      "Grid-scale precip"
+
+# Time series of vertical profile of U, V, GHT, THETA, QVAPOR, PRESSURE
+state    real   ts_u_profile   ?!k       misc      -         -      -        "TS_U_PROFILE"   "Wind u-Component, earth relative, vertical profile" "m/s"
+state    real   ts_v_profile   ?!k       misc      -         -      -        "TS_V_PROFILE"   "Wind v-Component, earth relative, vertical profile" "m/s"
+state    real   ts_w_profile   ?!k       misc      -         -      -        "TS_W_PROFILE"   "Wind w-Component, vertical profile" "m/s"
+state    real   ts_gph_profile ?!k       misc      -         -      -        "TS_GPH_PROFILE" "Total geopotential height, vertical profile" "m"
+state    real   ts_th_profile  ?!k       misc      -         -      -        "TS_TH_PROFILE"  "Total potential temperature, vertical profile" "K"
+state    real   ts_qv_profile  ?!k       misc      -         -      -        "TS_QV_PROFILE"  "Water vapor mixing ratio, vertical profile" "kg/kg"
+state    real   ts_p_profile   ?!k       misc      -         -      -        "TS_P_PROFILE"   "Pressure, vertical profile" "Pa"
+
+
+# urban model variables
+state    real   DZR             l        em      -         Z     r        "DZR"            "THICKNESSES OF ROOF LAYERS"                      "m"
+state    real   DZB             l        em      -         Z     r        "DZB"            "THICKNESSES OF WALL LAYERS"                      "m"
+state    real   DZG             l        em      -         Z     r        "DZG"            "THICKNESSES OF ROAD LAYERS"                      "m"
+state    real   URB_PARAM      i{urb}j  misc      1        -     i1       "URB_PARAM" "NUDAPT_NBSD Urban Parameters" "parameter"
+state    real   LP_URB2D       ij       misc      1        -     i0  "BUILD_AREA_FRACTION" "BUILDING PLAN AREA DENSITY"   "dimensionless"
+state    real   HI_URB2D       i{uhi}j  misc      1        Z     i0  "HEIGHT_HISTOGRAMS" "DISTRIBUTION OF BUILDING HEIGHTS" "dimensionless"
+state    real   LB_URB2D       ij       misc      1        -     i0  "BUILD_SURF_RATIO" "BUILDING SURFACE AREA TO PLAN AREA RATIO" "dimensionless"
+state    real   HGT_URB2D      ij       misc      1        -     i0  "BUILD_HEIGHT" "AVERAGE BUILDING HEIGHT WEIGHTED BY BUILDING PLAN AREA" "m"
+state    real   MH_URB2D       ij       misc      1        -     i0  "MH_URB2D"  "Mean Building Height" "m"
+state    real   STDH_URB2D     ij       misc      1        -     i0  "STDH_URB2D" "Standard Deviation of Building Height" "m2"
+state    real   LF_URB2D       i{udr}j  misc      1        Z     i0  "LF_URB2D"   "Frontal Area Index" "dimensionless"
+
+# lsm State Variables
+
+state    real   SMOIS            ilj     -          1         Z     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "SMOIS"            "SOIL MOISTURE"     "m3 m-3"
+state    real   SH2O             ilj     -          1         Z     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "SH2O"             "SOIL LIQUID WATER" "m3 m-3"
+state    real   SMCREL           ilj     -          1         Z     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "SMCREL"           "RELATIVE SOIL MOISTURE" ""
+state    real   XICE             ij     misc        1         -     i0124rhd=(interp_mask_field:lu_index,isice)u=(copy_fcnm)  "SEAICE"             "SEA ICE FLAG"  ""
+state    real   ICEDEPTH         ij     misc        1         -     i0124rhd=(interp_mask_field:lu_index,isice)u=(copy_fcnm)  "ICEDEPTH"     "SEA ICE THICKNESS"  "m"
+state    real   XICEM            ij     misc        1         -     rhd=(interp_mask_field:lu_index,isice)u=(copy_fcnm)  "XICEM"             "SEA ICE FLAG (PREVIOUS STEP)"  ""
+state    real   ALBSI            ij     misc        1         -     i0124rhd=(interp_mask_field:lu_index,isice)u=(copy_fcnm)  "ALBSI"        "SEA ICE ALBEDO"  ""
+state    real   SNOWSI           ij     misc        1         -     i0124rhd=(interp_mask_field:lu_index,isice)u=(copy_fcnm)  "SNOWSI"       "SNOW DEPTH ON SEA ICE"  "m"
+state    real   SMSTAV           ij     misc        1         -      rd=(interp_mask_field:lu_index,iswater)       "SMSTAV"           "MOISTURE AVAILABILITY" ""
+state    real   SMSTOT           ij     misc        1         -      r                                          "SMSTOT"           "TOTAL SOIL MOISTURE" "m3 m-3"
+state    real   SOLDRAIN         ij     misc        1         -      r                                          "SOLDRAIN"         "soil column drainage"  "mm"
+state    real   SFCHEADRT        ij     misc        1         -      r                                          "SFCHEADRT"        "surface water depth"  "mm"
+state    real   INFXSRT          ij     misc        1         -      r                                          "INFXSRT"          "time step infiltration excess"  "mm"
+state    real   SFCRUNOFF        ij     misc        1         -      rhd=(interp_mask_field:lu_index,iswater)      "SFROFF"           "SURFACE RUNOFF"     "mm"
+state    real   UDRUNOFF         ij     misc        1         -      rhd=(interp_mask_field:lu_index,iswater)      "UDROFF"           "UNDERGROUND RUNOFF" "mm"
+state  integer  IVGTYP           ij     misc        1         -     i02rhd=(interp_fcni)u=(copy_fcni)           "IVGTYP"           "DOMINANT VEGETATION CATEGORY" ""
+state  integer  ISLTYP           ij     misc        1         -     i02rhd=(interp_mask_soil:lu_index)u=(copy_fcni)           "ISLTYP"           "DOMINANT SOIL CATEGORY"       ""
+state    real   VEGFRA           ij     misc        1         -     i024rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "VEGFRA"           "VEGETATION FRACTION" ""
+state    real   SFCEVP           ij     misc        1         -      r                                          "SFCEVP"           "ACCUMULATED SURFACE EVAPORATION" "kg m-2"
+state    real   GRDFLX           ij     misc        1         -      rh                                         "GRDFLX"           "GROUND HEAT FLUX" "W m-2"
+state    real   ACGRDFLX         ij     misc        1         -      rhdu                                       "ACGRDFLX"         "ACCUMULATED GROUND HEAT FLUX" "J m-2"
+state    real   SFCEXC           ij     misc        1         -      r                                          "SFCEXC "          "SURFACE EXCHANGE COEFFICIENT"   "m s-1"
+
+state    real   ACSNOW           ij     misc        1         -      rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)       "ACSNOW"           "ACCUMULATED SNOW"         "kg m-2"
+state    real   ACRUNOFF         ij     misc        1         -     irhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)       "ACRUNOFF"         "ACCUMULATED RUNOFF"       "kg m-2"
+state    real   ACSNOM           ij     misc        1         -      rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)       "ACSNOM"           "ACCUMULATED MELTED SNOW"  "kg m-2"
+state    real   SNOW             ij     misc        1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "SNOW"             "SNOW WATER EQUIVALENT"    "kg m-2"
+state    real   SNOWH            ij     misc        1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "SNOWH"            "PHYSICAL SNOW DEPTH"      "m"
+#state    real   RHOSN            ij     misc        1         -    i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "RHOSN"            " SNOW DENSITY"      "kg m-3" 
+state    real   CANWAT           ij     misc        1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "CANWAT"           "CANOPY WATER"             "kg m-2"
+state  integer  IFNDSNOWH        -      misc        1         -     i         "FNDSNOWH" "SNOWH_LOGICAL"
+state  integer  IFNDSOILW        -      misc        1         -     i         "FNDSOILW" "SOILW_LOGICAL"
+state  integer  IFNDALBSI        -      misc        1         -     ir        "FNDALBSI" "ALBSI_LOGICAL"
+state  integer  IFNDSNOWSI       -      misc        1         -     ir        "FNDSNOWSI" "SNOWSI_LOGICAL"
+state  integer  IFNDICEDEPTH     -      misc        1         -     ir        "FNDICEDEPTH" "ICEDEPTH_LOGICAL"
+state    real   XLAIDYN          ij     misc        1         -     -         "XLAIDYN"     "Noah Dynamic LEAF AREA INDEX"       "m-2/m-2"
+# SKIN SST
+state    real   SSTSK            ij     misc        1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SSTSK"              "SKIN SEA SURFACE TEMPERATURE" "K"
+state    real   lake_depth            ij     misc        1    -     i012rd=(interp_mask_water_field:lu_index,islake)   "lake_depth"              "lake depth" "m"
+state    real   DTW              ij     misc        1         -     r   "DTW"              "WARM LAYER TEMP DIFF" "C"
+# Ocean surface currents
+state    real   UOCE            ij     misc        1         -     i0124rd=(interp_mask_water_field:lu_index,iswater)  "UOCE"  "SEA SURFACE ZONAL CURRENTS" "m s-1"
+state    real   VOCE            ij     misc        1         -     i0124rd=(interp_mask_water_field:lu_index,iswater)  "VOCE"  "SEA SURFACE MERIDIONAL CURRENTS" "m s-1"
+
+# DFI variables
+state   real   hcoeff         {ndfi} misc        1         -     -    "HCOEFF"               "initialization weights"
+state   real   hcoeff_tot       -    misc        1         -     -    "HCOEFF_TOT"               "initialization weights"
+state   real   dfi_p           ikj   misc        1         -     r    "P_DFI"           "perturbation pressure"         "Pa"
+state   real   dfi_al          ikj   misc        1         -     r    "AL_DFI"          "inverse perturbation density"  "m3 kg-1"
+state   real   dfi_mu          ij    misc        1         -     r    "MU_DFI"  "perturbation dry air mass in column" "Pa"
+state   real   dfi_phb         ikj   misc        1         Z     r    "PHB_DFI"  "base-state geopotential"  "m2 s-2"
+state   real   dfi_ph0         ikj   misc        1         Z     r    "PH0_DFI"  "initial geopotential"     "m2 s-2"
+state   real   dfi_php         ikj   misc        1         Z     r    "PHP_DFI"  "geopotential"             "m2 s-2"
+state   real   dfi_u           ikj   misc        1         -     r    "U_DFI"               "u accumulation array"          "   "
+state   real   dfi_v           ikj   misc        1         -     r    "V_DFI"               "v accumulation array"          "   "
+state   real   dfi_w           ikj   misc        1         -     r    "W_DFI"               "w accumulation array"          "   "
+state   real   dfi_ww          ikj   misc        1         Z     r    "WW_DFI"              "mu-coupled eta-dot"    "Pa s-1"
+state   real   dfi_t           ikj   misc        1         -     r    "TT_DFI"               "t accumulation array"          "   "
+state   real   dfi_rh          ikj   misc        1         -     r    "RH_DFI"               "initial relative humidity"     "   "
+state   real   dfi_ph          ikj   misc        1         -     r    "PH_DFI"               "p accumulation array"          "   "
+state   real   dfi_pb          ikj   misc        1         -     r    "PB_DFI"               "pb accumulation array"          "   "
+state   real   dfi_alt         ikj   misc        1         -     r    "ALT_DFI"             "1/rho accumulation array"          "   "
+state   real   dfi_tke         ikj   misc        1         -     r    "TKE_DFI"          "TURBULENCE KINETIC ENERGY"     "m2 s-2"
+state   real   dfi_tten_rad    ikj   misc        1         -     ir   "RAD_TTEN_DFI"     "RADAR POT. TEMP. TENDENCY"     "K s-1"
+state    real  dfi_TSLB        ilj   misc        1         Z     r    "TSLB_dfi"         "SOIL TEMPERATURE"   "K"
+state    real  dfi_SMOIS       ilj    -          1         Z     r    "SMOIS_dfi"        "SOIL MOISTURE"     "m3 m-3"
+state    real  dfi_SNOW        ij    misc        1         -     r    "SNOW_dfi"         "SNOW WATER EQUIVALENT"    "kg m-2"
+state    real  dfi_SNOWH       ij    misc        1         -     r    "SNOWH_dfi"        "PHYSICAL SNOW DEPTH"      "m"
+state    real  dfi_CANWAT      ij    misc        1         -     r    "CANWAT_dfi"       "CANOPY WATER"             "kg m-2"
+state    real  dfi_SMFR3D      ilj   misc        1         Z     r    "SMFR3D_dfi"           "SOIL ICE" ""
+state    real  dfi_KEEPFR3DFLAG ilj  misc        1         Z     r    "KEEPFR3DFLAG_dfi"     "FLAG - 1. FROZEN SOIL YES, 0 - NO"             ""
+
+# urban state variables
+state    real   TSK_RURAL        ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TSK_RURAL"   "TSK for rural fraction" "K"
+state    real   TR_URB2D         ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TR_URB"              "URBAN ROOF SKIN TEMPERATURE"        "K"
+state    real   TGR_URB2D        ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)        "TGR_URB"             "URBAN GREEN ROOF SKIN TEMPERATURE"  "K"
+state    real   TB_URB2D         ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TB_URB"              "URBAN WALL SKIN TEMPERATURE"        "K" 
+state    real   TG_URB2D         ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TG_URB"              "URBAN ROAD SKIN TEMPERATURE"        "K" 
+state    real   TC_URB2D         ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TC_URB"              "URBAN CANOPY TEMPERATURE"           "K"
+state    real   QC_URB2D         ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "QC_URB"              "URBAN CANOPY HUMIDITY"          "kg kg{-1}"
+state    real   UC_URB2D         ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "UC_URB"              "URBAN CANOPY WIND"          "m s{-1}"
+state    real   XXXR_URB2D       ij     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "XXXR_URB" "M-O LENGTH ABOVE URBAN ROOF"   "dimensionless"
+state    real   XXXB_URB2D       ij    misc        1         -      rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "XXXB_URB" "M-O LENGTH ABOVE URBAN WALL"   "dimensionless"
+state    real   XXXG_URB2D       ij    misc        1         -      rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)       "XXXG_URB" "M-O LENGTH ABOVE URBAN ROAD"   "dimensionless"
+state    real   XXXC_URB2D       ij    misc        1         -      rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)       "XXXC_URB" "M-O LENGTH ABOVE URBAN CANOPY" "dimensionless"
+state    real   CMCR_URB2D       ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "CMCR_URB"            "GREEN ROOF CANOPY INTERCAPTED WATER"  "m"                          
+state    real   DRELR_URB2D      ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "DRELR_URB"           "WATER HOLDING DEPTH ON ROOF IMPERVIOUS SURFACE"        "m"
+state    real   DRELB_URB2D      ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "DRELB_URB"           "WATER HOLDING DEPTH ON WALL IMPERVIOUS SURFACE"        "m"
+state    real   DRELG_URB2D      ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "DRELG_URB"           "WATER HOLDING DEPTH ON ROAD IMPERVIOUS SURFACE"        "m"
+state    real   FLXHUMR_URB2D    ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "FLXHUMR_URB"         "WATER FLUX ON ROOF IMPERVIOUS SURFACE"        "m/s"
+state    real   FLXHUMB_URB2D    ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "FLXHUMB_URB"         "WATER FLUX ON WALL IMPERVIOUS SURFACE"        "m/s"
+state    real   FLXHUMG_URB2D    ij     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "FLXHUMG_URB"         "WATER FLUX ON ROAD IMPERVIOUS SURFACE"        "m/s"
+state    real   TGRL_URB3D       ilj    misc        1         Z     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TGRL_URB" "GREEN ROOF LAYER TEMPERATURE"  
+state    real   SMR_URB3D        ilj    misc        1         Z     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "SMR_URB"  "GREEN ROOF LAYER SOIL MOISTURE"  
+state    real   TRL_URB3D        ilj    misc        1         Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "TRL_URB" "ROOF LAYER TEMPERATURE"          "K"
+state    real   TBL_URB3D        ilj    misc        1         Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "TBL_URB" "WALL LAYER TEMPERATURE"          "K"
+state    real   TGL_URB3D        ilj    misc        1         Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "TGL_URB" "ROAD LAYER TEMPERATURE"          "K"
+state    real   SH_URB2D        ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)        "SH_URB"  "SENSIBLE HEAT FLUX FROM URBAN SFC"  "W m{-2}"
+state    real   LH_URB2D        ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)       "LH_URB"  "LATENT HEAT FLUX FROM URBAN SFC"    "W m{-2}"
+state    real   G_URB2D         ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)        "G_URB"  "GROUND HEAT FLUX INTO URBAN"        "W m{-2}"
+state    real   RN_URB2D        ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)       "RN_URB"  "NET RADIATION ON URBAN SFC"         "W m{-2}"
+state    real   TS_URB2D        ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)       "TS_URB"  "SKIN TEMPERATURE"          "K"
+state    real   FRC_URB2D       ij    misc        1         -     i012rd=(interp_fcnm)u=(copy_fcnm)      "FRC_URB2D"  "URBAN FRACTION"         "dimensionless"
+state    integer   UTYPE_URB2D  ij    misc        1         -     rd=(interp_fcnm)u=(copy_fcnm)       "UTYPE_URB"  "URBAN TYPE"         "dimensionless"
+state    real   TRB_URB4D       i{umap1}j   misc       1         Z     r      "TRB_URB4D" "ROOF LAYER TEMPERATURE"          "K"
+state    real   TW1_URB4D       i{umap2}j   misc       1         Z     r      "TW1_URB4D" "WALL LAYER TEMPERATURE"          "K"
+state    real   TW2_URB4D       i{umap2}j   misc       1         Z     r      "TW2_URB4D" "WALL LAYER TEMPERATURE"          "K"
+state    real   TGB_URB4D       i{umap3}j   misc       1         Z     r      "TGB_URB4D" "ROAD LAYER TEMPERATURE"          "K"
+state    real   TLEV_URB3D      i{umap6}j   misc       1         Z     r      "TLEV_URB3D" "INDOOR TEMPERATURE"             "K"
+state    real   QLEV_URB3D      i{umap6}j   misc       1         Z     r      "QLEV_URB3D" "SPECIFIC HUMIDITY"              "dimensionless"
+state    real   TW1LEV_URB3D    i{umap7}j   misc       1         Z     r      "TW1LEV_URB3D" "WINDOW TEMPERATURE"           "K"
+state    real   TW2LEV_URB3D    i{umap7}j   misc       1         Z     r      "TW2LEV_URB3D" "WINDOW TEMPERATURE"           "K"
+state    real   TGLEV_URB3D     i{umap8}j   misc       1         Z     r      "TGLEV_URB3D" "GROUND TEMPERATURE BELOW A BUILDING"     "K"
+state    real   TFLEV_URB3D     i{umap9}j   misc       1         Z     r      "TFLEV_URB3D" "FLOOR TEMPERATURE"                       "K"
+state    real   SF_AC_URB3D     ij          misc       1         -     r      "SF_AC_URB3D"  "SENSIBLE HEAT FLUX FROM THE AIR COND." "W m{-2}"
+state    real   LF_AC_URB3D     ij          misc       1         -     r      "LF_AC_URB3D"  "LATENT HEAT FLUX FROM THE AIR COND." "W m{-2}"
+state    real   CM_AC_URB3D     ij          misc       1         -     r      "CM_AC_URB3D"  "CONSUMPTION OF THE AIR COND." "W m{-2}"
+state    real   SFVENT_URB3D    ij          misc       1         -     r      "SFVENT_URB3D" "SENSIBLE HEAT FLUX FROM URBAN VENTILATION" "W m{-2}"
+state    real   LFVENT_URB3D    ij          misc       1         -     r      "LFVENT_URB3D" "LATENT HEAT FLUX FROM URBAN VENTILATION" "W m{-2}"
+state    real   SFWIN1_URB3D    i{umap7}j   misc       1         Z     r      "SFWIN1_URB3D" "SENSIBLE HEAT FLUX FROM URBAN SFC WINDOW"  "W m{-2}"
+state    real   SFWIN2_URB3D    i{umap7}j   misc       1         Z     r      "SFWIN2_URB3D" "SENSIBLE HEAT FLUX FROM URBAN SFC WINDOW"  "W m{-2}"
+state    real   SFW1_URB3D      i{umap4}j   misc       1         Z     r      "SFW1_URB3D"  "SENSIBLE HEAT FLUX FROM URBAN SFC"  "W m{-2}"
+state    real   SFW2_URB3D      i{umap4}j   misc       1         Z     r      "SFW2_URB3D"  "SENSIBLE HEAT FLUX FROM URBAN SFC"  "W m{-2}"
+state    real   SFR_URB3D       i{umap5}j   misc       1         Z     r      "SFR_URB3D"  "SENSIBLE HEAT FLUX FROM URBAN SFC"  "W m{-2}"
+state    real   SFG_URB3D       i{umap0}j   misc       1         Z     r      "SFG_URB3D"  "SENSIBLE HEAT FLUX FROM URBAN SFC"  "W m{-2}"
+state    real   CMR_SFCDIF      ij          misc       1         -     r      "CMR_SFCDIF" "" ""
+state    real   CHR_SFCDIF      ij          misc       1         -     r      "CHR_SFCDIF" "" ""
+state    real   CMC_SFCDIF      ij          misc       1         -     r      "CMC_SFCDIF" "" ""
+state    real   CHC_SFCDIF      ij          misc       1         -     r      "CHC_SFCDIF" "" ""
+state    real   CMGR_SFCDIF     ij          misc       1         -     r      "CMGR_SFCDIF" "" ""
+state    real   CHGR_SFCDIF     ij          misc       1         -     r      "CHGR_SFCDIF" "" ""
+
+
+# solar location variables from radiation driver
+state    real   COSZEN           ij     misc        1         -      rh      "COSZEN"  "COS of SOLAR ZENITH ANGLE"     "dimensionless"
+state    real   HRANG            ij     misc        1         -      r       "HRANG"   "SOLAR HOUR ANGLE"          "radians"
+state    real   DECLIN            -     misc        1         -      r       "DECLIN"  "SOLAR DECLINATION"         "radians"
+state    real   SOLCON            -     misc        1         -      r       "SOLCON"  "SOLAR CONSTANT"         "W m-2"
+
+# RUC LSM
+state    real   RHOSNF           ij     misc        1         -      irh      "RHOSNF"               "DENSITY OF FROZEN PRECIP" "kg/m^3"
+state    real   SNOWFALLAC       ij     misc        1         -      irh      "SNOWFALLAC"           "RUN-TOTAL ACCUMULATED SNOWFALL [mm]" ""
+state    real   PRECIPFR         ij     misc        1         -      -        "PRECIPFR"             "TIME-STEP FROZEN PRECIP [mm]" ""
+state    real   SMFR3D           ilj    misc        1         Z      r        "SMFR3D"               "SOIL ICE" ""
+state    real   KEEPFR3DFLAG     ilj    misc        1         Z      r        "KEEPFR3DFLAG"          "FLAG - 1. FROZEN SOIL YES, 0 - NO"             ""
+
+state    real   SWVISDIR          ij    misc        1         Z      r        "SWVISDIR"              "SWR VIS DIR component"  ""
+state    real   SWVISDIF          ij    misc        1         Z      r        "SWVISDIF"              "SWR VIS DIF component"  ""
+state    real   SWNIRDIR          ij    misc        1         Z      r        "SWNIRDIR"              "SWR NIR DIR component"  ""
+state    real   SWNIRDIF          ij    misc        1         Z      r        "SWNIRDIF"              "SWR NIR DIF component"  ""
+state    real   ALSWVISDIR        ij    misc        1         Z      r        "ALSWVISDIR"            "ALB VIS DIR component"  ""
+state    real   ALSWVISDIF        ij    misc        1         Z      r        "ALSWVISDIF"            "ALB VIS DIF component"  ""
+state    real   ALSWNIRDIR        ij    misc        1         Z      r        "ALSWNIRDIR"            "ALB NIR DIR component"  ""
+state    real   ALSWNIRDIF        ij    misc        1         Z      r        "ALSWNIRDIF"            "ALB NIR DIF component"  ""
+
+
+# From P-X PBL and LSM; RS (RC) and RA also from Noah and NoahMP
+state    real   RA               ij     misc        1         -      r        "RA"           "AERODYNAMIC RESISTANCE"            "s m-1"
+state    real   RS               ij     misc        1         -      r        "RS"           "SURFACE RESISTANCE"                "s m-1"
+state    real   LAI              ij     misc        1         -      i0124rh  "LAI"          "LEAF AREA INDEX"                   "m-2/m-2"
+state    real   VEGF_PX          ij     misc        1         -      rh       "VEGF_PX"      "Vegetation Fraction for PX LSM"    "area/area"
+state    real   T2OBS            ij     misc        1         -      r        "T2OBS"        "2-m temperature from analysis "    "K"
+state    real   Q2OBS            ij     misc        1         -      r        "Q2OBS"        "2-m mixing ratio from analysis "   "kg/kg"
+state    real   IMPERV           ij     misc        1         -      i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "IMPERV"       "Impervious surface fraction NLCD"  "percent"
+state    real   CANFRA           ij     misc        1         -      i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)      "CANFRA"       "Satellite canopy fraction"         "percent"
+state    real   LAI_PX           ij     misc        1         -      rh        "LAI_PX"       "LAI used for PX LSM"              "m2/m2"
+state    real   WWLT_PX          ij     misc        1         -      rh       "WWLT_PX"       "Soil wilting point for PX LSM"    "m3/m3"
+state    real   WFC_PX           ij     misc        1         -      rh       "WFC_PX"        "Soil field capacity for PX LSM"    "m3/m3"
+state    real   WSAT_PX          ij     misc        1         -      rh       "WSAT_PX"       "Soil saturation for PX LSM"    "m3/m3"
+state    real   CLAY_PX          ij     misc        1         -      rh       "CLAY_PX"       "Clay perent for PX LSM"    "fraction"
+state    real   CSAND_PX         ij     misc        1         -      rh       "CSAND_PX"      "Coarse sand perent for PX LSM"    "fraction"
+state    real   FMSAND_PX        ij     misc        1         -      rh       "FMSAND_PX"     "Fine-medium sand perent for PX LSM"    "fraction"
+
+# sfclay PBL variables
+i1      real   PSIM           ij     misc        1         -     -         "PSIM"                "SIMILARITY FUNCTION FOR MOMENTUM"     ""
+i1      real   PSIH           ij     misc        1         -     -         "PSIH"                "SIMILARITY FUNCTION FOR HEAT"         ""
+state   real   FM             ij     misc        1         -     -         "FM"                  "INTEGRATED FUNCTION FOR MOMENTUM"     ""
+state   real   FH             ij     misc        1         -     -         "FH"                  "INTEGRATED FUNCTION FOR HEAT"         ""
+state   real   WSPD           ij     misc        1         -     -         "WSPD"                "Wind Speed At Lowest Model Level (may contain vconv)"           "m s-1"
+i1      real   GZ1OZ0         ij     misc        1         -     -         "GZ1OZ0"              "LOG OF Z1 over Z0"                     ""
+state   real   BR             ij     misc        1         -     -         "BR"                  "Bulk Richardson"                       ""
+state   real   ZOL            ij     misc        1         -     -         "ZOL"                 "z/L"                                   ""
+
+# ysupbl variables for grims shallow convection
+state   real   WSTAR_YSU      ij     misc        1         -     -        "WSTAR_YSU"           "mixed-layer velocity scale from ysupbl" "m/s"
+state   real   DELTA_YSU      ij     misc        1         -     -        "DELTA_YSU"           "entrainment layer depth from ysupbl"    "m"
+
+# MYJ PBL variables; GBM PBL: EXCH_H, EXCH_M
+state    real   EXCH_H          ikj     misc        1         Z     r         "EXCH_H"               "SCALAR EXCHANGE COEFFICIENTS "                "m2 s-1"
+state    real   EXCH_M          ikj     misc        1         Z     r         "EXCH_M"               "EXCHANGE COEFFICIENTS "                       "m2 s-1"
+state    real  CT              ij      misc        1         -      r        "CT"                    "COUNTERGRADIENT TERM"    "K"
+state   real   THZ0             ij     misc        1         -      r        "THZ0"                  "POTENTIAL TEMPERATURE AT ZNT"                 "K"
+state    real  Z0               ij     misc        1         -      r        "Z0"                    "Background ROUGHNESS LENGTH"                  "m"
+state   real   QZ0              ij     misc        1         -      r        "QZ0"                   "SPECIFIC HUMIDITY AT ZNT"                     "kg kg-1"
+state   real   UZ0              ij     misc        1         -      r        "UZ0"                   "U WIND COMPONENT AT ZNT"                      "m s-1"
+state   real   VZ0              ij     misc        1         -      r        "VZ0"                   "V WIND COMPONENT AT ZNT"                      "m s-1"
+state   real   QSFC             ij     misc        1         -      r        "QSFC"                  "SPECIFIC HUMIDITY AT LOWER BOUNDARY"          "kg kg-1"
+state   real   AKHS             ij     misc        1         -      r        "AKHS"                  "SFC EXCH COEFF FOR HEAT"                      "m s-1"    
+state   real   AKMS             ij     misc        1         -      r        "AKMS"                  "SFC EXCH COEFF FOR MOMENTUM"                  "m s-1"    
+state   integer KPBL            ij     misc        1         -     r         "KPBL"                  "LEVEL OF PBL TOP"                             ""
+#BSINGH - For CuP
+#~wig: added real pbl level index for output tests
+state   real   AKPBL            ij     misc        1         -      r        "AKPBL"                  "LEVEL OF PBL TOP"                             ""
+#BSINGH - ENDS
+state   real   TSHLTR           ij     misc        1         -      r        "TSHLTR"                "SHELTER THETA FROM MYJ"                       "K"
+state   real   QSHLTR           ij     misc        1         -      r        "QSHLTR"                "SHELTER SPECIFIC HUMIDITY FROM MYJ"           "kg kg-1"
+state   real   PSHLTR           ij     misc        1         -      r        "PSHLTR"                "SHELTER PRESSURE FROM MYJ"           "Pa"
+state   real   TH10             ij     misc        1         -      r        "TH10"                  "10-M THETA FROM MYJ"                          "K"
+state   real   Q10              ij     misc        1         -      r        "Q10"                   "10-M SPECIFIC HUMIDITY FROM MYJ"              "kg kg-1"
+i1      real   CHKLOWQ          ij     misc        1         -     -         "CHKLOWQ"               "SURFACE SATURATION FLAG"        ""
+
+# MF_SHCONV variables
+state   real   massflux_EDKF   ikj     misc        1         -      -        "MASS_FLUX"             "MASS FLUX FROM EDKF"              "Kg m s-1"
+state   real   entr_EDKF       ikj     misc        1         -      -        "ENTR"                  "ENTRAINMENT FROM EDKF"            "m-1"
+state   real   detr_EDKF       ikj     misc        1         -      -        "DETR"                  "ENTRAINMENT FROM EDKF"            "m-1"
+state   real   thl_up          ikj     misc        1         -      -        "THL_UP"                "THL OF UPDRAFT FROM EDKF"         "K"
+state   real   thv_up          ikj     misc        1         -      -        "THV_UP"                "THL OF UPDRAFT FROM EDKF"         "K"
+state   real   rv_up           ikj     misc        1         -      -        "RV_UP"                 "RV OF UPDRAFT FROM EDKF"          "kq/kg"
+state   real   rt_up           ikj     misc        1         -      -        "RT_UP"                 "RT OF UPDRAFT FROM EDKF"          "kq/kg"
+state   real   rc_up           ikj     misc        1         -      -        "RC_UP"                 "RC OF UPDRAFT FROM EDKF"          "kq/kg"
+state   real   u_up            ikj     misc        1         -      -        "U_UP"                  "U OF UPDRAFT FROM EDKF"           "m/s"
+state   real   v_up            ikj     misc        1         -      -        "V_UP"                  "U OF UPDRAFT FROM EDKF"           "m/s"
+state   real   frac_up         ikj     misc        1         -      -        "FRAC_UP"               "FRACTION OF UPDRAFT FROM EDKF"    ""
+state   real   rc_mf           ikj     misc        1         -      r        "RC_MF"                 "RC IN THE GRID COMPUTED BY EDKF"  "kg/kg"
+
+# TEMF PBL variables
+state    real   te_temf        ikj     misc        1         -      rh        "te_temf"               "Total energy from TEMF PBL scheme"      "m2 s-2"
+state    real   kh_temf        ikj     misc        1         -     rh          "kh_temf"               "Diffusion coefficient for heat from TEMF PBL"
+state    real   km_temf        ikj     misc        1         -     rh          "km_temf"               "Diffusion coefficient for momentum from TEMF PBL"
+state    real   shf_temf       ikj     misc        1         -     rh          "shf_temf"              "Sensible heat flux from TEMF PBL"      "K m s-1"
+state    real   qf_temf        ikj     misc        1         -     rh          "qf_temf"              "Sensible heat flux from TEMF PBL"       "kg/kg m s-1"
+state    real   uw_temf        ikj     misc        1         -     rh          "uw_temf"              "U momentum flux from TEMF PBL"       "m2 s-2"
+state    real   vw_temf        ikj     misc        1         -     rh          "vw_temf"              "V momentum flux from TEMF PBL"       "m2 s-2"
+state    real   wupd_temf      ikj     misc        1         -     rh          "wupd_temf"            "Updraft velocity from TEMF PBL"      "m s-1"
+state    real   mf_temf        ikj     misc        1         -     rh          "mf_temf"              "Mass flux from TEMF PBL"             "m s-1"
+state    real   thup_temf      ikj     misc        1         -     rh          "thup_temf"            "Updraft thetal from TEMF PBL"        "K"
+state    real   qtup_temf      ikj     misc        1         -     rh          "qtup_temf"            "Updraft qt from TEMF PBL"        "1"
+state    real   qlup_temf      ikj     misc        1         -     rh          "qlup_temf"            "Updraft ql (liquid water) from TEMF PBL"        "1"
+state    real   cf3d_temf      ikj     misc        1         -     rh          "cf3d_temf"            "3D Cloud fraction from TEMF PBL"        "1"
+state    real   hd_temf        ij      misc        1         -     rh          "hd_temf"              "Dry thermal top height from TEMF PBL"       "m"
+state    real   lcl_temf       ij      misc        1         -     rh          "lcl_temf"             "Lifting condensation level from TEMF PBL"       "m"
+state    real   hct_temf       ij      misc        1         -     rh          "hct_temf"             "Cloud top height from TEMF PBL"       "m"
+state    real   cfm_temf       ij      misc        1         -     rh          "cfm_temf"            "Column cloud fraction from TEMF PBL"        "1"
+state    real   wm_temf        ij      misc        1         -     rh        "wm_temf"               "Velocity scale in TEMF surface layer scheme"      "m s-1"
+
+# MYNN PBL variables
+state   real   qke_adv         ikjftb  scalar      1         -      i0rusdf=(bdy_interp:dt) "qke_adv"       "twice TKE from MYNN"      "m2 s-2"
+state   real   qke             ikj     misc        1         -      irh      "qke"               "twice TKE from MYNN"      "m2 s-2"
+state   real   qSHEAR          ikj     misc        1         Z      h        "qSHEAR"            "TKE Production - shear"          "m2 s-2"
+state   real   qBUOY           ikj     misc        1         Z      h        "qBUOY"             "TKE Production - buoyancy"       "m2 s-2"
+state   real   qDISS           ikj     misc        1         Z      h        "qDISS"             "TKE dissipation"                 "m2 s-2"
+state   real   qWT             ikj     misc        1         Z      h        "qWT"               "TKE vertical transport"          "m2 s-2"
+state   real   dqke            ikj     misc        1         -      h        "Dtke"              "TKE change"                     "m2 s-2"
+state   real   tsq             ikj     misc        1         -      r        "tsq"               "liquid water pottemp variance"      "K2"
+state   real   qsq             ikj     misc        1         -      r        "qsq"               "liquid water variance"      "(kg/kg)**2"
+state   real   cov             ikj     misc        1         -      r        "cov"               "liquid water-liquid water pottemp covariance"   "K kg/kg"
+state   real   Sh3d            ikj     misc        1         -      r        "Sh3d"              "Stability function for heat"   ""
+state   real   ch               ij     misc        1         -      -        "ch"                "surface exchange coeff for heat"    "m s-1"
+#state   real   K_m             ikj     misc        1         -     -          "K_m"               "EXCHANGE COEFFICIENT for momentum "
+#state   real   K_h             ikj     misc        1         -     -          "K_h"               "EXCHANGE COEFFICIENT for heat "
+#state   real   K_q             ikj     misc        1         -     -          "K_q"               "EXCHANGE COEFFICIENT for qke "
+#MYNN-EDMF VARIABLES
+state   real   edmf_a          ikj     misc        1         -      h         "edmf_a"           "EDMF relative updraft  area - moist updrafts" "-"
+state   real   edmf_w          ikj     misc        1         -      h         "edmf_w"           "EDMF vertical velocity  - mean moist updrafts" "m s-1"
+state   real   edmf_thl        ikj     misc        1         -      h         "edmf_thl"         "EDMF thetaL  - mean moist updrafts" "K"
+state   real   edmf_qt         ikj     misc        1         -      h         "edmf_qt"          "EDMF qt  - mean moist updrafts" "kg kg-1"
+state   real   edmf_ent        ikj     misc        1         -      h         "edmf_ent"         "EDMF entrainment  - mean moist updrafts" "m-1"
+state   real   edmf_qc         ikj     misc        1         -      h         "edmf_qc"          "EDMF qc - mean moist updrafts" "kg kg-1"
+state   integer  nupdraft       ij     misc        1         -      h         "nupdraft"         "Number of updrafts per grid cell"  ""
+state   real   maxMF            ij     misc        1         -      h         "maxMF"            "Maximum mass-flux (neg: all dry, pos: moist)"   "m/s * area"
+
+#FogDES variables
+state   real   fgdp             ij     misc        1         -      -        "fgdp"                "Accumulated fog deposition"    "mm"
+state   real   dfgdp            ij     misc        1         -      -        "dfgdp"               "Fog deposition during timestep"    "mm"
+state   real   vdfg             ij     misc        1         -      -        "vdfg"                "Deposition velocity of fog"    "m/s"
+
+# GBM PBL variable
+state   real   exch_tke       ikj     misc        1         -      h       "EXCH_TKE"                 "Exchange coefficient TKE enhanced"      "m2 s-1"
+
+# Additional for gravity wave drag
+state   real   DTAUX3D         ikj     misc        1         -     rh        "DTAUX3D"               "LOCAL U GWDO STRESS"   "m s-1"
+state   real   DTAUY3D         ikj     misc        1         -     rh        "DTAUY3D"               "LOCAL V GWDO STRESS"   "m s-1"  
+state   real   DUSFCG           ij     misc        1         -     rh        "DUSFCG"                "COLUMN-INTEGRATED U GWDO STRESS"   "Pa m s-1"
+state   real   DVSFCG           ij     misc        1         -     rh        "DVSFCG"                "COLUMN-INTEGRATED V GWDO STRESS"   "Pa m s-1"
+state   real   VAR2D            ij     misc        1         -     i012rhdus "VAR"                   "OROGRAPHIC VARIANCE"   ""   ""
+state   real   OC12D            ij     misc        1         -     i012rhdus "CON"                   "OROGRAPHIC CONVEXITY"   ""   ""
+state   real   OA1              ij     misc        1         -     i012rhdus "OA1"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OA2              ij     misc        1         -     i012rhdus "OA2"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OA3              ij     misc        1         -     i012rhdus "OA3"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OA4              ij     misc        1         -     i012rhdus "OA4"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OL1              ij     misc        1         -     i012rhdus "OL1"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OL2              ij     misc        1         -     i012rhdus "OL2"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OL3              ij     misc        1         -     i012rhdus "OL3"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+state   real   OL4              ij     misc        1         -     i012rhdus "OL4"                   "OROGRAPHIC DIRECTION ASYMMETRY FUNCTION"   ""   ""
+
+# Additional for topo_wind
+state    real   ctopo             ij      misc        1         -     rdu         "ctopo"              "Correction for topography"       ""
+state    real   ctopo2            ij      misc        1         -     rdu         "ctopo2"             "Correction for topography 2"     ""
+
+# BEP urban scheme  variables
+state    real    a_u_bep       ikj     misc        1         Z      -        "a_u_bep"               "IMPLICIT FOR X-COMP."      "s-1"
+state    real    a_v_bep       ikj     misc        1         Z      -        "a_v_bep"               "IMPLICIT FOR Y-COMP."      "s-1"
+state    real    a_t_bep       ikj     misc        1         Z      -        "a_t_bep"               "IMPLICIT FOR Pot. Temp"    "s-1"
+state    real    a_q_bep       ikj     misc        1         Z      -        "a_q_bep"               "IMPLICIT FOR Moisture"     "s-1"
+state    real    a_e_bep       ikj     misc        1         Z      -        "a_e_bep"               "IMPLICIT FOR TKE"          "s-1"
+state    real    b_u_bep       ikj     misc        1         Z      -        "b_u_bep"               "EXPLICIT FOR X-COMP."      "m s-2"
+state    real    b_v_bep       ikj     misc        1         Z      -        "b_v_bep"               "EXPLICIT FOR Y-COMP."      "m s-2"
+state    real    b_t_bep       ikj     misc        1         Z      -        "b_t_bep"               "EXPLICIT FOR Pot. Temp"    "K s-1"
+state    real    b_q_bep       ikj     misc        1         Z      -        "b_q_bep"               "EXPLICIT FOR Moisture"     "kg s-1"
+state    real    b_e_bep       ikj     misc        1         Z      -        "b_e_bep"               "EXPLICIT FOR TKE"          "m2 s-3"
+state    real    dlg_bep       ikj     misc        1         Z      -        "dlg_bep"               "length scale 1"            "m"
+state    real    dl_u_bep      ikj     misc        1         Z      -        "dl_u_bep"              "urban length scale"        "m"
+state    real    sf_bep        ikj     misc        1         Z      -        "sf_bep"                "surface grid"              "-"
+state    real    vl_bep        ikj     misc        1         Z      -        "vl_bep"                "volume grid"               "-"
+state    real   tke_pbl        ikj     misc        1         Z      rh       "tke_pbl"              "TKE from PBL"      "m2 s-2"
+state    real   el_pbl         ikj     misc        1         Z      h        "el_pbl"               "Length scale from PBL"      "m"
+# Diagnostic BOULAC PBL variables
+state    real   wu_tur         ikj     misc        1         -      r        "wu_tur"               "Turbulent flux of momentum(x)"      "m2 s-2"
+state    real   wv_tur         ikj     misc        1         -      r        "wv_tur"               "Turbulent flux of momentum(y)"      "m2 s-2"
+state    real   wt_tur         ikj     misc        1         -      r        "wt_tur"               "Turbulent flux of temperature"      "K m s-1"
+state    real   wq_tur         ikj     misc        1         -      r        "wq_tur"               "Turbulent flux of water vapor"      "- m s-1"
+
+# gfdl (eta) radiation State Variables
+state    real    HTOP            ij     misc        1         -      r        "HTOP"                 "TOP OF CONVECTION LEVEL"         ""
+state    real    HBOT            ij     misc        1         -      r        "HBOT"                 "BOT OF CONVECTION LEVEL"         ""
+state    real    HTOPR           ij     misc        1         -      r        "HTOPR"                "TOP OF CONVECTION LEVEL FOR RADIATION"    ""
+state    real    HBOTR           ij     misc        1         -      r        "HBOTR"                "BOT OF CONVECTION LEVEL FOR RADIATION"    ""
+state    real    CUTOP           ij     misc        1         -      r        "CUTOP"                "TOP OF CONVECTION LEVEL FROM CUMULUS PAR"    ""
+state    real    CUBOT           ij     misc        1         -      r        "CUBOT"                "BOT OF CONVECTION LEVEL FROM CUMULUS PAR"    ""
+state    real    CUPPT           ij     misc        1         -      r        "CUPPT"                "ACCUMULATED CONVECTIVE RAIN SINC LAST CALL TO THE RADIATION"         ""
+state    real   rswtoa           ij     misc        1         -      -
+state    real   rlwtoa           ij     misc        1         -      -
+state    real   czmean           ij     misc        1         -      -
+state    real   cfracl           ij     misc        1         -      -
+state    real   cfracm           ij     misc        1         -      -
+state    real   cfrach           ij     misc        1         -      -
+state    real   acfrst           ij     misc        1         -      -
+state integer   ncfrst           ij     misc        1         -      -
+state    real   acfrcv           ij     misc        1         -      -
+state integer   ncfrcv           ij     misc        1         -      -
+
+# new rad variables
+state    real   o3rad           ikj     misc        1         -      rdf=(p2c)      "o3rad"    "RADIATION 3D OZONE" "ppmv"
+
+# incoming optical depth derived from aerosol data
+state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -
+state  real   pina      {lsa}           misc        1    -   -      "PINA"     "PRESSURE LEVEL OF OZONE MIXING RATIO"  "millibar"
+
+# array to hold aerosol optical depth that has been interpolated to model levels and time
+state  real   -         ikjf            aerod       1    -   -             -
+state  real   ocarbon   ikjf            aerod       1    -   df=(p2c)     "ocarbon"         "organic carbon"          -
+state  real   seasalt   ikjf            aerod       1    -   df=(p2c)     "seasalt"         "sea salt"                -
+state  real   dust      ikjf            aerod       1    -   df=(p2c)     "dust"            "dust"                    -
+state  real   bcarbon   ikjf            aerod       1    -   df=(p2c)     "bcarbon"         "black carbon"            -
+state  real   sulfate   ikjf            aerod       1    -   df=(p2c)     "sulfate"         "sulfate"                 -
+state  real   upperaer  ikjf            aerod       1    -   df=(p2c)     "upperaer"        "volcanic ash"            -
+state  real   aodtot    ij              misc        1    -      r         "aodtot"          "TOTAL AEROSOL OPTICAL DEPTH"  -
+
+# incoming aerosol data for multiscale Kain Fritsch
+state  real   aeromcu   i{lsc}jm{tyc}   misc        1    -   -     -
+state  real   aeropcu   i{lsc}jm        misc        1    -   -      "AEROPCU"     "PRESSURE LEVEL OF AEROSOL DATA"  "millibar"
+
+# array to hold aerosol data that has been interpolated to model levels and time
+state  real   -            ikjf         aerocu      1    -   -             -
+state  real   cu_dust1     ikjf         aerocu      1    -   hdf=(p2c)     "cudust1"           "dust 1"                     "ug m-3"
+state  real   cu_dust2     ikjf         aerocu      1    -   hdf=(p2c)     "cudust2"           "dust 2"                     "ug m-3"
+state  real   cu_dust3     ikjf         aerocu      1    -   hdf=(p2c)     "cudust3"           "dust 3"                     "ug m-3"
+state  real   cu_dust4     ikjf         aerocu      1    -   hdf=(p2c)     "cudust4"           "dust 4"                     "ug m-3"
+state  real   cu_seasalt   ikjf         aerocu      1    -   hdf=(p2c)     "cuseasalt"         "sea salt"                   "ug m-3"
+state  real   cu_sulfate   ikjf         aerocu      1    -   hdf=(p2c)     "cusulfate"         "sulfate"                    "ug m-3"
+state  real   cu_phobcar   ikjf         aerocu      1    -   hdf=(p2c)     "cuphobcar"         "hydrophobic black carbon"   "ug m-3"
+state  real   cu_phibcar   ikjf         aerocu      1    -   hdf=(p2c)     "cuphibcar"         "hydrophilic black carbon"   "ug m-3"
+state  real   cu_phoocar   ikjf         aerocu      1    -   hdf=(p2c)     "cuphoocar"         "hydrophobic organic carbon"   "ug m-3"
+state  real   cu_phiocar   ikjf         aerocu      1    -   hdf=(p2c)     "cuphiocar"         "hydrophilic organic carbon"   "ug m-3"
+state  real   aerovar      ikj          misc        1    -      hr         "AEROVAR"           "Aerosol variable for MSKF"  "ug m-3"
+
+# cam radiation variables
+state  real    -       i{ls}jf ozmixm      1    -   -     -
+state  real   mth01    i{ls}jf ozmixm      1    -   -     -
+state  real   mth02    i{ls}jf ozmixm      1    -   -     -
+state  real   mth03    i{ls}jf ozmixm      1    -   -     -
+state  real   mth04    i{ls}jf ozmixm      1    -   -     -
+state  real   mth05    i{ls}jf ozmixm      1    -   -     -
+state  real   mth06    i{ls}jf ozmixm      1    -   -     -
+state  real   mth07    i{ls}jf ozmixm      1    -   -     -
+state  real   mth08    i{ls}jf ozmixm      1    -   -     -
+state  real   mth09    i{ls}jf ozmixm      1    -   -     -
+state  real   mth10    i{ls}jf ozmixm      1    -   -     -
+state  real   mth11    i{ls}jf ozmixm      1    -   -     -
+state  real   mth12    i{ls}jf ozmixm      1    -   -     -
+state  real   pin       {ls}     misc      1    -   -      "PIN"             "PRESSURE LEVEL OF OZONE MIXING RATIO"  "millibar"
+state  real   m_ps       ij   misc      2    -   -      "m_ps"            "PS from MATCH on WRF grids"
+state  real    -       idjf aerosolc    2    -   -       -
+state  real   SUL      idjf aerosolc    2    -   -     "SUL"        "SUL aerosol concentration"
+state  real   SSLT     idjf aerosolc    2    -   -     "SSLT"        "SSLT aerosol concentration"
+state  real   DUST1    idjf aerosolc    2    -   -     "DUST1"        "DUST1 aerosol concentration"
+state  real   DUST2    idjf aerosolc    2    -   -     "DUST2"        "DUST2 aerosol concentration"
+state  real   DUST3    idjf aerosolc    2    -   -     "DUST3"        "DUST3 aerosol concentration"
+state  real   DUST4    idjf aerosolc    2    -   -     "DUST4"        "DUST4 aerosol concentration"
+state  real   OCPHO    idjf aerosolc    2    -   -     "OCPHO"        "OCPHO aerosol concentration"
+state  real   BCPHO    idjf aerosolc    2    -   -     "BCPHO"        "BCPHO aerosol concentration"
+state  real   OCPHI    idjf aerosolc    2    -   -     "OCPHI"        "OCPHI aerosol concentration"
+state  real   BCPHI    idjf aerosolc    2    -   -     "BCPHI"        "BCPHI aerosol concentration"
+state  real   BG       idjf aerosolc    2    -   -     "BG"           "BG aerosol concentration"
+state  real   VOLC     idjf aerosolc    2    -   -     "VOLC"         "VOLC aerosol concentration"
+state  real   m_hybi    d     misc      1    -   -     "m_hybi"       "MATCH hybi"
+
+# new eta microphysics State Variables
+state   real    F_ICE_PHY      ikj     misc         1         -      rhdu     "F_ICE_PHY"            "FRACTION OF ICE"         ""
+state   real    F_RAIN_PHY     ikj     misc         1         -      rhdu     "F_RAIN_PHY"           "FRACTION OF RAIN "         ""
+state   real    F_RIMEF_PHY    ikj     misc         1         -      rhdu     "F_RIMEF_PHY"          "MASS RATIO OF RIMED ICE "         ""
+state   real    qndropsource   ikj     misc         1         -      r        "qndropsource"         "Droplet number source"   "#/kg/s"
+
+# cyl 3DPWP variables
+state   real    OM_TMP        i{nocnl}j      misc         1        Z     i012rhdu=(copy_fcnm)f=(c2f_interp:grid_id)    "OM_TMP" "temperature"   "k"
+state   real    OM_S          i{nocnl}j      misc         1        Z     i012rhdu=(copy_fcnm)f=(c2f_interp:grid_id)  "OM_S" "salinity"       "degree"
+state   real    OM_DEPTH      i{nocnl}j      misc         1        Z     i012rhd   "OM_DEPTH"   "depth"     "m"
+state   real    OM_U          i{nocnl}j      misc         1        Z     i012rhdu=(copy_fcnm)f=(c2f_interp:grid_id)   "OM_U"   "u current"     "m/s"
+state   real    OM_V          i{nocnl}j      misc         1        Z     i012rhdu=(copy_fcnm)f=(c2f_interp:grid_id)   "OM_V"   "v current"     "m/s"
+state   real    OM_LAT        ij       misc         1        -     i012rd   "OM_LAT"  "om lat"       "degree"
+state   real    OM_LON        ij       misc         1        -     i012rd   "OM_LON"  "om lon"       "degree"
+state   real    OM_ML         ij       misc         1        -     i012rhdu=(copy_fcnm)f=(c2f_interp:grid_id)   "OM_ML"  "om ml"       "m"
+state   real    OM_TINI       i{nocnl}j      misc         1        Z     i012rd   "OM_TINI"   "temperature init"     "k"
+state   real    OM_SINI       i{nocnl}j      misc         1        Z     i012rd   "OM_SINI"       "salinity init"     "degree"
+
+#BSINGH -  added CuP related variables
+# CuP fair-weather cumulus scheme variables; wig, 4-Aug-2006
+# The slopes and sigmas are really only needed for testing so they can
+# be dropped to i1 level, or even a simple real within cup_driver, once
+# they are no longer desired for output.
+state   logical cupflag        ij      misc         1         -      r        "CUPFLAG"        "CuP scheme activavted, T=yes, F=no" ""
+state   real    slopesfc       ij      misc         1         -      r        "SLOPESFC"       "Slope of surface layer dTheta/dMixRatio" "K"
+state   real    slopeez        ij      misc         1         -      r        "SLOPEEZ"        "Slope of entrainment layer dTheta/dMixRatio" "K"
+state   real    sigmasfc       ij      misc         1         -      r        "SIGMASFC"       "Std. dev. of surface layer dTheta/dMixRatio" "K kg kg-1"
+state   real    sigmaez        ij      misc         1         -      r        "SIGMAEZ"        "Std. dev. of entrainment layer dTheta/dMixRatio" "K kg kg-1"
+state   real    shall          ij      misc         1         -      r        "SHALL"         "Cumulus type, 0=deep, 1=shallow, 2=none" ""
+state   real    taucloud       ij      misc         1         -      r        "TAUCLOUD"      "CuP cloud time scale for lifetime" ""
+state   real    tactive        ij      misc         1         -      r        "TACTIVE"       "CuP cloud formation time scale" ""
+state   real    tcloud_cup     ij      misc         1         -      r        "TCLOUD_CUP"    "CuP cloud duration for modifying T,QV,chem,etc" ""
+state   real    wCloudBase     ij      misc         1         -      r        "wCloudBase"    "CuP cloud base vertical velocity" ""
+state   real    activeFrac     ij      misc         1         -      r         "activeFrac"    "Fraction of PDF the forms clouds" "fraction"
+state   real    cldfratend_cup ikj     misc         1         -      r        "CLDFRATEND_CUP" "Cloud fraction tendency due to CuP Scheme" "fraction"
+state   real    cldfra_cup     ikj     misc         1         -      r        "CLDFRA_CUP"     "Cloud fraction due to CuP Scheme" "fraction"
+state   real    updfra_cup     ikj     misc         1         -      r        "UPDFRA_CUP"     "Updraft fractional area due to CuP Scheme" "fraction"
+state   real    qc_iu_cup      ikj     misc         1         -      r        "QC_IU_CUP"      "Cloud water due to CuP Scheme (in cumulus updraft)" "kg kg-1"
+state   real    qc_ic_cup      ikj     misc         1         -      r        "QC_IC_CUP"      "Cloud water due to CuP Scheme (in cumulus cloud)" "kg kg-1"
+state   real    qndrop_ic_cup  ikj     misc         1         -      r        "QNDROP_IC_CUP"  "Cloud droplet number due to CuP Scheme (in cumulus cloud)" "# kg-1"
+state   real    wup_cup        ikj     misc         1         -      r        "WUP_CUP"        "Updraft vertical velocity" "m s-1"
+state   real    wact_cup       ij      misc         1         -      r         "WACT_CUP"       "CuP cloud base vertical velocity for activation" "m s-1"
+state   real    wulcl_cup      ij      misc         1         -      r         "WULCL_CUP"      "CuP updraft vertical velocity at top of first cloud layer" "m s-1"
+state   real    mfup_cup       ikj     misc         1         -      r        "MFUP_CUP"       "Updraft mass flux for shallow-cu in CuP Scheme" "kg m-2 s-1"
+state   real    mfup_ent_cup   ikj     misc         1         -      r        "MFUP_ENT_CUP"   "Updraft mass flux entrainment (across layer) for shallow-cu in CuP Scheme" "kg m-2 s-1"
+state   real    mfdn_cup       ikj     misc         1         -      r        "MFDN_CUP"       "Downdraft mass flux for shallow-cu in CuP Scheme" "kg m-2 s-1"
+state   real    mfdn_ent_cup   ikj     misc         1         -      r        "MFDN_ENT_CUP"   "Downdraft mass flux entrainment (across layer) for shallow-cu in CuP Scheme" "kg m-2 s-1"
+state   real    fcvt_qc_to_pr_cup  ikj  misc        1         -      r        "FCVT_QC_TO_PR_CUP"   "Fraction of cloudwater converted to precip. as air rises thru an updraft layer"  "--"
+state   real    fcvt_qc_to_qi_cup  ikj  misc        1         -      r        "FCVT_QC_TO_QI_CUP"   "Fraction of cloudwater converted to cloudice as air rises thru an updraft layer"  "--"
+state   real    fcvt_qi_to_pr_cup  ikj  misc        1         -      r        "FCVT_QI_TO_PR_CUP"   "Fraction of cloudice converted to precip. as air rises thru an updraft layer"  "--"
+state   real    tstar          ij      misc         1         -      r        "TSTAR"          "Boundary layer time scale" "s"
+state   real    lnterms        ikj     misc         1         -      r        "LNTERMS"        "Liquid+ice+1 ln term for cloud fraction" ""
+state   real    lnint          ij      misc         1         -      r        "LNINT"          "Integrated ln term for cloud fraction" ""
+#BSINGH -  adde CuP related variables -ENDS
+
+
+# Other Misc State Variables                                            
+state   real    h_diabatic     ikj     misc         1         -      rdu      "h_diabatic"            "MICROPHYSICS LATENT HEATING"         "K s-1"      
+state   real    qv_diabatic    ikj     misc         1         -      rdu      "qv_diabatic"           "MICROPHYSICS QV TENDENCY"            "g g-1 s-1"      
+state   real    qc_diabatic    ikj     misc         1         -      rdu      "qc_diabatic"           "MICROPHYSICS QC TENDENCY"            "g g-1 s-1"      
+state   real    msft           ij      misc         1         -     i012rhdu=(copy_fcnm)    "MAPFAC_M"         "Map scale factor on mass grid" ""
+state   real    msfu           ij      misc         1         X     i012rhdu=(copy_fcnm)    "MAPFAC_U"         "Map scale factor on u-grid" ""
+state   real    msfv           ij      misc         1         Y     i012rhdu=(copy_fcnm)    "MAPFAC_V"         "Map scale factor on v-grid" ""
+state   real    msftx          ij      misc         1         -     i012rhdu=(copy_fcnm)    "MAPFAC_MX"         "Map scale factor on mass grid, x direction" ""
+state   real    msfty          ij      misc         1         -     i012rhdu=(copy_fcnm)    "MAPFAC_MY"         "Map scale factor on mass grid, y direction" ""
+state   real    msfux          ij      misc         1         X     i012rhdu=(copy_fcnm)    "MAPFAC_UX"         "Map scale factor on u-grid, x direction" ""
+state   real    msfuy          ij      misc         1         X     i012rhdu=(copy_fcnm)    "MAPFAC_UY"         "Map scale factor on u-grid, y direction" ""
+state   real    msfvx          ij      misc         1         Y     i012rhdu=(copy_fcnm)    "MAPFAC_VX"         "Map scale factor on v-grid, x direction" ""
+state   real    msfvx_inv      ij      misc         1         Y     i012rhdu=(copy_fcnm)    "MF_VX_INV"         "Inverse map scale factor on v-grid, x direction" ""
+state   real    msfvy          ij      misc         1         Y     i012rhdu=(copy_fcnm)    "MAPFAC_VY"         "Map scale factor on v-grid, y direction" ""
+
+state   real    f              ij      misc         1         -     i012rhdu=(copy_fcnm)    "f"                "Coriolis sine latitude term"  "s-1"
+state   real    e              ij      misc         1         -     i012rhdu=(copy_fcnm)    "e"                "Coriolis cosine latitude term"  "s-1"
+state   real    sina           ij      misc         1         -     i012rhdu=(copy_fcnm)    "SINALPHA"         "Local sine of map rotation"   ""
+state   real    cosa           ij      misc         1         -     i012rhdu=(copy_fcnm)    "COSALPHA"         "Local cosine of map rotation"  ""
+state   real    ht             ij      misc         1         -     i012rh056dus  "HGT"              "Terrain Height"   "m"
+state   real    ht_fine        ij      misc         1         -     -          "HGT_FINE"         "Fine Terrain Height"   "m"
+state   real    ht_int         ij      misc         1         -     -          "HGT_INT"          "Terrain Height Horizontally Interpolated"   "m"
+state   real    ht_input       ij      misc         1         -     -          "HGT_INPUT"        "Terrain Height from FG Input File"   "m"
+state   real    ht_smooth      ij      misc         1         -     -          "HGT_SMOOTH"       "Terrain Height Smoothed with External Model Topo (d1 only)"   "m"
+state   real    ht_shad        ijb     misc         1         -     df=(bdy_interp:dt)         "HGT_SHAD"        "Height of orographic shadow"   "m"
+i1      real    ht_loc         ij      misc         1         -     - 
+state   integer  shadowmask    ij      misc         1         -     - 
+state   integer min_ptchsz     -       misc         1         -     r
+
+state   real    TSK            ij      misc         1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "TSK"                   "SURFACE SKIN TEMPERATURE"                  "K"
+state   real    dfi_TSK        ij      misc         1         -     r                       "TSK_dfi"               "saved SURFACE SKIN TEMPERATURE"
+state   real    TSK_SAVE       ij      misc         1         -     r         "TSK_SAVE" "SURFACE SKIN TEMPERATURE, EXTRA COPY FOR SEA ICE TESTS in REAL"       "K"
+state   real    u_base         k       misc         1         -     ir        "u_base"                "BASE STATE X WIND IN IDEALIZED CASES"         ""      
+state   real    v_base         k       misc         1         -     ir        "v_base"                "BASE STATE Y WIND IN IDEALIZED CASES"         ""      
+state   real    qv_base        k       misc         1         -     ir        "qv_base"               "BASE STATE QV IN IDEALIZED CASES"         ""      
+state   real    z_base         k       misc         1         -     ir        "z_base"                "BASE STATE HEIGHT IN IDEALIZED CASES"         ""      
+state   real    u_frame        -       misc         1         -     ir        "u_frame"               "FRAME X WIND"         "m s-1"      
+state   real    v_frame        -       misc         1         -     ir        "v_frame"               "FRAME Y WIND"         "m s-1"      
+# p_top appears as metadata between SI and real but as a state variable in real and WRF
+# since it is a scalar and a constant, it makes sense to have it as metadata -- there
+# are, however, probably post-processing programs that expect to see it as an I/O record
+# another problem: share/input_wrf tries to read this as metadata (fine for real reading
+# SI, but with model reading real output, it generates a warning when debug is > 0 in
+# namelist and causes repeated questions from users.  A third problem is the potential
+# collision between a metadata name and a field record in the I/O data
+# resolve this how?  Have the real program throw a switch to tell the code to get it
+# from the metadata?  Otherwise it's a field?
+state logical just_read_auxinput4  -      misc      -         -     r    "we_just_read_sst"          "1=AUXINPUT4 ALARM RINGING, 0=NO AUXINPUT4 ALARM"  "-"
+state logical just_read_boundary   -      misc      -         -     r    "we_just_d01_LBC"           "1=BOUNDARY  ALARM RINGING, 0=NO BOUNDARY  ALARM"  "-"
+state   real    mf_fft         -       misc         -         -     r        "mf_fft"                "Mass point map factor at equatorward FFT filter location"  ""
+state   real    p_top          -       misc         -         -     irh       "p_top"                "PRESSURE TOP OF THE MODEL"  "Pa"
+state logical got_var_sso	-	misc	    -	      -     i02r  "got_var_sso"		     "whether VAR_SSO was included in WPS output (beginning V3.4)" ""
+state logical v4_metgrid 	-	misc	    -	      -     -     "v4_metgrid"		     "for real, T/F: identify if this is v4 metgrid data" ""
+
+
+#BSINGH - Adding all these variables for CuP scheme[any var before t00]
+state   real    lat_ll_t       -       dyn_em       -         -     ir       "lat_ll_t"              "latitude lower left, temp point" "degrees"
+state   real    lat_ul_t       -       dyn_em       -         -     ir       "lat_ul_t"              "latitude up left, temp point" "degrees"
+state   real    lat_ur_t       -       dyn_em       -         -     ir       "lat_ur_t"              "latitude up right, temp point" "degrees"
+state   real    lat_lr_t       -       dyn_em       -         -     ir       "lat_lr_t"              "latitude lower right, temp point" "degrees"
+state   real    lat_ll_u       -       dyn_em       -         -     ir       "lat_ll_u"              "latitude lower left, u point" "degrees"
+state   real    lat_ul_u       -       dyn_em       -         -     ir       "lat_ul_u"              "latitude up left, u point" "degrees"
+state   real    lat_ur_u       -       dyn_em       -         -     ir       "lat_ur_u"              "latitude up right, u point" "degrees"
+state   real    lat_lr_u       -       dyn_em       -         -     ir       "lat_lr_u"              "latitude lower right, u point" "degrees"
+state   real    lat_ll_v       -       dyn_em       -         -     ir       "lat_ll_v"              "latitude lower left, v point" "degrees"
+state   real    lat_ul_v       -       dyn_em       -         -     ir       "lat_ul_v"              "latitude up left, v point" "degrees"
+state   real    lat_ur_v       -       dyn_em       -         -     ir       "lat_ur_v"              "latitude up right, v point" "degrees"
+state   real    lat_lr_v       -       dyn_em       -         -     ir       "lat_lr_v"              "latitude lower right, v point" "degrees"
+state   real    lat_ll_d       -       dyn_em       -         -     ir       "lat_ll_d"              "latitude lower left, massless point" "degrees"
+state   real    lat_ul_d       -       dyn_em       -         -     ir       "lat_ul_d"              "latitude up left, massless point" "degrees"
+state   real    lat_ur_d       -       dyn_em       -         -     ir       "lat_ur_d"              "latitude up right, massless point" "degrees"
+state   real    lat_lr_d       -       dyn_em       -         -     ir       "lat_lr_d"              "latitude lower right, massless point" "degrees"
+state   real    lon_ll_t       -       dyn_em       -         -     ir       "lon_ll_t"              "longitude lower left, temp point" "degrees"
+state   real    lon_ul_t       -       dyn_em       -         -     ir       "lon_ul_t"              "longitude up left, temp point" "degrees"
+state   real    lon_ur_t       -       dyn_em       -         -     ir       "lon_ur_t"              "longitude up right, temp point" "degrees"
+state   real    lon_lr_t       -       dyn_em       -         -     ir       "lon_lr_t"              "longitude lower right, temp point" "degrees"
+state   real    lon_ll_u       -       dyn_em       -         -     ir       "lon_ll_u"              "longitude lower left, u point" "degrees"
+state   real    lon_ul_u       -       dyn_em       -         -     ir       "lon_ul_u"              "longitude up left, u point" "degrees"
+state   real    lon_ur_u       -       dyn_em       -         -     ir       "lon_ur_u"              "longitude up right, u point" "degrees"
+state   real    lon_lr_u       -       dyn_em       -         -     ir       "lon_lr_u"              "longitude lower right, u point" "degrees"
+state   real    lon_ll_v       -       dyn_em       -         -     ir       "lon_ll_v"              "longitude lower left, v point" "degrees"
+state   real    lon_ul_v       -       dyn_em       -         -     ir       "lon_ul_v"              "longitude up left, v point" "degrees"
+state   real    lon_ur_v       -       dyn_em       -         -     ir       "lon_ur_v"              "longitude up right, v point" "degrees"
+state   real    lon_lr_v       -       dyn_em       -         -     ir       "lon_lr_v"              "longitude lower right, v point" "degrees"
+state   real    lon_ll_d       -       dyn_em       -         -     ir       "lon_ll_d"              "longitude lower left, massless point" "degrees"
+state   real    lon_ul_d       -       dyn_em       -         -     ir       "lon_ul_d"              "longitude up left, massless point" "degrees"
+state   real    lon_ur_d       -       dyn_em       -         -     ir       "lon_ur_d"              "longitude up right, massless point" "degrees"
+state   real    lon_lr_d       -       dyn_em       -         -     ir       "lon_lr_d"              "longitude lower right, massless point" "degrees"
+#BSINGH -ENDS
+
+state   real    t00            -       misc         -         -     i02rh     "t00"                   "BASE STATE TEMPERATURE   "  "K"
+state   real    p00            -       misc         -         -     i02rh     "p00"                   "BASE STATE PRESURE"         "Pa"
+state   real    tlp            -       misc         -         -     i02rh     "tlp"                   "BASE STATE LAPSE RATE    "  ""
+state   real    tiso           -       misc         -         -     i02rh     "tiso"                  "TEMP AT WHICH THE BASE T TURNS CONST"  "K"
+state   real    tlp_strat      -       misc         -         -     i02rh     "tlp_strat"             "BASE STATE LAPSE RATE (DT/D(LN(P)) IN STRATOSPHERE"  "K"
+state   real    p_strat        -       misc         -         -     i02rh     "p_strat"               "BASE STATE PRESSURE AT BOTTOM OF STRATOSPHERE" "Pa"
+state   real    max_msftx      -       misc         -         -      rh       "max_mstfx"             "Max map factor in domain"  ""
+state   real    max_msfty      -       misc         -         -      rh       "max_mstfy"             "Max map factor in domain"  ""
+
+# NUWRF:  State variables for Goddard microphysics
+state   real    phys_tot       ikj      misc        1         -     h         "PHYS_TOT"              "TOTAL LATENT HEATING RATE"                       "K s-1"
+state   real    physc          ikj      misc        1         -     -         "PHYSC"                 "LATENT HEATING RATE DUE TO CONDENSATION"         "K s-1"
+state   real    physe          ikj      misc        1         -     -         "PHYSE"                 "LATENT HEATING RATE DUE TO EVAPORATION"          "K s-1"
+state   real    physd          ikj      misc        1         -     -         "PHYSD"                 "LATENT HEATING RATE DUE TO DEPOSITION"           "K s-1"
+state   real    physs          ikj      misc        1         -     -         "PHYSS"                 "LATENT HEATING RATE DUE TO SUBLIMATION"          "K s-1"
+state   real    physm          ikj      misc        1         -     -         "PHYSM"                 "LATENT HEATING RATE DUE TO MELTING"              "K s-1"
+state   real    physf          ikj      misc        1         -     -         "PHYSF"                 "LATENT HEATING RATE DUE TO FREEZING"             "K s-1"
+# NUWRF EMK
+state   real    acphys_tot       ikj      misc        1         -     r       "ACPHYS_TOT"            "ACCUMULATED TOTAL LATENT HEATING"                "K"
+state   real    acphysc          ikj      misc        1         -     r       "ACPHYSC"               "ACCUMULATED LATENT HEATING DUE TO CONDENSATION"  "K"
+state   real    acphyse          ikj      misc        1         -     r       "ACPHYSE"               "ACCUMULATED LATENT HEATING DUE TO EVAPORATION"   "K"
+state   real    acphysd          ikj      misc        1         -     r       "ACPHYSD"               "ACCUMULATED LATENT HEATING DUE TO DEPOSITION"    "K"
+state   real    acphyss          ikj      misc        1         -     r       "ACPHYSS"               "ACCUMULATED LATENT HEATING DUE TO SUBLIMATION"   "K"
+state   real    acphysm          ikj      misc        1         -     r       "ACPHYSM"               "ACCUMULATED LATENT HEATING DUE TO MELTING"       "K"
+state   real    acphysf          ikj      misc        1         -     r       "ACPHYSF"               "ACCUMULATED LATENT HEATING DUE TO FREEZING"      "K"
+
+#state   real    dbz            ikj      misc        1         -     -         "DBZ"                   "RADAR REFLECTIVITIES"             "dbz"
+# NUWRF...4ICE output
+state   real    preci3d       ikj      misc        1         -     -       "PRECI3D"                   "Sedimentation Fluxes for cloud ice"             "KG/M^2/S"
+state   real    precs3d       ikj      misc        1         -     -       "PRECS3D"                   "Sedimentation Fluxes for snow"                  "KG/M^2/S"
+state   real    precg3d       ikj      misc        1         -     -       "PRECG3D"                   "Sedimentation Fluxes for graupel"               "KG/M^2/S"
+state   real    prech3d       ikj      misc        1         -     -       "PRECH3D"                   "Sedimentation Fluxes for hail"               "KG/M^2/S"
+state   real    precr3d       ikj      misc        1         -     -       "PRECR3D"                   "Sedimentation Fluxes for rain"                  "KG/M^2/S"
+
+# State variables for Goddard LW and SW radiation
+state    real  TLWDN           ij      misc        1         -      h         "TLWDN"                 "TOA LW downwelling flux"           "W m-2"
+state    real  TLWUP           ij      misc        1         -      h         "TLWUP"                 "TOA LW upwelling flux"             "W m-2"
+state    real  SLWDN           ij      misc        1         -      h         "SLWDN"                 "Surface LW downwelling flux"       "W m-2"
+state    real  SLWUP           ij      misc        1         -      h         "SLWUP"                 "Surface LW upwelling flux"         "W m-2"
+state    real  TSWDN           ij      misc        1         -      h         "TSWDN"                 "TOA SW downwelling flux"           "W m-2"
+state    real  TSWUP           ij      misc        1         -      h         "TSWUP"                 "TOA SW upwelling flux"             "W m-2"
+state    real  SSWDN           ij      misc        1         -      h         "SSWDN"                 "Surface SW downwelling flux"       "W m-2"
+state    real  SSWUP           ij      misc        1         -      h         "SSWUP"                 "Surface SW upwelling flux"         "W m-2"
+state    real  COD2D_OUT       ij      misc        1         -      h         "COD2D_OUT"             "Column Cloud Optical Depth"        " "
+state    real  CTOP2D_OUT      ij      misc        1         -      h         "CTOP2D_OUT"            "Cloud-Top Pressure"                "mb"
+                
+                                
+# Other physics variables
+
+state    real  RUSHTEN         ikj      misc        1         -      r        "RUSHTEN"               "X WIND TENDENCY DUE TO SHALLOW CUMULUS SCHEME"   "m s-2"
+state    real  RVSHTEN         ikj      misc        1         -      r        "RVSHTEN"               "Y WIND TENDENCY DUE TO SHALLOW CUMULUS SCHEME"   "m s-2"
+state    real  RTHSHTEN        ikj      misc        1         -      r        "RTHSHTEN"              "THETA TENDENCY DUE TO SHALLOW CUMULUS SCHEME"    "K s-1"
+state    real  RQVSHTEN        ikj      misc        1         -      r        "RQVSHTEN"              "Q_V TENDENCY DUE TO SHALLOW CUMULUS SCHEME"      "kg kg-1 s-1"
+state    real  RQRSHTEN        ikj      misc        1         -      r        "RQRSHTEN"              "Q_R TENDENCY DUE TO SHALLOW CUMULUS SCHEME"      "kg kg-1 s-1"
+state    real  RQCSHTEN        ikj      misc        1         -      r        "RQCSHTEN"              "Q_C TENDENCY DUE TO SHALLOW CUMULUS SCHEME"      "kg kg-1 s-1"
+state    real  RQSSHTEN        ikj      misc        1         -      r        "RQSSHTEN"              "Q_S TENDENCY DUE TO SHALLOW CUMULUS SCHEME"      "kg kg-1 s-1"
+state    real  RQISHTEN        ikj      misc        1         -      r        "RQISHTEN"              "Q_I TENDENCY DUE TO SHALLOW CUMULUS SCHEME"      "kg kg-1 s-1"
+state    real  RQGSHTEN        ikj      misc        1         -      r        "RQGSHTEN"              "Q_G TENDENCY DUE TO SHALLOW CUMULUS SCHEME"      "kg kg-1 s-1"
+state    real  RQCNSHTEN       ikj      misc        1         -      r        "RQCNSHTEN"             "Q_CN TENDENCY DUE TO SHALLOW CUMULUS SCHEME"     "# kg-1 s-1"
+state    real  RQINSHTEN       ikj      misc        1         -      r        "RQINSHTEN"             "Q_IN TENDENCY DUE TO SHALLOW CUMULUS SCHEME"     "# kg-1 s-1"
+
+# Deng Shallow Convection Parameterization
+state    real  RDCASHTEN       ikj      misc        1         -      r        "RDCASHTEN"             "CLOUD FRACTION AREA TENDENCY DUE TO DENG SHALLOW CUMULUS SCHEME"    "Pa s-1"
+state    real  RQCDCSHTEN      ikj      misc        1         -      r        "RQCDCSHTEN"            "CLOUD LIQUID TENDENCY DUE TO DENG SHALLOW CUMULUS SCHEME"   "kg kg-1 s-1"
+state    real  CLDAREAA        ikj      dyn_em      1         -      r        "CLDAREAA"              "CLOUD FRACTION FROM DENG SCHEME" ""
+state    real  CLDAREAB        ikj      dyn_em      1         -      r        "CLDAREAB"              "CLOUD FRACTION FROM DENG SCHEME" ""
+state    real  CA_RAD          ikj      dyn_em      1         -      r        "CA_RAD"                "CLOUD WATER CONTENT FROM DENG SCHEME FOR RADIATION" "kg kg-1"
+state    real  CW_RAD          ikj      dyn_em      1         -      r        "CW_RAD"                "CLOUD WATER CONTENT FROM DENG SCHEME FOR RADIATION" "kg kg-1"
+state    real  CLDLIQA         ikj      dyn_em      1         -      r        "CLDLIQA"               "CLOUD WATER CONTENT FROM DENG SCHEME" "kg kg-1"
+state    real  CLDLIQB         ikj      dyn_em      1         -      r        "CLDLIQB"               "CLOUD WATER CONTENT FROM DENG SCHEME" "kg kg-1"
+state    real  CLDDPTHB         ij      misc        1         -      r        "CLDDPTHB"              "CLOUD DEPTH FROM TAU-1"                "m"
+state    real  CLDTOPB          ij      misc        1         -      r        "CLDTOPB"               "CLOUD TOP FROM TAU-1"                "m"
+state    real  PBLMAX           ij      misc        1         -      r        "PBLMAX"                "MAXIMUM VALUE OF PBL DEPTH SINCE THE START OF THE MODEL RUN"                 "m"
+state    real  WUB             ikj      misc        1         -      r        "WUB"                   "UPDRAFT VERTICAL VELOCITY"                 "m s-1"
+state    real  RAINSHVB         ij      misc        1         -      r        "RAINSHVB"              "TIME-STEP SHCU PRECIPITATION FROM TAU-1"       "m s-1"
+state    real  CAPESAVE         ij      misc        1         -      r        "CAPESAVE"              "CAPE FROM TAU-1"       ""
+state    real  RADSAVE          ij      misc        1         -      r        "RADSAVE"               "CLOUD RADIUS FROM TAU-1"       "m"
+state    real  AINCKFSA        i{nsh}j  misc        1         -      r        "AINCKFSA"              "NUMBER OF CLOUDS FROM TAU-1"       ""
+state  integer LTOPB            ij      misc        1         -      r        "LTOPB"                 "LEVEL OF UPDRAFT TOP FROM TAU-1"       ""
+state  integer KDCLDTOP         ij      misc        1         -      r        "KDCLDTOP"              "LEVEL OF NBC TOP"                     ""
+state  integer KDCLDBAS         ij      misc        1         -      r        "KDCLDBAS"              "LEVEL OF NBC BASE"                    ""
+state    real  XTIME1           ij      misc        1         -      r        "XTIME1"                "TIME COUNTER AFTER RAIN"              "min."
+state    real  PBLHAVG          ij      misc        1         -      r        "PBLHAVG"               "TIME AVERAGE OF PBLH"                 "m"
+state    real  TKEAVG          ikj      misc        1         -      r        "TKEAVG"                "TIME AVERAGE OF TKE"                 "m2 s-2"
+state    real  WSUBSID          k       misc        1         -      -        "WSUBSID"               "LARGE-SCALE SUBSIDENCE IN DENG SHCU SCHEME"    "m s-1"
+# End Deng Shallow Convection Parameterization
+
+
+state    real  RUCUTEN         ikj      misc        1         -      r        "RUCUTEN"               "X WIND TENDENCY DUE TO CUMULUS PARAMETERIZATION"  "m s-2"
+state    real  RVCUTEN         ikj      misc        1         -      r        "RVCUTEN"               "Y WIND TENDENCY DUE TO CUMULUS PARAMETERIZATION"  "m s-2"
+state    real  RTHCUTEN        ikj      misc        1         -      r        "RTHCUTEN"              "THETA TENDENCY DUE TO CUMULUS SCHEME"     "K s-1"
+state    real  RQVCUTEN        ikj      misc        1         -      r        "RQVCUTEN"              "Q_V TENDENCY DUE TO CUMULUS SCHEME"       "kg kg-1 s-1"
+state    real  RQRCUTEN        ikj      misc        1         -      r        "RQRCUTEN"              "Q_R TENDENCY DUE TO CUMULUS SCHEME"       "kg kg-1 s-1"
+state    real  RQCCUTEN        ikj      misc        1         -      r        "RQCCUTEN"              "Q_C TENDENCY DUE TO CUMULUS SCHEME"       "kg kg-1 s-1"
+state    real  RQSCUTEN        ikj      misc        1         -      r        "RQSCUTEN"              "Q_S TENDENCY DUE TO CUMULUS SCHEME"       "kg kg-1 s-1"
+state    real  RQICUTEN        ikj      misc        1         -      r        "RQICUTEN"              "Q_I TENDENCY DUE TO CUMULUS SCHEME"       "kg kg-1 s-1"
+state    real  RQCNCUTEN       ikj      misc        1         -      r        "RQCNCUTEN"             "Q_CN TENDENCY DUE TO CUMULUS SCHEME"      "# kg-1 s-1"
+state    real  RQINCUTEN       ikj      misc        1         -      r        "RQINCUTEN"             "Q_IN TENDENCY DUE TO CUMULUS SCHEME"      "# kg-1 s-1"
+state    real  W0AVG           ikj      misc        1         -      r        "W0AVG"                 "AVERAGE VERTICAL VELOCITY FOR KF CUMULUS SCHEME"         "m s-1"
+
+state    real  RAINC            ij      misc        1         -      rh01du   "RAINC"                 "ACCUMULATED TOTAL CUMULUS PRECIPITATION"                 "mm"      
+state    real  RAINSH           ij      misc        1         -      rh01du   "RAINSH"                "ACCUMULATED SHALLOW CUMULUS PRECIPITATION"               "mm"
+state    real  RAINNC           ij      misc        1         -      rh01du   "RAINNC"                "ACCUMULATED TOTAL GRID SCALE PRECIPITATION"              "mm"      
+state  integer I_RAINC          ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_RAINC"            "BUCKET FOR RAINC"                    ""
+state  integer I_RAINNC         ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_RAINNC"           "BUCKET FOR RAINNC"                   ""
+state    real  PRATEC           ij      misc        1         -      r        "PRATEC"                "PRECIP RATE FROM CUMULUS SCHEME"                         "mm s-1"
+state    real  PRATESH          ij      misc        1         -      r        "PRATESH"               "PRECIP RATE FROM SHALLOW CUMULUS SCHEME"                 "mm s-1"
+state    real  RAINCV           ij      misc        1         -      r        "RAINCV"                "TIME-STEP CUMULUS PRECIPITATION"                         "mm"
+state    real  RAINSHV          ij      misc        1         -      r        "RAINSHV"               "TIME-STEP SHALLOW CUMULUS PRECIPITATION"                 "mm"
+state    real  RAINNCV          ij      misc        1         -      r        "RAINNCV"               "TIME-STEP NONCONVECTIVE PRECIPITATION"                   "mm"
+state    real  RAINBL           ij      misc        1         -      r        "RAINBL"                "PBL TIME-STEP TOTAL PRECIPITATION"                       "mm"      
+state    real  SNOWNC           ij      misc        1         -      rhdu     "SNOWNC"                "ACCUMULATED TOTAL GRID SCALE SNOW AND ICE"               "mm"
+state    real  GRAUPELNC        ij      misc        1         -      rhdu     "GRAUPELNC"             "ACCUMULATED TOTAL GRID SCALE GRAUPEL"                    "mm"
+state    real  HAILNC           ij      misc        1         -      rhdu     "HAILNC"                "ACCUMULATED TOTAL GRID SCALE HAIL"                       "mm"
+state    real  SNOWNCV          ij      misc        1         -      r        "SNOWNCV"               "TIME-STEP NONCONVECTIVE SNOW AND ICE"                    "mm"
+state    real  GRAUPELNCV       ij      misc        1         -      r        "GRAUPELNCV"            "TIME-STEP NONCONVECTIVE GRAUPEL"                         "mm"
+state    real  HAILNCV          ij      misc        1         -      r        "HAILNCV"               "TIME-STEP NONCONVECTIVE HAIL"                            "mm"
+state    real  refl_10cm       ikj      dyn_em      1         -      hdu      "refl_10cm"             "Radar reflectivity (lamda = 10 cm)"  "dBZ"
+state    real  mskf_refl_10cm  ikj      dyn_em      1         -      hdu      "mskf_refl_10cm"        "Full Radar reflectivity (lamda = 10 cm)"  "dBZ"
+state    real    th_old          ikj      misc        1         -      rusd        "TH_OLD"              "Old Value of Th"   "K"
+state    real    qv_old          ikj      misc        1         -      rusd        "QV_OLD"              "Old Value of qv"   "kg kg-1"
+state    real    vmi3d          ikj     misc        1         -     hdu       "v_ice"                 "Mass-weighted ice fallspeed cat 1"  "m s-1"
+state    real    di3d           ikj     misc        1         -     hdu       "d_ice"                 "Mass-weighted mean ice size cat 1"  "m"
+state    real    rhopo3d        ikj     misc        1         -     hdu       "rho_ice"               "Mass-weighted mean ice density cat 1"  "kg m-3"
+state    real    phii3d        ikj     misc        1         -     hdu       "phi_ice"               "Number-weighted mean ice aspect ratio cat 1"  ""
+state    real    vmi3d_2          ikj     misc        1         -     hdu     "v_ice2"                 "Mass-weighted ice fallspeed cat 2"  "m s-1"
+state    real    di3d_2           ikj     misc        1         -     hdu     "d_ice2"                 "Mass-weighted mean ice size cat 2"  "m"
+state    real    rhopo3d_2        ikj     misc        1         -     hdu     "rho_ice2"               "Mass-weighted mean ice density cat 2"  "kg m-3"
+state    real    phii3d_2        ikj     misc        1         -     hdu       "phi_ice2"               "Number-weighted mean ice aspect ratio cat 2"  ""
+state    real    vmi3d_3          ikj     misc        1         -     hdu     "v_ice3"                 "Mass-weighted ice fallspeed cat 3"  "m s-1"
+state    real    di3d_3           ikj     misc        1         -     hdu     "d_ice3"                 "Mass-weighted mean ice size cat 3"  "m"
+state    real    rhopo3d_3        ikj     misc        1         -     hdu     "rho_ice3"               "Mass-weighted mean ice density cat 3"  "kg m-3"
+state    real    phii3d_3        ikj     misc        1         -     hdu       "phi_ice3"               "Number-weighted mean ice aspect ratio cat 3"  ""
+state    real    itype          ikj     misc        1         -     hdu       "ice_type"             "Diagnostic ice type cat 1 ISHMAEL microphysics"  ""
+state    real    itype_2          ikj     misc        1         -     hdu       "ice_type2"             "Diagnostic ice type cat 2 ISHMAEL microphysics"  ""
+state    real    itype_3          ikj     misc        1         -     hdu       "ice_type3"             "Diagnostic ice type cat 3 ISHMAEL microphysics"  ""
+
+# LIGHTNING NUDGING
+#state    real    ltg_dat        ij      misc        1         -      r         "ltg_dat"               "gridded lightning data"  "Flash per xkm x xkm per LAD_INT sec"
+# END LIGHTNING NUDGING
+state    real  NCA              ij      misc        1         -      r        "NCA"                   "COUNTER OF THE CLOUD RELAXATION TIME IN KF CUMULUS SCHEME"    ""      
+state    integer  LOWLYR        ij      misc        1         -     -         "LOWLYR"                "INDEX OF LOWEST MODEL LAYER ABOVE THE GROUND IN BMJ SCHEME"   ""      
+state    real  MASS_FLUX        ij      misc        1         -      r        "MASS_FLUX"             "DOWNDRAFT MASS FLUX FOR IN GRELL CUMULUS SCHEME"  "mb hour-1"
+# ckay
+state    real  cldfra_dp        ikj     misc        1         -      r         "CLDFRA_DP"             "DEEP CONVECTIVE CLOUD FRACTION FROM KF"  ""
+state    real  cldfra_sh        ikj     misc        1         -      r         "CLDFRA_SH"             "SHALLOW CONVECTIVE CLOUD FRACTION FROM KF"  ""
+state    real  w_up             ikj     misc        1         -      rdu      "W_UP"                  "EFFECTIVE SUBGRID VELOCITY FROM KF"  "m s-1"
+state    real  udr_kf           ikj     misc        1         -      rh    "UDR_KF"                "UPDRAFT DETRAINMENT RATE FROM KF"  "kg s-1"
+state    real  ddr_kf           ikj     misc        1         -      rh    "DDR_KF"                "DOWNDRAFT DETRAINMENT RATE FROM KF"  "kg s-1"
+state    real  uer_kf           ikj     misc        1         -      rh    "UER_KF"                "UPDRAFT ENTRAINMENT RATE FROM KF"  "kg s-1"
+state    real  der_kf           ikj     misc        1         -      rh    "DER_KF"                "DOWNDRAFT ENTRAINMENT RATE FROM KF"  "kg s-1"
+state    real  timec_kf         ij      misc        1         -      rh    "TIMEC_KF"              "CONVECTIVE TIMESCALE FROM MSKF"  "s"
+state    real  apr_gr           ij      misc        1         -      r       "APR_GR"                "PRECIP FROM CLOSURE OLD_GRELL"   "mm hour-1"
+state    real  apr_w            ij      misc        1         -      r       "APR_W"                 "PRECIP FROM CLOSURE W"           "mm hour-1"
+state    real  apr_mc           ij      misc        1         -      r       "APR_MC"                "PRECIP FROM CLOSURE KRISH MV"    "mm hour-1"
+state    real  apr_st           ij      misc        1         -      r       "APR_ST"                "PRECIP FROM CLOSURE STABILITY"   "mm hour-1"
+state    real  apr_as           ij      misc        1         -      r       "APR_AS"                "PRECIP FROM CLOSURE AS-TYPE"     "mm hour-1"
+state    real  apr_capma        ij      misc        1         -      r       "APR_CAPMA"             "PRECIP FROM MAX CAP"             "mm hour-1"
+state    real  apr_capme        ij      misc        1         -      r       "APR_CAPME"             "PRECIP FROM MEAN CAP"            "mm hour-1"
+state    real  apr_capmi        ij      misc        1         -      r       "APR_CAPMI"             "PRECIP FROM MIN CAP"             "mm hour-1"
+state    real  edt_out          ij      misc        1         -      -        "EDT_OUT"             "EDT FROM GD SCHEME"             ""
+state    real  xmb_shallow      ij      misc        1         -      r        "XMB_SHALLOW"             "MASSFLUX FROM SHALLOW CONVECTION (G3 and GF only)"             ""
+state    integer  k22_shallow   ij      misc        1         -      r       "K22_SHALLOW"             "K22 LEVEL FROM SHALLOW CONVECTION (G3 and GF only)"             ""
+state    integer  kbcon_shallow   ij      misc        1         -    r       "KBCON_SHALLOW"             "KBCON LEVEL FROM SHALLOW CONVECTION (G3 and GF only)"             ""
+state    integer  ktop_shallow   ij      misc        1         -     r       "KTOP_SHALLOW"             "KTOP LEVEL FROM SHALLOW CONVECTION (G3 and GF only)"             ""
+state    integer  k22_deep     ij      misc        1         -       -       "K22_DEEP"             "K22 LEVEL FROM DEEPCONVECTION (G3 and GF only)"             ""
+state    integer  kbcon_deep     ij      misc        1         -     -       "KBCON_DEEP"             "KBCON LEVEL FROM DEEP CONVECTION (G3 and GF only)"             ""
+state    integer  ktop_deep     ij      misc        1         -      -       "KTOP_DEEP"             "KTOP LEVEL FROM DEEP CONVECTION (G3 and GF only)"             ""
+state    real  xf_ens           ije     misc        1         Z      r        "XF_ENS"                "MASS FLUX PDF IN GRELL CUMULUS SCHEME"     "mb hour-1"
+state    real  pr_ens           ije     misc        1         Z      r        "PR_ENS"                "PRECIP RATE PDF IN GRELL CUMULUS SCHEME"    "mb hour-1"
+state    real  cugd_tten        ikj     misc        1         -      r        "CUGD_TTEN"             "INITIAL TTENDENCY OUT OFF GRELL CUMULUS SCHEME"  "K s-1"
+state    real  cugd_qvten       ikj     misc        1         -      r        "CUGD_QVTEN"            "INITIAL QTENDENCY OUT OFF GRELL CUMULUS SCHEME"  "K s-1"
+state    real  cugd_ttens       ikj     misc        1         -      r        "CUGD_TTENS"            "INITIAL SUBSIDENCE TTENDENCY OUT OFF GRELL CUMULUS SCHEME"  "K s-1"
+state    real  cugd_qvtens      ikj     misc        1         -      r        "CUGD_QVTENS"           "INITIAL SUBSIDNCE QTENDENCY OUT OFF GRELL CUMULUS SCHEME"  "K s-1"
+state    real  cugd_qcten       ikj     misc        1         -      r        "CUGD_QCTEN"            "INITIAL TEMPERATURE TENDENCY OUT OFF GRELL CUMULUS SCHEME"  "K s-1"
+state    real  GD_CLOUD         ikj      misc        1         -      r      "GD_CLOUD"              "CLOUD WATER/ICE MIXING RAIO IN GD CLOUD"         "kg kg-1"
+state    real  GD_CLOUD2        ikj      misc        1         -      r      "GD_CLOUD2"              "TEST for GD CLOUD"         "kg kg-1"
+state    real  GD_CLDFR         ikj      misc        1         -      r     "GD_CLDFR"              "GD CLOUD Fraction"         " ? "
+state    real  RAINCV_A           ij      misc        1         -      r      "RAINCV_A"             "taveragd TIME-STEP CUMULUS PRECIPITATION"                         "mm"
+state    real  RAINCV_B           ij      misc        1         -      r      "RAINCV_B"             "taveragd TIME-STEP CUMULUS PRECIPITATION"                         "mm"
+state    real  GD_CLOUD_A        ikj      misc        1         -      r      "GD_CLOUD_A"           "taveragd CLOUD WATER MIXING RAIO IN GD CLOUD"         "kg kg-1"
+state    real  GD_CLOUD2_A       ikj      misc        1         -      r      "GD_CLOUD2_A"          "taveragd cloud ice mix ratio in GD"         "kg kg-1"
+state    real  QC_CU             ikj      misc        1         -      r      "QC_CU"                "CLOUD WATER MIXING RATIO FROM A CU SCHEME"         "kg kg-1"
+state    real  QI_CU             ikj      misc        1         -      r      "QI_CU"                "CLOUD ICE MIXUNG RATIO FROM A CU SCHEME"         "kg kg-1"
+state    real  QR_CU            ikj      misc        1         -      rh      "QR_CU"               "RAIN MIXING RATIO FROM A CU SCHEME"         "kg kg-1"
+state    real  QS_CU            ikj      misc        1         -      rh      "QS_CU"               "SNOW MIXING RATIO FROM A CU SCHEME"         "kg kg-1"
+state    real  NC_CU            ikj      misc        1         -      rh      "NC_CU"               "CLOUD WATER NUMBER CONCENTRATION FROM A CU SCHEME"         "kg-1"
+state    real  NI_CU            ikj      misc        1         -      rh      "NI_CU"               "CLOUD ICE NUMBER CONCENTRATION FROM A CU SCHEME"         "kg-1"
+state    real  NR_CU            ikj      misc        1         -      rh      "NR_CU"               "RAIN NUMBER CONCENTRATION FROM A CU SCHEME"         "kg-1"
+state    real  NS_CU            ikj      misc        1         -      rh      "NS_CU"               "SNOW NUMBER CONCENTRATION FROM A CU SCHEME"         "kg-1"
+state    real  CCN_CU           ikj      misc        1         -      rh      "CCN_CU"              "CLOUD CONDENSATION NUCLEI CONCENTRATION FROM A CU SCHEME"         "kg-1"
+state    real  CU_UAF            ij      misc        1         -      rh      "CU_UAF"              "CU Updraft Area Fraction"         ""
+state    real  EFCS             ikj      misc        1         -      rh      "EFCS"                "Sub-grid Scale Cloud Effective Radius"         "um"
+state    real  EFIS             ikj      misc        1         -      rh      "EFIS"                "Sub-grid Scale Ice Effective Radius"       "um"
+state    real  EFCG             ikj      misc        1         -      rh      "EFCG"                "Grid Scale Cloud Effective Radius"         "um"
+state    real  EFIG             ikj      misc        1         -      rh      "EFIG"                "Grid Scale Ice Effective Radius"       "um"
+state    real  EFSG             ikj      misc        1         -      rh      "EFSG"                "Grid Scale Snow Effective Radius"       "um"
+state    real  EFSS             ikj      misc        1         -      rh      "EFSS"                "Subgrid Scale Snow Effective Radius"       "um"
+state    real  WACT             ikj      misc        1         -      rh      "WACT"                "Aerosol Activation Updraft"       "m s-1"
+state    real  CCN1_GS          ikj      misc        1         -      rh      "CCN1_GS"             "Grid Scale Cloud Condensation Nuclei at S=0.02%"       "#/cm-3"
+state    real  CCN2_GS          ikj      misc        1         -      rh      "CCN2_GS"             "Grid Scale Cloud Condensation Nuclei at S=0.05%"       "#/cm-3"
+state    real  CCN3_GS          ikj      misc        1         -      rh      "CCN3_GS"             "Grid Scale Cloud Condensation Nuclei at S=0.1%"       "#/cm-3"
+state    real  CCN4_GS          ikj      misc        1         -      rh      "CCN4_GS"             "Grid Scale Cloud Condensation Nuclei at S=0.2%"       "#/cm-3"
+state    real  CCN5_GS          ikj      misc        1         -      rh      "CCN5_GS"             "Grid Scale Cloud Condensation Nuclei at S=0.3%"       "#/cm-3"
+state    real  CCN6_GS          ikj      misc        1         -      rh      "CCN6_GS"             "Grid Scale Cloud Condensation Nuclei at S=0.5%"       "#/cm-3"
+state    real  CCN7_GS          ikj      misc        1         -      rh      "CCN7_GS"             "Grid Scale Cloud Condensation Nuclei at S=1.0%"       "#/cm-3"
+state    real  QC_BL             ikj      misc        1         -      r      "QC_BL"                "CLOUD WATER MIXING RATIO IN PBL schemes"          "kg kg-1"
+state integer  STEPAVE_COUNT     -        misc        1         -      r      "STEPAVE_COUNT"        "time steps contained in averages for convective transport" ""
+
+#
+state    real  RTHFTEN          ikj     misc        1         -      r        "RTHFTEN"               "TOTAL ADVECTIVE POTENTIAL TEMPERATURE TENDENCY"  "K s-1"
+state    real  RQVFTEN          ikj     misc        1         -      r        "RQVFTEN"               "TOTAL ADVECTIVE MOISTURE TENDENCY"     "kg kg-1 s-1"
+
+state integer  STEPCU          -        misc        1         -      r        "STEPCU"                "NUMBER OF FUNDAMENTAL TIMESTEPS BETWEEN CONVECTION CALLS"  ""
+                                                
+state    real  RTHRATEN        ikj      misc        1         -      rd       "RTHRATEN"              "THETA TENDENCY DUE TO RADIATION"              "K s-1"
+state    real  RTHRATENLW      ikj      misc        1         -      r        "RTHRATLW"              "UNCOUPLED THETA TENDENCY DUE TO LONG WAVE RADIATION"    "K s-1"
+state    real  RTHRATENSW      ikj      misc        1         -      r        "RTHRATSW"              "UNCOUPLED THETA TENDENCY DUE TO SHORT WAVE RADIATION"   "K s-1"
+state    real  CLDFRA          ikj      misc        1         -      rh       "CLDFRA"                "CLOUD FRACTION"                                       ""
+state    real  CLDFRA_OLD      ikj      misc        1         -      r        "CLDFRA_OLD"            "previous time level cldfra"                           ""
+state    real  CLDFRA_BL       ikj      misc        1         -      -        "CLDFRA_BL"             "CLOUD FRACTION pbl"                                   ""
+state    real  CLDT             ij      misc        1         -      -        "CFRACT"                "TOTAL CLOUD FRACTION"                                 ""
+#state    real  CLDL             ij      misc        1         -      -        "CFRACL"                "LOW CLOUD FRACTION (ETA GREATER THAN 0.69)"           ""
+#state    real  LWP              ij      misc        1         -      -        "LWP"                   "LIQUID CLOUD WATER PATH"                              "kg m-2"
+state    real  SWDOWN           ij      misc        1         -      rhd      "SWDOWN"                "DOWNWARD SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
+state    real  SWDOWNC          ij      misc        1         -      -        "SWDOWNC"               "DOWNWARD CLEAR-SKY SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
+state    real  GSW              ij      misc        1         -      rd       "GSW"                   "NET SHORT WAVE FLUX AT GROUND SURFACE"           "W m-2"      
+state    real  GLW              ij      misc        1         -      rhd      "GLW"                   "DOWNWARD LONG WAVE FLUX AT GROUND SURFACE"            "W m-2"      
+state    real  SWNORM           ij      misc        1         -      rhd      "SWNORM"                "NORMAL SHORT WAVE FLUX AT GROUND SURFACE (SLOPE-DEPENDENT)"           "W m-2"
+state    real  diffuse_frac     ij      misc        1         -      rd       "DIFFUSE_FRAC"          "DIFFUSE FRACTION OF SURFACE SHORTWAVE IRRADIANCE"       ""
+# WRF-Solar
+state   real    swddir       ij     misc         1         -     rd     "SWDDIR"     "Shortwave surface downward direct irradiance" "W m-2" ""
+state   real    swddirc      ij     misc         1         -     rd     "SWDDIRC"    "Clear-sky Shortwave surface downward direct irradiance" "W m-2" ""
+state   real    swddni       ij     misc         1         -     rd     "SWDDNI"     "Shortwave surface downward direct normal irradiance" "W m-2" ""
+state   real    swddnic      ij     misc         1         -     rd     "SWDDNIC"    "Clear-sky Shortwave surface downward direct normal irradiance" "W m-2" ""
+state   real    swddif       ij     misc         1         -     rd     "SWDDIF"     "Shortwave surface downward diffuse irradiance" "W m-2" ""
+state   real    Gx           ij     misc         1         -     rd     "Gx" "" ""
+state   real    Bx           ij     misc         1         -     rd     "Bx" "" ""
+state   real    gg           ij     misc         1         -     rd     "gg" "" ""
+state   real    bb           ij     misc         1         -     rd     "bb" "" ""
+state   real    coszen_ref   ij     misc         1         -     rd     "coszen_ref" "" ""
+state   real    swdown_ref   ij     misc         1         -     rd     "swdown_ref" "" ""
+state   real    swddir_ref   ij     misc         1         -     rd     "swddir_ref" "" ""
+# jararias 2013/11
+state   real    aod5502d     ij     misc         1         -     i{15}r "AOD5502D"   "Total aerosol optical depth at 550 nm" ""
+state   real    angexp2d     ij     misc         1         -     i{15}r "ANGEXP2D"   "Aerosol Angstrom exponent" ""
+state   real    aerssa2d     ij     misc         1         -     i{15}r "AERSSA2D"   "Aerosol single-scattering albedo" ""
+state   real    aerasy2d     ij     misc         1         -     i{15}r "AERASY2D"   "Aerosol asymmetry factor" ""
+state   real    aod5503d     ikj    misc         1         -     r      "AOD5503D"   "3D aerosol optical depth at 550 nm" ""
+state   real    taod5503d    ikj    misc         1         -     r      "TAOD5503D"  "3D aerosol optical depth at 550 nm (MP=28)" ""
+state   real    taod5502d    ij     misc         1         -     rh     "TAOD5502D"  "2D aerosol optical depth at 550 nm (MP=28)" ""
+
+# CLWRF-WRF4G
+state    real  T2MIN            ij      misc        1         -      rh3      "T2MIN"                 "MINIMUM TEMPERATURE AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                      "K"
+state    real  T2MAX            ij      misc        1         -      rh3      "T2MAX"                 "MAXIMUM TEMPERATURE AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                      "K"
+state    real  TT2MIN           ij      misc        1         -      rh3      "TT2MIN"                 "TIME OF MINIMUM TEMPERATURE AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"             "minute"
+state    real  TT2MAX           ij      misc        1         -      rh3      "TT2MAX"                 "TIME OF MAXIMUM TEMPERATURE AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"             "minute"
+state    real  T2MEAN           ij      misc        1         -      rh3      "T2MEAN"                 "MEAN TEMPERATURE AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                        "K"
+state    real  T2STD            ij      misc        1         -      rh3      "T2STD"                  "STANDARD DEV. TEMPERATURE AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"               "k"
+state    real  Q2MIN            ij      misc        1         -      rh3      "Q2MIN"                  "MINIMUM WATER VAPOR MIX. RAT. AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"           "kg kg-1"
+state    real  Q2MAX            ij      misc        1         -      rh3      "Q2MAX"                  "MAXIMUM WATER VAPOR MIX. RAT. AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"           "kg kg-1"
+state    real  TQ2MIN           ij      misc        1         -      rh3      "TQ2MIN"                 "TIME OF MINIMUM WATER VAPOR MIX. RAT. AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"   "minute"
+state    real  TQ2MAX           ij      misc        1         -      rh3      "TQ2MAX"                 "TIME OF MAXIMUM WATER VAPOR MIX. RAT. AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"   "minute"
+state    real  Q2MEAN           ij      misc        1         -      rh3      "Q2MEAN"                 "MEAN WATER VAPOR MIX. RAT. AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"              "kg kg-1"
+state    real  Q2STD            ij      misc        1         -      rh3      "Q2STD"                  "STANDARD DEV. WATER VAPOR MIX. RAT. AT 2M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"     "kg kg-1"
+state    real  SKINTEMPMIN      ij      misc        1         -      rh3      "SKINTEMPMIN"            "MINIMUM SKIN TEMPERATURE IN DIAGNOSTIC OUTPUT INTERVAL"                             "K"
+state    real  SKINTEMPMAX      ij      misc        1         -      rh3      "SKINTEMPMAX"            "MAXIMUM SKIN TEMPERATURE IN DIAGNOSTIC OUTPUT INTERVAL"                             "K"
+state    real  TSKINTEMPMIN     ij      misc        1         -      rh3      "TSKINTEMPMIN"           "TIME OF MINIMUM SKIN TEMPERATURE IN DIAGNOSTIC OUTPUT INTERVAL"                     "minute"
+state    real  TSKINTEMPMAX     ij      misc        1         -      rh3      "TSKINTEMPMAX"           "TIME OF MAXIMUM SKIN TEMPERATURE IN DIAGNOSTIC OUTPUT INTERVAL"                     "minute"
+state    real  SKINTEMPMEAN     ij      misc        1         -      rh3      "SKINTEMPMEAN"           "MEAN SKIN TEMPERATURE IN DIAGNOSTIC OUTPUT INTERVAL"                                "K"
+state    real  SKINTEMPSTD      ij      misc        1         -      rh3      "SKINTEMPSTD"            "STANDARD DEV. OF SKIN TEMPERATURE IN CLWRF HOURS"                     "K"
+state    real  U10MAX           ij      misc        1         -      rh3      "U10MAX"                 "MAXIMUM U AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                              "m s-1"
+state    real  V10MAX           ij      misc        1         -      rh3      "V10MAX"                 "MAXIMUM V AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                              "m s-1"
+state    real  SPDUV10MAX       ij      misc        1         -      rh3      "SPDUV10MAX"             "MAXIMUM WIND SPEED AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                     "m s-1"
+state    real  TSPDUV10MAX      ij      misc        1         -      rh3      "TSPDUV10MAX"            "TIME OF MAXIMUM WIND SPEED AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"             "minute"
+state    real  U10MEAN          ij      misc        1         -      rh3      "U10MEAN"                "MEAN U AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                                 "m s-1"
+state    real  V10MEAN          ij      misc        1         -      rh3      "V10MEAN"                "MEAN V AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                                 "m s-1"
+state    real  SPDUV10MEAN      ij      misc        1         -      rh3      "SPDUV10MEAN"            "MEAN WIND SPEED AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                        "m s-1"
+state    real  U10STD           ij      misc        1         -      rh3      "U10STD"                 "STANDARD DEV. U AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                        "m s-1"
+state    real  V10STD           ij      misc        1         -      rh3      "V10STD"                 "STANDARD DEV. V AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"                        "m s-1"
+state    real  SPDUV10STD       ij      misc        1         -      rh3      "SPDUV10STD"             "STANDARD DEV. WIND SPEED AT 10M HEIGHT IN DIAGNOSTIC OUTPUT INTERVAL"               "m s-1"
+state    real  RAINCVMAX        ij      misc        1         -      rh3      "RAINCVMAX"              "MAXIMUM CUMULUS PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"                   "kg m-2 s-1"
+state    real  RAINNCVMAX       ij      misc        1         -      rh3      "RAINNCVMAX"              "MAXIMUM GRID SCALE PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"                "kg m-2 s-1"
+state    real  TRAINCVMAX       ij      misc        1         -      rh3      "TRAINCVMAX"             "TIME OF MAXIMUM CUMULUS PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"           "minute"
+state    real  TRAINNCVMAX      ij      misc        1         -      rh3      "TRAINNCVMAX"            "TIME OF MAXIMUM GRID SCALE PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"        "minute"
+state    real  RAINCVMEAN       ij      misc        1         -      rh3      "RAINCVMEAN"             "MEAN CUMULUS PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"                      "kg m-2 s-1"
+state    real  RAINNCVMEAN      ij      misc        1         -      rh3      "RAINNCVMEAN"            "MEAN GRID SCALE PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"                   "kg m-2 s-1"
+state    real  RAINCVSTD        ij      misc        1         -      rh3      "RAINCVSTD"              "STANDARD DEV. CUMULUS PRECIPITATION FLUX IN DIAGNOSTIC OUTPUT INTERVAL"             "kg m-2 s-1"
+state    real  RAINNCVSTD       ij      misc        1         -      rh3      "RAINNCVSTD"             "STANDARD DEV. GRID SCALE PRECIPITATION IN FLUX DIAGNOSTIC OUTPUT INTERVAL"          "kg m-2 s-1"
+state    integer  nsteps         -      misc        -         -       r       "NSTEPS"                 "Time Step Counter"           ""
+
+# upward and downward clearsky and total diagnostic fluxes for CAM radiation
+state    real  ACSWUPT          ij      misc        1         -      rhdu     "ACSWUPT"               "ACCUMULATED UPWELLING SHORTWAVE FLUX AT TOP"          "J m-2"
+state    real  ACSWUPTC         ij      misc        1         -      rhdu     "ACSWUPTC"              "ACCUMULATED UPWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "J m-2"
+state    real  ACSWDNT          ij      misc        1         -      rhdu     "ACSWDNT"               "ACCUMULATED DOWNWELLING SHORTWAVE FLUX AT TOP"          "J m-2"
+state    real  ACSWDNTC         ij      misc        1         -      rhdu     "ACSWDNTC"              "ACCUMULATED DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "J m-2"
+state    real  ACSWUPB          ij      misc        1         -      rhdu     "ACSWUPB"               "ACCUMULATED UPWELLING SHORTWAVE FLUX AT BOTTOM"          "J m-2"
+state    real  ACSWUPBC         ij      misc        1         -      rhdu     "ACSWUPBC"              "ACCUMULATED UPWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "J m-2"
+state    real  ACSWDNB          ij      misc        1         -      rhdu     "ACSWDNB"               "ACCUMULATED DOWNWELLING SHORTWAVE FLUX AT BOTTOM"          "J m-2"
+state    real  ACSWDNBC         ij      misc        1         -      rhdu     "ACSWDNBC"              "ACCUMULATED DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "J m-2"
+state    real  ACLWUPT          ij      misc        1         -      rhdu     "ACLWUPT"               "ACCUMULATED UPWELLING LONGWAVE FLUX AT TOP"          "J m-2"
+state    real  ACLWUPTC         ij      misc        1         -      rhdu     "ACLWUPTC"              "ACCUMULATED UPWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "J m-2"
+state    real  ACLWDNT          ij      misc        1         -      rhdu     "ACLWDNT"               "ACCUMULATED DOWNWELLING LONGWAVE FLUX AT TOP"          "J m-2"
+state    real  ACLWDNTC         ij      misc        1         -      rhdu     "ACLWDNTC"              "ACCUMULATED DOWNWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "J m-2"
+state    real  ACLWUPB          ij      misc        1         -      rhdu     "ACLWUPB"               "ACCUMULATED UPWELLING LONGWAVE FLUX AT BOTTOM"          "J m-2"
+state    real  ACLWUPBC         ij      misc        1         -      rhdu     "ACLWUPBC"              "ACCUMULATED UPWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "J m-2"
+state    real  ACLWDNB          ij      misc        1         -      rhdu     "ACLWDNB"               "ACCUMULATED DOWNWELLING LONGWAVE FLUX AT BOTTOM"          "J m-2"
+state    real  ACLWDNBC         ij      misc        1         -      rhdu     "ACLWDNBC"              "ACCUMULATED DOWNWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "J m-2"
+state integer  I_ACSWUPT        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWUPT"     "BUCKET FOR UPWELLING SHORTWAVE FLUX AT TOP"          "J m-2"
+state integer  I_ACSWUPTC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWUPTC"    "BUCKET FOR UPWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "J m-2"
+state integer  I_ACSWDNT        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWDNT"     "BUCKET FOR DOWNWELLING SHORTWAVE FLUX AT TOP"          "J m-2"
+state integer  I_ACSWDNTC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWDNTC"    "BUCKET FOR DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "J m-2"
+state integer  I_ACSWUPB        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWUPB"     "BUCKET FOR UPWELLING SHORTWAVE FLUX AT BOTTOM"          "J m-2"
+state integer  I_ACSWUPBC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWUPBC"    "BUCKET FOR UPWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "J m-2"
+state integer  I_ACSWDNB        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWDNB"     "BUCKET FOR DOWNWELLING SHORTWAVE FLUX AT BOTTOM"          "J m-2"
+state integer  I_ACSWDNBC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACSWDNBC"    "BUCKET FOR DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "J m-2"
+state integer  I_ACLWUPT        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWUPT"     "BUCKET FOR UPWELLING LONGWAVE FLUX AT TOP"          "J m-2"
+state integer  I_ACLWUPTC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWUPTC"    "BUCKET FOR UPWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "J m-2"
+state integer  I_ACLWDNT        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWDNT"     "BUCKET FOR DOWNWELLING LONGWAVE FLUX AT TOP"          "J m-2"
+state integer  I_ACLWDNTC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWDNTC"    "BUCKET FOR DOWNWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "J m-2"
+state integer  I_ACLWUPB        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWUPB"     "BUCKET FOR UPWELLING LONGWAVE FLUX AT BOTTOM"          "J m-2"
+state integer  I_ACLWUPBC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWUPBC"    "BUCKET FOR UPWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "J m-2"
+state integer  I_ACLWDNB        ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWDNB"     "BUCKET FOR DOWNWELLING LONGWAVE FLUX AT BOTTOM"          "J m-2"
+state integer  I_ACLWDNBC       ij      misc        1         -      rhd=(interp_fcni)u=(copy_fcni)     "I_ACLWDNBC"    "BUCKET FOR DOWNWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "J m-2"
+state    real  SWUPT            ij      misc        1         -      rhdu     "SWUPT"                 "INSTANTANEOUS UPWELLING SHORTWAVE FLUX AT TOP"          "W m-2"
+state    real  SWUPTC           ij      misc        1         -      rhdu     "SWUPTC"                "INSTANTANEOUS UPWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "W m-2"
+state    real  SWUPTCLN         ij      misc        1         -      rhdu     "SWUPTCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY SHORTWAVE FLUX AT TOP" "W m-2"
+state    real  SWDNT            ij      misc        1         -      rhdu     "SWDNT"                 "INSTANTANEOUS DOWNWELLING SHORTWAVE FLUX AT TOP"          "W m-2"
+state    real  SWDNTC           ij      misc        1         -      rhdu     "SWDNTC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT TOP" "W m-2"
+state    real  SWDNTCLN         ij      misc        1         -      rhdu     "SWDNTCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY SHORTWAVE FLUX AT TOP" "W m-2"
+state    real  SWUPB            ij      misc        1         -      rhdu     "SWUPB"                 "INSTANTANEOUS UPWELLING SHORTWAVE FLUX AT BOTTOM"          "W m-2"
+state    real  SWUPBC           ij      misc        1         -      rhdu     "SWUPBC"                "INSTANTANEOUS UPWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
+state    real  SWUPBCLN         ij      misc        1         -      rhdu     "SWUPBCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
+state    real  SWDNB            ij      misc        1         -      rhdu     "SWDNB"                 "INSTANTANEOUS DOWNWELLING SHORTWAVE FLUX AT BOTTOM"          "W m-2"
+state    real  SWDNBC           ij      misc        1         -      rhdu     "SWDNBC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
+state    real  SWDNBCLN         ij      misc        1         -      rhdu     "SWDNBCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY SHORTWAVE FLUX AT BOTTOM" "W m-2"
+state    real  LWUPT            ij      misc        1         -      rhdu     "LWUPT"                 "INSTANTANEOUS UPWELLING LONGWAVE FLUX AT TOP"          "W m-2"
+state    real  LWUPTC           ij      misc        1         -      rhdu     "LWUPTC"                "INSTANTANEOUS UPWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "W m-2"
+state    real  LWUPTCLN         ij      misc        1         -      rhdu     "LWUPTCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY LONGWAVE FLUX AT TOP" "W m-2"
+state    real  LWDNT            ij      misc        1         -      rhdu     "LWDNT"                 "INSTANTANEOUS DOWNWELLING LONGWAVE FLUX AT TOP"          "W m-2"
+state    real  LWDNTC           ij      misc        1         -      rhdu     "LWDNTC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY LONGWAVE FLUX AT TOP" "W m-2"
+state    real  LWDNTCLN         ij      misc        1         -      rhdu     "LWDNTCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY LONGWAVE FLUX AT TOP" "W m-2"
+state    real  LWUPB            ij      misc        1         -      rhdu     "LWUPB"                 "INSTANTANEOUS UPWELLING LONGWAVE FLUX AT BOTTOM"          "W m-2"
+state    real  LWUPBC           ij      misc        1         -      rhdu     "LWUPBC"                "INSTANTANEOUS UPWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
+state    real  LWUPBCLN         ij      misc        1         -      rhdu     "LWUPBCLN"              "INSTANTANEOUS UPWELLING CLEAN SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
+state    real  LWDNB            ij      misc        1         -      rhdu     "LWDNB"                 "INSTANTANEOUS DOWNWELLING LONGWAVE FLUX AT BOTTOM"          "W m-2"
+state    real  LWDNBC           ij      misc        1         -      rhdu     "LWDNBC"                "INSTANTANEOUS DOWNWELLING CLEAR SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
+state    real  LWDNBCLN         ij      misc        1         -      rhdu     "LWDNBCLN"              "INSTANTANEOUS DOWNWELLING CLEAN SKY LONGWAVE FLUX AT BOTTOM" "W m-2"
+state    real  SWCF             ij      misc        1         -      r        "SWCF"                  "SHORT WAVE CLOUD FORCING AT TOA"                     "W m-2"
+state    real  LWCF             ij      misc        1         -      r        "LWCF"                  "LONG WAVE CLOUD FORCING AT TOA"                      "W m-2"
+state    real  OLR              ij      misc        1         -      rh        "OLR"                   "TOA OUTGOING LONG WAVE"                              "W m-2"
+
+# these next 2 are for the HFSoLE/PET demo; writing these to auxhist1 output over MCEL for coupling
+# with wave model, only if compiled with -DMCELIO, JM 2003/05/29
+state    real  XLAT_U           ij      dyn_em      1         X     i012rhdu=(copy_fcnm)         "XLAT_U"              "LATITUDE, SOUTH IS NEGATIVE"                                          "degree_north"
+state    real  XLONG_U          ij      dyn_em      1         X     i012rhd=(interp_fcn_blint_ll:xlat_u,input_from_file)u=(copy_fcnm)         "XLONG_U"             "LONGITUDE, WEST IS NEGATIVE"                                          "degree_east"
+state    real  XLAT_V           ij      dyn_em      1         Y     i012rhdu=(copy_fcnm)         "XLAT_V"              "LATITUDE, SOUTH IS NEGATIVE"                                          "degree_north"
+state    real  XLONG_V          ij      dyn_em      1         Y     i012rhd=(interp_fcn_blint_ll:xlat_v,input_from_file)u=(copy_fcnm)         "XLONG_V"             "LONGITUDE, WEST IS NEGATIVE"                                          "degree_east"
+state    real  ALBEDO           ij      misc        1         -      rh          "ALBEDO"                   "ALBEDO"
+state    real  CLAT             ij      misc        1         -     i012rhdu=(copy_fcnm)         "CLAT"                "COMPUTATIONAL GRID LATITUDE, SOUTH IS NEGATIVE"                       "degree_north"
+state    real  ALBBCK           ij      misc        1         -     i0124rh   "ALBBCK"                "BACKGROUND ALBEDO"        ""
+state    real  EMBCK            ij      misc        1         -      r        "EMBCK"                 "BACKGROUND EMISSIVITY"         ""
+state    real  EMISS            ij      misc        1         -      rh       "EMISS"                 "SURFACE EMISSIVITY"         "" 
+state    real  SNOTIME          ij      misc        1         -      r        "SNOTIME"               "SNOTIME"         "" 
+state    real  NOAHRES          ij      misc        1         -      h        "NOAHRES"               "RESIDUAL OF THE NOAH SURFACE ENERGY BUDGET" "W m{-2}"
+state    real  CLDEFI           ij      misc        1         -      r        "CLDEFI"                "precipitation efficiency in BMJ SCHEME"    ""      
+state integer  STEPRA          -        misc        1         -      r        "STEPRA"                "NUMBER OF FUNDAMENTAL TIMESTEPS BETWEEN RADIATION CALLS"        ""
+                                                
+state    real  RUBLTEN         ikj      misc        1         -      r        "RUBLTEN"               "X WIND TENDENCY DUE TO PBL PARAMETERIZATION"  "m s-2"
+state    real  RVBLTEN         ikj      misc        1         -      r        "RVBLTEN"               "Y WIND TENDENCY DUE TO PBL PARAMETERIZATION"  "m s-2"
+state    real  RTHBLTEN        ikj      misc        1         -      r        "RTHBLTEN"              "THETA TENDENCY DUE TO PBL PARAMETERIZATION"   "K s-1"
+state    real  RQVBLTEN        ikj      misc        1         -      r        "RQVBLTEN"              "Q_V TENDENCY DUE TO PBL PARAMETERIZATION"     "kg kg-1 s-1"
+state    real  RQCBLTEN        ikj      misc        1         -      r        "RQCBLTEN"              "Q_C TENDENCY DUE TO PBL PARAMETERIZATION"     "kg kg-1 s-1"
+state    real  RQIBLTEN        ikj      misc        1         -      r        "RQIBLTEN"              "Q_I TENDENCY DUE TO PBL PARAMETERIZATION"     "kg kg-1 s-1"
+state    real  RQNIBLTEN       ikj      misc        1         -      r        "RQNIBLTEN"             "Q_NI TENDENCY DUE TO PBL PARAMETERIZATION"    "#  kg-1 s-1"
+
+# For Noah UA changes
+state    real   flx4            ij         -        1         -      -        "FLX4"         "sensible heat from canopy"              "W m{-2}"
+state    real   fvb             ij         -        1         -      -        "FVB"          "fraction of vegetation with snow below" ""
+state    real   fbur            ij         -        1         -      -        "FBUR"         "fraction of vegetation covered by snow" ""
+state    real   fgsn            ij         -        1         -      -        "FGSN"         "fraction of ground covered by snow"     ""
+
+# For Noah-Mosaic  danli
+
+state    real   TSK_mosaic        i{mocat}j     misc        1         -     i02rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TSK_mosaic"      "vegetation temperature"  "K"
+state    real   QSFC_mosaic       i{mocat}j     misc        1         -     i02rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "QSFC_mosaic"     "SPECIFIC HUMIDITY AT LOWER BOUNDARY"  ""
+state    real   TSLB_mosaic       i{mocat2}j    misc        1         Z     i02rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TSLB_mosaic"     "SOIL TEMPERATURE"   "K"
+state    real   SMOIS_mosaic      i{mocat2}j    misc        1         Z     i02rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "SMOIS_mosaic"    "SOIL MOISTURE"     "m3 m-3"
+state    real   SH2O_mosaic       i{mocat2}j    misc        1         Z     i02rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "SH2O_mosaic"     "SOIL LIQUID WATER" "m3 m-3"
+state    real   CANWAT_mosaic     i{mocat}j     misc        1         -     i012rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)    "CANWAT_mosaic"   "CANOPY WATER"             "kg m-2"
+state    real   SNOW_mosaic       i{mocat}j     misc        1         -     i012rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)    "SNOW_mosaic"     "SNOW WATER EQUIVALENT"    "kg m-2"
+state    real   SNOWH_mosaic      i{mocat}j     misc        1         -     i012rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)    "SNOWH_mosaic"    "PHYSICAL SNOW DEPTH"      "m"
+state    real   SNOWC_mosaic      i{mocat}j     misc        1         -     ird=(interp_mask_land_field:lu_index)u=(copy_fcnm)       "SNOWC_mosaic"    "FLAG INDICATING SNOW COVERAGE (1 FOR SNOW COVER)"  ""
+
+state    real   ALBEDO_mosaic     i{mocat}j     misc        1         -     r      "ALBEDO_mosaic"         "albedo"  ""
+state    real   ALBBCK_mosaic     i{mocat}j     misc        1         -     r      "ALBBCK_mosaic"         "background albedo"  ""
+state    real   EMISS_mosaic      i{mocat}j     misc        1         -     r      "EMISS_mosaic"          "emissivity"  ""
+state    real   EMBCK_mosaic      i{mocat}j     misc        1         -     r      "EMBCK_mosaic"          "background emissivity"  ""
+state    real   ZNT_mosaic        i{mocat}j     misc        1         -     r      "ZNT_mosaic"            "time_varying roughness length"  "m"
+state    real   Z0_mosaic         i{mocat}j     misc        1         -     r      "Z0_mosaic"             "background roughness length"  "m"
+state    real   LAI_mosaic        i{mocat}j     misc        1         -     r      "LAI_mosaic"            "LEAF AREA INDEX"             "m-2/m-2"
+state    real   RS_mosaic         i{mocat}j     misc        1         -     r      "RS_mosaic"             "CANOPY RESISTANCE"                "s m-1"
+state    real   HFX_mosaic        i{mocat}j     misc        1         -     r      "HFX_mosaic"            "UPWARD HEAT FLUX AT THE SURFACE"  "W m-2"
+state    real   QFX_mosaic        i{mocat}j     misc        1         -     r      "QFX_mosaic"            "UPWARD MOISTURE FLUX AT THE SURFACE"          "kg m-2 s-1"      
+state    real   LH_mosaic         i{mocat}j     misc        1         -     r      "LH_mosaic"             "LATENT HEAT FLUX AT THE SURFACE"              "W m-2"
+state    real   GRDFLX_mosaic     i{mocat}j     misc        1         -     r      "GRDFLX_mosaic"         "GROUND HEAT FLUX" "W m-2"
+state    real   SNOTIME_mosaic    i{mocat}j     misc        1         -     r      "SNOTIME_mosaic"        "SNOTIME"         "" 
+
+state    real   TR_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TR_URB2D_mosaic"    "ROOF TEMPERATURE"                "K"
+state    real   TB_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TB_URB2D_mosaic"    "WALL TEMPERATURE"                "K"      
+state    real   TG_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TG_URB2D_mosaic"    "GROUND TEMPERATURE"              "K"
+state    real   TC_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TC_URB2D_mosaic"    "CANYON TEMPERATURE"              "K"
+state    real   TS_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TS_URB2D_mosaic"    "URBAN TEMPERATURE"               "K"
+state    real   TS_RUL2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TS_RUL2D_mosaic"    "RURAL TEMPERATURE"               "K"
+state    real   QC_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TC_URB2D_mosaic"    "CANYON SPECIFIC HUMIDITY"              ""
+state    real   UC_URB2D_mosaic   i{mocat}j     misc        1         -     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)     "TC_URB2D_mosaic"    "CANYON WIND SPEED"              "m s-1"
+state    real   TRL_URB3D_mosaic  i{mocat2}j    misc        1         Z     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)      "TRL_URB3D_mosaic"  "ROOF LAYER TEMPERATURE"          "K"
+state    real   TBL_URB3D_mosaic  i{mocat2}j    misc        1         Z     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)      "TBL_URB3D_mosaic"  "WALL LAYER TEMPERATURE"          "K"
+state    real   TGL_URB3D_mosaic  i{mocat2}j    misc        1         Z     rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)      "TGL_URB3D_mosaic"  "ROAD LAYER TEMPERATURE"          "K"
+state    real   SH_URB2D_mosaic   i{mocat}j     misc        1         -     r     "SH_URB2D_mosaic"              "UPWARD HEAT FLUX AT THE SURFACE"     "W m-2"
+state    real   LH_URB2D_mosaic   i{mocat}j     misc        1         -     r     "LH_URB2D_mosaic"              "LATENT HEAT FLUX AT THE SURFACE"     "kg m-2 s-1"      
+state    real   G_URB2D_mosaic    i{mocat}j     misc        1         -     r     "G_URB2D_mosaic"               "GROUND HEAT FLUX  AT THE SURFACE"    "W m-2"
+state    real   RN_URB2D_mosaic   i{mocat}j     misc        1         -     r     "RN_URB2D_mosaic"              "NET RADIATION"                       "W m-2"
+
+state    integer   mosaic_cat_index  iuj        misc        1         Z     i012rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)    "mosaic_cat_index"          "  "   ""
+state    real      landusef2         iuj        misc        1         Z     i012rdu                                                  "LANDUSEF2"      "sorted landuse fraction"  ""
+
+# State vector for etampnew microphysics. Must be declared state because it is not read-once and is needed for restarting.
+state    real  mp_restart_state   p      misc        1         -      r       "MP_RESTART_STATE"       "STATE VECTOR FOR MICROPHYSICS RESTARTS"
+state    real  tbpvs_state        p      misc        1         -      r        "TBPVS_STATE"           "STATE FOR ETAMPNEW MICROPHYSICS"
+state    real  tbpvs0_state       p      misc        1         -      r        "TBPVS0_STATE"          "STATE FOR ETAMPNEW MICROPHYSICS"
+
+# State variables for landuse_init, Must be declared state because they are read in and needed for restarts. Had been SAVE vars in
+# landuse_init (phys/module_physics_init.F)
+state    integer  landuse_isice   -      misc       -          -     r
+state    integer  landuse_lucats  -      misc       -          -     r
+state    integer  landuse_luseas  -      misc       -          -     r
+state    integer  landuse_isn     -      misc       -          -     r
+state    real     lu_state        p      misc       -          -     r
+
+i1       real  th_phy          ikj      misc        1         -
+i1       real  pi_phy          ikj      misc        1         -
+i1       real  p_phy           ikj      misc        1         -
+state    real  t_phy           ikj      misc        1         -      r      "T_PHY"                        "Temperature"         "K"
+state    real  u_phy           ikj      misc        1         -      r      "U_PHY"                        "x-wind component at mass point"         "m s-1"
+state    real  v_phy           ikj      misc        1         -      r      "V_PHY"                        "y-wind component at mass point"         "m s-1"
+i1       real  dz8w            ikj      misc        1         Z
+i1       real  p8w             ikj      misc        1         Z
+i1       real  t8w             ikj      misc        1         Z
+i1       real  rho_phy         ikj      misc        1         -
+i1    logical  CU_ACT_FLAG     ij       misc        1         -
+
+                                                
+state    real  TMN              ij      misc        1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TMN"   "SOIL TEMPERATURE AT LOWER BOUNDARY"           "K"
+state    real  TYR              ij      misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TYR"        "ANNUAL MEAN SFC TEMPERATURE"           "K"
+state    real  TYRA             ij      misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TYRA"   "ACCUMULATED YEARLY SFC TEMPERATURE FOR CURRENT YEAR"  "K"
+state    real  TDLY             ij      misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TDLY"     "ACCUMULATED DAILY SFC TEMPERATURE FOR CURRENT DAY"  "K"
+state    real  TLAG             i&j     misc        1         -     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)     "TLAG"         "DAILY MEAN SFC TEMPERATURE OF PRIOR DAYS"       "K"
+state    integer NYEAR          -       misc        1         -     r        "NYEAR"                  "ACCUM DAYS IN A YEAR"                         ""
+state    real    NDAY           -       misc        1         -     r        "NDAY"                  "ACCUM TIMESTEPS IN A DAY"                      ""
+state    real  XLAND            ij      misc        1         -     i02rhd=(interp_fcnm_imask)u=(copy_fcnm)       "XLAND"                 "LAND MASK (1 FOR LAND, 2 FOR WATER)"          ""      
+state    real  cplmask       i{ncpldom}j      misc        1       z        i0r     "CPLMASK"    "COUPLING MASK (0:VALUE FROM SST UPDATE; 1:VALUE FROM COUPLED OCEAN), vertical dim is number of external domains"  ""
+state    real  ZNT              ij      misc        1         -      i3r     "ZNT"                   "TIME-VARYING ROUGHNESS LENGTH"                "m"      
+state    real  CK               ij      misc        1         -      r        "CK"                    "ENTHALPY EXCHANGE COEFF AT 10 m"                      ""
+state    real  CKA              ij      misc        1         -      r        "CKA"                   "ENTHALPY EXCHANGE COEFF AT LOWEST MODEL LVL"          ""
+state    real  CD               ij      misc        1         -      r        "CD"                    "DRAG COEFF AT 10m"                      ""
+state    real  CDA              ij      misc        1         -      r        "CDA"                   "DRAG COEFF AT LOWEST MODEL LVL"         ""
+state    real  UST              ij      misc        1         -      rh       "UST"                   "U* IN SIMILARITY THEORY"                      "m s-1"      
+state    real  USTM             ij      misc        1         -      r        "USTM"                  "U* IN SIMILARITY THEORY WITHOUT VCONV"        "m s-1"
+i1       real  HOL              ij      misc        1         -      -        "HOL"                   "PBL HEIGHT OVER MONIN-OBUKHOV LENGTH"         ""
+state    real  RMOL             ij      misc        1         -      r        "RMOL"                  "1./Monin Ob. Length"                      ""
+state    real  MOL              ij      misc        1         -      r        "MOL"                   "T* IN SIMILARITY THEORY"                      "K"      
+state    real  PBLH             ij      misc        1         -      rh       "PBLH"                  "PBL HEIGHT"         "m"      
+state    real  CAPG             ij      misc        1         -      r        "CAPG"                  "HEAT CAPACITY FOR SOIL"                       "J K-1 m-3"      
+state    real  THC              ij      misc        1         -      r        "THC"                   "THERMAL INERTIA"                              "Cal cm-2 K-1 s-0.5"      
+state    real  HFX              ij      misc        1         -      rh       "HFX"                   "UPWARD HEAT FLUX AT THE SURFACE"              "W m-2"      
+state    real  QFX              ij      misc        1         -      rh       "QFX"                   "UPWARD MOISTURE FLUX AT THE SURFACE"          "kg m-2 s-1"      
+state    real  LH               ij      misc        1         -      rh       "LH"                    "LATENT HEAT FLUX AT THE SURFACE"              "W m-2"
+state    real  ACHFX            ij      misc        1         -      rhdu     "ACHFX"                 "ACCUMULATED UPWARD HEAT FLUX AT THE SURFACE"  "J m-2"
+#BSINGH - Added WSTAR for CuP scheme
+state    real  WSTAR            ij      misc        1         -      -        "WSTAR"                 "DEARDORFF CONVECTIVE VELOCITY SCALE"          "m s-1"      
+state    real  ACLHF            ij      misc        1         -      rhdu     "ACLHF"                 "ACCUMULATED UPWARD LATENT HEAT FLUX AT THE SURFACE"  "J m-2"
+state    real  FLHC             ij      misc        1         -      r        "FLHC"                  "SURFACE EXCHANGE COEFFICIENT FOR HEAT"       ""
+state    real  FLQC             ij      misc        1         -      r        "FLQC"                  "SURFACE EXCHANGE COEFFICIENT FOR MOISTURE"   ""
+state    real  QSG              ij      misc        1         -      r        "QSG"                   "SURFACE SATURATION WATER VAPOR MIXING RATIO"   "kg kg-1"
+state    real  QVG              ij      misc        1         -      r        "QVG"                   "WATER VAPOR MIXING RATIO AT THE SURFACE"      "kg kg-1"
+state    real  dfi_QVG          ij      misc        1         -      r        "QVG_dfi"               "WATER VAPOR MIXING RATIO AT THE SURFACE"      "kg kg-1"
+state    real  QCG              ij      misc        1         -      r        "QCG"                   "CLOUD WATER MIXING RATIO AT THE GROUND SURFACE"      "kg kg-1"
+state    real  DEW              ij      misc        1         -      r        "DEW"                   "DEW MIXING RATIO AT THE SURFACE"              "kg kg-1"
+state    real  SOILT1           ij      misc        1         -      i012rh   "SOILT1"                "TEMPERATURE INSIDE SNOW "    "K"
+state    real  dfi_SOILT1       ij      misc        1         -      r        "SOILT1_dfi"            "TEMPERATURE INSIDE SNOW "    "K"
+state    real  TSNAV            ij      misc        1         -      r        "TSNAV"                 "AVERAGE SNOW TEMPERATURE "                    "C"
+state    real  dfi_TSNAV        ij      misc        1         -      r        "TSNAV_dfi"             "AVERAGE SNOW TEMPERATURE "                    "C"
+state    real  REGIME           ij      misc        1         -      r        "REGIME"  "FLAGS: 1=Night/Stable, 2=Mechanical Turbulent, 3=Forced Conv, 4=Free Conv" ""
+state    real  SNOWC            ij      misc        1         -      i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)  "SNOWC"  "FLAG INDICATING SNOW COVERAGE (1 FOR SNOW COVER)"  ""
+state    real  dfi_SNOWC        ij      misc        1         -      r        "SNOWC_dfi"             "FLAG INDICATING SNOW COVERAGE (1 FOR SNOW COVER)"         ""
+state    real  MAVAIL           ij      misc        1         -      r        "MAVAIL"                "SURFACE MOISTURE AVAILABILITY"                ""
+                                                
+state   real   tkesfcf          ij      misc        1         -      r        "tkesfcf"               "TKE AT THE SURFACE"                           "m2 s-2"      
+state    real   sr             ij      dyn_em      1         -      irh       "sr" "fraction of frozen precipitation"
+state    real   potevp         ij      dyn_em      1         -       r        "potevp" "accumulated potential evaporation" "m"
+state    real   snopcx         ij      dyn_em      1         -       r        "snopcx" "snow phase change heat flux" "W m-2"
+state    real   soiltb         ij      dyn_em      1         -       r        "soiltb" "bottom soil temperature" "K"
+                                                
+state integer  STEPBL          -        misc        1         -      r        "STEPBL"                "NUMBER OF FUNDAMENTAL TIMESTEPS BETWEEN PBL CALLS" ""      
+state    real  taucldi         ikj      misc        1         -      r        "TAUCLDI"               "CLOUD OPTICAL THICKNESS FOR ICE"              ""
+state    real  taucldc         ikj      misc        1         -      r        "TAUCLDC"               "CLOUD OPTICAL THICKNESS FOR WATER"            ""
+state   real  defor11          ikj      misc        1         -     r         "defor11"               "DEFORMATION 11"              "s-1"      
+state   real  defor22          ikj      misc        1         -     r         "defor22"               "DEFORMATION 22"              "s-1"      
+state   real  defor12          ikj      misc        1         -     r         "defor12"               "DEFORMATION 12"              "s-1"      
+state   real  defor33          ikj      misc        1         z     r         "defor33"               "DEFORMATION 33"              "s-1"      
+state   real  defor13          ikj      misc        1         z     r         "defor13"               "DEFORMATION 13"              "s-1"      
+state   real  defor23          ikj      misc        1         z     r         "defor23"               "DEFORMATION 23"              "s-1"      
+state   real   xkmv            ikj      misc        1         -     r         "xkmv"                  "VERTICAL EDDY VISCOSITY"     "m2 s-1"      
+state   real   xkmh            ikj      misc        1         -     r         "xkmh"                  "HORIZONTAL EDDY VISCOSITY"   "m2 s-1"      
+state   real   xkhv            ikj      misc        1         -     r         "xkhv"                  "VERTICAL EDDY DIFFUSIVITY OF HEAT"                               "m2 s-1"      
+state   real   xkhh            ikj      misc        1         -     r         "xkhh"                  "HORIZONTAL EDDY DIFFUSIVITY OF HEAT"                             "m2 s-1"      
+state   real    div            ikj      misc        1         -     r         "div"                   "DIVERGENCE"                                                      "s-1"
+state   real    BN2            ikj      misc        1         -     r         "BN2"                   "BRUNT-VAISALA FREQUENCY"                                         "s-2"
+state  logical warm_rain        -       misc        1         -     -         "warm_rain"              "WARM_RAIN_LOGICAL"
+state  logical adv_moist_cond   -       misc        1         -     -         "adv_moist_cond"         "ADVECT MOIST CONDENSATES LOGICAL"
+state  integer save_topo_from_real -    dyn_em	    1         -     i02rh     "save_topo_from_real"    "1=original topo from real/0=topo modified by WRF"      "flag"
+
+## FDDA variables
+
+state integer  STEPFG            -        misc        1         -      r        "STEPFG"                "NUMBER OF FUNDAMENTAL TIMESTEPS BETWEEN FDDA GRID CALLS" ""
+state    real  RUNDGDTEN         ikj      misc        1         X      r        "RUNDGDTEN"               "X WIND TENDENCY DUE TO FDDA GRID NUDGING"  "m s-2"
+state    real  RVNDGDTEN         ikj      misc        1         Y      r        "RVNDGDTEN"               "Y WIND TENDENCY DUE TO FDDA GRID NUDGING"  "m s-2"
+state    real  RTHNDGDTEN        ikj      misc        1         -      r        "RTHNDGDTEN"              "THETA TENDENCY DUE TO FDDA GRID NUDGING"   "K s-1"
+state    real  RPHNDGDTEN        ikj      misc        1         -      r        "RPHNDGDTEN"              "GEOPOTENTIAL TENDENCY DUE TO FDDA GRID NUDGING"   "m2 s-3"
+state    real  RQVNDGDTEN        ikj      misc        1         -      r        "RQVNDGDTEN"              "Q_V TENDENCY DUE TO FDDA GRID NUDGING"     "kg kg-1 s-1"
+state    real  RMUNDGDTEN        ij       misc        1         -      r        "RMUNDGDTEN"              "MU TENDENCY DUE TO FDDA GRID NUDGING"     "Pa s-1"
+state    real    -               ikjf     fdda3d      1         -     -    -
+state    real  U_NDG_NEW         ikjf     fdda3d      1         X      i{10}r   "U_NDG_NEW"               "NEW X WIND FOR FDDA GRID NUDGING"  "m s-1"
+state    real  V_NDG_NEW         ikjf     fdda3d      1         Y      i{10}r   "V_NDG_NEW"               "NEW Y WIND FOR FDDA GRID NUDGING"  "m s-1"
+state    real  T_NDG_NEW         ikjf     fdda3d      1         -      i{10}r   "T_NDG_NEW"               "NEW PERT POT TEMP FOR FDDA GRID NUDGING"  "K"
+state    real  Q_NDG_NEW         ikjf     fdda3d      1         -      i{10}r   "Q_NDG_NEW"               "NEW WATER VAPOR MIX RATIO FOR FDDA GRID NUDGING"  "kg/kg"
+state    real  PH_NDG_NEW        ikjf     fdda3d      1         Z      i{10}r   "PH_NDG_NEW"              "NEW PERT GEOPOTENTIAL FOR FDDA GRID NUDGING"  "kg/kg"
+state    real  U_NDG_OLD         ikjf     fdda3d      1         X      i{10}r   "U_NDG_OLD"               "OLD X WIND FOR FDDA GRID NUDGING"  "m s-1"
+state    real  V_NDG_OLD         ikjf     fdda3d      1         Y      i{10}r   "V_NDG_OLD"               "OLD Y WIND FOR FDDA GRID NUDGING"  "m s-1"
+state    real  T_NDG_OLD         ikjf     fdda3d      1         -      i{10}r   "T_NDG_OLD"               "OLD PERT POT TEMP FOR FDDA GRID NUDGING"  "K"
+state    real  Q_NDG_OLD         ikjf     fdda3d      1         -      i{10}r   "Q_NDG_OLD"               "OLD WATER VAPOR MIX RATIO FOR FDDA GRID NUDGING"  "kg/kg"
+state    real  PH_NDG_OLD        ikjf     fdda3d      1         Z      i{10}r   "PH_NDG_OLD"              "OLD PERT GEOPOTENTIAL FOR FDDA GRID NUDGING"  "kg/kg"
+state    real    -               ivjf     fdda2d      1         Z     -    -
+state    real  MU_NDG_NEW        ivjf     fdda2d      1         -      i{10}r   "MU_NDG_NEW"              "NEW PERT COLUMN DRY MASS FOR FDDA GRID NUDGING"  "Pa"
+state    real  MU_NDG_OLD        ivjf     fdda2d      1         -      i{10}r   "MU_NDG_OLD"              "OLD PERT COLUMN DRY MASS FOR FDDA GRID NUDGING"  "Pa"
+state    real  U10_NDG_OLD       ij         misc      1         X      i9r      "U10_NDG_OLD"             "OLD U10 FOR SURFACE FDDA GRID NUDGING"  "m s-1"
+state    real  U10_NDG_NEW       ij         misc      1         X      i9r      "U10_NDG_NEW"             "NEW U10 FOR SURFACE FDDA GRID NUDGING"  "m s-1"
+state    real  V10_NDG_OLD       ij         misc      1         Y      i9r      "V10_NDG_OLD"             "OLD V10 FOR SURFACE FDDA GRID NUDGING"  "m s-1"
+state    real  V10_NDG_NEW       ij         misc      1         Y      i9r      "V10_NDG_NEW"             "NEW V10 FOR SURFACE FDDA GRID NUDGING"  "m s-1"
+state    real  T2_NDG_OLD        ij         misc      1         -      i9r      "T2_NDG_OLD"              "OLD T2 FOR SURFACE FDDA GRID NUDGING"  "K"
+state    real  T2_NDG_NEW        ij         misc      1         -      i9r      "T2_NDG_NEW"              "NEW T2 FOR SURFACE FDDA GRID NUDGING"  "K"
+state    real  TH2_NDG_OLD       ij         misc      1         -      i9r      "TH2_NDG_OLD"             "OLD TH2 FOR SURFACE FDDA GRID NUDGING"  "K"
+state    real  TH2_NDG_NEW       ij         misc      1         -      i9r      "TH2_NDG_NEW"             "NEW TH2 FOR SURFACE FDDA GRID NUDGING"  "K"
+state    real  Q2_NDG_OLD        ij         misc      1         -      i9r      "Q2_NDG_OLD"              "OLD Q2 FOR SURFACE FDDA GRID NUDGING"  "kg kg-1"
+state    real  Q2_NDG_NEW        ij         misc      1         -      i9r      "Q2_NDG_NEW"              "NEW Q2 FOR SURFACE FDDA GRID NUDGING"  "kg kg-1"
+state    real  RH_NDG_OLD        ij         misc      1         -      i9r      "RH_NDG_OLD"              "OLD RH FOR SURFACE FDDA GRID NUDGING"  "%"
+state    real  RH_NDG_NEW        ij         misc      1         -      i9r      "RH_NDG_NEW"              "NEW RH FOR SURFACE FDDA GRID NUDGING"  "%"
+state    real  PSL_NDG_OLD       ij         misc      1         -      i9r      "PSL_NDG_OLD"             "OLD PSL FOR SURFACE FDDA GRID NUDGING"  "Pa"
+state    real  PSL_NDG_NEW       ij         misc      1         -      i9r      "PSL_NDG_NEW"             "NEW PSL FOR SURFACE FDDA GRID NUDGING"  "Pa"
+state    real  PS_NDG_OLD        ij         misc      1         -      i9r      "PS_NDG_OLD"              "OLD PS FOR SURFACE FDDA GRID NUDGING"  "Pa"
+state    real  PS_NDG_NEW        ij         misc      1         -      i9r      "PS_NDG_NEW"              "NEW PS FOR SURFACE FDDA GRID NUDGING"  "Pa"
+state    real  TOB_NDG_OLD       ij         misc      1         -      i9r      "TOB_NDG_OLD"             "OLD TOB FOR SURFACE FDDA GRID NUDGING"  ""
+state    real  ODIS_NDG_OLD      ij         misc      1         -      i9r      "ODIS_NDG_OLD"            "OLD ODIS FOR SURFACE FDDA GRID NUDGING"  "km"
+state    real  TOB_NDG_NEW       ij         misc      1         -      i9r      "TOB_NDG_NEW"             "NEW TOB FOR SURFACE FDDA GRID NUDGING"  ""
+state    real  ODIS_NDG_NEW      ij         misc      1         -      i9r      "ODIS_NDG_NEW"            "NEW ODIS FOR SURFACE FDDA GRID NUDGING"  "km"
+state    real  SN_NDG_NEW        ij         misc      1         -      i9r      "SN_NDG_NEW"              "NEW Snow Water Equivalent"  "mm"
+state    real  SN_NDG_OLD        ij         misc      1         -      i9r      "SN_NDG_OLD"              "OLD Snow Water Equivalent"  "mm"
+
+#FASDAS
+state    real  SDA_HFX           ij         misc      1         -       r       "SDA_HFX"                 "THETA TENDENCY AT THE FIRST MODEL LAYER"   "K s-1"
+state    real  SDA_QFX           ij         misc      1         -       r       "SDA_QFX"                 "MOISTURE TENDENCY AT THE FIRST MODEL LAYER"   "kg kg-1 s-1"
+state    real  QNORM             ij         misc      1         -       r       "QNORM"                   "NORMALIZED QV FACTOR"   "dimless"
+state    real  HFX_BOTH          ij         misc      1         -       rh      "HFX_BOTH"                "UPWARD HEAT FLUX AT THE SURFACE"              "W m-2"
+state    real  QFX_BOTH          ij         misc      1         -       rh      "QFX_BOTH"                "UPWARD MOISTURE FLUX AT THE SURFACE"          "kg m-2 s-1"
+state    real  HFX_FDDA          ikj        misc      1         -       rh      "HFX_FDDA"                "PSEUDO RADIATIVE HEAT FLUX FROM TEMPERATURE FDDA" "W m-2"
+#
+
+# flag for nest movement
+state  logical moved            -       misc        1         -     -          
+
+# special cam radiation restart arrays
+state  real   abstot   ikcj   misc      1    Z   -     ""   ""  " "
+state  real   absnxt   ikaj   misc      1    -   -     ""   ""  " "
+state  real   emstot   ikj    misc      1    Z   -     ""   ""  " "
+
+# model diagnostics
+state   real  dpsdt            ij       misc        1         -     -         "dpsdt"           "surface pressure tendency"                         "Pa/sec"
+state   real  dmudt            ij       misc        1         -     -         "dmudt"           "mu tendency"                                       "Pa/sec"
+state   real  pk1m             ij       misc        1         -     -         "pk1m"            "surface pressure at previous step"                 "Pa"
+state   real  mu_2m            ij       misc        1         -     -         "mu_2m"           "mu_2 at previous step"                             "Pa"
+
+# these are NSSL WRF diagnostics
+state    real    WSPD10MAX        ij     misc        1         -      rh02       "WSPD10MAX"      "WIND SPD MAX 10 M"       "m s-1"
+state    real    W_UP_MAX         ij     misc        1         -      rh02       "W_UP_MAX"       "MAX Z-WIND UPDRAFT"      "m s-1"
+state    real    W_DN_MAX         ij     misc        1         -      rh02       "W_DN_MAX"       "MAX Z-WIND DOWNDRAFT"    "m s-1"
+state    real    REFD_MAX         ij     misc        1         -      rh02       "REFD_MAX"       "MAX DERIVED RADAR REFL"  "dbZ"
+state    real    UP_HELI_MAX      ij     misc        1         -      rh02       "UP_HELI_MAX"    "MAX UPDRAFT HELICITY"    "m2 s-2"
+state    real    W_MEAN           ij     misc        1         -      rh         "W_MEAN"         "HOURLY MEAN Z-WIND"      "m s-1"
+state    real    GRPL_MAX         ij     misc        1         -      rh         "GRPL_MAX"       "MAX COL INT GRAUPEL"     "kg m-2"
+state    real    UH               ij     misc        1         -      r          "UH"             "UPDRAFT HELICITY"        "m2 s-2"
+state    real    W_COLMEAN        ij     misc        1         -     -           "W_COLMEAN"      "COLUMN MEAN Z-WIND"      "m s-1"
+state    real    NUMCOLPTS        ij     misc        1         -     -           "NUMCOLPTS"      "NUMBER OF COLUMN PTS"    "dimensionless"
+state    real    GRPL_COLINT      ij     misc        1         -     -           "GRPL_COLINT"    "COL INT GRAUPEL"         "kg m-2"
+state    real    HAIL_MAXK1       ij     misc        1         -      rh02       "HAIL_MAXK1"     "MAX HAIL DIAMETER K=1"   "m"
+state    real    HAIL_MAX2D       ij     misc        1         -      rh02       "HAIL_MAX2D"     "MAX HAIL DIAMETER ENTIRE COLUMN"   "m"
+
+state   real    max_cfl         -       misc        1         -     -       "max_cfl"           "maximum CFL value in grid at a time" "-"
+
+state   real  prec_acc_c       ij       misc        1         -     rhdu     "prec_acc_c"       "ACCUMULATED CUMULUS PRECIPITATION OVER prec_acc_dt PERIODS OF TIME"       "mm"
+state   real  prec_acc_nc      ij       misc        1         -     rhdu     "prec_acc_nc"      "ACCUMULATED GRID SCALE  PRECIPITATION OVER prec_acc_dt PERIODS OF TIME"   "mm"
+state   real  snow_acc_nc      ij       misc        1         -     rhdu     "snow_acc_nc"      "ACCUMULATED SNOW WATER EQUIVALENT OVER prec_acc_dt PERIODS OF TIME"       "mm"
+
+# Placeholder for decoupled advective tendency diagnostics for non-chem
+state   real  -               ikjf      advh_t      1         -     -         -
+state   real  advh_qv         ikjf      advh_t      1         -     -         "advh_qv"    "ACCUMULATED HORIZONTAL TENDENCY FOR WATER VAPOR"        "kg kg-1"
+
+state   real  -               ikjf      advz_t      1         -     -         -
+state   real  advz_qv         ikjf      advz_t      1         -     -         "advz_qv"    "ACCUMULATED VERTICAL TENDENCY FOR WATER VAPOR"          "kg kg-1"
+
+# Ocean Mixed-Layer State Variables
+state   real    TML            ij      misc         1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "TML"    "OCEAN MIXED-LAYER TEMPERATURE"   "K"
+state   real    T0ML           ij      misc         1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "T0ML"   "INITIAL OCEAN MIXED-LAYER TEMPERATURE"   "K"
+state   real    HML            ij      misc         1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "HML"    "OCEAN MIXED-LAYER DEPTH"   "m"
+state   real    H0ML           ij      misc         1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "H0ML"   "INITIAL OCEAN MIXED-LAYER DEPTH"   "m"
+state   real    HUML           ij      misc         1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "HUML"   "OCEAN MIXED-LAYER DEPTH * U-CURRENT"  " m2s-1 "
+state   real    HVML           ij      misc         1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "HVML"   "OCEAN MIXED-LAYER DEPTH * V-CURRENT"  " m2s-1 "
+state   real    TMOML          ij      misc         1         -     i012rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm) "TMOML"  "OCEAN LAYER MEAN TEMPERATURE   "   "K"
+# track output  
+state    real  track_z        {tl}k      misc     1         -      -       "track_z"            "mid-level Height"           "m"
+state    real  track_t        {tl}k      misc     1         -      -       "track_t"            "mid-level temperature"      "K"
+state    real  track_p        {tl}k      misc     1         -      -       "track_p"            "mid-level pressure"         "Pa"
+state    real  track_u        {tl}k      misc     1         -      -       "track_u"            "x-wind component"           "m s-1"
+state    real  track_v        {tl}k      misc     1         -      -       "track_v"            "y-wind component"           "m s-1"
+state    real  track_w        {tl}k      misc     1         -      -       "track_w"            "z-wind component"           "m s-1"
+state    real  track_rh       {tl}k      misc     1         -      -       "track_rh"           "relative humidity"          "0 - 1 fraction"
+state    real  track_alt      {tl}k      misc     1         -      -       "track_alt"          "inverse density"            "m3 kg-1"
+state    real  track_ele      {tl}       misc     1         -      -       "track_ele"          "elevation"                  "m"
+state    real  track_aircraft {tl}       misc     1         -      -       "track_aircraft"     "aircraft altitude"          "m"
+
+state    real  track_qcloud   {tl}k      misc     1         -      -       "track_qcloud"       "cloud water mixing ratio"   "kg kg-1"
+state    real  track_qrain    {tl}k      misc     1         -      -       "track_qrain"        "rain water mixing ratio"    "kg kg-1"
+state    real  track_qice     {tl}k      misc     1         -      -       "track_qice"         "ice mixing ratio"           "kg kg-1"
+state    real  track_qsnow    {tl}k      misc     1         -      -       "track_qsnow"        "snow mixing ratio"          "kg kg-1"
+state    real  track_qgraup   {tl}k      misc     1         -      -       "track_qgraup"       "graupel mixing ratio"       "kg kg-1"
+state    real  track_qvapor   {tl}k      misc     1         -      -       "track_qvapor"       "water vapor mixing ratio"   "kg kg-1"
+
+#
+#---------------------------------------------------------------------------------------------------------------------------------------
+#                                               
+
+######                                          
+#                                               
+# Variables that are set at run-time to control configuration  (namelist-settable)                                              
+#                                               
+#<Table>  <Type>  <Sym>                   <How set>          <Nentries>   <Default>                                             
+
+# Time Control
+rconfig   integer run_days                namelist,time_control		1             0       irh   "run_days"              "NUMBER OF DAYS TO RUN"
+rconfig   integer run_hours               namelist,time_control		1             0       irh   "run_hours"             "NUMBER OF HOURS TO RUN"
+rconfig   integer run_minutes             namelist,time_control		1             0       irh   "run_minutes"           "NUMBER OF MINUTES TO RUN"
+rconfig   integer run_seconds             namelist,time_control		1             0       irh   "run_seconds"           "NUMBER OF SECONDS TO RUN"
+rconfig   integer start_year              namelist,time_control 	max_domains    1993    irh   "start_year"            "4 DIGIT YEAR OF START OF MODEL" "YEARS"
+rconfig   integer start_month             namelist,time_control		max_domains      03    irh   "start_month"           "2 DIGIT MONTH OF THE YEAR OF START OF MODEL, 1-12" "MONTHS"
+rconfig   integer start_day               namelist,time_control		max_domains      13    irh   "start_day"             "2 DIGIT DAY OF THE MONTH OF START OF MODEL, 1-31" "DAYS"
+rconfig   integer start_hour              namelist,time_control		max_domains      12    irh   "start_hour"            "2 DIGIT HOUR OF THE DAY OF START OF MODEL, 0-23" "HOURS"
+rconfig   integer start_minute            namelist,time_control		max_domains      00    irh   "start_minute"          "2 DIGIT MINUTE OF THE HOUR OF START OF MODEL, 0-59" "MINUTES"
+rconfig   integer start_second            namelist,time_control		max_domains      00    irh   "start_second"          "2 DIGIT SECOND OF THE MINUTE OF START OF MODEL, 0-59" "SECONDS"
+rconfig   integer end_year                namelist,time_control		max_domains    1993    irh   "end_year"              "4 DIGIT YEAR OF END OF MODEL" "YEARS"
+rconfig   integer end_month               namelist,time_control		max_domains      03    irh   "end_month"             "2 DIGIT MONTH OF THE YEAR OF END OF MODEL, 1-12" "MONTHS"
+rconfig   integer end_day                 namelist,time_control		max_domains      14    irh   "end_day"               "2 DIGIT DAY OF THE MONTH OF END OF MODEL, 1-31" "DAYS"
+rconfig   integer end_hour                namelist,time_control		max_domains      12    irh   "end_hour"              "2 DIGIT HOUR OF THE DAY OF END OF MODEL, 0-23" "HOURS"
+rconfig   integer end_minute              namelist,time_control		max_domains      00    irh   "end_minute"            "2 DIGIT MINUTE OF THE HOUR OF END OF MODEL, 0-59" "MINUTES"
+rconfig   integer end_second              namelist,time_control		max_domains      00    irh   "end_second"            "2 DIGIT SECOND OF THE MINUTE OF END OF MODEL, 0-59" "SECONDS"
+rconfig   integer interval_seconds        namelist,time_control		1             10800    irh   "interval_seconds"      "SECONDS BETWEEN ANALYSIS AND BOUNDARY PERIODS" "SECONDS"
+rconfig   logical input_from_file         namelist,time_control		max_domains    .false. irh    "input_from_file"      "T/F INPUT FOR THIS DOMAIN FROM A SEPARATE INPUT FILE"  ""
+rconfig   integer fine_input_stream       namelist,time_control		max_domains    0       irh    "fine_input_stream"      "0 THROUGH 11, WHAT INPUT STREAM IS FINE GRID IC FROM"  ""
+rconfig   logical input_from_hires        namelist,time_control		max_domains    .false. irh    "input_from_hires"     "T/F INPUT FOR THIS DOMAIN FROM USGS HI RES TERRAIN"  ""
+rconfig   character rsmas_data_path       namelist,time_control		1              "."     -    "rsmas_data_path"      ""  ""
+rconfig   logical all_ic_times            namelist,time_control		1              .false. irh    "all_ic_times"     "T/F WRITE ALL IC TIME PERIODS"  ""
+
+
+rconfig   integer JULYR                   namelist,time_control		max_domains    0       h    "JULYR"                 ""      ""
+rconfig   integer JULDAY                  namelist,time_control		max_domains    1       h    "JULDAY"                ""      ""
+rconfig   real    GMT                     namelist,time_control		max_domains    0.      h    "GMT"           ""      ""
+rconfig   character  input_inname      namelist,time_control		1  "wrfinput_d<domain>"          -     "name of input   infile"   ""      ""
+rconfig   character  input_outname     namelist,time_control		1  "wrfinput_d<domain>"          -     "name of input   outfile"  ""      ""
+rconfig   character  bdy_inname        namelist,time_control		1  "wrfbdy_d<domain>"            -     "name of boundary infile"  ""      ""
+rconfig   character  bdy_outname       namelist,time_control		1  "wrfbdy_d<domain>"            -     "name of boundary outfile" ""      ""
+rconfig   character  rst_inname        namelist,time_control		1  "wrfrst_d<domain>_<date>"     -     "name of restrt infile"    ""      ""
+rconfig   character  rst_outname       namelist,time_control		1  "wrfrst_d<domain>_<date>"     -     "name of restrt outfile"   ""      ""
+rconfig   logical write_input             namelist,time_control		1             .false. -    "write input data for 3dvar etc."              ""      ""
+rconfig   logical write_restart_at_0h     namelist,time_control		1             .false. h    "write_restart_at_0h"              ""      ""
+rconfig   logical write_hist_at_0h_rst    namelist,time_control		1             .false. h    "write_hist_at_0h_rst" "T/F write hist at 0 h of restarted forecast"
+rconfig   logical adjust_output_times     namelist,time_control         1             .false. -    "adjust_output_times"
+rconfig   logical adjust_input_times      namelist,time_control         1             .false. -    "adjust_input_times"
+
+rconfig   integer diag_print              namelist,time_control         1              0      -    "print out time series of model diagnostics"
+rconfig   logical nocolons                namelist,time_control         1             .false. -    "nocolons"
+rconfig   logical cycling                 namelist,time_control         1             .false. -    "true for cycling (using wrfout file as input data)"
+rconfig   integer output_diagnostics      namelist,time_control         1              0
+rconfig   integer nwp_diagnostics         namelist,time_control         1              0
+rconfig   logical output_ready_flag       namelist,time_control         1             .false. -    "drop a flag called wrfoutReady_d<domain>_<date> after history write" "" ""
+rconfig   logical force_use_old_data      namelist,time_control         1             .false. -    "T=use v3 input data, F=only use v4 data" "" ""
+
+pioprocs, piostart, piostride, pioshift
+# PIO namelist
+rconfig   logical usepio                 namelist,pio_control   1     .false. rh   "pioprocs"                  ""      "" 
+rconfig   integer pioprocs               namelist,pio_control   1       0     rh   "pioprocs"                  ""      "" 
+rconfig   integer piostart               namelist,pio_control   1       1     rh   "piostart"                  ""      "" 
+rconfig   integer piostride              namelist,pio_control   1       1     rh   "piostride"                 ""      "" 
+rconfig   integer pioshift               namelist,pio_control   1       1     rh   "pioshift"                  ""      "" 
+
+# DFI namelist
+rconfig   integer dfi_opt                namelist,dfi_control   1       0     rh   "dfi_opt"                  ""      ""
+rconfig   integer dfi_savehydmeteors     namelist,dfi_control   1       0     rh   "dfi_radar"                "DFI radar switch"      ""
+rconfig   integer dfi_nfilter            namelist,dfi_control   1       7     rh   "dfi_nfilter"              "Digital filter type"      ""
+rconfig   logical dfi_write_filtered_input  namelist,dfi_control  1  .true.   rh   "dfi_write_filtered_input" "Write a wrfinput_filtered_d0n file?"      ""
+rconfig   logical dfi_write_dfi_history  namelist,dfi_control   1   .false.   rh   "dfi_write_dfi_history"    "Write history files during filtering?"      ""
+rconfig   integer dfi_cutoff_seconds     namelist,dfi_control   1    3600     rh   "dfi_cutoff_seconds"       "Digital filter cutoff time"      ""
+rconfig   integer dfi_time_dim           namelist,dfi_control   1    1000     rh   "dfi_time_dim"             "MAX DIMENSION FOR HCOEFF"
+rconfig   integer dfi_fwdstop_year       namelist,dfi_control   1    2004     rh   "dfi_fwdstop_year"         "4 DIGIT YEAR OF START OF DFI" "YEARS"
+rconfig   integer dfi_fwdstop_month      namelist,dfi_control   1      03     rh   "dfi_fwdstop_month"        "2 DIGIT MONTH OF THE YEAR OF START OF DFI" "MONTHS"
+rconfig   integer dfi_fwdstop_day        namelist,dfi_control   1      13     rh   "dfi_fwdstop_day"          "2 DIGIT DAY OF THE MONTH OF START OF DFI" "DAYS"
+rconfig   integer dfi_fwdstop_hour       namelist,dfi_control   1      12     rh   "dfi_fwdstop_hour"         "2 DIGIT HOUR OF THE DAY OF START OF DFI" "HOURS"
+rconfig   integer dfi_fwdstop_minute     namelist,dfi_control   1      00     rh   "dfi_fwdstop_minute"       "2 DIGIT MINUTE OF THE HOUR OF START OF DFI" "MINUTES"
+rconfig   integer dfi_fwdstop_second     namelist,dfi_control   1      00     rh   "dfi_fwdstop_second"       "2 DIGIT SECOND OF THE MINUTE OF START OF DFI" "SECONDS"
+rconfig   integer dfi_bckstop_year       namelist,dfi_control   1    2004     rh   "dfi_bckstop_year"         "4 DIGIT YEAR OF END OF DFI" "YEARS"
+rconfig   integer dfi_bckstop_month      namelist,dfi_control   1      03     rh   "dfi_bckstop_month"        "2 DIGIT MONTH OF THE YEAR OF END OF DFI" "MONTHS"
+rconfig   integer dfi_bckstop_day        namelist,dfi_control   1      14     rh   "dfi_bckstop_day"          "2 DIGIT DAY OF THE MONTH OF END OF DFI" "DAYS"
+rconfig   integer dfi_bckstop_hour       namelist,dfi_control   1      12     rh   "dfi_bckstop_hour"         "2 DIGIT HOUR OF THE DAY OF END OF DFI" "HOURS"
+rconfig   integer dfi_bckstop_minute     namelist,dfi_control   1      00     rh   "dfi_bckstop_minute"       "2 DIGIT MINUTE OF THE HOUR OF END OF DFI" "MINUTES"
+rconfig   integer dfi_bckstop_second     namelist,dfi_control   1      00     rh   "dfi_bckstop_second"       "2 DIGIT SECOND OF THE MINUTE OF END OF DFI" "SECONDS"
+
+# Domains
+rconfig   integer time_step               namelist,domains	1            -1       ih   "time_step"     
+rconfig   integer time_step_fract_num     namelist,domains	1             0       ih   "time_step_fract_num"     
+rconfig   integer time_step_fract_den     namelist,domains	1             1       ih   "time_step_fract_den"     
+rconfig   integer time_step_dfi           namelist,domains      1            -1       ih   "time_step_dfi"
+
+rconfig   real    reasonable_time_step_ratio namelist,domains   1             6.      ih   "reasonable_time_step_ratio" "Any d01, real-data case with a time step ratio larger than this is stopped"
+
+rconfig   integer min_time_step           namelist,domains      max_domains   -1      h    "min_time_step"
+rconfig   integer min_time_step_den       namelist,domains      max_domains    0      h    "min_time_step denominator"
+rconfig   integer max_time_step           namelist,domains      max_domains   -1      h    "max_time_step"
+rconfig   integer max_time_step_den       namelist,domains      max_domains    0      h    "max_time_step denominator"
+rconfig   real    target_cfl              namelist,domains      max_domains  1.2      h    "target_cfl"
+rconfig   real    target_hcfl             namelist,domains      max_domains  0.84     h    "target_hcfl"
+rconfig   integer max_step_increase_pct   namelist,domains      max_domains    5      h    "max_step_increase_pct"
+rconfig   integer starting_time_step      namelist,domains      max_domains   -1      h    "starting_time_step"
+rconfig   integer starting_time_step_den  namelist,domains      max_domains    0      h    "starting_time_step denominator"
+rconfig   logical step_to_output_time     namelist,domains      1         .true.      h    "step_to_output_time"
+rconfig   integer adaptation_domain       namelist,domains      1              1      h    "adaptation_domain"
+rconfig   logical use_adaptive_time_step  namelist,domains      1         .false.     h    "use_adaptive_time_step"
+rconfig   logical use_adaptive_time_step_dfi  namelist,domains  1         .false.     ih    "use_adaptive_time_step_dfi"
+
+rconfig   integer max_dom                 namelist,domains	1             1       irh  "max_dom"               ""      ""
+rconfig   integer lats_to_mic             namelist,domains	1             0        irh  "lats_to_mic"               ""      ""
+rconfig   integer s_we                    namelist,domains	max_domains    1       irh    "s_we"          ""      ""
+rconfig   integer e_we                    namelist,domains	max_domains    32      irh    "e_we"          ""      ""
+rconfig   integer s_sn                    namelist,domains	max_domains    1       irh    "s_sn"          ""      ""
+rconfig   integer e_sn                    namelist,domains	max_domains    32      irh    "e_sn"          ""      ""
+rconfig   integer s_vert                  namelist,domains	max_domains    1       irh    "s_vert"                ""      ""
+rconfig   integer e_vert                  namelist,domains	max_domains    31      irh    "e_vert"                ""      ""
+rconfig   integer num_metgrid_levels      namelist,domains	1              27      irh    "num_metgrid_levels"                ""      ""
+rconfig   integer num_metgrid_soil_levels namelist,domains	1             4        irh    "num_metgrid_soil_levels"               "number of input levels or layers in 3D sm, st, sw arrays"      ""
+rconfig   real    p_top_requested         namelist,domains      1              5000    irh    "p_top_requested" "Pa"      ""
+rconfig   logical interp_theta            namelist,domains	1              .false. irh    "interp_theta"  "inside real, vertically interpolate theta (T) or temperature (F)"  ""
+rconfig   integer interp_type             namelist,domains	1              2       irh    "interp_type"  "1=interp in pressure, 2=interp in LOG pressure"  ""
+rconfig   integer rebalance               namelist,domains      1              0       irh    "rebalance"  "0=no; 1=yes, always; 2=yes, but only when doing vertical nesting"
+rconfig   integer vert_refine_method      namelist,domains      max_domains    0       irh    "vert_refine_method"  "0=no vertical nesting, 1=integer refinement, 2=use specified eta levels or compute_eta routine" ""
+rconfig   integer vert_refine_fact        namelist,domains      1              1       irh    "vertical refinment factor for ndown, not used for concurrent vertical grid nesting"  "" ""
+rconfig   integer extrap_type             namelist,domains	1              2       irh    "extrap_type"  "1= use 2 lowest levels, 2=constant"  ""
+rconfig   integer t_extrap_type           namelist,domains	1              2       irh    "t_extrap_type"  "1=isothermal, 2=6.5 K/km, 3=adiabatic"   ""
+rconfig   integer hypsometric_opt         namelist,domains      1              2       irh    "hypsometric_opt"  "Z relates P, 1=linearly, 2=LOG-linearly"  ""
+rconfig   logical lowest_lev_from_sfc     namelist,domains	1             .false.  irh    "lowest_lev_from_sfc"                ""      ""
+rconfig   logical use_levels_below_ground namelist,domains	1             .true.   irh    "use_levels_below_ground"   "T/F: use input data levels below input sfc pres" ""
+rconfig   logical use_tavg_for_tsk        namelist,domains	1             .false.  irh    "use_tavg_for_tsk"   "T/F: use diurnal avg sfc temp for tsk" ""
+rconfig   logical use_surface             namelist,domains	1             .true.   irh    "use_surface"   "T/F: use input surface level in interpolation" ""
+rconfig   integer lagrange_order          namelist,domains	1              2       irh    "lagrange_order"   "1=linear, 2=quadratic vertical interpolation, 9=cubic spline"      ""
+rconfig   integer linear_interp           namelist,domains	1              1       irh    "linear_interp"   "1=linear"      ""
+rconfig   integer force_sfc_in_vinterp    namelist,domains	1              1       irh    "force_sfc_in_vinterp"   "number of eta levels forced to use sfc in vert interp"      ""
+rconfig   real    zap_close_levels        namelist,domains	1              500     irh    "zap_close_levels"   "delta p where level is removed in vert interp"      "Pa"
+rconfig   real    maxw_horiz_pres_diff    namelist,domains	1              5000    irh    "maxw_horiz_pres_diff"   "pressure limit (Pa), when horiz diff exceeded do not use max_wind level in real"
+rconfig   real    trop_horiz_pres_diff    namelist,domains	1              5000    irh    "trop_horiz_pres_diff"   "pressure limit (Pa), when horiz diff exceeded do not use tropopause level in real"
+rconfig   real    maxw_above_this_level   namelist,domains	1              30000   irh    "maxw_above_this_level"  "pressure limit (Pa), only use the max_wind data at or above this level"
+rconfig   integer use_maxw_level          namelist,domains	1              0       irh    "use_maxw_level"         "0=no/1=yes: in real, use the input metgrid U, V, T, GHT at the level of max wind speed"
+rconfig   integer use_trop_level          namelist,domains	1              0       irh    "use_trop_level"         "0=no/1=yes: in real, use the input metgrid U, V, T, GHT at the tropopause level"
+rconfig   logical sfcp_to_sfcp            namelist,domains	1              .false. irh    "sfcp_to_sfcp"   "T/F use incoming sfc pres to compute new sfc pres"      "flag"
+rconfig   logical adjust_heights          namelist,domains	1              .false. irh    "adjust_heights"   "T/F adjust pressure level input to match 500 mb height"      "flag"
+rconfig   logical smooth_cg_topo          namelist,domains	1              .false. irh    "smooth_cg_topo"   "T/F smooth CG topo on boundarries" "flag"
+rconfig   integer nest_interp_coord       namelist,domains	1              0       irh    "nest_interp_coord" "0=std horiz vi interpolation on eta, 1=attempt isobaric interpolation"
+rconfig   integer interp_method_type      namelist,domains	1              2       irh    "interp_method_type" "horiz interp for FG for nesting: 1=bilinear, 2=sint, 3=nearest neighbor is only for testing, 4=quadratic, 12=sint for infrastructure tests"
+rconfig   logical aggregate_lu            namelist,domains	1              .false. irh    "aggregate_lu"   "T/F aggregate the grass, shrubs, trees in LU"
+rconfig   logical rh2qv_wrt_liquid        namelist,domains	1              .true.  irh    "rh2qv_wrt_liquid" "T = rh=>Qv assumes RH wrt liquid water, F = allows ice"
+rconfig   integer rh2qv_method            namelist,domains	1              1       irh    "rh2qv_method" "1=old MM5 method, 2=new WMO method"
+rconfig   real    qv_max_p_safe           namelist,domains      1              10000   irh    "qv_max_p_safe" "Threshhold pressure, Qv > flag set to value"      "Pa"
+rconfig   real    qv_max_flag             namelist,domains      1              1.E-5   irh    "qv_max_flag" "Qv flag for max"  "kg kg{-1}"
+rconfig   real    qv_max_value            namelist,domains      1              3.E-6   irh    "qv_max_value" "Qv value for max"  "kg kg{-1}"
+rconfig   real    qv_min_p_safe           namelist,domains      1              110000  irh    "qv_min_p_safe" "Threshhold pressure, Qv < flag set to value"      "Pa"
+rconfig   real    qv_min_flag             namelist,domains      1              1.E-6   irh    "qv_min_flag" "Qv flag for min"  "kg kg{-1}"
+rconfig   real    qv_min_value            namelist,domains      1              1.E-6   irh    "qv_min_value" "Qv value for min"  "kg kg{-1}"
+rconfig   integer ideal_init_method       namelist,domains	1              1       irh    "ideal_init_method" "inside start_em: 1=alb from phb, 2=alb from t_init" " "
+rconfig   real    dx                      namelist,domains     max_domains    200     h     "dx"        "X HORIZONTAL RESOLUTION"   "METERS"
+rconfig   real    dy                      namelist,domains   	max_domains    200     h     "dy"        "Y HORIZONTAL RESOLUTION"   "METERS"
+rconfig   integer grid_id                 namelist,domains	max_domains    1       irh    "id"            ""      ""
+rconfig   logical grid_allowed            namelist,domains	max_domains    .true.  irh    "allowed"            ""      ""
+rconfig   integer parent_id               namelist,domains	max_domains    0       h     "parent_id"             ""      ""
+rconfig   integer i_parent_start          namelist,domains	max_domains    1       rh     "i_parent_start"                ""      ""
+rconfig   integer j_parent_start          namelist,domains	max_domains    1       rh     "j_parent_start"                ""      ""
+rconfig   integer parent_grid_ratio       namelist,domains	max_domains    1       h     "parent_grid_ratio"             ""      ""
+rconfig   integer parent_time_step_ratio  namelist,domains	max_domains    1       h     "parent_time_step_ratio"                ""      ""
+rconfig   integer feedback                namelist,domains	1    1       h     "feedback"          ""      ""
+rconfig   integer smooth_option           namelist,domains	1    2       h     "smooth_option"          ""      ""
+rconfig   integer blend_width             namelist,domains	1    5       h     "blend_width"  "width of cg fg terrain blended zone"      ""
+rconfig   real    ztop                    namelist,domains	max_domains    15000.  h    "ztop"          ""      ""
+rconfig   integer moad_grid_ratio         namelist,domains	max_domains    1       h     "moad_grid_ratio"               ""      ""
+rconfig   integer moad_time_step_ratio    namelist,domains	max_domains    1       h     "moad_time_step_ratio"          ""      ""
+rconfig   integer shw                     namelist,domains	max_domains    2       h     "stencil_half_width"   "HORIZONTAL INTERPOLATION STENCIL HALF-WIDTH"  "GRID POINTS"
+rconfig   integer tile_sz_x               namelist,domains	1             0       -      "tile_sz_x"             ""      ""
+rconfig   integer tile_sz_y               namelist,domains	1             0       -      "tile_sz_y"             ""      ""
+rconfig   integer numtiles                namelist,domains	1             1       -      "numtiles"              ""      ""
+rconfig   integer numtiles_inc            namelist,domains	1             0       -      "numtiles_inc"          ""      ""
+rconfig   integer numtiles_x              namelist,domains	1             0       -      "numtiles_x"            ""      ""
+rconfig   integer numtiles_y              namelist,domains	1             0       -      "numtiles_y"            ""      ""
+rconfig   integer tile_strategy           namelist,domains	1             0       -      "tile_strategy"         ""      ""
+rconfig   integer nproc_x                 namelist,domains	1             -1      -      "nproc_x"              "-1 means not set"      ""
+rconfig   integer nproc_y		  namelist,domains	1             -1      -      "nproc_y"              "-1 means not set"      ""
+rconfig   integer irand                   namelist,domains	1             0       -      "irand"           ""      ""
+rconfig   real    dt                      derived              max_domains    2.      h     "dt"        "TEMPORAL RESOLUTION"      "SECONDS"
+
+rconfig   integer fft_used                derived               1             0       -     "fft_used"  "stochastic, spectral nudging, polar filters - turn on if these are used"
+rconfig   integer cu_used                 derived               1             0       -     "cu_used"   "turn on if any cumulus scheme is used"
+rconfig   integer shcu_used               derived               1             0       -     "shcu_used" "turn on if any shallow cumulus scheme is used"
+rconfig   integer cam_used                derived               1             0       -     "cam_used"  "turn on if one of the following CAM schemes is used: MP, PBL, SHCU"
+rconfig   integer alloc_qndropsource      derived               1             0       -     "alloc_qndropsource"  "allocate qndropsource if CHEM==1 or if progn=1"
+
+rconfig   integer   num_moves       namelist,domains    1                0
+rconfig   integer   ts_buf_size     namelist,domains    1                200          -       "ts_buf_size"   "Size of time series buffer"
+rconfig   integer   max_ts_locs     namelist,domains    1                5            -       "max_ts_locs"   "Maximum number of time series locations"
+rconfig   logical   tslist_ij             derived       1              .false. rh  "tslist_ij"    "Use i,j locations in tslist"   ""
+rconfig   logical   tslist_unstagger_winds   namelist,domains    1              .false. rh  "tslist_unstagger_winds"    "interpolate u and v to cell centers"   ""
+rconfig   integer   vortex_interval  namelist,domains   max_domains      15  -  "" "" "minutes"
+rconfig   integer   max_vortex_speed namelist,domains   max_domains      40  -  "" "" "meters per second"
+rconfig   integer   corral_dist     namelist,domains    max_domains      8
+rconfig   integer   track_level     namelist,domains    1                50000
+rconfig   real      time_to_move    namelist,domains    max_domains      0.  -  "" "" "minutes"
+rconfig   integer   move_id         namelist,domains    max_moves        0
+rconfig   integer   move_interval   namelist,domains    max_moves        999999999
+rconfig   integer   move_cd_x       namelist,domains    max_moves        0
+rconfig   integer   move_cd_y       namelist,domains    max_moves        0
+rconfig   logical   swap_x          namelist,domains    max_domains    .false. rh    "swap_x"            ""      ""
+rconfig   logical   swap_y          namelist,domains    max_domains    .false. rh    "swap_y"            ""      ""
+rconfig   logical   cycle_x         namelist,domains    max_domains    .false. rh    "cycle_x"            ""      ""
+rconfig   logical   cycle_y         namelist,domains    max_domains    .false. rh    "cycle_y"            ""      ""
+rconfig   logical   reorder_mesh    namelist,domains    1              .false. rh    "reorder_mesh"       ""      ""
+rconfig   logical   perturb_input   namelist,domains    1              .false. h     "" "" ""
+rconfig   real      eta_levels      namelist,domains    max_eta        -1.
+rconfig   integer   auto_levels_opt namelist,domains    1               2      -     "auto_levels_opt" "automatic levels, 1=old, 2=new"
+rconfig   real      max_dz          namelist,domains    1               1000.  -     "max_dz"   "maximum thickness limit for eta calc" "m"
+rconfig   real      dzbot           namelist,domains    1               50.    -     "dzbot"    "surface dz thickness for eta calc" "m"
+rconfig   real      dzstretch_s     namelist,domains    1               1.3    -     "dzstretch_s"  "surface dz stretching factor for eta calc"    ""
+rconfig   real      dzstretch_u     namelist,domains    1               1.1    -     "dzstretch_u"  "upper dz stretching factor for eta calc"    ""
+rconfig   integer   ocean_levels    namelist,domains    1               30     irh   "ocean level"        ""      ""
+rconfig   real      ocean_z         namelist,domains    max_ocean      -1      -     "vertical profile of layer depths for ocean" "m"
+rconfig   real      ocean_t         namelist,domains    max_ocean      -1      -     "vertical profile of ocean temps" "K"
+rconfig   real      ocean_s         namelist,domains    max_ocean      -1      -     "vertical profile of salinity" 
+rconfig   integer   num_traj        namelist,domains    1               1000    irh   "num_traj" "#of trajectory" ""
+
+# variable for time series of vertical profile of U, V, Theta, GHT,a nd QVAPOR
+rconfig   integer   max_ts_level    namelist,domains    1              15       -       "max_ts_level"   "Highest model level for time series output"
+
+# track input
+rconfig   integer   track_loc_in    namelist,domains    1               0       -    "Number of track locations input"   ""    ""
+
+# number of external model domains for coupling
+rconfig   integer   num_ext_model_couple_dom    namelist,domains   1     1      -    "number of external models domains for coupling, used for the coupling mask"   ""    ""
+
+# TC (tropical cyclone bogusing)
+rconfig   logical insert_bogus_storm   namelist,tc     	1              .false. irh    "insert_bogus_storm"   "T/F for inserting a bogus typhoon"      "flag"
+rconfig   logical remove_storm         namelist,tc     	1              .false. irh    "remove_storm"  "T/F for only removing the original typhoon"  "flag"
+rconfig   integer num_storm            namelist,tc     	1              1       irh    "num_storm"     "Number of bogus typhoons"  ""
+rconfig   real    latc_loc             namelist,tc     	max_bogus      -999.   irh    "latc_loc"      "center latitude of the bogus tyhoon"  "DEGREES"
+rconfig   real    lonc_loc             namelist,tc     	max_bogus      -999.   irh    "lonc_loc"      "center longitude of the bogus tyhoon"  "DEGREES"
+rconfig   real    vmax_meters_per_second   namelist,tc  max_bogus      -999.   irh    "vmax_meters_per_second"  "vmax of bogus storm in meters per second"  ""
+rconfig   real    rmax                 namelist,tc     	max_bogus      -999.   irh    "rmax"  "maximum radius outward from storm center"  ""
+rconfig   real    vmax_ratio           namelist,tc      max_bogus      -999.   irh    "vmax_ratio"  ""  ""
+rconfig   real    rankine_lid          namelist,tc      1              -999.   irh    "top pressure limit for the tc bogus scheme"
+
+# Physics
+rconfig   character  physics_suite        namelist,physics      1           "none" rh "Physics suite selection" "physics suite to use for all domains: CONUS, tropical, or none" "character string"
+rconfig   logical  force_read_thompson   namelist,physics      1           .false.
+rconfig   logical  write_thompson_tables   namelist,physics     1           .true.
+rconfig   integer     mp_physics          namelist,physics	max_domains    -1     irh       "mp_physics"            ""      ""
+#rconfig   integer     milbrandt_ccntype   namelist,physics      max_domains    0       rh       "milbrandt select maritime(1)/continental(2)"  ""      ""
+rconfig   real     nssl_cccn              namelist,physics      max_domains  0.5e9    rh       "Base CCN concentration for NSSL microphysics"  ""      ""
+rconfig   real     nssl_alphah            namelist,physics      max_domains   0       rh       "Graupel PSD shape paramter"  ""      ""
+rconfig   real     nssl_alphahl           namelist,physics      max_domains   1       rh       "Hail PSD shape paramter"  ""      ""
+rconfig   real     nssl_cnoh              namelist,physics      max_domains  4.e5     rh       "Graupel intercept paramter"  ""      ""
+rconfig   real     nssl_cnohl             namelist,physics      max_domains  4.e4     rh       "Hail intercept paramter"  ""      ""
+rconfig   real     nssl_cnor              namelist,physics      max_domains  8.e5     rh       "Rain intercept paramter"  ""      ""
+rconfig   real     nssl_cnos              namelist,physics      max_domains  3.e6     rh       "Snow intercept paramter"  ""      ""
+rconfig   real     nssl_rho_qh            namelist,physics      max_domains  500.     rh       "Graupel particle density"  ""      ""
+rconfig   real     nssl_rho_qhl           namelist,physics      max_domains  900.     rh       "Hail particle density"  ""      ""
+rconfig   real     nssl_rho_qs            namelist,physics      max_domains  100.     rh       "Snow particle density"  ""      ""
+
+
+# Lightning Qv Nudging 
+rconfig   integer  nudge_lightning        namelist,physics      max_domains   0       rh       "flag for lightning Qv nudging"  ""      ""
+rconfig   integer  nudge_light_times      namelist,physics      max_domains   0       rh       "start time in sec (domain relative) for lightning Qv nudging"  ""      ""
+rconfig   integer  nudge_light_timee      namelist,physics      max_domains   7200    rh       "end time in sec (domain relative) for lightning Qv nudging"  ""      ""
+rconfig   integer  nudge_light_int        namelist,physics      max_domains   600     rh       "time interval in sec of input lightning data files"  ""      ""
+rconfig   character  path_to_files        namelist,physics      1             "~/WRFV3/"    rh   "path on local machine of input lightning data files"  ""      ""
+
+
+
+
+rconfig   integer     gsfcgce_hail        namelist,physics      1              0       rh       "gsfcgce select hail/graupel"  ""      ""
+rconfig   integer     gsfcgce_2ice        namelist,physics      1              0       rh       "gsfcgce select 2ice/3ice"  ""      ""
+rconfig   integer     progn               namelist,physics      max_domains    0       rh       "progn"                 ""      ""
+rconfig   real        accum_mode          namelist,physics      1             1000.0e6 rh       "accum_mode"                 ""      ""
+rconfig   real        aitken_mode         namelist,physics      1             300.0e6  rh       "aitken_mode"                 ""      ""
+rconfig   real        coarse_mode         namelist,physics      1             0.2e6    rh       "coarse_mode"                 ""      ""
+rconfig   integer     do_radar_ref        namelist,physics      1              0       rh       "compute radar reflectivity for a number of schemes"                 ""      ""
+rconfig   integer     compute_radar_ref   derived               1              0       -        "compute_radar_ref" "0/1 flag: compute radar reflectivity, either do_radar_ref=1 .or. (milbrandt or NSSL schemes)"
+rconfig   integer     ra_lw_physics       namelist,physics	max_domains    -1      rh       "ra_lw_physics"         ""      ""
+rconfig   integer     ra_sw_physics       namelist,physics	max_domains    -1      rh       "ra_sw_physics"         ""      ""
+rconfig   real    radt                    namelist,physics	max_domains    0       h    "RADT"          ""      ""
+rconfig   real    naer                    namelist,physics      max_domains    1e9     rh   "NAER"          ""      ""
+rconfig   integer     sf_sfclay_physics   namelist,physics	max_domains    -1      rh       "sf_sfclay_physics"             ""      ""
+rconfig   integer     sf_surface_physics  namelist,physics	max_domains    -1      rh       "sf_surface_physics"            ""      ""
+rconfig   integer     bl_pbl_physics      namelist,physics	max_domains    -1      rh       "bl_pbl_physics"                ""      ""
+rconfig   integer     bl_mynn_tkebudget   namelist,physics      max_domains    0       rh       "bl_mynn_tkebudget"             ""      ""
+rconfig   integer     ysu_topdown_pblmix  namelist,physics      1              0       rh       "ysu_topdown_pblmix"            ""      ""
+rconfig   integer     shinhong_tke_diag   namelist,physics      max_domains    0       rh       "shinhong_tke_diag"             ""      ""
+rconfig   logical     bl_mynn_tkeadvect   namelist,physics      max_domains    .false.  rh      "bl_mynn_tkeadvect"             ""      ""
+rconfig   integer     bl_mynn_cloudpdf    namelist,physics      1              2       irh      "bl_mynn_cloudpdf"              "0:original, 1:Kuwano, 2:Chaboreau-Bechtold"            ""
+rconfig   integer     bl_mynn_mixlength   namelist,physics      1              1       irh      "bl_mynn_mixlength"             "0:original,1:RAP/HRRR,2:new blending&cloud mix length" ""
+rconfig   integer     bl_mynn_edmf        namelist,physics      max_domains    1       irh      "bl_mynn_edmf"                  "0:off,1:activate mass-flux in mynn"                    ""
+rconfig   integer     bl_mynn_edmf_mom    namelist,physics      max_domains    1       irh      "bl_mynn_edmf_mom"              "0:off,1:activate mass-flux transport of momentum"      ""
+rconfig   integer     bl_mynn_edmf_tke    namelist,physics      max_domains    0       irh      "bl_mynn_edmf_tke"              "0:off,1:activate mass-flux transport of tke"           ""
+rconfig   integer     bl_mynn_mixscalars  namelist,physics      max_domains    0       irh      "bl_mynn_mixscalars"            "0:off,1:activate mixing of scalars (qnx, qnxfa) in MYNN"      ""
+rconfig   integer     bl_mynn_cloudmix    namelist,physics      max_domains    1       irh      "bl_mynn_cloudmix"              "0:off,1:activate mixing of all cloud species"          ""
+rconfig   integer     bl_mynn_mixqt       namelist,physics      max_domains    0       irh      "bl_mynn_mixqt"                 "0:mix moisture species separate,1: mix total water"    ""
+rconfig   integer     icloud_bl           namelist,physics      1              1       irh      "icloud_bl"                     "0:no subgrid cloud-radiation coupling,1:activated"     ""
+rconfig   integer     mfshconv            namelist,physics      max_domains    1       rh       "mfshconv"         "To activate mass flux scheme with qnse, 1=true or 0=false"      ""
+rconfig   integer     sf_urban_physics    namelist,physics      max_domains    0       rh       "sf_urban_physics"     "activate urban model  0=no, 1=Noah_UCM 2=BEP_UCM"   ""
+rconfig   real    BLDT                    namelist,physics      max_domains    0       h    "BLDT"          ""      ""
+rconfig   integer cu_physics              namelist,physics      max_domains    -1      rh   "cu_physics"    ""      ""
+rconfig   integer shcu_physics            namelist,physics      max_domains    0       rh   "shcu_physics"  ""      ""
+rconfig   integer cu_diag                 namelist,physics      max_domains    0       rh   "cu_diag"       "additional t-averaged stuff for cuphys"      ""
+rconfig   integer kf_edrates              namelist,physics      max_domains    0       rh   "kf_edrates"           "output entrainment/detrainment rates and convective timescale for KF schemes"      ""
+rconfig   integer kfeta_trigger           namelist,physics	1              1       rh   "KFETA Trigger function"    ""    ""
+rconfig   integer nsas_dx_factor          namelist,physics	1              0       rh   "NSAS DX-dependent option"    ""    ""
+rconfig   real    CUDT                    namelist,physics	max_domains    0       h    "CUDT"          ""      ""
+rconfig   real    GSMDT                   namelist,physics	max_domains    0       h    "GSMDT"          ""      ""
+rconfig   integer ISFFLX                  namelist,physics 	1             1       irh    "ISFFLX"                        ""      ""
+rconfig   integer IFSNOW                  namelist,physics	1             1       irh    "IFSNOW"                        ""      ""
+rconfig   integer ICLOUD                  namelist,physics	1             1       irh    "ICLOUD"                        ""      ""
+rconfig   integer cldovrlp                namelist,physics      1             2       irh    "cldovrlp"                      "1=random, 2=maximum-random, 3=maximum, 4=exponential, 5=exponential-random"      ""
+rconfig   integer ideal_xland             namelist,physics	1             1        rh    "IDEAL_XLAND"  "land=1(def), water=2, for ideal cases with no land-use"      ""
+rconfig   real    swrad_scat              namelist,physics	1             1       irh    "SWRAD_SCAT" "SCATTERING FACTOR IN SWRAD"      ""
+rconfig   integer surface_input_source    namelist,physics	1             3       irh    "surface_input_source"          "1=static (fractional), 2=time dependent (dominant), 3=dominant cateogry from metgrid"      ""
+rconfig   integer num_soil_layers         namelist,physics	1             5       irh    "num_soil_layers"               ""      ""
+rconfig   integer maxpatch                namelist,physics      1            10       irh    "maxpatch"                      ""      ""
+rconfig   integer num_snow_layers         namelist,physics	1             3       irh    "num_snow_layers"               ""      ""
+rconfig   integer num_snso_layers         namelist,physics	1             7       irh    "num_snso_layers"               ""      ""
+
+rconfig   integer num_urban_ndm           derived               1             1       irh    "num_urban_ndm"   "maximum number of street dimensions (ndm in BEP or BEM header)"                     ""
+rconfig   integer num_urban_ng            derived               1             1       irh    "num_urban_ng"    "number of grid levels in the ground (ng_u in BEP or BEM header)"                    ""
+rconfig   integer num_urban_nwr           derived               1             1       irh    "num_urban_nwr"   "number of grid levels in the walls or roof (nwr_u in BEP or BEM header)"            ""
+rconfig   integer num_urban_ngb           derived               1             1       irh    "num_urban_ngb"   "number of grid levels in the ground below building (ngb_u in BEM header)"           ""
+rconfig   integer num_urban_nf            derived               1             1       irh    "num_urban_nf"    "number of grid levels in the floors (nf_u in BEM header)"                           ""
+rconfig   integer num_urban_nz            derived               1             1       irh    "num_urban_nz"    "maximum number of vertical levels in the urban grid (nz_um in BEP or BEM header)"   ""
+rconfig   integer num_urban_nbui          derived               1             1       irh    "num_urban_nbui"  "maximum number of types of buildings in an urban class (nbui_max in BEM header)"    ""
+
+rconfig   integer urban_map_zrd           derived         	1             1        rh    "urban_map_zrd"   "urban mapping 1: ind_zrd"      ""  
+rconfig   integer urban_map_zwd           derived         	1             1        rh    "urban_map_zwd"   "urban mapping 2: ind_zwd"      ""  
+rconfig   integer urban_map_gd            derived         	1             1        rh    "urban_map_gd"    "urban mapping 3: ind_gd"       ""  
+rconfig   integer urban_map_zd            derived         	1             1        rh    "urban_map_zd"    "urban mapping 4: ind_zd"       ""  
+rconfig   integer urban_map_zdf           derived         	1             1        rh    "urban_map_zdf"   "urban mapping 5: ind_zdf"      ""  
+rconfig   integer urban_map_bd            derived         	1             1        rh    "urban_map_bd"    "urban mapping 6: ind_bd"       ""  
+rconfig   integer urban_map_wd            derived         	1             1        rh    "urban_map_wd"    "urban mapping 7: ind_wd"       ""  
+rconfig   integer urban_map_gbd           derived         	1             1        rh    "urban_map_gbd"   "urban mapping 8: ind_gbd"      ""  
+rconfig   integer urban_map_fbd           derived         	1             1        rh    "urban_map_fbd"   "urban mapping 9: ind_fbd"      ""  
+
+rconfig   integer num_urban_hi            namelist,physics      1            15       irh    "num_urban_hi"             ""      ""
+rconfig   integer num_months              namelist,physics      1            12       irh    "num_months"               ""      ""
+rconfig   integer sf_surface_mosaic       namelist,physics	1             0       rh     "sf_surface_mosaic"        "1= mosaic, 0=no mosaic method, add by danli"      ""  
+rconfig   integer mosaic_cat              namelist,physics	1             3       rh     "mosaic_cat"               "works when sf_surface_mosaic=1;  it is the number of mosaic tiles"      ""  
+rconfig   integer mosaic_cat_soil         derived         	1            12       rh     "mosaic_cat_soil"          "should be the number of soil layers times the mosaic_cat"      ""  
+rconfig   integer mosaic_lu               namelist,physics      1             0       irh    "mosaic_lu"             ""      ""
+rconfig   integer mosaic_soil             namelist,physics      1             0       irh    "mosaic_soil"           ""      ""
+rconfig   integer flag_sm_adj             namelist,physics      1             0       irh    "flag_sm_adj" "1-adjustment, 0-no soil moisture adjustment in RUC soil moisture initialization from Noah LSM"      ""
+rconfig   integer maxiens                 namelist,physics	1             1       irh    "maxiens"                    ""      ""
+rconfig   integer maxens                  namelist,physics	1             3       irh    "maxens"                    ""      ""
+rconfig   integer maxens2                 namelist,physics	1             3       irh    "maxens2"                    ""      ""
+rconfig   integer maxens3                 namelist,physics	1            16       irh    "maxens3"                    ""      ""
+rconfig   integer ensdim                  namelist,physics      1            144      irh    "ensdim"                    ""      ""
+rconfig   integer cugd_avedx              namelist,physics      1            1      irh    "cugd_avedx"                    ""      ""
+rconfig   integer clos_choice             namelist,physics      1             0       rh    "clos_choice"                    ""      ""
+rconfig   integer imomentum               namelist,physics      1             0       rh    "imomentum"                    "momentum transport in G3 scheme"      ""
+rconfig   integer ishallow                namelist,physics      1             0       rh    "ishallow"  "shallow convection in G3 scheme"      ""
+rconfig   real    convtrans_avglen_m      namelist,physics      1             30      rh    "convtrans_avglen_m"  "averaging time for convective transport output variables (minutes)"      ""
+rconfig   integer num_land_cat            namelist,physics	1            21       -      "num_land_cat"                  ""      ""
+rconfig   integer num_soil_cat            namelist,physics	1            16       -      "num_soil_cat"                  ""      ""
+rconfig   integer mp_zero_out             namelist,physics	1             0       -      "mp_zero_out"  "microphysics fields set to zero  0=no action taken, 1=all fields but Qv, 2=all fields including Qv"      "flag"
+rconfig   real mp_zero_out_thresh         namelist,physics	1          1.e-8      -      "mp_zero_out_thresh"  "minimum threshold for non-Qv moist fields, below are set to zero"  "kg/kg"
+rconfig   real    seaice_threshold        namelist,physics	1            100       h    "seaice_threshold"  "tsk below which which water points are set to sea ice for slab scheme"   "K"
+rconfig   integer sst_update              namelist,physics	1            0         h    "sst_update"  "update sst from wrflowinp file  0=no, 1=yes"   ""
+
+rconfig   integer sst_skin                namelist,physics      1            0         h    "sst_skin" "calculate sst skin temperature 0=no, 1=yes"   ""
+rconfig   integer tmn_update              namelist,physics      1            0         h    "tmn_update" "update tmn from calculation  0=no, 1=yes"   ""
+rconfig   logical usemonalb               namelist,physics      1            .false.   h    "usemonalb"   "use 2d field vs table values  false=table, True=2d"   ""
+rconfig   logical rdmaxalb                namelist,physics      1            .true.    h     "rdmaxalb"    "false set it to table values"   ""
+rconfig   logical rdlai2d                 namelist,physics      1            .false.   h     "rdlai2d"     "false set it to table values"   ""
+rconfig   logical ua_phys                 namelist,physics      1            .false.   h     "ua_phys"     "activate UA Noah changes"   ""
+rconfig   integer opt_thcnd               namelist,physics      1            1         h     "opt_thcnd" "thermal conductivity option in Noah LSM"   ""
+rconfig   integer co2tf                   namelist,physics	1            1         -    "co2tf" "GFDL radiation co2 flag" ""
+rconfig   integer ra_call_offset          namelist,physics	1            0         -    "ra_call_offset" "radiation call offset in timesteps (-1=old, 0=new offset)" ""
+rconfig   real    cam_abs_freq_s          namelist,physics      1         21600.      -      "cam_abs_freq_s" "CAM radiation frequency for clear-sky longwave calculations" "s"
+rconfig   integer levsiz                  namelist,physics      1             1       -      "levsiz" "Number of ozone data levels for CAM radiation (59)"  ""
+rconfig   integer paerlev                 namelist,physics      1             1       -      "paerlev" "Number of aerosol data levels for CAM radiation (29)"  ""
+rconfig   integer cam_abs_dim1            namelist,physics      1             1       -      "cam_abs_dim1" "dimension for absnxt in CAM radiation"  ""
+rconfig   integer cam_abs_dim2            namelist,physics      1             1       -      "cam_abs_dim2" "dimension for abstot in CAM radiation"  ""
+rconfig   integer lagday                  namelist,physics      1             150     -      "lagday"         ""      ""
+rconfig   integer no_src_types            namelist,physics      1             1       -      "no_src_types" "Number of aerosol types from EC. (6 - Tegan aerosols)"  ""
+rconfig   integer alevsiz                 namelist,physics      1             1       -      "alevsiz" "Number of aerosol optical depth data levels from EC (12)"  ""
+rconfig   integer o3input                 namelist,physics      1             2       -      "o3input"      "ozone input for RRTMG for CG domain: original = 0; CAM ozone = 2"      ""
+rconfig   integer aer_opt                 namelist,physics      1             0       -      "aer_opt"      "aerosol input option for radiation"      ""
+rconfig   integer swint_opt               namelist,physics      1             0       -      "swint_opt"    "interpolation option for sw radiation"      ""
+rconfig   integer aer_type                namelist,physics      max_domains   1       irh    "aer_type"       "aerosol type: 1 is SF79 rural, 2 is SF79 urban" ""
+rconfig   integer aer_aod550_opt          namelist,physics      max_domains   1       irh    "aer_aod550_opt" "input option for aerosol optical depth at 550 nm" ""
+rconfig   integer aer_angexp_opt          namelist,physics      max_domains   1       irh    "aer_angexp_opt" "input option for aerosol Angstrom exponent" ""
+rconfig   integer aer_ssa_opt             namelist,physics      max_domains   1       irh    "aer_ssa_opt"    "input option for aerosol single-scattering albedo" ""
+rconfig   integer aer_asy_opt             namelist,physics      max_domains   1       irh    "aer_asy_opt"    "input option for aerosol asymmetry parameter" ""
+rconfig   real    aer_aod550_val          namelist,physics      max_domains   0.12    irh    "aer_aod550_val" "fixed value for aerosol optical depth at 550 nm. Valid when aer_aod550_opt=1" ""
+rconfig   real    aer_angexp_val          namelist,physics      max_domains   1.3     irh    "aer_angexp_val" "fixed value for aerosol Angstrom exponent. Valid when aer_angexp_opt=1" ""
+rconfig   real    aer_ssa_val             namelist,physics      max_domains   0.85    irh    "aer_ssa_val"    "fixed value for aerosol single-scattering albedo. Valid when aer_ssa_opt=1" ""
+rconfig   real    aer_asy_val             namelist,physics      max_domains   0.90    irh    "aer_asy_val"    "fixed value for aerosol asymmetry parameter. Valid when aer_asy_opt=1" ""
+rconfig   logical cu_rad_feedback         namelist,physics      max_domains   .false. irh    "feedback of cumulus cloud to radiation"  ""
+rconfig   integer dust_emis               namelist,physics      1             0        rh    "option for dust emission outside of chem"  ""      ""
+rconfig   integer erosion_dim             namelist,physics      1             3        -     "erosion_dim"            ""      ""
+rconfig   integer no_src_types_cu         namelist,physics      1             1       -      "no_src_types_cu" "Number of aerosoal species in global aerosol data"  ""
+rconfig   integer alevsiz_cu              namelist,physics      1             1       -      "alevsiz_cu" "Number of levels in global aerosol data"  ""
+rconfig   integer aercu_opt               namelist,physics      1             0       -      "aercu_opt"    "aerosol input option for multiscale KF"      ""
+rconfig   real    aercu_fct               namelist,physics      1             1.0     -      "aercu_fct"    "aerosol multiplication factor"               ""
+rconfig   integer aercu_used              derived               1             0       -      "aercu_used"   "derived nml for packaging"      ""
+
+#BSINGH - added shallowcu_forced_ra, numBins, thBinSize, rBinSize, minDeepFreq, minShallowFreq, shcu_aerosols_opt for CuP scheme
+
+rconfig   logical shallowcu_forced_ra     namelist,physics      max_domains    .false.  -    "force radiative impact of shallow Cu (KF-Eta and KF-CuP)"
+rconfig   integer numBins                 namelist,physics      max_domains    1  -     "number of bins to use in the CuP PDF"
+rconfig   real thBinSize                  namelist,physics      max_domains    1  -     "bin size of theta bins of PDF"
+rconfig   real rBinSize                   namelist,physics      max_domains    1  -     "bin size of mixing ratio bins of PDF"
+rconfig   real minDeepFreq                namelist,physics      max_domains    1  -     "Minimum frequency required for deep convection"
+rconfig   real minShallowFreq             namelist,physics      max_domains    1  -     "Minimum frequency required for shallow convection"
+rconfig   integer shcu_aerosols_opt       namelist,physics      max_domains    0  -     "aerosols in shcu:  0=none, 2=prognostic "  ""
+
+rconfig   integer ICLOUD_CU               derived               max_domains   0        -     "ICLOUD_CU"                     ""      ""
+rconfig   integer pxlsm_smois_init        namelist,physics      max_domains   1       irh    "PXLSM_SMOIS_INIT"    "Soil moisture initialization option 0-From analysis 1-From MAVAIL"   ""
+rconfig   integer pxlsm_modis_veg         namelist,physics      max_domains   0       irh    "PXLSM_MODIS_VEG"     "If 1 use MODIS VEGFRA from wrflowinp updates, 1=yes"   ""
+rconfig   integer omlcall                 namelist,physics      1            0         h     "omlcall"     "temporary holder to allow checking for new name: oml_opt"
+rconfig   integer sf_ocean_physics        namelist,physics      1            0         h     "sf_ocean_physics"     "activate ocean model  0=no, 1=1d mixed layer, 2=3D PWP" ""
+rconfig   integer traj_opt                namelist,physics      1            0         h     "traj_opt"    "activate trajectory calculation  0=no, 1=on"   ""
+rconfig   logical dm_has_traj             namelist,physics      max_domains  .false.   rh    "has_traj"    "activate trajectory calculation per domain"   ""
+rconfig   integer tracercall              namelist,physics      1            0         h     "tracercall"  "activate tracer calculation  0=no, 1=on"   ""
+rconfig   real    OMDT                    namelist,physics      1            1         h     "OMDT"        "Timestep of ocean model"      "s"
+rconfig   real    oml_hml0                namelist,physics      1            50        h     "oml_hml0"    "oml initial mixed layer depth value"   "m"
+rconfig   real    oml_gamma               namelist,physics      1            0.14      h     "oml_gamma"   "oml deep water lapse rate"   "K m-1"
+rconfig   real    oml_relaxation_time     namelist,physics      1            0.        h     "oml_relaxation_time"   "Relaxation time of mixed layer ocean model back to original values"      "s"
+rconfig   integer isftcflx                namelist,physics      1            0         h     "isftcflx"    "switch to control sfc fluxes"   ""
+rconfig   integer iz0tlnd                 namelist,physics      1            0         h     "iz0tlnd"    "switch to control land thermal roughness length"   ""
+rconfig   real    shadlen                 namelist,physics      1            25000.    -     "shadow_length" "maximum length of orographic shadow" "m"
+rconfig   integer slope_rad               namelist,physics      max_domains    0       -     "slope_rad"  "1: use slope-dependent radiation, 0:not" ""
+rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
+rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
+rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
+rconfig   integer fractional_seaice       namelist,physics      1              0       -     "fractional_seaice" "Fractional sea-ice option"
+rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
+rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
+rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"
+rconfig   integer seaice_albedo_opt       namelist,physics      1              0       -     "seaice_albedo_opt" "Method for setting albedo over sea ice"
+rconfig   real    seaice_albedo_default   namelist,physics      1             0.65     -     "seaice_albedo_default" "Default value for sea-ice over albedo with seaice_albeo_opt=0"
+rconfig   integer seaice_thickness_opt    namelist,physics      1              0       -     "seaice_thickness_opt" "Method for setting sea-ice thickness"
+rconfig   real   seaice_thickness_default namelist,physics      1              3.0     -     "seaice_thickness_default" "Default value for sea-ice thickness"
+rconfig   logical tice2tsk_if2cold        namelist,physics      1              .false. -     "tice2tsk_if2cold" "Avoid low ice temps when ice frac and Tsk are inconsistent"
+rconfig   real    bucket_mm               namelist,physics      1             -1.      h     "bucket_mm" "bucket reset value for water accumulations -1: inactive"   ""
+rconfig   real    bucket_J                namelist,physics      1             -1.      h     "bucket_J"  "bucket reset value for energy accumulations -1: inactive"   ""
+rconfig   real    mp_tend_lim             namelist,physics      1             10.      -     "mp_tend_lim" "limit on temp tendency from mp latent heating"   "K/s"
+rconfig   real    prec_acc_dt             namelist,physics      max_domains    0.      h     "prec_acc_dt" "bucket reset time interval between outputs for cumulus or grid scale precipitation"   "minutes"
+rconfig   integer prec_acc_opt            derived               1              0       -     "prec_acc_opt" "option to output precip in a time window"          ""
+rconfig   integer bucketr_opt             derived               1              0       -     "bucketr_opt"  "option to output water accum based on bucket_mm "          ""
+rconfig   integer bucketf_opt             derived               1              0       -     "bucketf_opt"  "option to output radiation accum based on bucket_J "          ""
+
+rconfig   integer process_time_series     derived               1              0       -     "process_time_series" "0=no, 1=yes"  ""
+
+rconfig   integer grav_settling           namelist,physics      max_domains  0         h    "grav_settling"     "activate gravitationalsettling of fog  0=no, 1=yes"
+rconfig   real    sas_pgcon               namelist,physics      max_domains  0.55      irh   "sas_pgcon"   "convectively forced pressure gradient factor (SAS scheme)" ""
+rconfig   integer scalar_pblmix           namelist,physics      max_domains  0         h    "mix 4d scalar variables with pbl scheme 0=no 1=yes" ""
+rconfig   integer tracer_pblmix           namelist,physics      max_domains  1         h    "mix 4d tracer variables with pbl scheme 0=no 1=yes" ""
+rconfig   logical use_aero_icbc           namelist,physics     	1              .false. rh    "use_aero_icbc"  "Use GOCART climo 3D aerosols IC/BC data in Thompson-MP-Aero"  "logical flag"
+rconfig   logical use_rap_aero_icbc       namelist,physics      1              .false. r     "use_rap_aero_icbc"  "Use GOCART climo 3D aerosols IC/BC data in Thompson-MP-Aero from RAP"  "logical flag"
+rconfig   integer use_mp_re               namelist,physics     	1              1       h     "use_mp_re"  "use effective radii computed in some mp schemes in RRTMG"  "flag"
+#dynamic lightning
+  rconfig   real     coul_pos            namelist,physics      max_domains  0.25E-4     rh       "Constant for Positive Charging of Clouds"  "Coulombs"      ""
+  rconfig   real     coul_neg            namelist,physics      max_domains  0.25E-4     rh       "Constant for Negative Charging of Clouds"  "Coulombs"      ""
+  rconfig   real     coul_neu            namelist,physics      max_domains  0.25E-4     rh       "Constant for Charging of Intracloud Lightning"  "Coulombs"      ""
+   rconfig   real     j_pos            namelist,physics      max_domains  5.E9     rh       "Threshold for Producing Positive Event"  "J"      ""
+   rconfig   real     j_neg            namelist,physics      max_domains  1.E9     rh       "Threshold for Producing Negative Event"  "J"      ""
+   rconfig   real     j_neu            namelist,physics      max_domains  1.E9     rh       "Threshold for Producing IC Event"  ""      "J"
+#  end dynamic lightning
+#
+
+# The following two options are hooked into various microphysics schemes to allow for ensemble perturbations of CCN and hail/graupel PSDs - GAC (AFWA)
+rconfig   real    ccn_conc                namelist,physics      1           1.0E8      h     "ccn_conc"                 "CCN concentration"                                                             "# m-3"
+rconfig   integer hail_opt                namelist,physics      1              0       rh    "hail_opt"                 "Hail/Graupel switch, 1:hail, 0:graupel"                                        ""
+rconfig   integer morr_rimed_ice          namelist,physics      1              1       rh    "morr_rimed_ice "          "Hail/Graupel switch for Morrison Scheme (options 10 and 40), 1:hail, 0:graupel"                                        ""
+
+rconfig   integer clean_atm_diag          namelist,physics      1              0       rh    "clean_atm_diag"     "option to switch on clean sky diagnostics (for chem)"   "flag"
+rconfig   integer calc_clean_atm_diag     derived               1              0       -     "calc_clean_atm_diag" "carries decision on using clean sky diagnostics"       "flag"
+
+
+# For Noah-MP
+rconfig   integer dveg        namelist,noah_mp      1           4         h    "dveg"     "dynamic vegetation (1 -> off ; 2 -> on)"   ""
+rconfig   integer opt_crs     namelist,noah_mp      1           1         h    "opt_crs"  "canopy stomatal resistance (1-> Ball-Berry; 2->Jarvis)"   ""
+rconfig   integer opt_btr     namelist,noah_mp      1           1         h    "opt_btr"  "soil moisture factor for stomatal resistance (1-> Noah; 2-> CLM; 3-> SSiB)"   ""
+rconfig   integer opt_run     namelist,noah_mp      1           3         h    "opt_run"  "runoff and groundwater (1->SIMGM; 2->SIMTOP; 3->Schaake96; 4->BATS)"   ""
+rconfig   integer opt_sfc     namelist,noah_mp      1           1         h    "opt_sfc"  "surface layer drag coeff (CH & CM) (1->M-O; 2->Chen97)"   ""
+rconfig   integer opt_frz     namelist,noah_mp      1           1         h    "opt_frz"  "supercooled liquid water (1-> NY06; 2->Koren99)"   ""
+rconfig   integer opt_inf     namelist,noah_mp      1           1         h    "opt_inf"  "frozen soil permeability (1-> NY06; 2->Koren99)"   ""
+rconfig   integer opt_rad     namelist,noah_mp      1           3         h    "opt_rad"  "radiation transfer (1->gap=F(3D,cosz); 2->gap=0; 3->gap=1-Fveg)"   ""
+rconfig   integer opt_alb     namelist,noah_mp      1           2         h    "opt_alb"  "snow surface albedo (1->BATS; 2->CLASS)"   ""
+rconfig   integer opt_snf     namelist,noah_mp      1           1         h    "opt_snf"  "rainfall & snowfall (1-Jordan91; 2->BATS; 3->Noah)"   ""
+rconfig   integer opt_tbot    namelist,noah_mp      1           2         h    "opt_tbot" "lower boundary of soil temperature (1->zero-flux; 2->Noah)"   ""
+rconfig   integer opt_stc     namelist,noah_mp      1           1         h    "opt_stc"  "soil/snow temperature time scheme 1->semi-implicit; 2->full-implicit (original Noah)"   ""
+rconfig   integer opt_gla     namelist,noah_mp      1           1         h    "opt_gla"  "glacier treatment option 1->includes phase change; 2->slab ice (Noah)"   ""
+rconfig   integer opt_rsf     namelist,noah_mp      1           1         h    "opt_rsf"  "surface evaporation resistance option"   ""
+rconfig   integer opt_soil    namelist,noah_mp      1           1         h    "opt_soil" "flag for using different input soil information"   ""
+rconfig   integer opt_pedo    namelist,noah_mp      1           1         h    "opt_pedo" "pedo_transfer function option"   ""
+rconfig   integer opt_crop    namelist,noah_mp      1           0         h    "opt_crop" "crop model option"   ""
+rconfig   real    WTDDT               namelist,physics         max_domains     30.      h     "wtddt"    "minutes between calls to lateral hydro"  ""
+
+# For WRF Hydro
+rconfig   integer wrf_hydro               derived              1     0      h     "wrf_hydro"   "descrip"  "unit"
+
+
+#FDDA namelist parameters
+rconfig   real    FGDT                    namelist,fdda         max_domains    0       h        "FGDT"          ""      ""
+rconfig   integer  FGDTZERO               namelist,fdda         max_domains    0       rh       "FGDTZERO"             ""      ""
+rconfig   integer  grid_fdda              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  grid_sfdda             namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_no_pbl_nudging_uv   namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_no_pbl_nudging_t    namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_no_pbl_nudging_ph   namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_no_pbl_nudging_q    namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_zfac_uv             namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer   k_zfac_uv             namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_zfac_t              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer   k_zfac_t              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_zfac_ph             namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer   k_zfac_ph             namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  if_zfac_q              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer   k_zfac_q              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   integer  dk_zfac_uv             namelist,fdda         max_domains    1       rh       "grid_fdda"            ""      ""
+rconfig   integer  dk_zfac_t              namelist,fdda         max_domains    1       rh       "grid_fdda"            ""      ""
+rconfig   integer  dk_zfac_ph             namelist,fdda         max_domains    1       rh       "grid_fdda"            ""      ""
+rconfig   integer  dk_zfac_q              namelist,fdda         max_domains    1       rh       "grid_fdda"            ""      ""
+rconfig   integer  ktrop                  namelist,fdda         1              0       rh       "grid_fdda"            ""      ""
+rconfig   real        guv                 namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real        guv_sfc             namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real        gt                  namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real        gt_sfc              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real        gq                  namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real        gq_sfc              namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real        gph                 namelist,fdda         max_domains    0       rh       "grid_fdda"            ""      ""
+rconfig   real    dtramp_min              namelist,fdda         1              0       h        "grid_fdda"            ""      ""
+rconfig   integer if_ramping              namelist,fdda         1              0       h        "grid_fdda"            ""      ""
+rconfig   real    rinblw                  namelist,fdda         max_domains    0       h        "grid_fdda"            ""      ""
+rconfig   integer xwavenum                namelist,fdda         max_domains    0       rh       "grid_fdda"            "top wave number to nudge in x direction"      ""
+rconfig   integer ywavenum                namelist,fdda         max_domains    0       rh       "grid_fdda"            "top wave number to nudge in y direction"      ""
+rconfig   integer pxlsm_soil_nudge        namelist,fdda         max_domains    0       rh       "pxlsm_soil_nudge"     "nudge pxlsm soil"      ""
+
+#FASDAS
+rconfig   integer  fasdas                 derived               max_domains    0       -        "fasdas"            ""      ""
+
+#Observational Nudging
+rconfig   integer     obs_nudge_opt       namelist,fdda            max_domains    0       rh       "obs_nudge_opt"     "Obs-nudging flag for domain"          ""
+rconfig   integer     max_obs             namelist,fdda            1              0       h        "max_obs"           "Maximum number of observations"       ""
+rconfig   real        fdda_start          namelist,fdda            max_domains    0       rh       "fdda_start"        "Nudging start time for domain"        "min"
+rconfig   real        fdda_end            namelist,fdda            max_domains    0       rh       "fdda_end"          "Nudging end time for domain"          "min"
+rconfig   integer     obs_nudge_wind      namelist,fdda            max_domains    0       rh       "obs_nudge_wind"    "Wind-nudging flag for domain"         ""
+rconfig   real        obs_coef_wind       namelist,fdda            max_domains    0       rh       "obs_coef_wind"     "Wind-nudging coeficient for domain"   "s-1"
+rconfig   integer     obs_nudge_temp      namelist,fdda            max_domains    0       rh       "obs_nudge_temp"    "Temperature-nudging flag for domain"  ""
+rconfig   real        obs_coef_temp       namelist,fdda            max_domains    0       rh       "obs_coef_temp"     "Temperature-nudging coef for domain"  "s-1"
+rconfig   integer     obs_nudge_mois      namelist,fdda            max_domains    0       rh       "obs_nudge_mois"    "Moisture-nudging flag for domain"     ""
+rconfig   real        obs_coef_mois       namelist,fdda            max_domains    0       rh       "obs_coef_mois"     "Moisture-nudging coef for domain"     "s-1"
+rconfig   integer     obs_nudge_pstr      namelist,fdda            max_domains    0       rh       "obs_nudge_pstr"    "Not used"                             ""
+rconfig   real        obs_coef_pstr       namelist,fdda            max_domains    0       rh       "obs_coef_pstr"     "Not used"                             ""
+rconfig   integer     obs_no_pbl_nudge_uv namelist,fdda            max_domains    0       rh       "obs_no_pbl_nudge_uv" "1=no wind-nudging within pbl"          ""
+rconfig   integer     obs_no_pbl_nudge_t  namelist,fdda            max_domains    0       rh       "obs_no_pbl_nudge_t"  "1=no temperature-nudging within pbl"   ""
+rconfig   integer     obs_no_pbl_nudge_q  namelist,fdda            max_domains    0       rh       "obs_no_pbl_nudge_q"  "1=no moisture-nudging within pbl"      ""
+rconfig   integer     obs_sfc_scheme_horiz namelist,fdda           1              0       rh       "obs_sfcscheme_horiz" "0=wrf scheme, 1=original mm5 scheme" ""
+rconfig   integer     obs_sfc_scheme_vert  namelist,fdda           1              0       rh       "obs_sfcscheme_vert"  "0=regime vif scheme, 1=original simple scheme" ""
+rconfig   real        obs_max_sndng_gap   namelist,fdda            1              20      rh       "obs_max_sndng_gap"   "Max press gap between soundings" "centibars"
+rconfig   real        obs_nudgezfullr1_uv namelist,fdda            1              50      rh       "obs_nudgezfullr1_uv" "Vert infl full weight  height for LML obs, regime 1, winds"        ""
+rconfig   real        obs_nudgezrampr1_uv namelist,fdda            1              50      rh       "obs_nudgezrampr1_uv" "Vert infl ramp-to-zero height for LML obs, regime 1, winds"        ""
+rconfig   real        obs_nudgezfullr2_uv namelist,fdda            1              50      rh       "obs_nudgezfullr2_uv" "Vert infl full weight  height for LML obs, regime 2, winds"        ""
+rconfig   real        obs_nudgezrampr2_uv namelist,fdda            1              50      rh       "obs_nudgezrampr2_uv" "Vert infl ramp-to-zero height for LML obs, regime 2, winds"        ""
+rconfig   real        obs_nudgezfullr4_uv namelist,fdda            1              -5000   rh       "obs_nudgezfullr4_uv" "Vert infl full weight  height for LML obs, regime 4, winds"        ""
+rconfig   real        obs_nudgezrampr4_uv namelist,fdda            1              50      rh       "obs_nudgezrampr4_uv" "Vert infl ramp-to-zero height for LML obs, regime 4, winds"        ""
+rconfig   real        obs_nudgezfullr1_t  namelist,fdda            1              50      rh       "obs_nudgezfullr1_t" "Vert infl full weight  height for LML obs, regime 1, temperature"  ""
+rconfig   real        obs_nudgezrampr1_t  namelist,fdda            1              50      rh       "obs_nudgezrampr1_t" "Vert infl ramp-to-zero height for LML obs, regime 1, temperature"  ""
+rconfig   real        obs_nudgezfullr2_t  namelist,fdda            1              50      rh       "obs_nudgezfullr2_t" "Vert infl full weight  height for LML obs, regime 2, temperature"  ""
+rconfig   real        obs_nudgezrampr2_t  namelist,fdda            1              50      rh       "obs_nudgezrampr2_t" "Vert infl ramp-to-zero height for LML obs, regime 2, temperature"  ""
+rconfig   real        obs_nudgezfullr4_t  namelist,fdda            1              -5000   rh       "obs_nudgezfullr4_t" "Vert infl full weight  height for LML obs, regime 4, temperature"  ""
+rconfig   real        obs_nudgezrampr4_t  namelist,fdda            1              50      rh       "obs_nudgezrampr4_t" "Vert infl ramp-to-zero height for LML obs, regime 4, temperature"  ""
+rconfig   real        obs_nudgezfullr1_q  namelist,fdda            1              50      rh       "obs_nudgezfullr1_q" "Vert infl full weight  height for LML obs, regime 1, moisture"     ""
+rconfig   real        obs_nudgezrampr1_q  namelist,fdda            1              50      rh       "obs_nudgezrampr1_q" "Vert infl ramp-to-zero height for LML obs, regime 1, moisture"     ""
+rconfig   real        obs_nudgezfullr2_q  namelist,fdda            1              50      rh       "obs_nudgezfullr2_q" "Vert infl full weight  height for LML obs, regime 2, moisture"     ""
+rconfig   real        obs_nudgezrampr2_q  namelist,fdda            1              50      rh       "obs_nudgezrampr2_q" "Vert infl ramp-to-zero height for LML obs, regime 2, moisture"     ""
+rconfig   real        obs_nudgezfullr4_q  namelist,fdda            1              -5000   rh       "obs_nudgezfullr4_q" "Vert infl full weight  height for LML obs, regime 4, moisture"     ""
+rconfig   real        obs_nudgezrampr4_q  namelist,fdda            1              50      rh       "obs_nudgezrampr4_q" "Vert infl ramp-to-zero height for LML obs, regime 4, moisture"     ""
+rconfig   real        obs_nudgezfullmin   namelist,fdda            1                 50   rh       "obs_nudgezfullmin" "Minimum depth through which vertical influence fcn remains 1.0"     "m"
+rconfig   real        obs_nudgezrampmin   namelist,fdda            1                 50   rh       "obs_nudgezrampmin" "Minimum depth through which vertical influence fcn decreases from 1.0 to 0.0" "m"
+rconfig   real        obs_nudgezmax       namelist,fdda            1               3000   rh       "obs_nudgezmax" "Maximum depth in which vertical influence function is nonzero" "m"
+rconfig   real        obs_sfcfact         namelist,fdda            1              1.0     h        "obs_sfcfact"       "Scale factor applied to time window for surface obs"     ""
+rconfig   real        obs_sfcfacr         namelist,fdda            1              1.0     h        "obs_sfcfacr"       "Scale factor applied to horiz radius of influence for surface obs"     ""
+rconfig   real        obs_dpsmx           namelist,fdda            1              7.5     h        "obs_dpsmx"         "Max pressure change allowed within horiz radius of influence"     "centibars"
+rconfig   real        obs_rinxy           namelist,fdda            max_domains    0       rh       "obs_rinxy"         "Horizontal radius of influence"       "km"
+rconfig   real        obs_rinsig          namelist,fdda            1              0       h        "obs_rinsig"        "Vertical radius of influence"         "sigma"
+rconfig   real        obs_twindo          namelist,fdda            max_domains    0       rh       "obs_twindo"        "Half-period time window for nudging"  "hrs"
+rconfig   integer     obs_npfi            namelist,fdda            1              0       h        "obs_npfi"          "Freq in cg timesteps for diag print"  ""
+rconfig   integer     obs_ionf            namelist,fdda            max_domains    1       rh       "obs_ionf"          "Freq in cg timesteps for obs input and error calc"   ""
+rconfig   integer     obs_idynin          namelist,fdda            1              0       h        "obs_idynin"        "Flag for dynamic initialization"      ""
+rconfig   real        obs_dtramp          namelist,fdda            1              0       h        "obs_dtramp"        "Time period for ramping (idynin)"     "min"
+rconfig   integer     obs_prt_max         namelist,fdda            1              1000    rh       "obs_prt_max"       "Maximum allowed obs entries in diagnostic printout"      ""
+rconfig   integer     obs_prt_freq        namelist,fdda            max_domains    1000    rh       "obs_prt_freq"      "Frequency in obs index for diagnostic printout."   ""
+rconfig   logical     obs_ipf_in4dob      namelist,fdda            1              .false. h        "obs_ipf_in4dob"    "Print obs input diagnostics"   ""
+rconfig   logical     obs_ipf_errob       namelist,fdda            1              .false. h        "obs_ipf_errob"     "Print obs error diagnostics"   ""
+rconfig   logical     obs_ipf_nudob       namelist,fdda            1              .false. h        "obs_ipf_nudob"     "Print obs nudge diagnostics"   ""
+rconfig   logical     obs_ipf_init        namelist,fdda            1              .true.  h        "obs_ipf_init"      "Enable obs init warning messages"   ""
+rconfig   integer     obs_scl_neg_qv_innov namelist,fdda           1              0       h        "obs_scl_neg_qv_innov" "Scale certain negative QV innovations"   ""
+
+# Single-column model (SCM)
+rconfig   integer scm_force               namelist,scm  1       0           rh   "scm_force"            "SCM forcing switch" ""
+rconfig   real    scm_force_dx            namelist,scm  1       4000.       rh   "scm_force_dx"         "DX for SCM forcing" "m"
+rconfig   integer num_force_layers        namelist,scm  1       8           rh   "num_force_layers"     "Number of SCM forcing layers" ""
+rconfig   integer scm_lu_index            namelist,scm  1       2           rh   "scm_lu_index"         "SCM landuse index" ""
+rconfig   integer scm_isltyp              namelist,scm  1       4           rh   "scm_isltyp"           "SCM soil category" ""
+rconfig   real    scm_vegfra              namelist,scm  1       50.         rh   "scm_vegfra"           "SCM vegetation fraction" ""
+rconfig   real    scm_canwat              namelist,scm  1       0.0         rh   "scm_canwat"           "SCM canopy water" "kg m-2"
+rconfig   real    scm_lat                 namelist,scm  1        36.605     rh   "scm_lat"              "SCM latitude" "degrees"
+rconfig   real    scm_lon                 namelist,scm  1       -97.485     rh   "scm_lon"              "SCM longitude" "degrees"
+rconfig   logical scm_th_t_tend           namelist,scm  1       .true.      rh   "scm_th_t_adv"         "Turn on large scale theta tendency in SCM"   ""
+rconfig   logical scm_qv_t_tend           namelist,scm  1       .true.      rh   "scm_qv_t_adv"         "Turn on large scale qv tendency in SCM"      ""
+rconfig   logical scm_th_adv              namelist,scm  1       .true.      rh   "scm_th_adv"           "Turn on theta advection in SCM"      ""
+rconfig   logical scm_wind_adv            namelist,scm  1       .true.      rh   "scm_wind_adv"         "Turn on wind advection in SCM"      ""
+rconfig   logical scm_qv_adv              namelist,scm  1       .true.      rh   "scm_qv_adv"           "Turn on qv advection in SCM"      ""
+rconfig   logical scm_ql_adv              namelist,scm  1       .false.     rh   "scm_ql_adv"           "Turn on ql advection in SCM"      ""
+rconfig   logical scm_vert_adv            namelist,scm  1       .true.      rh   "scm_vert_adv"         "Turn on vertical advection in SCM"      ""
+rconfig   integer num_force_soil_layers   namelist,scm  1       5           rh   "num_force_soil_layers" "Number of SCM soil forcing layers" ""
+rconfig   logical scm_soilT_force         namelist,scm  1       .false.     rh   "scm_soilT_force"      "Turn on soil temp forcing in SCM"      ""
+rconfig   logical scm_soilq_force         namelist,scm  1       .false.     rh   "scm_soilq_force"      "Turn on soil moisture forcing in SCM"      ""
+rconfig   logical scm_force_th_largescale namelist,scm  1       .false.     rh   "scm_force_th_largescale" "Turn on large scale theta forcing in SCM"      ""
+rconfig   logical scm_force_qv_largescale namelist,scm  1       .false.     rh   "scm_force_qv_largescale" "Turn on large scale qv forcing in SCM"      ""
+rconfig   logical scm_force_ql_largescale namelist,scm  1       .false.     rh   "scm_force_ql_largescale" "Turn on large scale ql forcing in SCM"      ""
+rconfig   logical scm_force_wind_largescale namelist,scm  1     .false.     rh   "scm_force_wind_largescale" "Turn on large scale wind forcing in SCM"      ""
+rconfig   integer scm_force_skintemp      namelist,scm  1       0           rh   "scm_force_skin"       "SCM surface forcing by skin temperature 0=no 1=yes"      ""
+rconfig   integer scm_force_flux          namelist,scm  1       0           rh   "scm_force_flux"       "SCM surface forcing by surface fluxes 0=no 1=yes"      ""
+
+# Dynamics
+# dynamics option (see package definitions, below)
+rconfig   integer dyn_opt                 namelist,dynamics	1             2 
+rconfig   integer rk_ord                  namelist,dynamics	1             3       irh   "rk_order"               ""      ""
+rconfig   integer w_damping               namelist,dynamics	1             0       irh    "w_damping"             ""      ""
+# diff_opt 1=old diffusion, 2=new
+rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh    "diff_opt"              ""      ""
+# diff_opt_dfi is needed for backwards integration in dfi
+rconfig   integer diff_opt_dfi            namelist,dynamics	max_domains   0       irh    "diff_opt_dfi"          ""      ""
+# km_opt   1=old coefs, 2=tke, 3=Smagorinksy
+rconfig   integer km_opt                  namelist,dynamics	max_domains   -1      irh    "km_opt"                ""      ""
+# km_opt_dfi is needed for backward integration in dfi
+rconfig   integer km_opt_dfi              namelist,dynamics	max_domains   1       irh    "km_opt_dfi"            ""      ""
+rconfig   integer damp_opt                namelist,dynamics	1             0       irh    "damp_opt"              ""      ""
+rconfig   integer rad_nudge               namelist,dynamics	1             0       irh    "rad_nudge"             ""      ""
+rconfig   integer gwd_opt                 namelist,dynamics     1             0       irh    "gwd_opt"              ""      ""
+rconfig   real    max_rot_angle_gwd       namelist,dynamics     1             22.5    irh    "max_rot_angle_gwd"    "max projection rotation angle permitted for gwd_opt=1"      ""
+rconfig   real    zdamp                   namelist,dynamics	max_domains    5000.   h    "zdamp"         ""      ""
+rconfig   real    dampcoef                namelist,dynamics     max_domains    0.      h    "dampcoef"              ""      ""
+rconfig   real    khdif                   namelist,dynamics	max_domains    0       h    "khdif"         ""      ""
+rconfig   real    kvdif                   namelist,dynamics	max_domains    0       h    "kvdif"         ""      ""
+rconfig   real    diff_6th_factor         namelist,dynamics     max_domains    0.12    h    "diff_6th_factor" "factor that controls rate of 6th-order numerical diffusion"
+rconfig   integer diff_6th_opt            namelist,dynamics     max_domains    0      irh   "diff_6th_opt" "switch for 6th-order numerical diffusion"
+rconfig   integer diff_6th_slopeopt       namelist,dynamics     max_domains    0      irh   "diff_6th_slopeopt" "switch for 6th-order numerical diffusion - terrain-slope tapering"
+rconfig   real    diff_6th_thresh         namelist,dynamics     max_domains    0.10    ih    "diff_6th_thresh" "slope threshold (m/m) that turns off 6th order diff is steep terrain"
+rconfig   integer use_theta_m             namelist,dynamics	1              1       rh    "use_theta_m" "theta_m = theta (1 + 1.61 Qv); 0-no, 1=yes"     ""
+rconfig   integer use_q_diabatic          namelist,dynamics     1              0       rh    "use_q_diabatic" "account for q diabatic terms in advection "     ""
+rconfig   real    c_s                     namelist,dynamics     max_domains    0.25    h    "c_s"         "Smagorinsky coeff"      ""
+rconfig   real    c_k                     namelist,dynamics     max_domains    0.15    h    "c_k"         "TKE coeff"      ""
+rconfig   real    smdiv                   namelist,dynamics	max_domains    0.1     h    "smdiv"         ""      ""
+rconfig   real    emdiv                   namelist,dynamics	max_domains    0.01    h    "emdiv"         ""      ""
+rconfig   real    epssm                   namelist,dynamics	max_domains    .1      h    "epssm"         ""      ""
+rconfig   logical non_hydrostatic         namelist,dynamics	max_domains  .true.   irh  "non_hydrostatic"    ""   ""
+rconfig   logical use_input_w             namelist,dynamics	1            .false.  irh  "use_input_w"    ""   ""
+rconfig   integer time_step_sound         namelist,dynamics	max_domains    0       h     "time_step_sound"               ""      ""
+rconfig   integer     h_mom_adv_order     namelist,dynamics	max_domains    5       rh       "h_mom_adv_order"               ""      ""
+rconfig   integer     v_mom_adv_order     namelist,dynamics	max_domains    3       rh       "v_mom_adv_order"               ""      ""
+rconfig   integer     h_sca_adv_order     namelist,dynamics	max_domains    5       rh       "h_sca_adv_order"               ""      ""
+rconfig   integer     v_sca_adv_order     namelist,dynamics	max_domains    3       rh       "v_sca_adv_order"               ""      ""
+rconfig   integer  momentum_adv_opt       namelist,dynamics     max_domains    1       rh    "momentum_adv_opt"      "weno RK3 transport switch"      ""
+rconfig   integer  moist_adv_opt          namelist,dynamics	max_domains    1       rh    "moist_adv_opt"         "positive-definite RK3 transport switch"      ""
+rconfig   integer  moist_adv_dfi_opt      namelist,dynamics	max_domains    0       rh    "moist_adv_dfi_opt"     "positive-definite RK3 transport switch"      ""
+rconfig   integer  chem_adv_opt           namelist,dynamics	max_domains    1       rh    "chem_adv_opt"          "positive-definite RK3 transport switch"      ""
+rconfig   integer  tracer_adv_opt         namelist,dynamics     max_domains    1       rh    "tracer_adv_opt"        "positive-definite RK3 transport switch"      ""
+rconfig   integer  scalar_adv_opt         namelist,dynamics	max_domains    1       rh    "scalar_adv_opt"        "positive-definite RK3 transport switch"      ""
+rconfig   integer  tke_adv_opt            namelist,dynamics	max_domains    1       rh    "tke_adv_opt"           "positive-definite RK3 transport switch"      ""
+# switches for selectively deactivating 2nd and 6th order horizontal filters for specific scalar variable classes
+rconfig   logical  moist_mix2_off         namelist,dynamics	max_domains    .false. rh    "moist_mix2_off"        "de-activate 2nd-order horizontal mixing for moisture"      ""
+rconfig   logical  chem_mix2_off          namelist,dynamics	max_domains    .false. rh    "chem_mix2_off"         "de-activate 2nd-order horizontal mixing for chem species"  ""
+rconfig   logical  tracer_mix2_off        namelist,dynamics	max_domains    .false. rh    "tracer_mix2_off"       "de-activate 2nd-order horizontal mixing for tracers"       ""
+rconfig   logical  scalar_mix2_off        namelist,dynamics	max_domains    .false. rh    "scalar_mix2_off"       "de-activate 2nd-order horizontal mixing for scalars"       ""
+rconfig   logical  tke_mix2_off           namelist,dynamics	max_domains    .false. rh    "tke_mix2_off"          "de-activate 2nd-order horizontal mixing for tke"           ""
+#
+rconfig   logical  moist_mix6_off         namelist,dynamics	max_domains    .false. rh    "moist_mix6_off"        "de-activate 6th-order horizontal filter for moisture"      ""
+rconfig   logical  chem_mix6_off          namelist,dynamics	max_domains    .false. rh    "chem_mix6_off"         "de-activate 6th-order horizontal filter for chem species"  ""
+rconfig   logical  tracer_mix6_off        namelist,dynamics	max_domains    .false. rh    "tracer_mix6_off"       "de-activate 6th-order horizontal filter for tracers"       ""
+rconfig   logical  scalar_mix6_off        namelist,dynamics	max_domains    .false. rh    "scalar_mix6_off"       "de-activate 6th-order horizontal filter for scalars"       ""
+rconfig   logical  tke_mix6_off           namelist,dynamics	max_domains    .false. rh    "tke_mix6_off"          "de-activate 6th-order horizontal filter for tke"           ""
+#
+rconfig   logical top_radiation           namelist,dynamics	max_domains    .false. rh    "top_radiation"         ""      ""
+rconfig   integer mix_isotropic           namelist,dynamics     max_domains    0       h    "mix_isotropic"            "0=anistropic, 1=isotropic"      ""
+rconfig   real    mix_upper_bound         namelist,dynamics     max_domains    0.1     h    "mix_upper_bound"          "non-dimensional limit"      ""
+rconfig   logical top_lid                 namelist,dynamics     max_domains    .false. rh    "top_lid"               ""      ""
+rconfig   real    tke_upper_bound         namelist,dynamics	max_domains    1000.   h    "tke_upper_bound"            ""      ""
+rconfig   real    tke_drag_coefficient    namelist,dynamics	max_domains    0.      h    "tke_drag_coefficient"       ""      "dimensionless"
+rconfig   real    tke_heat_flux           namelist,dynamics	max_domains    0.      h    "tke_heat_flux"              ""      "K m s-1"
+rconfig   logical pert_coriolis           namelist,dynamics	max_domains  .false.  irh  "pert_coriolis"    ""   ""
+rconfig   logical coriolis2d              namelist,dynamics	max_domains  .false.  irh  "coriolis2d"    ""   ""
+rconfig   logical mix_full_fields         namelist,dynamics     max_domains  .false.  irh  "mix_full_field"   ""   ""
+rconfig   real    base_pres               namelist,dynamics	1          100000.     h    "base_pres"  "Base state pressure - do not change (10^5 Pa), real only"      "Pa"
+rconfig   real    base_temp               namelist,dynamics	1             290.     h    "base_temp"  "Base state sea level temperature, real only"      "K"
+rconfig   real    base_lapse              namelist,dynamics	1              50.     h    "base_lapse" "Base state temperature difference between base pres and 1/e of atm depth - do not change, real only"      "K"
+rconfig   real    iso_temp                namelist,dynamics     1             200.00   h    "iso_temp"   "Isothermal temperature in stratosphere, real only"      "K"
+rconfig   real    base_pres_strat         namelist,dynamics     1               0.     h    "base_pres_strat" "Base state pressure (Pa) at bottom of the stratosphere, std atm = 5500 Pa" "Pa"
+rconfig   real    base_lapse_strat        namelist,dynamics     1             -11.     h    "base_lapse_strat", "Base state lapse rate ( dT / d(lnP) ) in stratosphere, std atm = -11 K/(ln delta p)" "K"
+rconfig   logical use_baseparam_fr_nml    namelist,dynamics     1            .false.  irh   "use_baseparam_fr_nml"    ""   ""
+rconfig   real    fft_filter_lat          namelist,dynamics     1              91.     h    "fft_filter_lat"   "degrees"   "grid latitude to start polar filter"
+rconfig   logical coupled_filtering       namelist,dynamics     1            .true.    h    "coupled_filtering"   "for scalar/tracer/chem/moist, T/F filter the fields coupled with mu"
+rconfig   logical pos_def                 namelist,dynamics     1            .false.   h    "pos_def"   "for scalar/tracer/chem/moist, T/F after filtering, reset negative values to zero"
+rconfig   logical swap_pole_with_next_j   namelist,dynamics     1            .false.   h    "swap_pole_with_next_j"   "for scalar/tracer/chem/moist, T/F replace the most poleward latitude of data with the next row in"
+rconfig   logical actual_distance_average namelist,dynamics     1            .false.   h    "actual_distance_average"   "for scalar/tracer/chem/moist, T/F the number of points to use in the latitudinal average is based on the ratio of map factors"
+rconfig   logical rotated_pole            namelist,dynamics     1            .false.  irh   "rotated_pole"    ""   ""
+rconfig   logical do_coriolis             namelist,dynamics	max_domains  .true.   irh  "do_coriolis"    ""   ""
+rconfig   logical do_curvature            namelist,dynamics	max_domains  .true.   irh  "do_curvature"   ""   ""
+rconfig   logical do_gradp                namelist,dynamics	max_domains  .true.   irh  "do_gradp"    ""   ""
+rconfig   integer tracer_opt              namelist,dynamics     max_domains    0       rh    "tracer_opt"          ""      ""
+# Placeholder for decoupled advective tendency diagnostics
+rconfig   integer tenddiag                namelist,dynamics     max_domains    0       -     "Decoupled tendency diagnostics"   ""    ""
+
+# Bdy_control
+rconfig   integer spec_bdy_width          namelist,bdy_control		1             5       irh    "spec_bdy_width"                ""      ""
+rconfig   integer spec_zone               namelist,bdy_control		1             1       irh    "spec_zone"                     ""      ""
+rconfig   integer relax_zone              namelist,bdy_control		1             4       irh    "relax_zone"                    ""      ""
+rconfig   logical specified               namelist,bdy_control	max_domains    .false. rh    "specified"             ""      ""
+rconfig   logical constant_bc             namelist,bdy_control          1      .false. rh    "constant_bc"           ""      ""
+rconfig   logical periodic_x              namelist,bdy_control	max_domains    .false. rh    "periodic_x"            ""      ""
+rconfig   logical symmetric_xs            namelist,bdy_control	max_domains    .false. rh    "symmetric_xs"          ""      ""
+rconfig   logical symmetric_xe            namelist,bdy_control	max_domains    .false. rh    "symmetric_xe"          ""      ""
+rconfig   logical open_xs                 namelist,bdy_control	max_domains    .false. rh    "open_xs"               ""      ""
+rconfig   logical open_xe                 namelist,bdy_control	max_domains    .false. rh    "open_xe"               ""      ""
+rconfig   logical periodic_y              namelist,bdy_control	max_domains    .false. rh    "periodic_y"            ""      ""
+rconfig   logical symmetric_ys            namelist,bdy_control	max_domains    .false. rh    "symmetric_ys"          ""      ""
+rconfig   logical symmetric_ye            namelist,bdy_control	max_domains    .false. rh    "symmetric_ye"          ""      ""
+rconfig   logical open_ys                 namelist,bdy_control	max_domains    .false. rh    "open_ys"               ""      ""
+rconfig   logical open_ye                 namelist,bdy_control	max_domains    .false. rh    "open_ye"               ""      ""
+rconfig   logical polar                   namelist,bdy_control	max_domains    .false. rh    "polar"                 ""      ""
+rconfig   logical nested                  namelist,bdy_control	max_domains    .false. rh    "nested"                ""      ""
+rconfig   real    spec_exp                namelist,bdy_control          1     0.      irh    "spec_exp"              ""      ""
+rconfig   integer spec_bdy_final_mu       namelist,bdy_control	        1     1        rh    "call spec_bdy_final for mu"    ""      ""
+rconfig   integer real_data_init_type     namelist,bdy_control		1                 1    irh   "real_data_init_type"   "REAL DATA INITIALIZATION OPTIONS: 1=SI, 2=MM5, 3=GENERIC" "PRE-PROCESSOR TYPES"
+rconfig   logical have_bcs_moist          namelist,bdy_control  max_domains    .false. rh    "have_bcs_moist"           ""      ""
+rconfig   logical have_bcs_scalar         namelist,bdy_control  max_domains    .false. rh    "have_bcs_scalar"          ""      ""
+
+rconfig   integer background_proc_id      namelist,grib2 	        1     255    rh    "background_proc_id"    "Background processing id for grib2"  ""
+rconfig   integer forecast_proc_id        namelist,grib2 	        1     255    rh    "forecast_proc_id"      "Analysis and forecast processing id for grib2"  ""
+rconfig   integer production_status       namelist,grib2 	        1     255    rh    "production_status"     "Background processing id for grib2"  ""
+rconfig   integer compression             namelist,grib2 	        1      40    rh    "compression"           "grib2 compression, 40 for JPEG2000 or 41 for PNG"  ""
+
+# NAMELIST DERIVED
+rconfig   integer nobs_ndg_vars           derived                       1         6       -        "num_ndg_vars"         "Number of nudging variables"          ""
+rconfig   integer nobs_err_flds           derived                       1         10      -        "num_err_flds"         "Number of error fields"               ""
+rconfig   real    cen_lat                 derived                  max_domains    0       -        "cen_lat"              "center latitude"      "degrees, negative is south"
+rconfig   real    cen_lon                 derived                  max_domains    0       -        "cen_lon"              "central longitude"      "degrees, negative is west"
+rconfig   real    truelat1                derived                  max_domains    0       -        "true_lat1"             "first standard parallel"      "degrees, negative is south"
+rconfig   real    truelat2                derived                  max_domains    0       -        "true_lat2"             "second standard parallel"      "degrees, negative is south"
+rconfig   real    moad_cen_lat            derived                  max_domains    0       -        "moad_cen_lat"             "center latitude of the most coarse grid"      "degrees, negative is south"
+rconfig   real    stand_lon               derived                  max_domains    0       -        "stand_lon"             "standard longitude, parallel to j-direction, perpendicular to i-direction "      "degrees, negative is west"
+rconfig   real    pole_lat                derived                  max_domains    0       -        "pole_lat"              "projection info: latitude of pole" "degrees, positive north"
+rconfig   real    pole_lon                derived                  max_domains    0       -        "pole_lon"              "projection info: longitude of pole" "degrees, positive east"
+rconfig   integer  FLAG_METGRID           derived                      1          0       -        "FLAG_METGRID"         "Flag in global attributes for metgrid data"
+rconfig   integer  FLAG_SNOW              derived                      1          0       -        "FLAG_SNOW"             "Flag for snow in the global attributes for metgrid data"
+rconfig   integer  FLAG_PSFC              derived                      1          0       -        "FLAG_PSFC"             "Flag for surface pressure in the global attributes for metgrid data"
+rconfig   integer  FLAG_SM000010          derived                      1          0       -        "FLAG_SM000010"         "Flag for soil moisture in the global attributes for metgrid data"
+rconfig   integer  FLAG_SM010040          derived                      1          0       -        "FLAG_SM010040"         "Flag for soil moisture in the global attributes for metgrid data"
+rconfig   integer  FLAG_SM040100          derived                      1          0       -        "FLAG_SM040100"         "Flag for soil moisture in the global attributes for metgrid data"
+rconfig   integer  FLAG_SM100200          derived                      1          0       -        "FLAG_SM100200"         "Flag for soil moisture in the global attributes for metgrid data"
+rconfig   integer  FLAG_ST000010          derived                      1          0       -        "FLAG_ST000010"         "Flag for soil temperature in the global attributes for metgrid data"
+rconfig   integer  FLAG_ST010040          derived                      1          0       -        "FLAG_ST000010"         "Flag for soil temperature  in the global attributes for metgrid data"
+rconfig   integer  FLAG_ST040100          derived                      1          0       -        "FLAG_ST010040"         "Flag for soil temperature  in the global attributes for metgrid data"
+rconfig   integer  FLAG_ST100200          derived                      1          0       -        "FLAG_ST100200"         "Flag for soil temperature  in the global attributes for metgrid data"
+rconfig   integer  FLAG_SOIL_LAYERS       derived                      1          0       -        "FLAG_SOIL_LAYERS"      "Flag for input 3d soil data for metgrid data"
+rconfig   integer  FLAG_SLP               derived                      1          0       -        "FLAG_SLP"              "Flag for sea level pressure in the global attributes for metgrid data"
+rconfig   integer  FLAG_SOILHGT           derived                      1          0       -        "FLAG_SOILHGT"          "Flag for soil height in the global attributes for metgrid data"
+rconfig   integer  FLAG_MF_XY             derived                      1          0       -        "FLAG_MF_XY"            "Flag for MF_XYin the global attributes for metgrid data"
+rconfig   integer  FLAG_UM_SOIL           derived                      1          0       -        "FLAG_UM_SOIL"          "Flag for soil fields from the Unified Model in the globl attributes for metgrid data"
+rconfig   real    bdyfrq                  derived                  max_domains    0       -        "bdyfrq"               "lateral boundary input frequency"      "seconds"
+rconfig   character mminlu                derived                  max_domains    " "     -        "mminlu"               "land use dataset"             ""
+rconfig   integer iswater                 derived                  max_domains    0       -        "iswater"              "land use index of water"      "index category"
+rconfig   integer islake                  derived                  max_domains    0       -        "islake"               "land use index of inland lake"      "index category"
+rconfig   integer isice                   derived                  max_domains    0       -        "isice"                "land use index of ice"        "index category"
+rconfig   integer isurban                 derived                  max_domains    0       -        "isurban"              "land use index for 'urban and built-up"     "index category"
+rconfig   integer isoilwater              derived                  max_domains    0       -        "isoilwater"           "land use index of water for soil"        "index category"
+rconfig   integer map_proj                derived                  max_domains    0       -        "map_proj"             "domain map projection"      "0=none (Cylindrical), 1=Lambert, 2=polar, 3=Mercator"
+rconfig   integer use_wps_input           derived                       1         0       -        "use_wps_input"        "0/1/2 flag, using wps input"   "0=no, 1=real, 2=tc"
+rconfig   integer dfi_stage               derived                  max_domains    3       -        "dfi_stage"            "current stage of DFI processing"      "0=DFI setup, 1=DFI backward integration, 2=DFI forward integration, 3=WRF forecast"
+rconfig   integer mp_physics_dfi          derived                  max_domains   -1       -        "mp_physics_dfi"       ""      "-1 = no DFI and so no need to allocate DFI moist and scalar variables, >0 = running with DFI, so allocate DFI moist and scalar variables appropriate for selected microphysics package"
+rconfig   integer bl_pbl_physics_dfi      derived                  max_domains   -1       -        "bl_pbl_physics_dfi"   ""      "-1 = no DFI and so no need to allocate DFI qke_adv variable, >0 = running with DFI, so allocate DFI qke_adv variable appropriate for selected PBL package"
+
+#
+# Single dummy declaration to define a nodyn dyn option
+state integer nodyn_dummy - dyn_nodyn -  -  -  "" "" ""      
+
+# Turbine drag physics.
+rconfig   integer     windfarm_opt        namelist,physics      max_domains    0       rh       "windfarm_opt"                ""      ""
+rconfig   integer     windfarm_ij         namelist,physics      1              0       rh       "windfarm_ij"                ""      ""
+#
+# Ideal case selection
+rconfig   integer     ideal_case          namelist,ideal        1              0       rh       "ideal_case"                 ""      ""
+#---------------------------------------------------------------------------------------------------------------------------------------
+# Package Declarations
+#                                               
+
+#key      package       associated                package          associated 4d scalars
+#         name          namelist choice           state vars
+
+#package   passivec1      chem_opt==0                  -             
+ifdef DA_CORE=0
+package   passiveqv       mp_physics==0                -             moist:qv
+package   kesslerscheme   mp_physics==1                -             moist:qv,qc,qr
+package   linscheme       mp_physics==2                -             moist:qv,qc,qr,qi,qs,qg
+package   wsm3scheme      mp_physics==3                -             moist:qv,qc,qr;state:re_cloud,re_ice,re_snow
+package   wsm5scheme      mp_physics==4                -             moist:qv,qc,qr,qi,qs;state:re_cloud,re_ice,re_snow
+package   fer_mp_hires    mp_physics==5                -             moist:qv,qc,qr,qi;scalar:qt;state:f_ice_phy,f_rain_phy,f_rimef_phy
+package   fer_mp_hires_advect  mp_physics==15          -             moist:qv,qc,qr,qi;scalar:qrimef
+package   wsm6scheme      mp_physics==6                -             moist:qv,qc,qr,qi,qs,qg;state:re_cloud,re_ice,re_snow
+package   nuwrf4icescheme mp_physics==7              -               moist:qv,qc,qr,qi,qs,qg,qh;state:phys_tot,physc,physe,physd,physs,physm,physf,acphys_tot,acphysc,acphyse,acphysd,acphyss,acphysm,acphysf,preci3d,precs3d,precg3d,precr3d,prech3d,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,re_cloud,re_ice,re_snow
+package   thompson        mp_physics==8                -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr;state:re_cloud,re_ice,re_snow
+package   milbrandt2mom   mp_physics==9                -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnc,qnr,qni,qns,qng,qnh
+package   morr_two_moment mp_physics==10               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qns,qnr,qng;state:rqrcuten,rqscuten,rqicuten
+package   cammgmpscheme   mp_physics==11               -             moist:qv,qc,qi,qr,qs;scalar:qnc,qni,qnr,qns;state:rh_old_mp,lcd_old_mp,cldfra_old_mp,cldfra_mp,cldfra_mp_all,cldfra_conv,cldfrai,cldfral,turbtype3d,smaw3d,wsedl3d,icwmrdp3d,dp3d,shfrc3d,dlf,dlf2,tke_pbl,lradius,iradius
+#package   milbrandt3mom  mp_physics==12               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnc,qnr,qni,qns,qng,qnh,qzr,qzi,qzs,qzg,qzh
+package   sbu_ylinscheme  mp_physics==13               -             moist:qv,qc,qr,qi,qs;state:rimi
+package   wdm5scheme      mp_physics==14               -             moist:qv,qc,qr,qi,qs;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
+package   wdm6scheme      mp_physics==16               -             moist:qv,qc,qr,qi,qs,qg;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
+package   nssl_2mom       mp_physics==17               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qndrop,qnr,qni,qns,qng,qnh,qvolg,qvolh;state:re_cloud,re_ice,re_snow
+package   nssl_2momccn    mp_physics==18               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnn,qndrop,qnr,qni,qns,qng,qnh,qvolg,qvolh;state:re_cloud,re_ice,re_snow
+package   nssl_1mom       mp_physics==19               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qvolg
+package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc,qr,qi,qs,qg
+package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg;scalar:qndrop,qnr,qni,qns,qng,qvolg;state:re_cloud,re_ice,re_snow
+package   wsm7scheme      mp_physics==24               -             moist:qv,qc,qr,qi,qs,qg,qh;state:re_cloud,re_ice,re_snow
+package   wdm7scheme      mp_physics==26               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
+package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa;state:re_cloud,re_ice,re_snow,qnwfa2d,qnifa2d,taod5503d,taod5502d
+package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;scalar:qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
+package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;scalar:qnc,qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
+package   p3_2category    mp_physics==52               -             moist:qv,qc,qr,qi,qi2;scalar:qnc,qni,qnr,qir,qib,qni2,qir2,qib2;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,vmi3d_2,rhopo3d_2,di3d_2,refl_10cm,th_old,qv_old
+package   morr_tm_aero    mp_physics==40               -             moist:qv,qc,qr,qi,qs,qg;scalar:qnc,qni,qns,qnr,qng;state:rqrcuten,rqscuten,rqicuten,EFCG,EFIG,EFSG,WACT,CCN1_GS,CCN2_GS,CCN3_GS,CCN4_GS,CCN5_GS,CCN6_GS,CCN7_GS,re_cloud,re_ice,re_snow,mskf_refl_10cm
+package   jensen_ishmael  mp_physics==55               -             moist:qv,qc,qr,qi,qi2,qi3;scalar:qnr,qni,qvoli,qaoli,qni2,qvoli2,qaoli2,qni3,qvoli3,qaoli3;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,phii3d,itype,vmi3d_2,rhopo3d_2,di3d_2,phii3d_2,itype_2,vmi3d_3,rhopo3d_3,di3d_3,phii3d_3,itype_3,refl_10cm
+package   etampnew        mp_physics==95               -             moist:qv,qc,qr,qs;scalar:qt;state:f_ice_phy,f_rain_phy,f_rimef_phy
+package   gsfcgcescheme   mp_physics==97               -             moist:qv,qc,qr,qi,qs,qg
+
+
+package   radar_refl      compute_radar_ref==1         -             state:refl_10cm,refd_max
+endif
+
+package   nodfimoist        mp_physics_dfi==-1       -             -
+package   passiveqv_dfi     mp_physics_dfi==0        -             dfi_moist:dfi_qv
+package   kesslerscheme_dfi mp_physics_dfi==1        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr
+package   linscheme_dfi     mp_physics_dfi==2        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
+package   wsm3scheme_dfi    mp_physics_dfi==3        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   wsm5scheme_dfi    mp_physics_dfi==4        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   fer_mp_hires_dfi  mp_physics_dfi==5        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qt
+package   wsm6scheme_dfi    mp_physics_dfi==6        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   nuwrf4icescheme_dfi mp_physics_dfi==7      -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud_gsfc,dfi_re_rain_gsfc,dfi_re_ice_gsfc,dfi_re_snow_gsfc,dfi_re_graupel_gsfc,dfi_re_hail_gsfc,dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   thompson_dfi      mp_physics_dfi==8        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   milbrandt2mom_dfi mp_physics_dfi==9        -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnc,dfi_qnr,dfi_qni,dfi_qns,dfi_qng,dfi_qnh
+package   morr_two_moment_dfi  mp_physics_dfi==10    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qns,dfi_qnr,dfi_qng
+#package   milbrandt3mom_dfi mp_physics_dfi==12       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnc,dfi_qnr,dfi_qni,dfi_qns,dfi_qng,dfi_qnh,dfi_qzr,dfi_qzi,dfi_qzs,dfi_qzg,dfi_qzh
+#package   sbu_ylinscheme_dfi    mp_physics==13           -         dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs;state:rimi
+package   wdm5scheme_dfi    mp_physics_dfi==14       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   wdm6scheme_dfi    mp_physics_dfi==16       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   nssl_2mom_dfi     mp_physics_dfi==17       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qndrop,dfi_qnr,dfi_qni,dfi_qns,dfi_qng,dfi_qnh,dfi_qvolg,dfi_qvolh;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   nssl_2mom_dficcn  mp_physics_dfi==18       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qndrop,dfi_qnn,dfi_qnr,dfi_qni,dfi_qns,dfi_qng,dfi_qnh,dfi_qvolg;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   nssl_1mom_dfi     mp_physics_dfi==19       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qvolg
+package   nssl_1momlfo_dfi  mp_physics_dfi==21       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
+package   wsm7scheme_dfi    mp_physics_dfi==24       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   wdm7scheme_dfi    mp_physics_dfi==26       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   p3_1category_dfi  mp_physics_dfi==50       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
+package   p3_1category_nc_dfi  mp_physics_dfi==51    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
+package   p3_2category_dfi  mp_physics_dfi==52    -                dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qi2;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib,dfi_qni2,dfi_qir2,dfi_qib2;state:dfi_re_cloud,dfi_re_ice
+package   jensen_ishmael_dfi  mp_physics_dfi==55         -         dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qi2,dfi_qi3;dfi_scalar:dfi_qnr,dfi_qni,dfi_qvoli,dfi_qaoli,dfi_qni2,dfi_qvoli2,dfi_qaoli2,dfi_qni3,dfi_qvoli3,dfi_qaoli3;state:dfi_re_cloud,dfi_re_ice
+package   etampnew_dfi      mp_physics_dfi==95       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qs;dfi_scalar:dfi_qt
+package   gsfcgcescheme_dfi   mp_physics_dfi==97     -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
+
+package   noprogn       progn==0                     -             -
+package   progndrop     progn==1                     -             scalar:qndrop;dfi_scalar:dfi_qndrop;state:qndropsource
+
+package   noqndrop      alloc_qndropsource==0        -             -
+package   qndrop        alloc_qndropsource==1        -             state:qndropsource
+
+package   rrtmscheme       ra_lw_physics==1          -             -
+package   camlwscheme      ra_lw_physics==3          -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;aerosolc:sul,sslt,dust1,dust2,dust3,dust4,ocpho,bcpho,ocphi,bcphi,bg,volc;state:emstot,abstot,absnxt,acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,taucldc,taucldi
+package   rrtmg_lwscheme   ra_lw_physics==4          -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,o3rad
+package   rrtmk_lwscheme   ra_lw_physics==14          -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,o3rad
+package   rrtmg_lwscheme_fast  ra_lw_physics==24     -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,o3rad
+package   goddardlwscheme  ra_lw_physics==5          -             state:tlwdn,tlwup,slwdn,slwup,taucldc,taucldi,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,cod2d_out,ctop2d_out,re_cloud,re_ice,re_snow
+package   flglwscheme      ra_lw_physics==7          -             -
+package   heldsuarez       ra_lw_physics==31         -             -
+package   gfdllwscheme     ra_lw_physics==99         -             -
+
+package   swradscheme     ra_sw_physics==1           -             -
+package   gsfcswscheme    ra_sw_physics==2           -             state:taucldc,taucldi
+package   camswscheme     ra_sw_physics==3           -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;aerosolc:sul,sslt,dust1,dust2,dust3,dust4,ocpho,bcpho,ocphi,bcphi,bg,volc;state:emstot,abstot,absnxt,acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,aclwupt,aclwuptc,aclwdnt,aclwdntc,aclwupb,aclwupbc,aclwdnb,aclwdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,taucldc,taucldi
+package   rrtmg_swscheme  ra_sw_physics==4           -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,o3rad;aerod:ocarbon,seasalt,dust,bcarbon,sulfate,upperaer
+package   rrtmk_swscheme  ra_sw_physics==14           -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,o3rad;aerod:ocarbon,seasalt,dust,bcarbon,sulfate,upperaer
+package   rrtmg_swscheme_fast  ra_sw_physics==24     -             ozmixm:mth01,mth02,mth03,mth04,mth05,mth06,mth07,mth08,mth09,mth10,mth11,mth12;state:acswupt,acswuptc,acswdnt,acswdntc,acswupb,acswupbc,acswdnb,acswdnbc,swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc,o3rad;aerod:ocarbon,seasalt,dust,bcarbon,sulfate,upperaer
+package   goddardswscheme ra_sw_physics==5           -             state:tswdn,tswup,sswdn,sswup,taucldc,taucldi,re_cloud_gsfc,re_rain_gsfc,re_ice_gsfc,re_snow_gsfc,re_graupel_gsfc,re_hail_gsfc,cod2d_out,ctop2d_out,re_cloud,re_ice,re_snow
+package   flgswscheme     ra_sw_physics==7           -             -
+package   gfdlswscheme    ra_sw_physics==99          -             -
+
+package   sfclayrevscheme    sf_sfclay_physics==1        -             -
+package   myjsfcscheme       sf_sfclay_physics==2        -             state:tke_pbl
+package   gfssfcscheme       sf_sfclay_physics==3        -             -
+package   qnsesfcscheme      sf_sfclay_physics==4        -             -
+package   mynnsfcscheme      sf_sfclay_physics==5        -             -
+package   pxsfcscheme        sf_sfclay_physics==7        -             -
+package   temfsfcscheme      sf_sfclay_physics==10       -             state:wm_temf
+package   idealscmsfcscheme  sf_sfclay_physics==89       -             -
+package   sfclayscheme       sf_sfclay_physics==91       -             -
+
+package   noahucmscheme  sf_urban_physics==1         -             state:trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,a_u_bep,a_v_bep,a_t_bep,a_q_bep,a_e_bep,b_u_bep,b_v_bep,b_t_bep,b_q_bep,b_e_bep,dlg_bep,dl_u_bep,sf_bep,vl_bep,mh_urb2d,stdh_urb2d,lf_urb2d,lp_urb2d,hgt_urb2d,lb_urb2d,tgr_urb2d,cmcr_urb2d,drelr_urb2d,drelb_urb2d,drelg_urb2d,flxhumr_urb2d,flxhumb_urb2d,flxhumg_urb2d,tgrl_urb3d,smr_urb3d,cmgr_sfcdif,chgr_sfcdif,trl_urb3d,tgl_urb3d,tbl_urb3d
+package   bepscheme      sf_urban_physics==2         -             state:a_u_bep,a_v_bep,a_t_bep,a_q_bep,a_e_bep,b_u_bep,b_v_bep,b_t_bep,b_q_bep,b_e_bep,dlg_bep,dl_u_bep,sf_bep,vl_bep,trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,hi_urb2d,lp_urb2d,hgt_urb2d,lb_urb2d,trl_urb3d,tgl_urb3d,tbl_urb3d,tsk_rural
+package   bep_bemscheme  sf_urban_physics==3         -             state:a_u_bep,a_v_bep,a_t_bep,a_q_bep,a_e_bep,b_u_bep,b_v_bep,b_t_bep,b_q_bep,b_e_bep,dlg_bep,dl_u_bep,sf_bep,vl_bep,trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,tlev_urb3d,qlev_urb3d,tw1lev_urb3d,tw2lev_urb3d,tglev_urb3d,tflev_urb3d,sf_ac_urb3d,lf_ac_urb3d,cm_ac_urb3d,sfvent_urb3d,lfvent_urb3d,sfwin1_urb3d,sfwin2_urb3d,sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,hi_urb2d,lp_urb2d,hgt_urb2d,lb_urb2d,trl_urb3d,tgl_urb3d,tbl_urb3d,tsk_rural
+
+package   nolsmscheme    sf_surface_physics==0       -             -
+package   slabscheme     sf_surface_physics==1       -             -
+package   lsmscheme      sf_surface_physics==2       -             state:flx4,fvb,fbur,fgsn,smcrel,xlaidyn
+package   ruclsmscheme   sf_surface_physics==3       -             state:smfr3d,keepfr3dflag,soilt1,rhosnf,snowfallac,precipfr,acrunoff
+package   noahmpscheme   sf_surface_physics==4       -             state:isnowxy,tvxy,tgxy,canliqxy,canicexy,eahxy,tahxy,cmxy,chxy,fwetxy,sneqvoxy,alboldxy,qsnowxy,wslakexy,zwtxy,waxy,wtxy,tsnoxy,zsnsoxy,snicexy,snliqxy,lfmassxy,rtmassxy,stmassxy,woodxy,stblcpxy,fastcpxy,xsaixy,taussxy,t2mvxy,t2mbxy,q2mvxy,q2mbxy,tradxy,neexy,gppxy,nppxy,fvegxy,qinxy,runsfxy,runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,psnxy,savxy,sagxy,rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy,chbxy,shgxy,shcxy,shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy,trxy,evcxy,chleafxy,chucxy,chv2xy,chb2xy,chstarxy,smoiseq,smcwtdxy,rechxy,deeprechxy,fdepthxy,areaxy,rivercondxy,riverbedxy,eqzwt,pexpxy,qrfxy,qrfsxy,qspringxy,qspringsxy,qslatxy,stepwtd,rechclim,gddxy,grainxy,croptype,planting,harvest,season_gdd,cropcat,pgsxy,soilcomp,soilcl1,soilcl2,soilcl3,soilcl4
+package   clmscheme      sf_surface_physics==5       -             state:numc,nump,sabv,sabg,lwup,lhsoi,lhveg,lhtran,snl,snowdp,wtc,wtp,h2osno,t_grnd,t_veg,h2ocan,h2ocan_col,t2m_max,t2m_min,t2clm,t_ref2m,h2osoi_liq_s1,h2osoi_liq_s2,h2osoi_liq_s3,h2osoi_liq_s4,h2osoi_liq_s5,h2osoi_liq1,h2osoi_liq2,h2osoi_liq3,h2osoi_liq4,h2osoi_liq5,h2osoi_liq6,h2osoi_liq7,h2osoi_liq8,h2osoi_liq9,h2osoi_liq10,h2osoi_ice_s1,h2osoi_ice_s2,h2osoi_ice_s3,h2osoi_ice_s4,h2osoi_ice_s5,h2osoi_ice1,h2osoi_ice2,h2osoi_ice3,h2osoi_ice4,h2osoi_ice5,h2osoi_ice6,h2osoi_ice7,h2osoi_ice8,h2osoi_ice9,h2osoi_ice10,t_soisno_s1,t_soisno_s2,t_soisno_s3,t_soisno_s4,t_soisno_s5,t_soisno1,t_soisno2,t_soisno3,t_soisno4,t_soisno5,t_soisno6,t_soisno7,t_soisno8,t_soisno9,t_soisno10,dzsnow1,dzsnow2,dzsnow3,dzsnow4,dzsnow5,snowrds1,snowrds2,snowrds3,snowrds4,snowrds5,t_lake1,t_lake2,t_lake3,t_lake4,t_lake5,t_lake6,t_lake7,t_lake8,t_lake9,t_lake10,h2osoi_vol1,h2osoi_vol2,h2osoi_vol3,h2osoi_vol4,h2osoi_vol5,h2osoi_vol6,h2osoi_vol7,h2osoi_vol8,h2osoi_vol9,h2osoi_vol10,albedosubgrid,lhsubgrid,hfxsubgrid,lwupsubgrid,q2subgrid,sabvsubgrid,sabgsubgrid,nrasubgrid,swupsubgrid
+package   pxlsmscheme    sf_surface_physics==7       -             state:t2_ndg_new,q2_ndg_new,t2_ndg_old,q2_ndg_old,t2obs,q2obs,vegf_px,imperv,canfra,lai_px,wwlt_px,wfc_px,wsat_px,clay_px,csand_px,fmsand_px
+package   ssibscheme     sf_surface_physics==8       -             state:ssib_fm,ssib_fh,ssib_cm,ssibxdd,ssib_br,ssib_lhf,ssib_shf,ssib_ghf,ssib_egs,ssib_eci,ssib_ect,ssib_egi,ssib_egt,ssib_sdn,ssib_sup,ssib_ldn,ssib_lup,ssib_wat,ssib_shc,ssib_shg,ssib_lai,ssib_vcf,ssib_z00,ssib_veg,isnow,swe,snowden,snowdepth,tkair,dzo1,wo1,tssn1,tssno1,bwo1,bto1,cto1,fio1,flo1,bio1,blo1,ho1,dzo2,wo2,tssn2,tssno2,bwo2,bto2,cto2,fio2,flo2,bio2,blo2,ho2,dzo3,wo3,tssn3,tssno3,bwo3,bto3,cto3,fio3,flo3,bio3,blo3,ho3,dzo4,wo4,tssn4,tssno4,bwo4,bto4,cto4,fio4,flo4,bio4,blo4,ho4
+
+package   noahmpoptcrop2 opt_crop==2                 -             state:gecros_state
+
+package   noahmosaicscheme  sf_surface_mosaic==1         -        state:TSK_mosaic,QSFC_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic,CANWAT_mosaic,SNOW_mosaic,SNOWH_mosaic,SNOWC_mosaic,ALBEDO_mosaic,ALBBCK_mosaic,EMISS_mosaic,EMBCK_mosaic,ZNT_mosaic,Z0_mosaic,HFX_mosaic,QFX_mosaic,LH_mosaic,GRDFLX_mosaic,SNOTIME_mosaic,TR_URB2D_mosaic,TB_URB2D_mosaic,TG_URB2D_mosaic,TC_URB2D_mosaic,TS_URB2D_mosaic,TS_RUL2D_mosaic,QC_URB2D_mosaic,UC_URB2D_mosaic,TRL_URB3D_mosaic,TBL_URB3D_mosaic,TGL_URB3D_mosaic,SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,mosaic_cat_index,landusef2,smcrel,RS_mosaic,LAI_mosaic
+
+package   ysuscheme      bl_pbl_physics==1           -             -
+package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
+package   gfsscheme      bl_pbl_physics==3           -             -
+package   qnsepblscheme  bl_pbl_physics==4           -             state:tke_pbl,el_pbl,massflux_EDKF,entr_EDKF,detr_EDKF,thl_up,thv_up,rv_up,rt_up,rc_up,u_up,v_up,frac_up,rc_mf
+package   mynnpblscheme2 bl_pbl_physics==5           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
+package   mynnpblscheme3 bl_pbl_physics==6           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
+package   acmpblscheme   bl_pbl_physics==7           -             -
+package   boulacscheme   bl_pbl_physics==8           -             state:el_pbl,tke_pbl,wu_tur,wv_tur,wt_tur,wq_tur
+package   camuwpblscheme bl_pbl_physics==9           -             state:tauresx2d,tauresy2d,tpert2d,qpert2d,wpert2d,tke_pbl,smaw3d,wsedl3d,turbtype3d
+package   temfpblscheme  bl_pbl_physics==10          -             state:te_temf,kh_temf,km_temf,shf_temf,qf_temf,uw_temf,vw_temf,wupd_temf,mf_temf,thup_temf,qlup_temf,qtup_temf,cf3d_temf,hd_temf,lcl_temf,hct_temf,cfm_temf
+package   shinhongscheme bl_pbl_physics==11          -             state:el_pbl,tke_pbl
+package   gbmpblscheme   bl_pbl_physics==12          -             state:exch_tke,el_pbl,tke_pbl
+package   mrfscheme      bl_pbl_physics==99          -             -
+
+package   mynn_tkebudget bl_mynn_tkebudget==1        -             state:qSHEAR,qBUOY,qDISS,qWT,dqke
+package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,ktop_shallow,maxmf,nupdraft
+package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
+
+# dfi
+package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv
+package   mynnpblscheme3_dfi bl_pbl_physics_dfi==6   -             dfi_scalar:dfi_qke_adv
+
+package   nocuscheme     cu_physics==0               -             -
+package   kfetascheme    cu_physics==1               -             state:w0avg
+package   bmjscheme      cu_physics==2               -             -
+package   gfscheme       cu_physics==3               -             state:cugd_qvten,cugd_tten,cugd_qvtens,cugd_ttens,cugd_qcten,xmb_shallow,k22_shallow,kbcon_shallow,ktop_shallow
+package   scalesasscheme cu_physics==4               -             -
+package   g3scheme       cu_physics==5               -             state:cugd_qvten,cugd_tten,cugd_qvtens,cugd_ttens,cugd_qcten,xmb_shallow,k22_shallow,kbcon_shallow,ktop_shallow
+package   tiedtkescheme  cu_physics==6               -             -
+package   camzmscheme    cu_physics==7               -             state:precz,zmdt,zmdq,zmdice,zmdliq,evaptzm,fzsntzm,evsntzm,evapqzm,zmflxprc,zmflxsnw,zmntprpd,zmntsnpd,zmeiheat,cmfmc,cmfmcdzm,preccdzm,pconvb,pconvt,cape,zmmtu,zmmtv,zmmu,zmmd,zmupgu,zmupgd,zmvpgu,zmvpgd,zmicuu,zmicud,zmicvu,zmicvd,evapcdp3d,icwmrdp3d,rprddp3d,dp3d,du3d,ed3d,eu3d,md3d,mu3d,dsubcld2d,ideep2d,jt2d,maxg2d,lengath2d,dlf,rliq,tpert2d
+package   kfcupscheme    cu_physics==10              -             state:cldfratend_cup,cldfra_cup,updfra_cup,qc_iu_cup,qc_ic_cup,qndrop_ic_cup,wup_cup,mfup_cup,mfup_ent_cup,mfdn_cup,mfdn_ent_cup,fcvt_qc_to_pr_cup,fcvt_qc_to_qi_cup,fcvt_qi_to_pr_cup,lnterms,w0avg
+package   mskfscheme   cu_physics==11              -             state:w0avg,w_up
+package   ksasscheme     cu_physics==14              -             -
+package   nsasscheme     cu_physics==96              -             -
+package   ntiedtkescheme cu_physics==16              -             -
+package   gdscheme       cu_physics==93              -             -
+package   sasscheme      cu_physics==94              -             -
+package   osasscheme     cu_physics==95               -             -
+package   kfscheme       cu_physics==99              -             state:w0avg
+
+package   g3tave         cu_diag==1                  -             state:GD_CLOUD,GD_CLOUD2,GD_CLDFR,GD_CLOUD_A,GD_CLOUD2_A,kbcon_deep,ktop_deep,k22_deep
+
+package   kfedrates      kf_edrates==1               -             state:udr_kf,ddr_kf,uer_kf,der_kf,timec_kf
+
+package   no_cu_used     cu_used==0                  -             -
+package   any_cu_used    cu_used==1                  -             state:rucuten,rvcuten,rthcuten,rqvcuten,rqrcuten,rqccuten,rqscuten,rqicuten,rqcncuten,rqincuten
+
+package   no_cam_used    cam_used==0                 -             -
+package   any_cam_used   cam_used==1                 -             state:cldfra_old
+
+package   noshcuscheme    shcu_physics==0            -             -
+package   g3shcuscheme    shcu_physics==1            -             -
+package   camuwshcuscheme shcu_physics==2            -             state:shfrc3d,dlf,dlf2,cmfmc,cmfmc2,qtflx_cu,slflx_cu,uflx_cu,vflx_cu,qtten_cu,slten_cu,uten_cu,vten_cu,qvten_cu,qlten_cu,qiten_cu,cbmf_cu,ufrcinvbase_cu,ufrclcl_cu,winvbase_cu,wlcl_cu,plcl_cu,pinv_cu,plfc_cu,pbup_cu,ppen_cu,qtsrc_cu,thlsrc_cu,thvlsrc_cu,emkfbup_cu,cin_cu,cinlcl_cu,cbmflimit_cu,tkeavg_cu,zinv_cu,rcwp_cu,rlwp_cu,riwp_cu,tophgt_cu,wu_cu,ufrc_cu,qtu_cu,thlu_cu,thvu_cu,uu_cu,vu_cu,qtu_emf_cu,thlu_emf_cu,uu_emf_cu,vu_emf_cu,umf_cu,uemf_cu,qcu_cu,qlu_cu,qiu_cu,cufrc_cu,fer_cu,fdr_cu,dwten_cu,diten_cu,qrten_cu,qsten_cu,flxrain_cu,flxsnow_cu,ntraprd_cu,ntsnprd_cu,excessu_cu,excessu0_cu,xc_cu,aquad_cu,bquad_cu,cquad_cu,bogbot_cu,bogtop_cu,exit_uwcu_cu,exit_conden_cu,exit_klclmkx_cu,exit_klfcmkx_cu,exit_ufrc_cu,exit_wtw_cu,exit_drycore_cu,exit_wu_cu,exit_cufliter_cu,exit_kinv1_cu,exit_rei_cu,limit_shcu_cu,limit_negcon_cu,limit_ufrc_cu,limit_ppen_cu,limit_emf_cu,limit_cinlcl_cu,limit_cin_cu,limit_cbmf_cu,limit_rei_cu,ind_delcin_cu,evapcsh,cmfsl,cmflq,cldfrash,cush,icwmrsh,snowsh,rprdsh,rliq2,rliq
+package   grimsshcuscheme shcu_physics==3            -             -
+package   nscvshcuscheme  shcu_physics==4            -             -
+package   dengshcuscheme  shcu_physics==5            -             state:RDCASHTEN,RQCDCSHTEN,CLDAREAA,CLDAREAB,CA_RAD,CW_RAD,CLDLIQA,CLDLIQB,CLDDPTHB,CLDTOPB,PBLMAX,WUB,RAINSHVB,CAPESAVE,RADSAVE,AINCKFSA,LTOPB,KDCLDTOP,KDCLDBAS,XTIME1,PBLHAVG,TKEAVG,W0AVG
+
+package   no_shcu_used    shcu_used==0               -             -
+package   any_shcu_used   shcu_used==1               -             state:rushten,rvshten,rthshten,rqvshten,rqrshten,rqcshten,rqsshten,rqishten,rqgshten,rqcnshten,rqinshten
+
+package   fogsettling0   grav_settling==0            -             state:vdfg
+package   fogsettling1   grav_settling==1            -             state:vdfg,fgdp,dfgdp
+package   fogsettling2   grav_settling==2            -             state:vdfg,fgdp,dfgdp
+
+package   psufddagd      grid_fdda==1                -             fdda3d:u_ndg_old,v_ndg_old,t_ndg_old,q_ndg_old,ph_ndg_old,u_ndg_new,v_ndg_new,t_ndg_new,q_ndg_new,ph_ndg_new;fdda2d:mu_ndg_old,mu_ndg_new;state:rundgdten,rvndgdten,rthndgdten,rphndgdten,rqvndgdten,rmundgdten,hfx_fdda
+package   spnudging      grid_fdda==2               -              fdda3d:u_ndg_old,v_ndg_old,t_ndg_old,q_ndg_old,ph_ndg_old,u_ndg_new,v_ndg_new,t_ndg_new,q_ndg_new,ph_ndg_new;fdda2d:mu_ndg_old,mu_ndg_new;state:rundgdten,rvndgdten,rthndgdten,rphndgdten,rqvndgdten,rmundgdten,dif_analysis,dif_xxx,dif_yyy
+
+package   psusfddagd     grid_sfdda==1               -             state:u10_ndg_old,v10_ndg_old,t2_ndg_old,th2_ndg_old,q2_ndg_old,rh_ndg_old,psl_ndg_old,ps_ndg_old,u10_ndg_new,v10_ndg_new,t2_ndg_new,th2_ndg_new,q2_ndg_new,rh_ndg_new,psl_ndg_new,ps_ndg_new,tob_ndg_old,odis_ndg_old,tob_ndg_new,odis_ndg_new,hfx_fdda
+
+package   obsnudging     obs_nudge_opt==1           -              state:obs_savwt,fdob
+
+package   fasdas         grid_sfdda==2              -              state:u10_ndg_old,v10_ndg_old,t2_ndg_old,th2_ndg_old,q2_ndg_old,rh_ndg_old,psl_ndg_old,ps_ndg_old,u10_ndg_new,v10_ndg_new,t2_ndg_new,th2_ndg_new,q2_ndg_new,rh_ndg_new,psl_ndg_new,ps_ndg_new,tob_ndg_old,odis_ndg_old,tob_ndg_new,odis_ndg_new,sda_hfx,sda_qfx,qnorm,hfx_both,qfx_both,hfx_fdda
+
+package   aeropt1        aer_opt==1                 -              state:aerodm
+package   aeropt2        aer_opt==2                 -              state:aod5503d
+
+package   aercuopt       aercu_used==1              -              state:aeromcu,CU_UAF,EFCS,EFIS,EFSS,qr_cu,qs_cu,nc_cu,ni_cu,nr_cu,ns_cu,ccn_cu,aerovar;aerocu:cu_sulfate,cu_seasalt,cu_dust1,cu_dust2,cu_dust3,cu_dust4,cu_phoocar,cu_phiocar,cu_phobcar,cu_phibcar
+
+package   slopeopt       slope_rad==1               -              -
+package   gwdopt         gwd_opt==1                 -              state:oc12d,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4,dtaux3d,dtauy3d,dusfcg,dvsfcg
+package   omlscheme      sf_ocean_physics==1        -              state:tml,t0ml,hml,h0ml,huml,hvml,tmoml
+package   pwp3dscheme    sf_ocean_physics==2        -              state:tml,t0ml,hml,h0ml,huml,hvml,tmoml,om_tmp,om_s,om_depth,om_u,om_v,om_lat,om_lon,om_ml,om_tini,om_sini
+
+package   scmopt         scm_force==1               -              state:z_force,z_force_tend,u_g,u_g_tend,v_g,v_g_tend,w_subs,w_subs_tend,th_upstream_x,th_upstream_x_tend,th_upstream_y,th_upstream_y_tend,qv_upstream_x,qv_upstream_x_tend,qv_upstream_y,qv_upstream_y_tend,u_upstream_x,u_upstream_x_tend,u_upstream_y,u_upstream_y_tend,v_upstream_x,v_upstream_x_tend,v_upstream_y,v_upstream_y_tend,tau_x,tau_x_tend,tau_y,tau_y_tend,th_largescale,th_largescale_tend,qv_largescale,qv_largescale_tend,ql_largescale,ql_largescale_tend,u_largescale,u_largescale_tend,v_largescale,v_largescale_tend,tau_largescale,tau_largescale_tend,ql_upstream_x,ql_upstream_x_tend,ql_upstream_y,ql_upstream_y_tend,t_soil_forcing_val,t_soil_forcing_tend,q_soil_forcing_val,q_soil_forcing_tend,tau_soil,soil_depth_force,th_t_tend,qv_t_tend
+
+package   prec_acc       prec_acc_opt==1            -              state:prec_acc_c,prec_acc_nc,snow_acc_nc
+package   bucketropt     bucketr_opt==1             -              state:i_rainc,i_rainnc
+package   bucketfopt     bucketf_opt==1             -              state:i_acswupt,i_acswuptc,i_acswdnt,i_acswdntc,i_acswupb,i_acswupbc,i_acswdnb,i_acswdnbc,i_aclwupt,i_aclwuptc,i_aclwdnt,i_aclwdntc,i_aclwupb,i_aclwupbc,i_aclwdnb,i_aclwdnbc
+package   original_mom   momentum_adv_opt==1
+package   weno_mom       momentum_adv_opt==3
+
+package   original       moist_adv_opt==0            -             -
+package   positivedef    moist_adv_opt==1            -             -
+package   monotonic      moist_adv_opt==2            -             -
+package   weno_scalar    moist_adv_opt==3            -             -
+package   wenopd_scalar  moist_adv_opt==4            -             -
+
+package   maxmin_output  output_diagnostics==1            -    state:t2min,t2max,tt2min,tt2max,t2mean,t2std,q2min,q2max,tq2min,tq2max,q2mean,q2std,skintempmin,skintempmax,tskintempmin,tskintempmax,skintempmean,skintempstd,u10max,v10max,spduv10max,tspduv10max,u10mean,v10mean,spduv10mean,u10std,v10std,spduv10std,raincvmax,rainncvmax,traincvmax,trainncvmax,raincvmean,rainncvmean,raincvstd,rainncvstd
+package   nwp_output     nwp_diagnostics==1            -       state:wspd10max,w_up_max,w_dn_max,up_heli_max,w_mean,grpl_max,hail_maxk1,hail_max2d
+
+package   dfi_setup      dfi_stage==0                -             -
+package   dfi_bck        dfi_stage==1                -             -
+package   dfi_fwd        dfi_stage==2                -             -
+package   dfi_fst        dfi_stage==3                -             -
+package   dfi_startfwd   dfi_stage==4                -             -
+package   dfi_startbck   dfi_stage==5                -             -
+
+package   dfi_nodfi      dfi_opt==0                  -             -
+package   dfi_dfl        dfi_opt==1                  -             state:dfi_u,dfi_v,dfi_w,dfi_ph,dfi_phb,dfi_ph0,dfi_php,dfi_t,dfi_p,dfi_ww,dfi_mu,dfi_tke,dfi_pb,dfi_al,dfi_alt,dfi_TSLB,dfi_SMOIS,dfi_SNOW,dfi_SNOWH,dfi_CANWAT,dfi_SMFR3D,dfi_KEEPFR3DFLAG,dfi_TSK,dfi_SOILT1,dfi_TSNAV,dfi_SNOWC,dfi_QVG,dfi_rh,dfi_tten_rad
+package   dfi_ddfi       dfi_opt==2                  -             state:dfi_u,dfi_v,dfi_w,dfi_ph,dfi_phb,dfi_ph0,dfi_php,dfi_t,dfi_p,dfi_ww,dfi_mu,dfi_tke,dfi_pb,dfi_al,dfi_alt,dfi_TSLB,dfi_SMOIS,dfi_SNOW,dfi_SNOWH,dfi_CANWAT,dfi_SMFR3D,dfi_KEEPFR3DFLAG,dfi_TSK,dfi_SOILT1,dfi_TSNAV,dfi_SNOWC,dfi_QVG,dfi_rh,dfi_tten_rad
+package   dfi_tdfi       dfi_opt==3                  -             state:dfi_u,dfi_v,dfi_w,dfi_ph,dfi_phb,dfi_ph0,dfi_php,dfi_t,dfi_p,dfi_ww,dfi_mu,dfi_tke,dfi_pb,dfi_al,dfi_alt,dfi_TSLB,dfi_SMOIS,dfi_SNOW,dfi_SNOWH,dfi_CANWAT,dfi_SMFR3D,dfi_KEEPFR3DFLAG,dfi_TSK,dfi_SOILT1,dfi_TSNAV,dfi_SNOWC,dfi_QVG,dfi_rh,dfi_tten_rad
+
+package   reg_interp    nest_interp_coord==0         -             - 
+package   flat_p_interp nest_interp_coord==1         -             state:t_max_p,ght_max_p,max_p,t_min_p,ght_min_p,min_p
+
+# Tendency diagnostics for non-chemistry decoupled advective tendency arrays
+package   notenddiag    tenddiag==0                  -             -
+package   usetenddiag   tenddiag==1                  -             advh_t:advh_qv;advz_t:advz_qv
+
+package   no_trajectory traj_opt==0                  -             -
+package   um_trajectory traj_opt==1                  -             state:traj_i,traj_j,traj_k,traj_lat,traj_long
+
+package   albsi_zero     seaice_albedo_opt==0        -             -
+package   albsi_one      seaice_albedo_opt==1        -             -
+package   albsi_two      seaice_albedo_opt==2        -             state:albsi
+
+package   snowsi_zero    seaice_snowdepth_opt==0     -             -
+package   snowsi_one     seaice_snowdepth_opt==1     -             state:snowsi
+
+package   icedepth_zero  seaice_thickness_opt==0     -             -
+package   icedepth_one   seaice_thickness_opt==1     -             state:icedepth
+
+#Time series options for text output
+package   notseries   process_time_series==0                 -             -
+package   tseries     process_time_series==1                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile
+
+# WRF-HAILCAST
+state    real   HAILCAST_DHAIL1   ij     misc        1         -      r          "HAILCAST_DHAIL1"     "WRF-HAILCAST Hail Diameter, 1st rank order"     "mm"
+state    real   HAILCAST_DHAIL2   ij     misc        1         -      r          "HAILCAST_DHAIL2"     "WRF-HAILCAST Hail Diameter, 2nd rank order"     "mm"
+state    real   HAILCAST_DHAIL3   ij     misc        1         -      r          "HAILCAST_DHAIL3"     "WRF-HAILCAST Hail Diameter, 3rd rank order"     "mm"
+state    real   HAILCAST_DHAIL4   ij     misc        1         -      r          "HAILCAST_DHAIL4"     "WRF-HAILCAST Hail Diameter, 4th rank order"     "mm"
+state    real   HAILCAST_DHAIL5   ij     misc        1         -      r          "HAILCAST_DHAIL5"     "WRF-HAILCAST Hail Diameter, 5th rank order"     "mm"
+state    real   HAILCAST_DIAM_MAX   ij   misc        1         -      h02       "HAILCAST_DIAM_MAX"   "WRF-HAILCAST MAX Hail Diameter"        "mm"
+state    real   HAILCAST_DIAM_MEAN  ij   misc        1         -      -          "HAILCAST_DIAM_MEAN"  "WRF-HAILCAST Mean Hail Diameter"        "mm"
+state    real   HAILCAST_DIAM_STD   ij   misc        1         -      -          "HAILCAST_DIAM_STD"   "WRF-HAILCAST Stand. Dev. Hail Diameter" "mm"
+state    real   HAILCAST_WUP_MASK   ij     misc        1         -      r        "HAILCAST_WUP_MASK"           "Updraft mask, 1 if > 10m/s"                             ""
+state    real   HAILCAST_WDUR       ij     misc        1         -      r        "HAILCAST_WDUR"               "Updraft duration"                                       "sec"
+state    real   haildtacttime        -       -         -         -      r        "haildtacttime"              "HAILDTACTTIME"         "HAILCAST ACTIVATION TIME in s"
+
+
+package   hailcast  hailcast_opt==1        -                    state:hailcast_diam_max,hailcast_diam_mean,hailcast_diam_std,hailcast_dhail1,hailcast_dhail2,hailcast_dhail3,hailcast_dhail4,hailcast_dhail5
+rconfig   integer   hailcast_opt       namelist,physics           max_domains    0       rh    "hailcast_opt"        "WRF-HAILCAST option, 1: on"                   ""
+rconfig   real      HAILDT             namelist,physics           max_domains    0       h     "HAILDT"              "seconds between WRF-HAILCAST calls"           "sec"
+halo      HALO_EM_PHYS_HCW   dyn_em 8:hailcast_wup_mask, hailcast_wdur
+
+# lightning
+
+state    real    ic_flashcount     ij     misc    1   -   rh    "ic_flashcount"      "Accumulated IC flash count"     "#"
+state    real    ic_flashrate      ij     misc    1   -   r     "ic_flashrate"       "IC flash rate"                  "#/s"
+state    real    cg_flashcount     ij     misc    1   -   rh    "cg_flashcount"      "Accumulated CG flash count"     "#"
+state    real    cg_flashrate      ij     misc    1   -   r     "cg_flashrate"       "CG flash rate"                  "#/s"
+
+
+rconfig  integer    lightning_option         namelist,physics   max_domains    0      h    "lightning_option"          "Lightning flash parameterization"       ""
+rconfig  real       lightning_dt             namelist,physics   max_domains    0.     -    "lightning_dt"              ""                                       "s"
+rconfig  real       lightning_start_seconds  namelist,physics   max_domains    0.     -    "lightning_start_seconds"   ""                                       "s"
+rconfig  real       flashrate_factor         namelist,physics   max_domains    1.0    h    "flashrate_factor"          "Tuning factor"                          ""
+
+rconfig  integer    iccg_method              namelist,physics   max_domains    0       -   "iccg_method"               "IC:CG partitioning method"                         ""
+rconfig  real       iccg_prescribed_num      namelist,physics   max_domains    0.0     -   "iccg_prescribed_num"       "Numerator of user-specified prescribed IC:CG"      ""
+rconfig  real       iccg_prescribed_den      namelist,physics   max_domains    1.0     -   "iccg_prescribed_dem"       "Denominator of user-specified prescribed IC:CG"    ""
+rconfig  integer    cellcount_method         namelist,physics   max_domains    0       -   "cellcount_method"          "0=auto, 1=tile, 2=domain"                   ""
+rconfig  real       cldtop_adjustment        namelist,physics   max_domains    0.      -   "cldtop_adjustment"         "Adjustment to cloud top for ltng param"     "km"
+rconfig  integer    sf_lake_physics          namelist,physics   max_domains    0       -   "sf_lake_physics"           "activate lake model  0=no, 1=yes"   ""
+
+state    real  iccg_in_num    ij      misc        1         -      i{16}r     "iccg_in_num"      "IC:CG input numerator"      ""
+state    real  iccg_in_den    ij      misc        1         -      i{16}r     "iccg_in_den"      "IC:CG input denominator"    ""
+
+package	ltng_none           lightning_option==0            -       -
+package	ltng_crm_PR92w      lightning_option==1            -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
+package ltng_crm_PR92z      lightning_option==2            -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
+package	ltng_cpm_PR92z      lightning_option==11           -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
+package	ltng_lpi            lightning_option==3           -        state:lpi
+state   real    light_ne            ikjftb  scalar      1         -     \
+   i0rhusdf=(bdy_interp:dt)    "LIGHTNING_NE"       "LIGHTNING NEG TOTAL ENERGY " "J"
+state   real    light_pe            ikjftb  scalar      1         -     \
+     i0rhusdf=(bdy_interp:dt)    "LIGHTNING_PE"       "LIGHTNING POS TOTAL ENERGY" "J"
+state   real    light_neu            ikjftb  scalar      1         -     \
+       i0rhusdf=(bdy_interp:dt)    "LIGHTNING_NEU"       "LIGHTNING NEU TOTAL ENERGY" "J"
+state    real   LPOS            ij     misc        1         -     irh05du      "LPOS"                   "Positive Cloud to Ground Lightning Density"       "# time-l"
+state    real   LNEG            ij     misc        1         -     irh05du      "LNEG"                   "Negative Cloud to Ground Lightning Density"       "# time-1"
+state    real   LNEU            ij     misc        1         -     irh05du      "LNEU"                   "Intra-Cloud Lightning Density"  "# time-1"
+state    real  l_obs          i{lp}j      misc        1         -      irh5       "L_OBS"                  "Lightning OBS"      " "
+package ltng_dyn_lightning      lightning_option==4   -   scalar:light_pe,light_ne,light_neu;state:lneu,lneg,lpos,l_obs
+#
+# only need to specify these once; not for every io_form* variable
+package   io_intio    io_form_restart==1                     -             -
+package   io_netcdf   io_form_restart==2                     -             -
+# Placeholders for additional packages (we can go beyond zzz
+# but that will entail modifying frame/module_io.F and frame/md_calls.m4)
+# Please note these are placeholders; HDF has not been implemented yet.
+package   io_hdf      io_form_restart==3                     -             -
+package   io_phdf5    io_form_restart==4                     -             -
+package   io_grib1    io_form_restart==5                     -             -
+package   io_mcel     io_form_restart==6                     -             -
+package   io_esmf     io_form_restart==7                     -             -
+package   io_yyy      io_form_restart==8                     -             -
+package   io_zzz      io_form_restart==9                     -             -
+package   io_grib2    io_form_restart==10                    -             -
+package   io_pnetcdf  io_form_restart==11                    -             -
+package   io_pio      io_form_restart==12                    -             -
+
+#WRF Hydro
+package   no_wrfhydro    wrf_hydro==0                -            -
+package   wrfhydro       wrf_hydro==1                -            state:SOLDRAIN, SFCHEADRT, INFXSRT
+
+#WRF Windfarm
+package   no_windfarm    windfarm_opt==0             -            -
+package   fitchscheme    windfarm_opt==1             -            state:power
+
+#Ideal Cases
+package   realcase       ideal_case==0               -            -
+package   hill2d_x       ideal_case==1               -            -
+package   quarter_ss     ideal_case==2               -            -
+package   convrad        ideal_case==3               -            -
+package   squall2d_x     ideal_case==4               -            -
+package   squall2d_y     ideal_case==5               -            -
+package   grav2d_x       ideal_case==6               -            -
+package   b_wave         ideal_case==7               -            -
+package   seabreeze2d_x  ideal_case==8               -            -
+package   les            ideal_case==9               -            -
+# WRF-Chem specific diagnostics
+package   clnatmdiag     calc_clean_atm_diag==1      -            state:SWUPTCLN,SWDNTCLN,SWUPBCLN,SWDNBCLN,LWUPTCLN,LWDNTCLN,LWUPBCLN,LWDNBCLN 
+
+
+#---------------------------------------------------------------------------------------------------------------------------------------
+## communications                                               
+
+### 8. Edit the Registry file and create a halo-exchange for x_1.
+
+# Halo Update Communications
+halo      HALO_EM_INIT_1 dyn_em 48:u_1,u_2,v_1,v_2,w_1,w_2,ph_1,ph_2
+halo      HALO_EM_INIT_2 dyn_em 48:t_1,t_2,mu_1,mu_2,tke_1,tke_2,ww,phb
+halo      HALO_EM_INIT_3 dyn_em 48:ph0,php,t_init,mub,mu0,p,al,alt,alb
+halo      HALO_EM_INIT_4 dyn_em 48:pb,h_diabatic,qv_diabatic,qc_diabatic,msftx,msfty,msfux,msfuy,msfvx,msfvy,msfvx_inv,f,e,sina,cosa,ht,potevp,snopcx,soiltb,xlat,xlong,xlat_u,xlat_v,xlong_u,xlong_v,clat,msft,msfu,msfv
+halo      HALO_EM_INIT_5 dyn_em 48:moist,chem,scalar,tracer
+halo      HALO_EM_INIT_6 dyn_em 48:om_tmp,om_s,om_u,om_v,om_depth,om_tini,om_sini,om_lat,om_lon,om_ml
+halo      HALO_EM_VINTERP_UV_1 dyn_em 48:pd_gc,pb,pmaxw,ptrop,pmaxwnn,ptropnn
+halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
+halo      HALO_EM_PHYS_A  dyn_em 4:u_2,v_2
+halo      HALO_EM_PHYS_PBL dyn_em        4:rublten,rvblten
+halo      HALO_EM_PHYS_CU dyn_em         4:rucuten,rvcuten
+halo      HALO_EM_PHYS_SHCU dyn_em       4:rushten,rvshten
+halo      HALO_EM_FDDA dyn_em            4:rundgdten,rvndgdten
+halo      HALO_EM_FDDA_SFC dyn_em 48:z,z_at_w,pblh,regime,znt,odis_ndg_old,odis_ndg_new
+halo      HALO_EM_PHYS_DIFFUSION dyn_em  4:defor11,defor22,defor12,defor13,defor23,div,xkmv,xkmh,xkhv,xkhh,tke_1,tke_2
+halo      HALO_EM_SBM dyn_em 8:p_phy,pi_phy,dz8w,th_phy,rho,qv_old,th_old,u_phy,v_phy,moist
+halo      HALO_EM_TKE_ADVECT_3 dyn_em 24:tke_2
+halo      HALO_EM_TKE_ADVECT_5 dyn_em 48:tke_2
+halo      HALO_EM_TKE_A dyn_em 4:ph_2,phb
+halo      HALO_EM_TKE_B dyn_em 4:z,rdz,rdzw,zx,zy
+halo      HALO_EM_TKE_C dyn_em 8:u_2,v_2,z,zx,zy,rdz,rdzw,ustm,ust
+halo      HALO_EM_TKE_D dyn_em 8:defor11,defor22,defor33,defor12,defor13,defor23,div
+halo      HALO_EM_TKE_E dyn_em 8:xkmv,xkmh,xkhv,xkhh,BN2,moist,rho
+halo      HALO_EM_TKE_3 dyn_em   24:tke_1,tke_2
+halo      HALO_EM_TKE_5 dyn_em   48:tke_1,tke_2
+halo      HALO_EM_TKE_7 dyn_em   80:tke_1,tke_2
+halo      HALO_EM_TKE_OLD_E_5 dyn_em   48:tke_1
+halo      HALO_EM_TKE_OLD_E_7 dyn_em   80:tke_1
+halo      HALO_EM_HELICITY dyn_em 48:u_2,v_2,w_2,ph_2,zx,zy,rdz,rdzw
+halo      HALO_EM_B dyn_em 4:ph_2,al,p,t_1,t_save,u_save,v_save,mu_1,mu_2,mudf,php,alt,pb
+halo      HALO_EM_B2 dyn_em 4:ru_tend,rv_tend
+halo      HALO_EM_C dyn_em    4:u_2,v_2
+halo      HALO_EM_C2 dyn_em    4:ph_2,al,p,mu_2,muts,mudf
+halo      HALO_EM_D dyn_em    24:ru_m,rv_m,ww_m,mut,muts
+halo      HALO_EM_D_PV dyn_em 24:u_2,v_2,t_2
+halo      HALO_EM_D2_3 dyn_em 24:u_2,v_2,w_2,t_2,ph_2;24:moist,chem,tracer,scalar,tke_2;4:mu_2,al
+halo      HALO_EM_D2_5 dyn_em 48:u_2,v_2,w_2,t_2,ph_2;24:moist,chem,tracer,scalar,tke_2;4:mu_2,al
+halo      HALO_EM_D3_3 dyn_em 24:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,moist,chem,tracer,scalar;4:mu_1,mu_2
+halo      HALO_EM_D3_5 dyn_em 48:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,moist,chem,tracer,scalar;4:mu_1,mu_2
+halo      HALO_EM_E_3 dyn_em 24:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,;4:mu_1,mu_2
+halo      HALO_EM_E_5 dyn_em 48:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,;4:mu_1,mu_2
+halo      HALO_EM_MOIST_E_3 dyn_em 24:moist
+halo      HALO_EM_MOIST_E_5 dyn_em 48:moist
+halo      HALO_EM_MOIST_E_7 dyn_em 80:moist
+halo      HALO_CUP_G3_IN dyn_em 24:RTHFTEN,RQVFTEN,w_2,t_phy
+halo      HALO_CUP_G3_OUT dyn_em 48:cugd_tten,cugd_qvten,cugd_ttens,cugd_qvtens,raincv
+halo      HALO_EM_CHEM_E_3 dyn_em 24:chem
+halo      HALO_EM_CHEM_E_5 dyn_em 48:chem
+halo      HALO_EM_CHEM_E_7 dyn_em 80:chem
+halo      HALO_EM_TRACER_E_3 dyn_em 24:tracer
+halo      HALO_EM_TRACER_E_5 dyn_em 48:tracer
+halo      HALO_EM_TRACER_E_7 dyn_em 80:tracer
+halo      HALO_EM_SCALAR_E_3 dyn_em 24:scalar
+halo      HALO_EM_SCALAR_E_5 dyn_em 48:scalar
+halo      HALO_EM_SCALAR_E_7 dyn_em 80:scalar
+halo      HALO_TOPOSHAD phys 24:ht_shad
+halo      HALO_EM_HORIZ_INTERP dyn_em 24:t_2,ph_2,ht,t_max_p,ght_max_p,max_p,t_min_p,ght_min_p,min_p
+halo      HALO_EM_THETAM dyn_em 48:h_diabatic
+
+halo      HALO_EM_MOIST_OLD_E_3 dyn_em 24:moist_old
+halo      HALO_EM_MOIST_OLD_E_5 dyn_em 48:moist_old
+halo      HALO_EM_MOIST_OLD_E_7 dyn_em 80:moist_old
+halo      HALO_EM_CHEM_OLD_E_3 dyn_em 24:chem_old
+halo      HALO_EM_CHEM_OLD_E_5 dyn_em 48:chem_old
+halo      HALO_EM_CHEM_OLD_E_7 dyn_em 80:chem_old
+halo      HALO_EM_TRACER_OLD_E_3 dyn_em 24:tracer_old
+halo      HALO_EM_TRACER_OLD_E_5 dyn_em 48:tracer_old
+halo      HALO_EM_TRACER_OLD_E_7 dyn_em 80:tracer_old
+halo      HALO_EM_SCALAR_OLD_E_3 dyn_em 24:scalar_old
+halo      HALO_EM_SCALAR_OLD_E_5 dyn_em 48:scalar_old
+halo      HALO_EM_SCALAR_OLD_E_7 dyn_em 80:scalar_old
+
+halo      HALO_EM_FEEDBACK   dyn_em 48:ht
+halo      HALO_EM_HYDRO_UV   dyn_em 8:u_2,v_2
+halo      HALO_EM_HYDRO_NOAHMP dyn_em 8:ZWTXY
+halo      HALO_EM_HYDRO_NOAHMP_INIT dyn_em 8:ZWTXY,FDEPTHXY,HT,ISLTYP
+
+halo      HALO_EM_COUPLE_A   dyn_em 24:mub,mu_1,mu_2
+period    PERIOD_EM_COUPLE_A dyn_em 2:mub,mu_1,mu_2
+halo      HALO_EM_COUPLE_B   dyn_em 48:ph_1,ph_2,w_1,w_2,t_1,t_2,u_1,u_2,v_1,v_2,\
+                                       moist,chem,tracer,scalar
+period    PERIOD_EM_COUPLE_B dyn_em 3:ph_1,ph_2,w_1,w_2,t_1,t_2,u_1,u_2,v_1,v_2,\
+                                       moist,chem,tracer,scalar
+
+#cyl for trajectory 
+halo      HALO_EM_F dyn_em  24:muu,muv,mut
+halo      HALO_EM_F_1 dyn_em  24:muus,muvs
+
+## For moving nests
+#halo      em_shift_halo_y  dyn_em 48:imask_nostag,imask_xstag,imask_ystag,imask_xystag,u_2,v_2,t_2
+#halo      em_shift_halo_x  dyn_em 48:imask_nostag,imask_xstag,imask_ystag,imask_xystag,u_2,v_2,t_2
+
+# For observational nudging
+halo      HALO_OBS_NUDGE dyn_em 24:ph_2,p,uratx,vratx,tratx,kpbl
+
+# cyl: For 3DPWP
+halo      HALO_PWP dyn_em 8: OM_TMP,OM_S,OM_U,OM_V,OM_DEPTH,OM_TINI,OM_SINI
+
+# Periodic Boundary Communications
+
+period    PERIOD_BDY_EM_INIT dyn_em 3:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,t_init,phb,ph0,php,pb,al,alt,alb,mu_1,mu_2,mub,mu0,ht,msftx,msfty,msfux,msfuy,msfvx,msfvy,msfvx_inv,sina,cosa,e,f
+
+# Monotonic, positive definite advection requires 4 values for moist, chem, tke, and scalar for periodic lateral boundaries
+
+period    PERIOD_BDY_EM_MOIST dyn_em 4:moist
+period    PERIOD_BDY_EM_CHEM dyn_em 4:chem
+period    PERIOD_BDY_EM_TRACER dyn_em 4:tracer
+period    PERIOD_BDY_EM_SCALAR dyn_em 4:scalar
+period    PERIOD_BDY_EM_TKE dyn_em 4:tke_2
+period    PERIOD_BDY_EM_MOIST2 dyn_em 4:moist
+period    PERIOD_BDY_EM_CHEM2 dyn_em 4:chem
+period    PERIOD_BDY_EM_TRACER2 dyn_em 4:tracer
+period    PERIOD_BDY_EM_SCALAR2 dyn_em 4:scalar
+period    PERIOD_BDY_EM_MOIST_OLD dyn_em 4:moist_old
+period    PERIOD_BDY_EM_CHEM_OLD dyn_em 4:chem_old
+period    PERIOD_BDY_EM_TRACER_OLD dyn_em 4:tracer_old
+period    PERIOD_BDY_EM_SCALAR_OLD dyn_em 4:scalar_old
+period    PERIOD_BDY_EM_TKE_OLD dyn_em 4:tke_1
+
+period    PERIOD_BDY_EM_E dyn_em 2:u_2,v_2,ht
+period    PERIOD_EM_HYDRO_UV dyn_em 1:u_2,v_2
+period    PERIOD_BDY_EM_A dyn_em 2:ru,rv,rw,ww,php,alt,p,muu,muv,mut,ph_2,al
+period    PERIOD_BDY_EM_A1  dyn_em 3:rdzw,rdz,z,zx,zy,ustm,ust
+period    PERIOD_BDY_EM_PHY_BC dyn_em 2:rublten,rvblten,rucuten,rvcuten,xkmh,xkmv,xkhh,xkhv,div,defor11,defor22,defor12,defor13,defor23,defor33,tke_2,rho
+period    PERIOD_BDY_EM_FDDA_BC dyn_em 2:rundgdten,rvndgdten
+period    PERIOD_BDY_EM_B dyn_em 2:ru_tend,rv_tend,ph_2,al,p,t_1,t_save,u_save,v_save,mu_1,mu_2,mudf,php,alt,pb
+period    PERIOD_BDY_EM_B3 dyn_em 2:ph_2,al,p,mu_2,muts,mudf
+period    PERIOD_BDY_EM_B2 dyn_em 2:ru_tend,rv_tend
+period    PERIOD_BDY_EM_C dyn_em 2:u_2,u_save,v_2,v_save,t_2,t_save,muv,msfvx,msfvy,muu,msfux,msfuy,msfvx_inv
+period    PERIOD_BDY_EM_D dyn_em 3:u_2,v_2,w_2,t_2,ph_2,mu_2,tke_2
+period    PERIOD_BDY_EM_D3 dyn_em 3:u_1,u_2,v_1,v_2,w_1,w_2,t_1,t_2,ph_1,ph_2,tke_1,tke_2,mu_1,mu_2
+period    PERIOD_EM_DA dyn_em 2:ru_m,rv_m,ww_m,mut,muts
+period    PERIOD_EM_F dyn_em 2:muus,muvs
+period    PERIOD_EM_G dyn_em 2:msftx,msfux,msfvy
+period    PERIOD_EM_THETAM dyn_em 3:h_diabatic
+
+#
+#swap SWAP_ETAMP_NEW  dyn_em 1:dz8w,p_phy,pi_phy,rho,th_phy,moist,F_ICE_PHY,F_RAIN_PHY,F_RIMEF_PHY,RAINNC,RAINNCV,SR,LOWLYR
+#swap SWAP_WSM3       dyn_em 1:th_phy,moist,w_2,rho,pi_phy,p_phy,dz8w,rainnc,rainncv
+#cycle CYCLE_TEST       dyn_em 1:xlong
+
+##
+
+# FDDA (Observational-nudging) Variables
+typedef fdob_type integer domain_tot   # total number of domains to apply obs-nudging
+typedef fdob_type integer IEODI        # end of obs data flag for current model step
+typedef fdob_type integer IWTSIG       # flag for nudging on pressure surfaces
+typedef fdob_type integer NSTAT        # number of obs stations used to nudge current model step
+typedef fdob_type integer NSTAW        # number of obs stations within current time window
+typedef fdob_type integer KTAUR        # restart model step
+typedef fdob_type integer LEVIDN(max_domains)   # level of nest
+typedef fdob_type integer REFPRT(max_domains)   # reference obs index for diagnostic printout
+typedef fdob_type real    WINDOW       # time window half-period for nudging (in minutes) 
+typedef fdob_type real    RTLAST       # time in hours of last obs used in current model step
+typedef fdob_type real    DATEND       # time in minutes after which data are asuumed to have ended
+typedef fdob_type logical NUDGE_UV_PBL # Flag for wind nudging within the PBL
+typedef fdob_type logical NUDGE_T_PBL  # Flag for temperature nudging within the PBL
+typedef fdob_type logical NUDGE_Q_PBL  # Flag for moisture nudging within the PBL
+typedef fdob_type integer SFC_SCHEME_HORIZ # Flag for horizontal spreading scheme for surface obs
+typedef fdob_type integer SFC_SCHEME_VERT  # Flag for vertical   spreading scheme for surface obs
+typedef fdob_type real    MAX_SNDNG_GAP # Maximum pressure gap allowed for interpolating between soundings (centibars)
+typedef fdob_type real    SFCFACT      # scale factor applied to time window for surface obs
+typedef fdob_type real    SFCFACR      # scale factor applied to horiz radius of influence for surface obs
+typedef fdob_type real    RINFMN       # minimum radius of influence
+typedef fdob_type real    RINFMX       # maximum radius of influence
+typedef fdob_type real    PFREE        # pressure level (cb) where terrain effect becomes small
+typedef fdob_type real    DCON         # 1/DPSMX
+typedef fdob_type real    DPSMX        # max pres change (cb) allowed within infl range of surf obs 
+typedef fdob_type real    TFACI        # scale factor used for ramp-down in dynamic initialization
+typedef fdob_type real    KNOWN_LAT    # Latitude  of origin point (i,j)=(1,1)
+typedef fdob_type real    KNOWN_LON    # Longitude of origin point (i,j)=(1,1)
+typedef fdob_type character SDATE      # domain starting date (YYYY-MM-DD_hh:mm:ss)
+typedef fdob_type real    XTIME_AT_REST # xtime at restart time
+typedef fdob_type real    VIF_UV(6)    # Vertical influence function parameters for wind nudging
+typedef fdob_type real    VIF_T(6)     # Vertical influence function parameters for temperature nudging
+typedef fdob_type real    VIF_Q(6)     # Vertical influence function parameters for moisture nudging
+typedef fdob_type real    VIF_FULLMIN  # Minimum depth through which vert infl fcn remains 1.0 (m)
+typedef fdob_type real    VIF_RAMPMIN  # Minimum depth through which vif decreases 1.0 to 0.0 (m)
+typedef fdob_type real    VIF_MAX      # Maximum depth in which vif is nonzero (m)
+
+# table entries are of the form
+#      <Table>  <Type>  <Sym>                <Dims>   <Use>   <NumTLev> <Stagger> <IO>     <DNAME>             <DESCRIP>     <UNITS>
+#Grid variables
+typedef fdob_type real    varobs         {nndgvar}{obs} -         1        -       -       "varobs"          "observational values in each variable"
+typedef fdob_type real    errf              h{obs}      -         1        -       -       "errf"            "errors between model and obs values"
+typedef fdob_type real    timeob             {obs}      -         1        -       -       "timeob"          "model times for each observation"          "hours"
+typedef fdob_type real    nlevs_ob           {obs}      -         1        -       -       "nlevs_ob"        "numbers of levels in sounding obs"
+typedef fdob_type real    lev_in_ob          {obs}      -         1        -       -       "lev_in_ob"       "level in sounding-type obs"
+typedef fdob_type real    plfo               {obs}      -         1        -       -       "plfo"            "index for type of obs-platform"
+typedef fdob_type real    elevob             {obs}      -         1        -       -       "elevob"          "elevation of observation"                  "meters"
+typedef fdob_type real    rio                {obs}      -         1        -       -       "rio"             "west-east grid coordinate"
+typedef fdob_type real    rjo                {obs}      -         1        -       -       "rjo"             "south-north grid coordinate"
+typedef fdob_type real    rko                {obs}      -         1        -       -       "rko"             "vertical grid coordinate"
+typedef fdob_type integer obsprt               [        -         1        -       -       "obsprt"          "obs index for diagnostic printout"
+typedef fdob_type real    latprt               [        -         1        -       -       "latprt"          "obs latitude for diagnostic printout"
+typedef fdob_type real    lonprt               [        -         1        -       -       "lonprt"          "obs longitude for diagnostic printout"
+typedef fdob_type real    mlatprt              [        -         1        -       -       "mlatprt"         "model latitude at obs location"
+typedef fdob_type real    mlonprt              [        -         1        -       -       "mlonprt"         "model longitude at obs location"
+typedef fdob_type integer stnidprt       {obsstid}{[}   -         1        -       -       "stnidprt"        "obs station id for diagnostic printout"
+typedef fdob_type real    base_state           k        -         1        -       -       "base_state"      "base-state height on half (mass) levels"   "meters"
+
+state fdob_type fdob - -
+
+# xpose variables for polar fft
+state    real   t_xxx          ikjx    -           1        -
+state    real   u_xxx          ikjx    -           1        X
+state    real   ru_xxx         ikjx    -           1        X
+state    real   v_xxx          ikjx    -           1        Y
+state    real   rv_xxx         ikjx    -           1        Y
+state    real   w_xxx          ikjx    -           1        Z
+state    real   ww_xxx         ikjx    -           1        Z
+state    real   ph_xxx         ikjx    -           1        Z
+state    real   dum_yyy        ikjy    -           1        -
+state    real   fourd_xxx      ikjx    -           1        -
+state    real   clat_xxx       ijx     -           1        -
+state    real   ht_xxx         ijx     -           1        -
+state    real   mf_xxx         ijx     -           1        -
+
+xpose XPOSE_POLAR_FILTER_TOPO dyn_em t_init,t_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_T  dyn_em t_2,t_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_U  dyn_em u_2,u_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_RU dyn_em ru_m,ru_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_V  dyn_em v_2,v_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_RV dyn_em rv_m,rv_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_W  dyn_em w_2,w_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_WW dyn_em ww_m,ww_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_PH dyn_em ph_2,ph_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_MOIST dyn_em moist,fourd_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_CHEM dyn_em chem,fourd_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_TRACER dyn_em tracer,fourd_xxx,dum_yyy
+xpose XPOSE_POLAR_FILTER_SCALAR dyn_em scalar,fourd_xxx,dum_yyy
+
+# xpose variables for spectral nudging
+state    real   dif_analysis     ikj     -           1
+state    real   dif_xxx          ikjx    -           1
+state    real   dif_yyy          ikjy    -           1
+
+xpose XPOSE_SPECTRAL_NUDGING dyn_em dif_analysis,dif_xxx,dif_yyy
+##
+
+package   no_fft_used    fft_used==0                  -             -
+package   any_fft_used   fft_used==1                  -             state:t_xxx,u_xxx,ru_xxx,v_xxx,rv_xxx,w_xxx,ww_xxx,ph_xxx,dum_yyy,fourd_xxx
+

--- a/branch_check.file
+++ b/branch_check.file
@@ -1,0 +1,1 @@
+Dummy file to check my branch

--- a/dyn_em/module_after_all_rk_steps.F
+++ b/dyn_em/module_after_all_rk_steps.F
@@ -1,4 +1,5 @@
 !WRF:MEDIATION_LAYER:SOLVER
+! modified
 
 MODULE module_after_all_rk_steps
 

--- a/dyn_em/module_after_all_rk_steps.F
+++ b/dyn_em/module_after_all_rk_steps.F
@@ -79,12 +79,13 @@ CONTAINS
 
       TYPE ( grid_config_rec_type ), INTENT(IN) :: config_flags
 
-      !  The 4d arrays are input only, no mods to them.
+      !  The 4d arrays are input only, no mods to them -- except for scalar
+      !  which is is modified in the call to the dynamic lightning scheme.
 
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_moist ) , INTENT(IN) :: moist
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_chem  ) , INTENT(IN) :: chem
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_tracer) , INTENT(IN) :: tracer
-      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_scalar) , INTENT(IN) :: scalar
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_scalar) , INTENT(INOUT) :: scalar
 
       !  A few handy 3d arrays computed for the physics scheme: pressure (Pa) and
       !  temperature (K), on both half (_phy) and full levels.

--- a/dyn_em/module_after_all_rk_steps_add.F
+++ b/dyn_em/module_after_all_rk_steps_add.F
@@ -1,0 +1,170 @@
+!WRF:MEDIATION_LAYER:SOLVER
+
+MODULE module_after_all_rk_steps
+
+CONTAINS
+
+   !  This subroutine is called once per domain per time step.  It is outside
+   !  of and after the end of the Runge-Kutta time steps, after the calls to 
+   !  the explicit moisture driver, and after the polar filtering calls.  The
+   !  variables in here are all up-to-date with the end of this current time 
+   !  step.
+
+
+   SUBROUTINE after_all_rk_steps ( grid, config_flags,                  &
+                                   moist, chem, tracer, scalar,         &
+                                   th_phy, pi_phy, p_phy, rho_phy,      & 
+                                   p8w, t8w, dz8w,                      &
+                                   curr_secs, curr_secs2,               &
+                                   diag_flag,                           &
+                                   ids,  ide,  jds,  jde,  kds,  kde,   &
+                                   ims,  ime,  jms,  jme,  kms,  kme,   &
+                                   ips,  ipe,  jps,  jpe,  kps,  kpe,   &
+                                   imsx, imex, jmsx, jmex, kmsx, kmex,  &
+                                   ipsx, ipex, jpsx, jpex, kpsx, kpex,  &
+                                   imsy, imey, jmsy, jmey, kmsy, kmey,  &
+                                   ipsy, ipey, jpsy, jpey, kpsy, kpey   )
+
+
+      !=============================================================
+      !  USE Association for Generic WRF Infrastructure
+      !=============================================================
+
+      !  Pick up the number of members for each of the 4d arrays - for declaration purposes.
+
+      USE module_state_description, ONLY: num_moist, num_chem, num_tracer, num_scalar
+
+      !  This gives us the type definition for grid (domain)
+
+      USE module_domain, ONLY : domain
+
+      !  All of the information from the namelist is in config_flags.  The
+      !  type declaration for this puppy must be available.
+
+      USE module_configure, ONLY : grid_config_rec_type
+
+#ifdef DM_PARALLEL
+      !  Ensure some of the fancy diagnostics variables that need to
+      !  talk to other patches can do so.
+
+      USE module_dm, ONLY : &
+                  local_communicator, mytask, ntasks, ntasks_x, ntasks_y                   &
+                 ,local_communicator_periodic, wrf_dm_maxval
+
+      USE module_comm_dm, ONLY : &
+                  halo_em_phys_w_sub, halo_em_phys_hcw_sub
+#endif
+
+      !=============================================================
+      !  USE Association for the Diagnostic Packages
+      !=============================================================
+      
+      USE module_diagnostics_driver, ONLY : diagnostics_driver
+
+
+      IMPLICIT NONE
+
+
+      !=============================================================
+      !  Subroutine Arguments
+      !=============================================================
+
+      !  Arguments passed in.  All of the diagnostics are part of the grid structure, so
+      !  even though we are not changing any of the fundamental variables, we are computing
+      !  the diagnostics.  Therefore grid is INOUT.
+
+      TYPE ( domain ), INTENT(INOUT) :: grid
+
+      !  We are not changing any of the namelist settings.
+
+      TYPE ( grid_config_rec_type ), INTENT(IN) :: config_flags
+
+      !  The 4d arrays are input only, no mods to them -- except for scalar
+      !  which is is modified in the call to the dynamic lightning scheme.
+
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_moist ) , INTENT(IN) :: moist
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_chem  ) , INTENT(IN) :: chem
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_tracer) , INTENT(IN) :: tracer
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_scalar) , INTENT(INOUT) :: scalar
+
+      !  A few handy 3d arrays computed for the physics scheme: pressure (Pa) and
+      !  temperature (K), on both half (_phy) and full levels.
+
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme)            , INTENT(IN) :: th_phy  , &
+                                                                           p_phy   , &
+                                                                           pi_phy  , &
+                                                                           rho_phy , &
+                                                                           dz8w    , &
+                                                                           p8w     , &
+                                                                           t8w
+
+      !  Time (s) since the beginning of the restart.
+
+      REAL(8) :: curr_secs
+      REAL :: curr_secs2
+
+      !  Is this to be a history output time?  If so, compute the diagnostics.
+
+      LOGICAL :: diag_flag
+
+      !  The sundry dimensions required to keep a model running smoothly:
+      !     The first letter:
+      !        i: refers to the nominally west east direction, the inner-most (fastest)
+      !           incrementing index
+      !        j: refers to the nominally south north direction, the outer-most (slowest)
+      !           incrementing index
+      !        k: refers to the vertical direction form bottom to top, the second dimension
+      !           in all 3d arrays
+      !     The second letter: 
+      !        d: refers to the domain size, the geophysical extent of the entire domain,
+      !           not used in dimensions or looping, used to determine when we are close to
+      !           the edge of the boundary
+      !        m: refers to the memory size size, all 2d and 3d arrays from the Registry
+      !           (passed into here via the grid structure or the I1 variables [such as
+      !           p_phy, for example]) use these values for dimensioning
+      !        p: refers to the patch size, the extent over which computational loops run
+
+      INTEGER , INTENT(IN) :: ids, ide, jds, jde, kds, kde,     &
+                              ims, ime, jms, jme, kms, kme,     &
+                              ips, ipe, jps, jpe, kps, kpe
+
+      !  Hopefully unnecessary, these are the filtered dimensions.
+
+      INTEGER , INTENT(IN) :: imsx,imex,jmsx,jmex,kmsx,kmex,    &
+                              ipsx,ipex,jpsx,jpex,kpsx,kpex,    &
+                              imsy,imey,jmsy,jmey,kmsy,kmey,    &
+                              ipsy,ipey,jpsy,jpey,kpsy,kpey
+
+#ifdef DM_PARALLEL
+      !=============================================================
+      !  Include patch communications
+      !=============================================================
+#     include "HALO_EM_PHYS_W.inc"
+#     include "HALO_EM_PHYS_HCW.inc"
+#endif
+
+      !=============================================================
+      !  Start of executable code
+      !=============================================================
+
+      CALL wrf_debug ( 100 , '--> TOP OF AFTER ALL RK STEPS' ) 
+      CALL wrf_debug ( 100 , '--> CALLING DIAGNOSTICS DRIVER' )
+
+      CALL diagnostics_driver ( grid, config_flags,               &
+                                moist, chem, tracer, scalar,         &
+                                th_phy, pi_phy, p_phy, rho_phy,      & 
+                                p8w, t8w, dz8w,                      &
+                                curr_secs, curr_secs2,               &
+                                diag_flag,                           &
+                                ids,  ide,  jds,  jde,  kds,  kde,   &
+                                ims,  ime,  jms,  jme,  kms,  kme,   &
+                                ips,  ipe,  jps,  jpe,  kps,  kpe,   &
+                                imsx, imex, jmsx, jmex, kmsx, kmex,  &
+                                ipsx, ipex, jpsx, jpex, kpsx, kpex,  &
+                                imsy, imey, jmsy, jmey, kmsy, kmey,  &
+                                ipsy, ipey, jpsy, jpey, kpsy, kpey   )
+
+
+   END SUBROUTINE after_all_rk_steps
+
+END MODULE module_after_all_rk_steps

--- a/phys/Makefile
+++ b/phys/Makefile
@@ -89,9 +89,9 @@ MODULES = \
 	module_mp_thompson.o \
 	module_mp_full_sbm.o \
 	module_mp_fast_sbm.o \
-	module_ltng_lpi.o \
         module_ltng_pe.o \
         module_ltng_strokes.o \
+	module_ltng_lpi.o \
 	module_mp_gsfcgce.o \
 	module_mp_gsfcgce_4ice_nuwrf.o \
 	module_mp_morr_two_moment.o \

--- a/phys/Makefile
+++ b/phys/Makefile
@@ -90,6 +90,8 @@ MODULES = \
 	module_mp_full_sbm.o \
 	module_mp_fast_sbm.o \
 	module_ltng_lpi.o \
+        module_ltng_pe.o \
+        module_ltng_strokes.o \
 	module_mp_gsfcgce.o \
 	module_mp_gsfcgce_4ice_nuwrf.o \
 	module_mp_morr_two_moment.o \

--- a/phys/module_diagnostics_driver.F
+++ b/phys/module_diagnostics_driver.F
@@ -1,4 +1,5 @@
 #if (NMM_CORE == 1)
+!Modifed
 MODULE module_diagnostics_driver
 CONTAINS
    SUBROUTINE diagnostics_driver_stub

--- a/phys/module_diagnostics_driver.F
+++ b/phys/module_diagnostics_driver.F
@@ -104,7 +104,7 @@ CONTAINS
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_moist ) , INTENT(IN) :: moist
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_chem  ) , INTENT(IN) :: chem
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_tracer) , INTENT(IN) :: tracer
-      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_scalar) , INTENT(IN) :: scalar
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_scalar) , INTENT(INOUT) :: scalar
 
       !  A few handy 3d arrays computed for the physics scheme: pressure (Pa) and
       !  temperature (K), on both half (_phy) and full levels.
@@ -205,7 +205,7 @@ CONTAINS
             grid%t_phy, p_phy, grid%rho,                       &
             grid%u_phy, grid%v_phy, grid%w_2,                  &    
             th_phy,     pi_phy,dz8w,                           &  
-            grid%z, moist,                                     &
+            grid%z, moist,scalar,                              &
           ! Scheme specific prognostics
             grid%ktop_deep, grid%refl_10cm,                    &
             domain_get_current_time( grid ),                   &
@@ -224,6 +224,17 @@ CONTAINS
           ! Scheme specific namelist inputs
             config_flags%cellcount_method,                     &
             config_flags%cldtop_adjustment,                    &
+         ! Dynamic_Lightning inputs
+            config_flags%coul_pos,                     &
+            config_flags%coul_neg,                     &
+            config_flags%coul_neu,                     &
+            config_flags%j_pos,                     &
+            config_flags%j_neg,                     &
+            config_flags%j_neu,                     &
+         ! Dynamic_Lightning Outputs
+            grid%lpos, &
+            grid%lneg, &
+            grid%lneu, &
           ! Order dependent args for domain, mem, and tile dims 
             ids, ide, jds, jde, kds, kde,         &
             ims, ime, jms, jme, kms, kme,         &

--- a/phys/module_diagnostics_driver_add.F
+++ b/phys/module_diagnostics_driver_add.F
@@ -1,0 +1,1270 @@
+#if (NMM_CORE == 1)
+MODULE module_diagnostics_driver
+CONTAINS
+   SUBROUTINE diagnostics_driver_stub
+   END SUBROUTINE diagnostics_driver_stub
+END MODULE module_diagnostics_driver
+#else
+!WRF:MODEL_LAYER:PHYSICS
+
+MODULE module_diagnostics_driver
+
+CONTAINS
+
+   !  This subroutine is the driver for the diagnostics packages.
+
+
+   SUBROUTINE diagnostics_driver ( grid, config_flags,                  &
+                                   moist, chem, tracer, scalar,         &
+                                   th_phy, pi_phy, p_phy, rho_phy,      & 
+                                   p8w, t8w, dz8w,                      &
+                                   curr_secs, curr_secs2,               &
+                                   diag_flag,                           &
+                                   ids,  ide,  jds,  jde,  kds,  kde,   &
+                                   ims,  ime,  jms,  jme,  kms,  kme,   &
+                                   ips,  ipe,  jps,  jpe,  kps,  kpe,   &
+                                   imsx, imex, jmsx, jmex, kmsx, kmex,  &
+                                   ipsx, ipex, jpsx, jpex, kpsx, kpex,  &
+                                   imsy, imey, jmsy, jmey, kmsy, kmey,  &
+                                   ipsy, ipey, jpsy, jpey, kpsy, kpey   )
+
+
+      !=============================================================
+      !  USE Association for Generic WRF Infrastructure
+      !=============================================================
+
+      !  Pick up the number of members for each of the 4d arrays - for declaration purposes.
+
+      USE module_state_description, ONLY: num_moist, num_chem, num_tracer, num_scalar, &
+                                          SKIP_PRESS_DIAGS, SKIP_Z_DIAGS,              &
+                                          DO_TRAD_FIELDS,                              &
+                                          P_QG, P_QH, P_QV, P_QC,                      &
+                                          P_QNG, P_QH, P_QNH, P_QR, P_QNR,             &
+                     KESSLERSCHEME, LINSCHEME, SBU_YLINSCHEME, WSM3SCHEME, WSM5SCHEME, &
+                     WSM6SCHEME, ETAMPNEW, THOMPSON, THOMPSONAERO,                     &
+                     MORR_TWO_MOMENT, GSFCGCESCHEME, WDM5SCHEME, WDM6SCHEME,           &
+                     NSSL_2MOM, NSSL_2MOMCCN, NSSL_1MOM, NSSL_1MOMLFO,                 &
+                     MILBRANDT2MOM , CAMMGMPSCHEME, FAST_KHAIN_LYNN, FULL_KHAIN_LYNN,  &
+                     MORR_TM_AERO !TWG add    !,MILBRANDT3MOM, NSSL_3MOM, MORR_MILB_P3
+
+      USE module_driver_constants, ONLY: max_plevs, max_zlevs
+
+      !  From where we preferably are pulling g, Cp, etc.
+
+      USE module_model_constants, ONLY: g, R_v, R_d, Cp, T0, RCP
+
+      !  This gives us the type definition for grid (domain) and some clock information.
+
+!     USE module_domain, ONLY : domain, domain_clock_get, get_ijk_from_subgrid
+      USE module_domain, ONLY : domain, domain_clock_get, domain_get_current_time
+
+      !  All of the information from the namelist is in config_flags.  The
+      !  type declaration for this puppy must be available.  While each domain
+      !  has a config_flags, together they are stored in model_config_rec.
+
+      USE module_configure, ONLY : grid_config_rec_type, &
+                                   model_config_rec
+
+      USE module_streams
+      USE module_utility, ONLY : WRFU_Time 
+
+      !=============================================================
+      !  USE Association for the Diagnostic Packages
+      !=============================================================
+      
+      USE module_lightning_driver, ONLY : lightning_driver      
+      USE module_diag_misc, ONLY : diagnostic_output_calc
+      USE module_diag_cl, ONLY : clwrf_output_calc
+      USE module_diag_pld, ONLY : pld
+      USE module_diag_zld, ONLY : zld
+      USE module_diag_afwa, ONLY : afwa_diagnostics_driver
+      USE module_diag_rasm, ONLY : mean_output_calc, diurnalcycle_output_calc
+      USE module_diag_hailcast, ONLY : hailcast_diagnostic_driver
+      USE module_trad_fields, ONLY : trad_fields
+
+      IMPLICIT NONE
+
+
+      !=============================================================
+      !  Subroutine Arguments
+      !=============================================================
+
+      !  Arguments passed in.  All of the diagnostics are part of the grid structure, so
+      !  even though we are not changing any of the fundamental variables, we are computing
+      !  the diagnostics.  Therefore grid is INOUT.
+
+      TYPE ( domain ), INTENT(INOUT) :: grid
+
+      !  We are not changing any of the namelist settings.
+
+      TYPE ( grid_config_rec_type ), INTENT(IN) :: config_flags
+
+      !  The 4d arrays are input only, no mods to them.
+
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_moist ) , INTENT(IN) :: moist
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_chem  ) , INTENT(IN) :: chem
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_tracer) , INTENT(IN) :: tracer
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_scalar) , INTENT(INOUT) :: scalar
+
+      !  A few handy 3d arrays computed for the physics scheme: pressure (Pa) and
+      !  temperature (K), on both half (_phy) and full levels.
+
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme)            , INTENT(IN) :: th_phy  , &
+                                                                           p_phy   , &
+                                                                           pi_phy  , &
+                                                                           rho_phy , &
+                                                                           dz8w    , &
+                                                                           p8w     , &
+                                                                           t8w
+
+      !  Time (s) since the beginning of the simulation, restart.
+
+      REAL(8) :: curr_secs
+      REAL :: curr_secs2
+
+      !  Is this to be a history output time?  If so, compute the diagnostics.
+
+      LOGICAL :: diag_flag
+
+      !  The sundry dimensions required to keep a model running smoothly:
+      !     The first letter:
+      !        i: refers to the nominally west east direction, the inner-most (fastest)
+      !           incrementing index
+      !        j: refers to the nominally south north direction, the outer-most (slowest)
+      !           incrementing index
+      !        k: refers to the vertical direction form bottom to top, the second dimension
+      !           in all 3d arrays
+      !     The second letter: 
+      !        d: refers to the domain size, the geophysical extent of the entire domain,
+      !           not used in dimensions or looping, used to determine when we are close to
+      !           the edge of the boundary
+      !        m: refers to the memory size size, all 2d and 3d arrays from the Registry
+      !           (passed into here via the grid structure or the I1 variables [such as
+      !           p_phy, for example]) use these values for dimensioning
+      !        p: refers to the patch size, the extent over which computational loops run
+
+      INTEGER , INTENT(IN) :: ids, ide, jds, jde, kds, kde,     &
+                              ims, ime, jms, jme, kms, kme,     &
+                              ips, ipe, jps, jpe, kps, kpe
+
+      !  Hopefully unnecessary, these are the filtered dimensions.
+
+      INTEGER , INTENT(IN) :: imsx,imex,jmsx,jmex,kmsx,kmex,    &
+                              ipsx,ipex,jpsx,jpex,kpsx,kpex,    &
+                              imsy,imey,jmsy,jmey,kmsy,kmey,    &
+                              ipsy,ipey,jpsy,jpey,kpsy,kpey
+
+
+      !=============================================================
+      !  Local Variables
+      !=============================================================
+
+      !  Handy little character string for use instead of print statements.
+
+      CHARACTER (LEN=1000) :: diag_message
+
+      !  OpenMP indexing of tiles.
+
+      INTEGER :: ij
+
+      !  Vertical indexing that only goes up to the half levels.
+
+      INTEGER :: k_start, k_end
+
+      ! Current time associated with current simulation step (RASM_DIAGS)
+
+      TYPE(WRFU_Time) :: currentTime
+
+      !=============================================================
+      !  Start of executable code
+      !=============================================================
+
+      CALL wrf_debug ( 100 , '--> TOP OF DIAGNOSTICS PACKAGE' )
+
+      !  Some routine initializations.
+
+      k_start = kps
+      k_end   = kpe-1
+
+      !  There are some fields that were defined in the first RK loop for
+      !  physics and are now a time-step old.
+
+      CALL update_phys_fields ( grid, config_flags, moist,           &
+                                ids,  ide,  jds,  jde,  kds,  kde,   &
+                                ims,  ime,  jms,  jme,  kms,  kme,   &
+                                ips,  ipe,  jps,  jpe,  kps,  kpe    )
+
+      !  Lightning flash rate diagnostic production.
+
+      LIGHTNING: IF ( config_flags%lightning_option /= 0 ) THEN 
+         CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: LIGHTNING_DRIVER' )
+         CALL lightning_driver ( &
+          ! Frequently used prognostics
+            curr_secs, grid%dt, grid%dx, grid%dy,              &
+            grid%xlat, grid%xlong, grid%xland, grid%ht,        &
+            grid%t_phy, p_phy, grid%rho,                       &
+            grid%u_phy, grid%v_phy, grid%w_2,                  &    
+            th_phy,     pi_phy,dz8w,                           &  
+            grid%z, moist,scalar,                              &
+          ! Scheme specific prognostics
+            grid%ktop_deep, grid%refl_10cm,                    &
+            domain_get_current_time( grid ),                   &
+          ! Flashrate namelist inputs
+            config_flags%lightning_option,                     &
+            config_flags%lightning_dt,                         &
+            config_flags%lightning_start_seconds,              &
+            grid%ltngacttime,                                  &
+            config_flags%flashrate_factor,                     &
+          ! IC:CG namelist settings
+            config_flags%iccg_method,                          &
+            config_flags%iccg_prescribed_num,                  &
+            config_flags%iccg_prescribed_den,                  &
+          ! IC:CG inputs
+            grid%iccg_in_num, grid%iccg_in_den,                &
+          ! Scheme specific namelist inputs
+            config_flags%cellcount_method,                     &
+            config_flags%cldtop_adjustment,                    &
+         ! Dynamic_Lightning inputs
+            config_flags%coul_pos,                     &
+            config_flags%coul_neg,                     &
+            config_flags%coul_neu,                     &
+            config_flags%j_pos,                     &
+            config_flags%j_neg,                     &
+            config_flags%j_neu,                     &
+         ! Dynamic_Lightning Outputs
+            grid%lpos, &
+            grid%lneg, &
+            grid%lneu, &
+          ! Order dependent args for domain, mem, and tile dims 
+            ids, ide, jds, jde, kds, kde,         &
+            ims, ime, jms, jme, kms, kme,         &
+            ips, ipe, jps, jpe, kps, kpe,         &
+          ! Mandatory outputs for all quantitative schemes
+            grid%ic_flashcount, grid%ic_flashrate,          &
+            grid%cg_flashcount, grid%cg_flashrate,          &
+            grid%lpi                                        &   
+      )    
+      END IF LIGHTNING
+
+
+      !WRF-HAILCAST diagnostic - hail size prediction
+      HAILCAST: IF ( config_flags%hailcast_opt /= 0 ) THEN
+
+      IF ( ( config_flags%history_interval == 0 ) ) THEN
+            WRITE (diag_message , * ) &
+            "HAILCAST Error : No 'history_interval' defined in namelist"
+            CALL wrf_error_fatal ( diag_message )
+        END IF
+
+        !$OMP PARALLEL DO   &
+        !$OMP PRIVATE ( ij )
+        DO ij = 1 , grid%num_tiles
+
+           CALL wrf_debug ( 100 ,                                             &
+             '--> CALL DIAGNOSTICS PACKAGE: HAILCAST_DIAGNOSTIC_DRIVER' )
+
+           CALL hailcast_diagnostic_driver (    grid , config_flags           &
+                         ,moist, grid%rho                                     &
+                         ,ids, ide, jds, jde, kds, kde                        &
+                         ,ims, ime, jms, jme, kms, kme                        &
+                         ,ips, ipe, jps, jpe, kps, kpe                        &
+                         ,ITS=grid%i_start(ij),ITE=grid%i_end(ij)             &
+                         ,JTS=grid%j_start(ij),JTE=grid%j_end(ij)             &
+                         ,K_START=k_start,K_END=k_end                         &
+                         ,dt=grid%dt, itimestep=grid%itimestep                &
+                         ,haildt=grid%haildt, curr_secs=curr_secs2            &
+                         ,haildtacttime=grid%haildtacttime                    )
+
+        END DO
+        !$OMP END PARALLEL DO
+      END IF HAILCAST
+
+      TRADITIONAL_FIELDS: IF ( config_flags%diag_nwp2 == do_trad_fields ) THEN 
+         !$OMP PARALLEL DO   &
+         !$OMP PRIVATE ( ij )
+         DO ij = 1 , grid%num_tiles
+
+            CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: TRAD_FIELDS' )
+            CALL trad_fields ( &
+               !  Input data for computing
+               U=grid%u_2                                           &
+               ,V=grid%v_2                                          &
+               ,W=grid%w_2                                          &
+               ,t=grid%th_phy_m_t0                                  &
+               ,qv=moist(:,:,:,P_QV)                                &
+               ,zp=grid%ph_2                                        &
+               ,zb=grid%phb                                         &
+               ,pp=grid%p                                           &
+               ,pb=grid%pb                                          &
+               ,p=grid%p_hyd                                        &
+               ,pw=grid%p_hyd_w                                     &
+               !  Map factors, coriolis for diags
+               ,msfux=grid%msfux                                    &
+               ,msfuy=grid%msfuy                                    &
+               ,msfvx=grid%msfvx                                    &
+               ,msfvy=grid%msfvy                                    &
+               ,msftx=grid%msftx                                    &
+               ,msfty=grid%msfty                                    &
+               ,f=grid%f                                            &
+               ,e=grid%e                                            &
+               ,sina=grid%sina                                      &
+               ,cosa=grid%cosa                                      &
+               !  Input model diagnostic vraiables 
+               ,rho=grid%rho                                        &
+               ,dz8w=dz8w                                           &
+               ,qc=moist(:,:,:,P_QC)                                &
+               ,rainc=grid%rainc                                    &
+               ,rainnc=grid%rainnc                                  &
+               ,snownc=grid%snownc                                  &
+               ,graupelnc=grid%graupelnc                            &
+               ,hailnc=grid%hailnc                                  & 
+               !  Terrestrial data                
+               ,ht=grid%ht                                          &
+               !  Namelist info
+               ,use_theta_m=config_flags%use_theta_m                &
+               !  The diagnostic output variables
+               ,sealevelp=grid%sealevelp                            &
+               ,temperature=grid%temperature                        &
+               ,pressure=grid%pressure                              &
+               ,geoheight=grid%geoheight                            &
+               ,umet=grid%umet                                      &
+               ,vmet=grid%vmet                                      &
+               ,speed=grid%speed                                    &
+               ,dir=grid%dir                                        &
+               ,psfc=grid%psfc                                      &
+               ,rain=grid%rain                                      &
+               ,liqrain=grid%liqrain                                &
+               ,tpw=grid%tpw                                        &
+               ,potential_t=grid%potential_t                        &
+               ,rh=grid%rh                                          &
+               !  Various indexes for declarations, loop bounds
+               ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+               ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+               ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+               ,ITS=grid%i_start(ij),ITE=grid%i_end(ij)             &
+               ,JTS=grid%j_start(ij),JTE=grid%j_end(ij)             &
+               ,kts=kps,kte=kpe                                     )
+          END DO
+        !$OMP END PARALLEL DO
+      END IF TRADITIONAL_FIELDS
+
+
+      !  Mostly surface values, precip, column integrated quantities.
+
+      CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: NWP DIAGNOSTICS' )
+
+
+
+      mp_select: SELECT CASE(config_flags%mp_physics)
+
+        CASE (LINSCHEME, WSM6SCHEME, WDM6SCHEME, GSFCGCESCHEME, NSSL_1MOMLFO)
+
+      CALL diagnostic_output_calc(                                   &
+                 DPSDT=grid%dpsdt   ,DMUDT=grid%dmudt                &
+                ,P8W=p8w   ,PK1M=grid%pk1m                           &
+                ,MU_2=grid%mu_2  ,MU_2M=grid%mu_2m                   &
+                ,U=grid%u_2    ,V=grid%v_2                           &
+                ,TEMP=grid%t_phy                                     &
+                ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv         &
+                ,RAINC=grid%rainc    ,RAINNC=grid%rainnc             &
+                ,I_RAINC=grid%i_rainc    ,I_RAINNC=grid%i_rainnc     &
+                ,HFX=grid%hfx   ,SFCEVP=grid%sfcevp    ,LH=grid%lh   &    
+                ,DT=grid%dt      ,SBW=config_flags%spec_bdy_width    &    
+                ,XTIME=grid%xtime   ,T2=grid%t2                      &
+           ,ACSWUPT=grid%acswupt    ,ACSWUPTC=grid%acswuptc          &
+           ,ACSWDNT=grid%acswdnt    ,ACSWDNTC=grid%acswdntc          &
+           ,ACSWUPB=grid%acswupb    ,ACSWUPBC=grid%acswupbc          &
+           ,ACSWDNB=grid%acswdnb    ,ACSWDNBC=grid%acswdnbc          &
+           ,ACLWUPT=grid%aclwupt    ,ACLWUPTC=grid%aclwuptc          &
+           ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc          &
+           ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc          &
+           ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc          &
+         ,I_ACSWUPT=grid%i_acswupt  ,I_ACSWUPTC=grid%i_acswuptc      &
+         ,I_ACSWDNT=grid%i_acswdnt  ,I_ACSWDNTC=grid%i_acswdntc      &
+         ,I_ACSWUPB=grid%i_acswupb  ,I_ACSWUPBC=grid%i_acswupbc      &
+         ,I_ACSWDNB=grid%i_acswdnb  ,I_ACSWDNBC=grid%i_acswdnbc      &
+         ,I_ACLWUPT=grid%i_aclwupt  ,I_ACLWUPTC=grid%i_aclwuptc      &
+         ,I_ACLWDNT=grid%i_aclwdnt  ,I_ACLWDNTC=grid%i_aclwdntc      &
+         ,I_ACLWUPB=grid%i_aclwupb  ,I_ACLWUPBC=grid%i_aclwupbc      &
+         ,I_ACLWDNB=grid%i_aclwdnb  ,I_ACLWDNBC=grid%i_aclwdnbc      &
+      ! Selection flag 
+                ,DIAG_PRINT=config_flags%diag_print                  &
+                ,BUCKET_MM=config_flags%bucket_mm                    &
+                ,BUCKET_J =config_flags%bucket_J                     &
+                ,MPHYSICS_OPT=config_flags%mp_physics                &  !  gthompsn
+                ,GSFCGCE_HAIL=config_flags%gsfcgce_hail              &  !  gthompsn
+                ,GSFCGCE_2ICE=config_flags%gsfcgce_2ice              &  !  gthompsn
+                ,MPUSE_HAIL=config_flags%hail_opt                    &  !  gthompsn
+                ,NSSL_ALPHAH=config_flags%nssl_alphah                &  !  gthompsn
+                ,NSSL_ALPHAHL=config_flags%nssl_alphahl              &  !  gthompsn
+                ,NSSL_CNOH=config_flags%nssl_cnoh                    &  !  gthompsn
+                ,NSSL_CNOHL=config_flags%nssl_cnohl                  &  !  gthompsn
+                ,NSSL_RHO_QH=config_flags%nssl_rho_qh                &  !  gthompsn
+                ,NSSL_RHO_QHL=config_flags%nssl_rho_qhl              &  !  gthompsn
+                ,SNOWNCV=grid%snowncv, SNOW_ACC_NC=grid%snow_acc_nc  &    
+                ,PREC_ACC_C=grid%prec_acc_c                          &
+                ,PREC_ACC_NC=grid%prec_acc_nc                        &
+                ,PREC_ACC_DT=config_flags%prec_acc_dt                &
+                ,CURR_SECS2=curr_secs2                               &
+                ,NWP_DIAGNOSTICS=config_flags%nwp_diagnostics        &
+                ,DIAGFLAG=diag_flag                                  &
+                ,HISTORY_INTERVAL=grid%history_interval              &
+                ,ITIMESTEP=grid%itimestep                            &
+                ,U10=grid%u10,V10=grid%v10,W=grid%w_2                &
+                ,WSPD10MAX=grid%wspd10max                            &
+                ,UP_HELI_MAX=grid%up_heli_max                        &
+                ,W_UP_MAX=grid%w_up_max,W_DN_MAX=grid%w_dn_max       &
+                ,ZNW=grid%znw,W_COLMEAN=grid%w_colmean               &
+                ,NUMCOLPTS=grid%numcolpts,W_MEAN=grid%w_mean         &
+                ,GRPL_MAX=grid%grpl_max,GRPL_COLINT=grid%grpl_colint &
+                ,REFD_MAX=grid%refd_max                              &
+                ,refl_10cm=grid%refl_10cm                            &
+                ,HAIL_MAXK1=grid%hail_maxk1,HAIL_MAX2D=grid%hail_max2d &  !  gthompsn
+                ,QG_CURR=moist(ims,kms,jms,P_QG)                     &
+                ,RHO=grid%rho,PH=grid%ph_2,PHB=grid%phb,G=g          &
+      ! Dimension arguments
+                ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+                ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+                ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)   &
+                ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
+                ,KTS=k_start, KTE=min(k_end,kde-1)                   &
+                ,NUM_TILES=grid%num_tiles                            &
+                                                                    )
+
+        CASE (THOMPSON, THOMPSONAERO)
+
+      CALL diagnostic_output_calc(                                   &
+                 DPSDT=grid%dpsdt   ,DMUDT=grid%dmudt                &
+                ,P8W=p8w   ,PK1M=grid%pk1m                           &
+                ,MU_2=grid%mu_2  ,MU_2M=grid%mu_2m                   &
+                ,U=grid%u_2    ,V=grid%v_2                           &
+                ,TEMP=grid%t_phy                                     &
+                ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv         &
+                ,RAINC=grid%rainc    ,RAINNC=grid%rainnc             &
+                ,I_RAINC=grid%i_rainc    ,I_RAINNC=grid%i_rainnc     &
+                ,HFX=grid%hfx   ,SFCEVP=grid%sfcevp    ,LH=grid%lh   &    
+                ,DT=grid%dt      ,SBW=config_flags%spec_bdy_width    &    
+                ,XTIME=grid%xtime   ,T2=grid%t2                      &
+           ,ACSWUPT=grid%acswupt    ,ACSWUPTC=grid%acswuptc          &
+           ,ACSWDNT=grid%acswdnt    ,ACSWDNTC=grid%acswdntc          &
+           ,ACSWUPB=grid%acswupb    ,ACSWUPBC=grid%acswupbc          &
+           ,ACSWDNB=grid%acswdnb    ,ACSWDNBC=grid%acswdnbc          &
+           ,ACLWUPT=grid%aclwupt    ,ACLWUPTC=grid%aclwuptc          &
+           ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc          &
+           ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc          &
+           ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc          &
+         ,I_ACSWUPT=grid%i_acswupt  ,I_ACSWUPTC=grid%i_acswuptc      &
+         ,I_ACSWDNT=grid%i_acswdnt  ,I_ACSWDNTC=grid%i_acswdntc      &
+         ,I_ACSWUPB=grid%i_acswupb  ,I_ACSWUPBC=grid%i_acswupbc      &
+         ,I_ACSWDNB=grid%i_acswdnb  ,I_ACSWDNBC=grid%i_acswdnbc      &
+         ,I_ACLWUPT=grid%i_aclwupt  ,I_ACLWUPTC=grid%i_aclwuptc      &
+         ,I_ACLWDNT=grid%i_aclwdnt  ,I_ACLWDNTC=grid%i_aclwdntc      &
+         ,I_ACLWUPB=grid%i_aclwupb  ,I_ACLWUPBC=grid%i_aclwupbc      &
+         ,I_ACLWDNB=grid%i_aclwdnb  ,I_ACLWDNBC=grid%i_aclwdnbc      &
+      ! Selection flag 
+                ,DIAG_PRINT=config_flags%diag_print                  &
+                ,BUCKET_MM=config_flags%bucket_mm                    &
+                ,BUCKET_J =config_flags%bucket_J                     &
+                ,MPHYSICS_OPT=config_flags%mp_physics                &  !  gthompsn
+                ,GSFCGCE_HAIL=config_flags%gsfcgce_hail              &  !  gthompsn
+                ,GSFCGCE_2ICE=config_flags%gsfcgce_2ice              &  !  gthompsn
+                ,MPUSE_HAIL=config_flags%hail_opt                    &  !  gthompsn
+                ,NSSL_ALPHAH=config_flags%nssl_alphah                &  !  gthompsn
+                ,NSSL_ALPHAHL=config_flags%nssl_alphahl              &  !  gthompsn
+                ,NSSL_CNOH=config_flags%nssl_cnoh                    &  !  gthompsn
+                ,NSSL_CNOHL=config_flags%nssl_cnohl                  &  !  gthompsn
+                ,NSSL_RHO_QH=config_flags%nssl_rho_qh                &  !  gthompsn
+                ,NSSL_RHO_QHL=config_flags%nssl_rho_qhl              &  !  gthompsn
+                ,SNOWNCV=grid%snowncv, SNOW_ACC_NC=grid%snow_acc_nc  &    
+                ,PREC_ACC_C=grid%prec_acc_c                          &
+                ,PREC_ACC_NC=grid%prec_acc_nc                        &
+                ,PREC_ACC_DT=config_flags%prec_acc_dt                &
+                ,CURR_SECS2=curr_secs2                               &
+                ,NWP_DIAGNOSTICS=config_flags%nwp_diagnostics        &
+                ,DIAGFLAG=diag_flag                                  &
+                ,HISTORY_INTERVAL=grid%history_interval              &
+                ,ITIMESTEP=grid%itimestep                            &
+                ,U10=grid%u10,V10=grid%v10,W=grid%w_2                &
+                ,WSPD10MAX=grid%wspd10max                            &
+                ,UP_HELI_MAX=grid%up_heli_max                        &
+                ,W_UP_MAX=grid%w_up_max,W_DN_MAX=grid%w_dn_max       &
+                ,ZNW=grid%znw,W_COLMEAN=grid%w_colmean               &
+                ,NUMCOLPTS=grid%numcolpts,W_MEAN=grid%w_mean         &
+                ,GRPL_MAX=grid%grpl_max,GRPL_COLINT=grid%grpl_colint &
+                ,REFD_MAX=grid%refd_max                              &
+                ,refl_10cm=grid%refl_10cm                            &
+                ,HAIL_MAXK1=grid%hail_maxk1,HAIL_MAX2D=grid%hail_max2d &  !  gthompsn
+                ,QG_CURR=moist(ims,kms,jms,P_QG)                     &
+                ,QR_CURR=moist(ims,kms,jms,P_QR)                     &  !  gthompsn
+                ,NR_CURR=scalar(ims,kms,jms,P_QNR)                   &  !  gthompsn
+                ,RHO=grid%rho,PH=grid%ph_2,PHB=grid%phb,G=g          &
+      ! Dimension arguments
+                ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+                ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+                ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)   &
+                ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
+                ,KTS=k_start, KTE=min(k_end,kde-1)                   &
+                ,NUM_TILES=grid%num_tiles                            &
+                                                                    )
+
+        CASE (MORR_TWO_MOMENT, MORR_TM_AERO)  ! TWG add
+
+      CALL diagnostic_output_calc(                                   &
+                 DPSDT=grid%dpsdt   ,DMUDT=grid%dmudt                &
+                ,P8W=p8w   ,PK1M=grid%pk1m                           &
+                ,MU_2=grid%mu_2  ,MU_2M=grid%mu_2m                   &
+                ,U=grid%u_2    ,V=grid%v_2                           &
+                ,TEMP=grid%t_phy                                     &
+                ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv         &
+                ,RAINC=grid%rainc    ,RAINNC=grid%rainnc             &
+                ,I_RAINC=grid%i_rainc    ,I_RAINNC=grid%i_rainnc     &
+                ,HFX=grid%hfx   ,SFCEVP=grid%sfcevp    ,LH=grid%lh   &    
+                ,DT=grid%dt      ,SBW=config_flags%spec_bdy_width    &    
+                ,XTIME=grid%xtime   ,T2=grid%t2                      &
+           ,ACSWUPT=grid%acswupt    ,ACSWUPTC=grid%acswuptc          &
+           ,ACSWDNT=grid%acswdnt    ,ACSWDNTC=grid%acswdntc          &
+           ,ACSWUPB=grid%acswupb    ,ACSWUPBC=grid%acswupbc          &
+           ,ACSWDNB=grid%acswdnb    ,ACSWDNBC=grid%acswdnbc          &
+           ,ACLWUPT=grid%aclwupt    ,ACLWUPTC=grid%aclwuptc          &
+           ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc          &
+           ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc          &
+           ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc          &
+         ,I_ACSWUPT=grid%i_acswupt  ,I_ACSWUPTC=grid%i_acswuptc      &
+         ,I_ACSWDNT=grid%i_acswdnt  ,I_ACSWDNTC=grid%i_acswdntc      &
+         ,I_ACSWUPB=grid%i_acswupb  ,I_ACSWUPBC=grid%i_acswupbc      &
+         ,I_ACSWDNB=grid%i_acswdnb  ,I_ACSWDNBC=grid%i_acswdnbc      &
+         ,I_ACLWUPT=grid%i_aclwupt  ,I_ACLWUPTC=grid%i_aclwuptc      &
+         ,I_ACLWDNT=grid%i_aclwdnt  ,I_ACLWDNTC=grid%i_aclwdntc      &
+         ,I_ACLWUPB=grid%i_aclwupb  ,I_ACLWUPBC=grid%i_aclwupbc      &
+         ,I_ACLWDNB=grid%i_aclwdnb  ,I_ACLWDNBC=grid%i_aclwdnbc      &
+      ! Selection flag 
+                ,DIAG_PRINT=config_flags%diag_print                  &
+                ,BUCKET_MM=config_flags%bucket_mm                    &
+                ,BUCKET_J =config_flags%bucket_J                     &
+                ,MPHYSICS_OPT=config_flags%mp_physics                &  !  gthompsn
+                ,GSFCGCE_HAIL=config_flags%gsfcgce_hail              &  !  gthompsn
+                ,GSFCGCE_2ICE=config_flags%gsfcgce_2ice              &  !  gthompsn
+                ,MPUSE_HAIL=config_flags%morr_rimed_ice              &  !  gthompsn
+                ,NSSL_ALPHAH=config_flags%nssl_alphah                &  !  gthompsn
+                ,NSSL_ALPHAHL=config_flags%nssl_alphahl              &  !  gthompsn
+                ,NSSL_CNOH=config_flags%nssl_cnoh                    &  !  gthompsn
+                ,NSSL_CNOHL=config_flags%nssl_cnohl                  &  !  gthompsn
+                ,NSSL_RHO_QH=config_flags%nssl_rho_qh                &  !  gthompsn
+                ,NSSL_RHO_QHL=config_flags%nssl_rho_qhl              &  !  gthompsn
+                ,SNOWNCV=grid%snowncv, SNOW_ACC_NC=grid%snow_acc_nc  &    
+                ,PREC_ACC_C=grid%prec_acc_c                          &
+                ,PREC_ACC_NC=grid%prec_acc_nc                        &
+                ,PREC_ACC_DT=config_flags%prec_acc_dt                &
+                ,CURR_SECS2=curr_secs2                               &
+                ,NWP_DIAGNOSTICS=config_flags%nwp_diagnostics        &
+                ,DIAGFLAG=diag_flag                                  &
+                ,HISTORY_INTERVAL=grid%history_interval              &
+                ,ITIMESTEP=grid%itimestep                            &
+                ,U10=grid%u10,V10=grid%v10,W=grid%w_2                &
+                ,WSPD10MAX=grid%wspd10max                            &
+                ,UP_HELI_MAX=grid%up_heli_max                        &
+                ,W_UP_MAX=grid%w_up_max,W_DN_MAX=grid%w_dn_max       &
+                ,ZNW=grid%znw,W_COLMEAN=grid%w_colmean               &
+                ,NUMCOLPTS=grid%numcolpts,W_MEAN=grid%w_mean         &
+                ,GRPL_MAX=grid%grpl_max,GRPL_COLINT=grid%grpl_colint &
+                ,REFD_MAX=grid%refd_max                              &
+                ,refl_10cm=grid%refl_10cm                            &
+                ,HAIL_MAXK1=grid%hail_maxk1,HAIL_MAX2D=grid%hail_max2d &  !  gthompsn
+                ,QG_CURR=moist(ims,kms,jms,P_QG)                     &
+                ,NG_CURR=scalar(ims,kms,jms,P_QNG)                   &  !  gthompsn
+                ,RHO=grid%rho,PH=grid%ph_2,PHB=grid%phb,G=g          &
+      ! Dimension arguments
+                ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+                ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+                ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)   &
+                ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
+                ,KTS=k_start, KTE=min(k_end,kde-1)                   &
+                ,NUM_TILES=grid%num_tiles                            &
+                                                                    )
+
+        CASE (NSSL_1MOM)
+
+      CALL diagnostic_output_calc(                                   &
+                 DPSDT=grid%dpsdt   ,DMUDT=grid%dmudt                &
+                ,P8W=p8w   ,PK1M=grid%pk1m                           &
+                ,MU_2=grid%mu_2  ,MU_2M=grid%mu_2m                   &
+                ,U=grid%u_2    ,V=grid%v_2                           &
+                ,TEMP=grid%t_phy                                     &
+                ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv         &
+                ,RAINC=grid%rainc    ,RAINNC=grid%rainnc             &
+                ,I_RAINC=grid%i_rainc    ,I_RAINNC=grid%i_rainnc     &
+                ,HFX=grid%hfx   ,SFCEVP=grid%sfcevp    ,LH=grid%lh   &    
+                ,DT=grid%dt      ,SBW=config_flags%spec_bdy_width    &    
+                ,XTIME=grid%xtime   ,T2=grid%t2                      &
+           ,ACSWUPT=grid%acswupt    ,ACSWUPTC=grid%acswuptc          &
+           ,ACSWDNT=grid%acswdnt    ,ACSWDNTC=grid%acswdntc          &
+           ,ACSWUPB=grid%acswupb    ,ACSWUPBC=grid%acswupbc          &
+           ,ACSWDNB=grid%acswdnb    ,ACSWDNBC=grid%acswdnbc          &
+           ,ACLWUPT=grid%aclwupt    ,ACLWUPTC=grid%aclwuptc          &
+           ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc          &
+           ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc          &
+           ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc          &
+         ,I_ACSWUPT=grid%i_acswupt  ,I_ACSWUPTC=grid%i_acswuptc      &
+         ,I_ACSWDNT=grid%i_acswdnt  ,I_ACSWDNTC=grid%i_acswdntc      &
+         ,I_ACSWUPB=grid%i_acswupb  ,I_ACSWUPBC=grid%i_acswupbc      &
+         ,I_ACSWDNB=grid%i_acswdnb  ,I_ACSWDNBC=grid%i_acswdnbc      &
+         ,I_ACLWUPT=grid%i_aclwupt  ,I_ACLWUPTC=grid%i_aclwuptc      &
+         ,I_ACLWDNT=grid%i_aclwdnt  ,I_ACLWDNTC=grid%i_aclwdntc      &
+         ,I_ACLWUPB=grid%i_aclwupb  ,I_ACLWUPBC=grid%i_aclwupbc      &
+         ,I_ACLWDNB=grid%i_aclwdnb  ,I_ACLWDNBC=grid%i_aclwdnbc      &
+      ! Selection flag 
+                ,DIAG_PRINT=config_flags%diag_print                  &
+                ,BUCKET_MM=config_flags%bucket_mm                    &
+                ,BUCKET_J =config_flags%bucket_J                     &
+                ,MPHYSICS_OPT=config_flags%mp_physics                &  !  gthompsn
+                ,GSFCGCE_HAIL=config_flags%gsfcgce_hail              &  !  gthompsn
+                ,GSFCGCE_2ICE=config_flags%gsfcgce_2ice              &  !  gthompsn
+                ,MPUSE_HAIL=config_flags%hail_opt                    &  !  gthompsn
+                ,NSSL_ALPHAH=config_flags%nssl_alphah                &  !  gthompsn
+                ,NSSL_ALPHAHL=config_flags%nssl_alphahl              &  !  gthompsn
+                ,NSSL_CNOH=config_flags%nssl_cnoh                    &  !  gthompsn
+                ,NSSL_CNOHL=config_flags%nssl_cnohl                  &  !  gthompsn
+                ,NSSL_RHO_QH=config_flags%nssl_rho_qh                &  !  gthompsn
+                ,NSSL_RHO_QHL=config_flags%nssl_rho_qhl              &  !  gthompsn
+                ,SNOWNCV=grid%snowncv, SNOW_ACC_NC=grid%snow_acc_nc  &    
+                ,PREC_ACC_C=grid%prec_acc_c                          &
+                ,PREC_ACC_NC=grid%prec_acc_nc                        &
+                ,PREC_ACC_DT=config_flags%prec_acc_dt                &
+                ,CURR_SECS2=curr_secs2                               &
+                ,NWP_DIAGNOSTICS=config_flags%nwp_diagnostics        &
+                ,DIAGFLAG=diag_flag                                  &
+                ,HISTORY_INTERVAL=grid%history_interval              &
+                ,ITIMESTEP=grid%itimestep                            &
+                ,U10=grid%u10,V10=grid%v10,W=grid%w_2                &
+                ,WSPD10MAX=grid%wspd10max                            &
+                ,UP_HELI_MAX=grid%up_heli_max                        &
+                ,W_UP_MAX=grid%w_up_max,W_DN_MAX=grid%w_dn_max       &
+                ,ZNW=grid%znw,W_COLMEAN=grid%w_colmean               &
+                ,NUMCOLPTS=grid%numcolpts,W_MEAN=grid%w_mean         &
+                ,GRPL_MAX=grid%grpl_max,GRPL_COLINT=grid%grpl_colint &
+                ,REFD_MAX=grid%refd_max                              &
+                ,refl_10cm=grid%refl_10cm                            &
+                ,HAIL_MAXK1=grid%hail_maxk1,HAIL_MAX2D=grid%hail_max2d &  !  gthompsn
+                ,QG_CURR=moist(ims,kms,jms,P_QG)                     &
+                ,QH_CURR=moist(ims,kms,jms,P_QH)                     &  !  gthompsn
+                ,RHO=grid%rho,PH=grid%ph_2,PHB=grid%phb,G=g          &
+      ! Dimension arguments
+                ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+                ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+                ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)   &
+                ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
+                ,KTS=k_start, KTE=min(k_end,kde-1)                   &
+                ,NUM_TILES=grid%num_tiles                            &
+                                                                    )
+
+        CASE (MILBRANDT2MOM, NSSL_2MOM, NSSL_2MOMCCN)
+
+      CALL diagnostic_output_calc(                                   &
+                 DPSDT=grid%dpsdt   ,DMUDT=grid%dmudt                &
+                ,P8W=p8w   ,PK1M=grid%pk1m                           &
+                ,MU_2=grid%mu_2  ,MU_2M=grid%mu_2m                   &
+                ,U=grid%u_2    ,V=grid%v_2                           &
+                ,TEMP=grid%t_phy                                     &
+                ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv         &
+                ,RAINC=grid%rainc    ,RAINNC=grid%rainnc             &
+                ,I_RAINC=grid%i_rainc    ,I_RAINNC=grid%i_rainnc     &
+                ,HFX=grid%hfx   ,SFCEVP=grid%sfcevp    ,LH=grid%lh   &    
+                ,DT=grid%dt      ,SBW=config_flags%spec_bdy_width    &    
+                ,XTIME=grid%xtime   ,T2=grid%t2                      &
+           ,ACSWUPT=grid%acswupt    ,ACSWUPTC=grid%acswuptc          &
+           ,ACSWDNT=grid%acswdnt    ,ACSWDNTC=grid%acswdntc          &
+           ,ACSWUPB=grid%acswupb    ,ACSWUPBC=grid%acswupbc          &
+           ,ACSWDNB=grid%acswdnb    ,ACSWDNBC=grid%acswdnbc          &
+           ,ACLWUPT=grid%aclwupt    ,ACLWUPTC=grid%aclwuptc          &
+           ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc          &
+           ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc          &
+           ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc          &
+         ,I_ACSWUPT=grid%i_acswupt  ,I_ACSWUPTC=grid%i_acswuptc      &
+         ,I_ACSWDNT=grid%i_acswdnt  ,I_ACSWDNTC=grid%i_acswdntc      &
+         ,I_ACSWUPB=grid%i_acswupb  ,I_ACSWUPBC=grid%i_acswupbc      &
+         ,I_ACSWDNB=grid%i_acswdnb  ,I_ACSWDNBC=grid%i_acswdnbc      &
+         ,I_ACLWUPT=grid%i_aclwupt  ,I_ACLWUPTC=grid%i_aclwuptc      &
+         ,I_ACLWDNT=grid%i_aclwdnt  ,I_ACLWDNTC=grid%i_aclwdntc      &
+         ,I_ACLWUPB=grid%i_aclwupb  ,I_ACLWUPBC=grid%i_aclwupbc      &
+         ,I_ACLWDNB=grid%i_aclwdnb  ,I_ACLWDNBC=grid%i_aclwdnbc      &
+      ! Selection flag 
+                ,DIAG_PRINT=config_flags%diag_print                  &
+                ,BUCKET_MM=config_flags%bucket_mm                    &
+                ,BUCKET_J =config_flags%bucket_J                     &
+                ,MPHYSICS_OPT=config_flags%mp_physics                &  !  gthompsn
+                ,GSFCGCE_HAIL=config_flags%gsfcgce_hail              &  !  gthompsn
+                ,GSFCGCE_2ICE=config_flags%gsfcgce_2ice              &  !  gthompsn
+                ,MPUSE_HAIL=config_flags%hail_opt                    &  !  gthompsn
+                ,NSSL_ALPHAH=config_flags%nssl_alphah                &  !  gthompsn
+                ,NSSL_ALPHAHL=config_flags%nssl_alphahl              &  !  gthompsn
+                ,NSSL_CNOH=config_flags%nssl_cnoh                    &  !  gthompsn
+                ,NSSL_CNOHL=config_flags%nssl_cnohl                  &  !  gthompsn
+                ,NSSL_RHO_QH=config_flags%nssl_rho_qh                &  !  gthompsn
+                ,NSSL_RHO_QHL=config_flags%nssl_rho_qhl              &  !  gthompsn
+                ,SNOWNCV=grid%snowncv, SNOW_ACC_NC=grid%snow_acc_nc  &    
+                ,PREC_ACC_C=grid%prec_acc_c                          &
+                ,PREC_ACC_NC=grid%prec_acc_nc                        &
+                ,PREC_ACC_DT=config_flags%prec_acc_dt                &
+                ,CURR_SECS2=curr_secs2                               &
+                ,NWP_DIAGNOSTICS=config_flags%nwp_diagnostics        &
+                ,DIAGFLAG=diag_flag                                  &
+                ,HISTORY_INTERVAL=grid%history_interval              &
+                ,ITIMESTEP=grid%itimestep                            &
+                ,U10=grid%u10,V10=grid%v10,W=grid%w_2                &
+                ,WSPD10MAX=grid%wspd10max                            &
+                ,UP_HELI_MAX=grid%up_heli_max                        &
+                ,W_UP_MAX=grid%w_up_max,W_DN_MAX=grid%w_dn_max       &
+                ,ZNW=grid%znw,W_COLMEAN=grid%w_colmean               &
+                ,NUMCOLPTS=grid%numcolpts,W_MEAN=grid%w_mean         &
+                ,GRPL_MAX=grid%grpl_max,GRPL_COLINT=grid%grpl_colint &
+                ,REFD_MAX=grid%refd_max                              &
+                ,refl_10cm=grid%refl_10cm                            &
+                ,HAIL_MAXK1=grid%hail_maxk1,HAIL_MAX2D=grid%hail_max2d &  !  gthompsn
+                ,QG_CURR=moist(ims,kms,jms,P_QG)                     &
+                ,NG_CURR=scalar(ims,kms,jms,P_QNG)                   &  !  gthompsn
+                ,QH_CURR=moist(ims,kms,jms,P_QH)                     &  !  gthompsn
+                ,NH_CURR=scalar(ims,kms,jms,P_QNH)                   &  !  gthompsn
+                ,RHO=grid%rho,PH=grid%ph_2,PHB=grid%phb,G=g          &
+      ! Dimension arguments
+                ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+                ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+                ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)   &
+                ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
+                ,KTS=k_start, KTE=min(k_end,kde-1)                   &
+                ,NUM_TILES=grid%num_tiles                            &
+                                                                    )
+
+
+        !..The remaining microphysics schemes do not have graupel, but
+        !..P_QG will just be empty and the remaining NWP-diagnostics can
+        !..still be computed, so go ahead, under DEFAULT, not their own.
+
+!       CASE (KESSLERSCHEME)
+
+!       CASE (WDM5SCHEME)
+
+!       CASE (SBU_YLINSCHEME)
+
+!       CASE (ETAMPNEW)
+
+!       CASE (NSSL_3MOM)
+
+!       CASE (MILBRANDT3MOM)
+
+!       CASE (MORR_MILB_P3)
+
+!       CASE (CAMMGMPSCHEME)
+
+!       CASE (FULL_KHAIN_LYNN)
+
+!       CASE (FAST_KHAIN_LYNN)
+
+!       CASE (WSM3SCHEME)
+
+!       CASE (WSM5SCHEME)
+
+        CASE DEFAULT
+
+      CALL diagnostic_output_calc(                                   &
+                 DPSDT=grid%dpsdt   ,DMUDT=grid%dmudt                &
+                ,P8W=p8w   ,PK1M=grid%pk1m                           &
+                ,MU_2=grid%mu_2  ,MU_2M=grid%mu_2m                   &
+                ,U=grid%u_2    ,V=grid%v_2                           &
+                ,TEMP=grid%t_phy                                     &
+                ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv         &
+                ,RAINC=grid%rainc    ,RAINNC=grid%rainnc             &
+                ,I_RAINC=grid%i_rainc    ,I_RAINNC=grid%i_rainnc     &
+                ,HFX=grid%hfx   ,SFCEVP=grid%sfcevp    ,LH=grid%lh   &    
+                ,DT=grid%dt      ,SBW=config_flags%spec_bdy_width    &    
+                ,XTIME=grid%xtime   ,T2=grid%t2                      &
+           ,ACSWUPT=grid%acswupt    ,ACSWUPTC=grid%acswuptc          &
+           ,ACSWDNT=grid%acswdnt    ,ACSWDNTC=grid%acswdntc          &
+           ,ACSWUPB=grid%acswupb    ,ACSWUPBC=grid%acswupbc          &
+           ,ACSWDNB=grid%acswdnb    ,ACSWDNBC=grid%acswdnbc          &
+           ,ACLWUPT=grid%aclwupt    ,ACLWUPTC=grid%aclwuptc          &
+           ,ACLWDNT=grid%aclwdnt    ,ACLWDNTC=grid%aclwdntc          &
+           ,ACLWUPB=grid%aclwupb    ,ACLWUPBC=grid%aclwupbc          &
+           ,ACLWDNB=grid%aclwdnb    ,ACLWDNBC=grid%aclwdnbc          &
+         ,I_ACSWUPT=grid%i_acswupt  ,I_ACSWUPTC=grid%i_acswuptc      &
+         ,I_ACSWDNT=grid%i_acswdnt  ,I_ACSWDNTC=grid%i_acswdntc      &
+         ,I_ACSWUPB=grid%i_acswupb  ,I_ACSWUPBC=grid%i_acswupbc      &
+         ,I_ACSWDNB=grid%i_acswdnb  ,I_ACSWDNBC=grid%i_acswdnbc      &
+         ,I_ACLWUPT=grid%i_aclwupt  ,I_ACLWUPTC=grid%i_aclwuptc      &
+         ,I_ACLWDNT=grid%i_aclwdnt  ,I_ACLWDNTC=grid%i_aclwdntc      &
+         ,I_ACLWUPB=grid%i_aclwupb  ,I_ACLWUPBC=grid%i_aclwupbc      &
+         ,I_ACLWDNB=grid%i_aclwdnb  ,I_ACLWDNBC=grid%i_aclwdnbc      &
+      ! Selection flag 
+                ,DIAG_PRINT=config_flags%diag_print                  &
+                ,BUCKET_MM=config_flags%bucket_mm                    &
+                ,BUCKET_J =config_flags%bucket_J                     &
+                ,MPHYSICS_OPT=config_flags%mp_physics                &  !  gthompsn
+                ,GSFCGCE_HAIL=config_flags%gsfcgce_hail              &  !  gthompsn
+                ,GSFCGCE_2ICE=config_flags%gsfcgce_2ice              &  !  gthompsn
+                ,MPUSE_HAIL=config_flags%hail_opt                    &  !  gthompsn
+                ,NSSL_ALPHAH=config_flags%nssl_alphah                &  !  gthompsn
+                ,NSSL_ALPHAHL=config_flags%nssl_alphahl              &  !  gthompsn
+                ,NSSL_CNOH=config_flags%nssl_cnoh                    &  !  gthompsn
+                ,NSSL_CNOHL=config_flags%nssl_cnohl                  &  !  gthompsn
+                ,NSSL_RHO_QH=config_flags%nssl_rho_qh                &  !  gthompsn
+                ,NSSL_RHO_QHL=config_flags%nssl_rho_qhl              &  !  gthompsn
+                ,SNOWNCV=grid%snowncv, SNOW_ACC_NC=grid%snow_acc_nc  &    
+                ,PREC_ACC_C=grid%prec_acc_c                          &
+                ,PREC_ACC_NC=grid%prec_acc_nc                        &
+                ,PREC_ACC_DT=config_flags%prec_acc_dt                &
+                ,CURR_SECS2=curr_secs2                               &
+                ,NWP_DIAGNOSTICS=config_flags%nwp_diagnostics        &
+                ,DIAGFLAG=diag_flag                                  &
+                ,HISTORY_INTERVAL=grid%history_interval              &
+                ,ITIMESTEP=grid%itimestep                            &
+                ,U10=grid%u10,V10=grid%v10,W=grid%w_2                &
+                ,WSPD10MAX=grid%wspd10max                            &
+                ,UP_HELI_MAX=grid%up_heli_max                        &
+                ,W_UP_MAX=grid%w_up_max,W_DN_MAX=grid%w_dn_max       &
+                ,ZNW=grid%znw,W_COLMEAN=grid%w_colmean               &
+                ,NUMCOLPTS=grid%numcolpts,W_MEAN=grid%w_mean         &
+                ,GRPL_MAX=grid%grpl_max,GRPL_COLINT=grid%grpl_colint &
+                ,REFD_MAX=grid%refd_max                              &
+                ,refl_10cm=grid%refl_10cm                            &
+                ,HAIL_MAXK1=grid%hail_maxk1,HAIL_MAX2D=grid%hail_max2d &  !  gthompsn
+                ,QG_CURR=moist(ims,kms,jms,P_QG)                     &
+                ,RHO=grid%rho,PH=grid%ph_2,PHB=grid%phb,G=g          &
+      ! Dimension arguments
+                ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme   &
+                ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe   &
+                ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)   &
+                ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)   &
+                ,KTS=k_start, KTE=min(k_end,kde-1)                   &
+                ,NUM_TILES=grid%num_tiles                            &
+                                                                    )
+
+
+
+   END SELECT mp_select
+
+
+      !  Climate-oriented diagnostic quantities.
+
+      CLIMATE_DIAGS : IF ( config_flags%output_diagnostics == 1 ) THEN
+
+         IF ( ( config_flags%auxhist3_interval == 0 ) ) THEN
+            WRITE (diag_message , * ) &
+            "CLWRF: ERROR -- error -- ERROR -- error : NO 'auxhist3_interval' has been defined in 'namelist.input'"
+            CALL wrf_error_fatal ( diag_message )
+         END IF
+
+         CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: CLIMATE DIAGNOSTICS' )
+
+         CALL clwrf_output_calc(                                           &
+                     is_restart=config_flags%restart                       &
+                    ,clwrfH=config_flags%auxhist3_interval                 &
+                    ,T2=grid%t2, Q2=grid%q2, U10=grid%u10, V10=grid%v10    &
+                    ,SKINTEMP=grid%tsk                                     &
+                    ,T2CLMIN=grid%t2min, T2CLMAX=grid%t2max                &
+                    ,TT2CLMIN=grid%tt2min, TT2CLMAX=grid%tt2max            &
+                    ,T2CLMEAN=grid%t2mean, T2CLSTD=grid%t2std              &
+                    ,Q2CLMIN=grid%q2min, Q2CLMAX=grid%q2max                &
+                    ,TQ2CLMIN=grid%tq2min, TQ2CLMAX=grid%tq2max            &
+                    ,Q2CLMEAN=grid%q2mean, Q2CLSTD=grid%q2std              &
+                    ,U10CLMAX=grid%u10max, V10CLMAX=grid%v10max            &
+                    ,SPDUV10CLMAX=grid%spduv10max                          &
+                    ,TSPDUV10CLMAX=grid%tspduv10max                        &
+                    ,U10CLMEAN=grid%u10mean, V10CLMEAN=grid%v10mean        &
+                    ,SPDUV10CLMEAN=grid%spduv10mean                        &
+                    ,U10CLSTD=grid%u10std, V10CLSTD=grid%v10std            &
+                    ,SPDUV10CLSTD=grid%spduv10std                          &
+                    ,RAINCCLMAX=grid%raincvmax                             &
+                    ,RAINNCCLMAX=grid%rainncvmax                           &
+                    ,TRAINCCLMAX=grid%traincvmax                           &
+                    ,TRAINNCCLMAX=grid%trainncvmax                         &
+                    ,RAINCCLMEAN=grid%raincvmean                           &
+                    ,RAINNCCLMEAN=grid%rainncvmean                         &
+                    ,RAINCCLSTD=grid%raincvstd                             &
+                    ,RAINNCCLSTD=grid%rainncvstd                           &
+                    ,SKINTEMPCLMIN=grid%skintempmin                        &
+                    ,SKINTEMPCLMAX=grid%skintempmax                        &
+                    ,TSKINTEMPCLMIN=grid%tskintempmin                      &
+                    ,TSKINTEMPCLMAX=grid%tskintempmax                      &
+                    ,SKINTEMPCLMEAN=grid%skintempmean                      &
+                    ,SKINTEMPCLSTD=grid%skintempstd                        &
+                    ,RAINCV=grid%raincv    ,RAINNCV=grid%rainncv           &
+                    ,DT=grid%dt                                            &
+                    ,XTIME=grid%xtime,CURR_SECS2=curr_secs2                &
+                    ,NSTEPS=grid%nsteps                                    &
+         ! Dimension arguments
+                    ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde     &
+                    ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme     &
+                    ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe     &
+                    ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)     &
+                    ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)     &
+                    ,KTS=k_start, KTE=k_end                                &
+                    ,NUM_TILES=grid%num_tiles                              &
+                                                                   )
+      END IF CLIMATE_DIAGS
+
+
+
+
+
+      !  Pressure level diagnostics.
+
+
+      PL_DIAGNOSTICS : IF ( config_flags%p_lev_diags .NE. SKIP_PRESS_DIAGS ) THEN
+
+      !  Process the diags if this is the correct time step OR
+      !  if this is an adaptive timestep forecast.
+
+         TIME_TO_DO_PL_DIAGS : IF ( ( ( MOD(NINT(curr_secs2+grid%dt),NINT(config_flags%p_lev_interval)) .EQ. 0 ) ) .OR. &
+               ( config_flags%use_adaptive_time_step ) ) THEN
+
+            !$OMP PARALLEL DO   &
+            !$OMP PRIVATE ( ij )
+            DO ij = 1 , grid%num_tiles
+
+               CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: PRESSURE LEVEL DIAGNOSTICS' )
+
+               CALL pld (                                                   &
+               !  Input data for computing
+                       U=grid%u_2                                           &
+                      ,V=grid%v_2                                           &
+                      ,W=grid%w_2                                           &
+                      ,t=grid%th_phy_m_t0                                   &
+                      ,qv=moist(:,:,:,P_QV)                                 &
+                      ,zp=grid%ph_2                                         &
+                      ,zb=grid%phb                                          &
+                      ,pp=grid%p                                            &
+                      ,pb=grid%pb                                           &
+                      ,p=grid%p_hyd                                         &
+                      ,pw=grid%p_hyd_w                                      &
+               !  Map factors, coriolis for diags
+                      ,msfux=grid%msfux                                     &
+                      ,msfuy=grid%msfuy                                     &
+                      ,msfvx=grid%msfvx                                     &
+                      ,msfvy=grid%msfvy                                     &
+                      ,msftx=grid%msftx                                     &
+                      ,msfty=grid%msfty                                     &
+                      ,f=grid%f                                             &
+                      ,e=grid%e                                             &
+               !  Namelist info
+                      ,use_tot_or_hyd_p=config_flags%use_tot_or_hyd_p       &
+                      ,extrap_below_grnd=config_flags%extrap_below_grnd     &
+                      ,missing=config_flags%p_lev_missing                   &
+               !  The diagnostics, mostly output variables
+                      ,num_press_levels=config_flags%num_press_levels       &
+                      ,max_press_levels=max_plevs                           &
+                      ,press_levels=model_config_rec%press_levels           &
+                      ,p_pl  = grid%p_pl                                    &
+                      ,u_pl  = grid%u_pl                                    &
+                      ,v_pl  = grid%v_pl                                    &
+                      ,t_pl  = grid%t_pl                                    &
+                      ,rh_pl = grid%rh_pl                                   &
+                      ,ght_pl= grid%ght_pl                                  &
+                      ,s_pl  = grid%s_pl                                    &
+                      ,td_pl = grid%td_pl                                   &
+                      ,q_pl = grid%q_pl                                     &
+               !  Dimension arguments
+                      ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde    &
+                      ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme    &
+                      ,ITS=grid%i_start(ij),ITE=grid%i_end(ij)              &
+                      ,JTS=grid%j_start(ij),JTE=grid%j_end(ij)              &
+                      ,KTS=k_start,KTE=k_end+1                              )
+            END DO
+            !$OMP END PARALLEL DO
+         END IF TIME_TO_DO_PL_DIAGS
+      END IF PL_DIAGNOSTICS
+
+
+
+
+
+      !  Height level and AGL diagnostics.
+
+
+      ZL_DIAGNOSTICS : IF ( config_flags%z_lev_diags .NE. SKIP_Z_DIAGS ) THEN
+
+      !  Process the diags if this is the correct time step OR
+      !  if this is an adaptive timestep forecast.
+
+         TIME_TO_DO_ZL_DIAGS : IF ( ( ( MOD(NINT(curr_secs2+grid%dt),NINT(config_flags%z_lev_interval)) .EQ. 0 ) ) .OR. &
+               ( config_flags%use_adaptive_time_step ) ) THEN
+
+            !$OMP PARALLEL DO   &
+            !$OMP PRIVATE ( ij )
+            DO ij = 1 , grid%num_tiles
+
+               CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: HEIGHT LEVEL AND AGL DIAGNOSTICS' )
+
+               CALL zld (                                                   &
+               !  Input data for computing
+                       U=grid%u_2                                           &
+                      ,V=grid%v_2                                           &
+                      ,W=grid%w_2                                           &
+                      ,t=grid%th_phy_m_t0                                   &
+                      ,qv=moist(:,:,:,P_QV)                                 &
+                      ,zp=grid%ph_2                                         &
+                      ,zb=grid%phb                                          &
+                      ,pp=grid%p                                            &
+                      ,pb=grid%pb                                           &
+                      ,p=grid%p_hyd                                         &
+                      ,pw=grid%p_hyd_w                                      &
+               !  Map factors, coriolis for diags
+                      ,msfux=grid%msfux                                     &
+                      ,msfuy=grid%msfuy                                     &
+                      ,msfvx=grid%msfvx                                     &
+                      ,msfvy=grid%msfvy                                     &
+                      ,msftx=grid%msftx                                     &
+                      ,msfty=grid%msfty                                     &
+                      ,f=grid%f                                             &
+                      ,e=grid%e                                             &
+                      ,ht=grid%ht                                           &
+               !  Namelist info
+                      ,use_tot_or_hyd_p=config_flags%use_tot_or_hyd_p       &
+                      ,extrap_below_grnd=config_flags%extrap_below_grnd     &
+                      ,missing=config_flags%z_lev_missing                   &
+               !  The diagnostics, mostly output variables
+                      ,num_z_levels=config_flags%num_z_levels               &
+                      ,max_z_levels=max_zlevs                               &
+                      ,z_levels=model_config_rec%z_levels                   &
+                      ,z_zl  = grid%z_zl                                    &
+                      ,u_zl  = grid%u_zl                                    &
+                      ,v_zl  = grid%v_zl                                    &
+                      ,t_zl  = grid%t_zl                                    &
+                      ,rh_zl = grid%rh_zl                                   &
+                      ,ght_zl= grid%ght_zl                                  &
+                      ,s_zl  = grid%s_zl                                    &
+                      ,td_zl = grid%td_zl                                   &
+                      ,q_zl = grid%q_zl                                     &
+               !  Dimension arguments
+                      ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde    &
+                      ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme    &
+                      ,ITS=grid%i_start(ij),ITE=grid%i_end(ij)              &
+                      ,JTS=grid%j_start(ij),JTE=grid%j_end(ij)              &
+                      ,KTS=k_start,KTE=k_end+1                              )
+            END DO
+            !$OMP END PARALLEL DO
+         END IF TIME_TO_DO_ZL_DIAGS
+      END IF ZL_DIAGNOSTICS
+
+
+
+
+      !  AFWA diagnostic package.
+
+      AFWA_DIAGS : IF ( config_flags%afwa_diag_opt == 1 ) THEN
+
+         IF ( ( config_flags%history_interval == 0 ) ) THEN
+            WRITE (diag_message , * ) &
+            "AFWA Diagnostics Error : No 'history_interval' defined in namelist"
+            CALL wrf_error_fatal ( diag_message )
+         END IF
+
+         !$OMP PARALLEL DO   &
+         !$OMP PRIVATE ( ij )
+         DO ij = 1 , grid%num_tiles
+
+            CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: AFWA DIAGNOSTICS' )
+
+            CALL afwa_diagnostics_driver (   grid , config_flags              &
+                         ,moist                                               &
+                         ,scalar                                              &
+                         ,chem                                                &
+                         ,th_phy , pi_phy , p_phy                             &
+                         ,grid%u_phy , grid%v_phy                             &
+                         ,dz8w , p8w , t8w , rho_phy, grid%rho                &
+                         ,ids, ide, jds, jde, kds, kde                        &
+                         ,ims, ime, jms, jme, kms, kme                        &
+                         ,ips, ipe, jps, jpe, kps, kpe                        &
+                         ,ITS=grid%i_start(ij),ITE=grid%i_end(ij)             &
+                         ,JTS=grid%j_start(ij),JTE=grid%j_end(ij)             &
+                         ,K_START=k_start,K_END=k_end                         )
+
+            END DO
+            !$OMP END PARALLEL DO
+      ENDIF AFWA_DIAGS
+
+
+
+
+      !  RASM Climate Diagnostics - mean output
+
+      RASM_DIAGS_MEAN : IF ( config_flags%mean_diag == 1 ) THEN
+
+         !IF ( ( config_flags%auxhist3_interval == 0 ) ) THEN
+         !   WRITE (diag_message , * ) &
+         !   "CLWRF: ERROR -- error -- ERROR -- error : NO 'auxhist3_interval' has been defined in 'namelist.input'"
+         !   CALL wrf_error_fatal ( diag_message )
+         !END IF
+
+         CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: RASM DIAGNOSTICS - MEAN' )
+
+         CALL domain_clock_get ( grid, current_time=currentTime)
+
+         CALL mean_output_calc(                                               &
+                        is_restart=config_flags%restart                       &
+                       ,CURRENTTIME=currentTime                               &
+                       ,stats_interval=config_flags%mean_interval             &
+                       ,output_freq=config_flags%mean_freq                    &
+                       ,run_days=config_flags%run_days                        &
+                       ,DT=grid%dt, XTIME=grid%xtime                          &
+                       ,PSFC=grid%psfc, PSFC_MEAN=grid%psfc_mean              &
+                       ,TSK=grid%tsk, TSK_MEAN=grid%tsk_mean                  &
+                       ,PMSL_MEAN=grid%pmsl_mean                              &
+                       ,T2=grid%t2, T2_MEAN=grid%t2_mean                      &
+                       ,T=grid%th_phy_m_t0, P=grid%p, PB=grid%pb              &
+                       ,MOIST=grid%moist(:,:,:,P_QV), HT=grid%ht              &
+                       ,TH2=grid%th2, TH2_MEAN=grid%th2_mean                  &
+                       ,Q2=grid%q2, Q2_MEAN=grid%q2_mean                      &
+                       ,U10=grid%u10, U10_MEAN=grid%u10_mean                  &
+                       ,V10=grid%v10, V10_MEAN=grid%v10_mean                  &           
+                       ,HFX=grid%hfx, HFX_MEAN=grid%hfx_mean                  &
+                       ,LH=grid%lh, LH_MEAN=grid%lh_mean                      &
+                       ,SWDNB=grid%swdnb, SWDNB_MEAN=grid%swdnb_mean          &
+                       ,GLW=grid%glw , GLW_MEAN=grid%glw_mean                 &
+                       ,LWUPB=grid%lwupb, LWUPB_MEAN=grid%lwupb_mean          &
+                       ,SWUPB=grid%swupb, SWUPB_MEAN=grid%swupb_mean          &
+                       ,SWUPT=grid%swupt, SWUPT_MEAN=grid%swupt_mean          &
+                       ,SWDNT=grid%swdnt, SWDNT_MEAN=grid%swdnt_mean          &
+                       ,LWUPT=grid%lwupt, LWUPT_MEAN=grid%lwupt_mean          &
+                       ,LWDNT=grid%lwdnt, LWDNT_MEAN=grid%lwdnt_mean          &
+                       ,AVGOUTALARM=grid%alarms(AUXHIST5_ALARM)               &
+                       ,AVGOUTDATESTR=grid%OUTDATE_MEAN                       &
+                       ,NSTEPS=grid%NSTEPS_MEAN                               &
+         ! Dimension arguments
+                       ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde     &
+                       ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme     &
+                       ,IPS=ips,IPE=ipe, JPS=jps,JPE=jpe, KPS=kps,KPE=kpe     &
+                       ,I_START=grid%i_start,I_END=min(grid%i_end, ide-1)     &
+                       ,J_START=grid%j_start,J_END=min(grid%j_end, jde-1)     &
+                       ,NUM_TILES=grid%num_tiles                              &
+                                                                      )
+      END IF RASM_DIAGS_MEAN
+
+
+
+
+      !  RASM Climate Diagnostics - diurnal output
+
+      RASM_DIAGS_DIURNAL : IF ( config_flags%diurnal_diag == 1 ) THEN
+
+         !IF ( ( config_flags%auxhist3_interval == 0 ) ) THEN
+         !   WRITE (diag_message , * ) &
+         !   "CLWRF: ERROR -- error -- ERROR -- error : NO 'auxhist3_interval' has been defined in 'namelist.input'"
+         !   CALL wrf_error_fatal ( diag_message )
+         !END IF
+
+         CALL wrf_debug ( 100 , '--> CALL DIAGNOSTICS PACKAGE: RASM DIAGNOSTICS - DIURNAL' )
+
+         CALL domain_clock_get ( grid, current_time=currentTime)
+
+         CALL diurnalcycle_output_calc(                                       &
+            is_restart=config_flags%restart                                   &
+           ,CURRENTTIME=currentTime                                           &
+           ,DT=grid%dt, XTIME=grid%xtime                                      &
+           ,PSFC=grid%psfc, PSFC_DTMP=grid%psfc_dtmp                          &
+           ,TSK=grid%tsk, TSK_DTMP=grid%tsk_dtmp                              &
+           ,T2=grid%t2, T2_DTMP=grid%t2_dtmp                                  &
+           ,T=grid%th_phy_m_t0, P=grid%p, PB=grid%pb                          &
+           ,MOIST=grid%moist(:,:,:,P_QV)                                     &
+           ,TH2=grid%th2, TH2_DTMP=grid%th2_dtmp                              &
+           ,Q2=grid%q2, Q2_DTMP=grid%q2_dtmp                                  &
+           ,U10=grid%u10, U10_DTMP=grid%u10_dtmp                              &
+           ,V10=grid%v10, V10_DTMP=grid%v10_dtmp                              &
+           ,HFX=grid%hfx, HFX_DTMP=grid%hfx_dtmp                              &
+           ,LH=grid%lh, LH_DTMP=grid%lh_dtmp                                  &
+           ,SWDNB=grid%swdnb, SWDNB_DTMP=grid%swdnb_dtmp                      &
+           ,GLW=grid%glw, GLW_DTMP=grid%glw_dtmp                              &
+           ,LWUPB=grid%lwupb, LWUPB_DTMP=grid%lwupb_dtmp                      &
+           ,SWUPB=grid%swupb, SWUPB_DTMP=grid%swupb_dtmp                      &
+           ,SWUPT=grid%swupt, SWUPT_DTMP=grid%swupt_dtmp                      &
+           ,SWDNT=grid%swdnt, SWDNT_DTMP=grid%swdnt_dtmp                      &
+           ,LWUPT=grid%lwupt, LWUPT_DTMP=grid%lwupt_dtmp                      &
+           ,LWDNT=grid%lwdnt, LWDNT_DTMP=grid%lwdnt_dtmp                      &
+           ,AVGOUTALARM=grid%alarms(AUXHIST6_ALARM)                           &
+           ,DIURNOUTDATESTR=grid%OUTDATE_DIURN                                &
+           ,AVG_NSTEPS=grid%NSTEPSMEAN_DIURN                                  &
+           ,DIURNAL_NSTEPS=grid%NSTEPS_DIURN                                  &
+           ,PSFC_DIURN=grid%PSFC_DIURN                                        &
+           ,TSK_DIURN=grid%TSK_DIURN, T2_DIURN=grid%T2_DIURN                  &
+           ,TH2_DIURN=grid%TH2_DIURN, Q2_DIURN=grid%Q2_DIURN                  &
+           ,U10_DIURN=grid%U10_DIURN, V10_DIURN=grid%V10_DIURN                &
+           ,HFX_DIURN=grid%HFX_DIURN, LH_DIURN=grid%LH_DIURN                  &
+           ,SWDNB_DIURN=grid%SWDNB_DIURN, GLW_DIURN=grid%GLW_DIURN            &
+           ,LWUPB_DIURN=grid%LWUPB_DIURN, SWUPB_DIURN=grid%SWUPB_DIURN        &
+           ,SWUPT_DIURN=grid%SWUPT_DIURN, SWDNT_DIURN=grid%SWDNT_DIURN        &
+           ,LWUPT_DIURN=grid%LWUPT_DIURN, LWDNT_DIURN=grid%LWDNT_DIURN        &
+         ! Dimension arguments
+           ,IDS=ids, IDE=ide, JDS=jds, JDE=jde, KDS=kds, KDE=kde              &
+           ,IMS=ims, IME=ime, JMS=jms, JME=jme, KMS=kms, KME=kme              & 
+           ,IPS=ips, IPE=ipe, JPS=jps, JPE=jpe, KPS=kps, KPE=kpe              &         
+           ,I_START=grid%i_start, I_END=min(grid%i_end, ide-1)                &
+           ,J_START=grid%j_start, J_END=min(grid%j_end, jde-1)                &
+           ,NUM_TILES=grid%num_tiles                                          &
+                                                                   )
+      END IF RASM_DIAGS_DIURNAL
+
+
+
+
+   END SUBROUTINE diagnostics_driver
+
+
+
+   SUBROUTINE update_phys_fields ( grid, config_flags, moist,           &
+                                   ids,  ide,  jds,  jde,  kds,  kde,   &
+                                   ims,  ime,  jms,  jme,  kms,  kme,   &
+                                   ips,  ipe,  jps,  jpe,  kps,  kpe    ) 
+
+      USE module_domain, ONLY : domain
+      USE module_configure, ONLY : grid_config_rec_type
+      USE module_state_description, ONLY: num_moist, P_Qv
+      USE module_model_constants, ONLY: g, R_v, R_d, Cp, T0, RCP
+
+      TYPE ( domain ), INTENT(INOUT) :: grid
+
+      !  We are not changing any of the namelist settings.
+
+      TYPE ( grid_config_rec_type ), INTENT(IN) :: config_flags
+
+      !  The 4d arrays are input only, no mods to them.
+
+      REAL , DIMENSION(ims:ime,kms:kme,jms:jme,num_moist ) , INTENT(IN) :: moist
+
+      !  Domain indices - no change to these puppies.
+
+      INTEGER , INTENT(IN) :: ids, ide, jds, jde, kds, kde,     &
+                              ims, ime, jms, jme, kms, kme,     &
+                              ips, ipe, jps, jpe, kps, kpe
+
+      !  Local variables
+
+      INTEGER :: i, j, k 
+
+      !  Moist or dry theta
+
+      IF ( config_flags%use_theta_m .EQ. 1 ) THEN
+         DO j = jps, MIN(jde-1, jpe)
+            DO k = kps, kde-1
+               DO i = ips, MIN(ide-1, ipe)
+                  grid%th_phy_m_t0(i,k,j) = (grid%t_2(i,k,j)+T0) / &
+                                            (1.+(R_v/R_d)*moist(i,k,j,P_Qv)) - T0
+               END  DO
+            END  DO
+         END  DO
+      ELSE
+         DO j = jps, MIN(jde-1, jpe)
+            DO k = kps, kde-1
+               DO i = ips, MIN(ide-1, ipe)
+                  grid%th_phy_m_t0(i,k,j) =  grid%t_2(i,k,j)
+               END  DO
+            END  DO
+         END  DO
+      END IF
+   END SUBROUTINE update_phys_fields
+
+END MODULE module_diagnostics_driver
+#endif

--- a/phys/module_lightning_driver.F
+++ b/phys/module_lightning_driver.F
@@ -1,4 +1,5 @@
 !WRF:MEDIATION_LAYER:PHYSICS
+!Modified
 !
 ! Contains initialization subroutine lightning_init and driver subroutine
 ! lightning_driver.

--- a/phys/module_lightning_driver.F
+++ b/phys/module_lightning_driver.F
@@ -141,6 +141,12 @@
         WRITE(message, * ) ' lightning_init: LPIM lightning option selected: ', lightning_option
         CALL wrf_debug ( 100 , message )
 #endif
+#if (EM_CORE==1)
+    CASE (ltng_dyn_lightning)
+
+        WRITE(message, * ) ' lightning_init: LPIM lightning option selected: ', lightning_option
+        CALL wrf_debug ( 100 , message )
+#endif
     ! Non-existing options
     CASE DEFAULT
         CALL wrf_error_fatal ( ' lightning_init: invalid lightning_option')
@@ -211,7 +217,7 @@
                             xlat, xlon, xland, ht,                &
                             t_phy, p_phy, rho, u, v, w,           &
                             th_phy, pi_phy,dz8w,                  &  
-                            z, moist,                             &
+                            z, moist,scalar,                      &
                           ! Scheme specific prognostics
                             ktop_deep,                            &
                             refl,                                 &
@@ -231,6 +237,15 @@
                           ! Scheme specific namelist inputs
                             cellcount_method,                     &
                             cldtop_adjustment,                    &
+                         ! Dynamic Lightning Input
+                            coul_pos, &
+                            coul_neg, &
+                            coul_neu, &
+                            j_pos, &
+                            j_neg, &
+                            j_neu, &
+                          ! Dynamic Lightning output
+                            lpos,lneu,lneg, &
                           ! Order dependent args for domain, mem, and tile dims
                             ids, ide, jds, jde, kds, kde,         &
                             ims, ime, jms, jme, kms, kme,         &
@@ -261,6 +276,11 @@
 #if (EM_CORE==1)
   USE module_ltng_lpi
 #endif
+! Dynamic Lightning
+#if (EM_CORE==1)
+  USE module_ltng_pe
+  USE module_ltng_strokes
+#endif
 
  IMPLICIT NONE
 !-----------------------------------------------------------------
@@ -274,6 +294,7 @@
  REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: th_phy, pi_phy, dz8w  
  REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: u, v, w, z
  REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, num_moist), INTENT(IN   ) :: moist
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, num_scalar), INTENT(INOUT   ) :: scalar
 
 ! Scheme specific prognostics
  INTEGER, DIMENSION( ims:ime,          jms:jme ),           INTENT(IN   ) :: ktop_deep     ! model LNB from cu_physics
@@ -281,6 +302,10 @@
  TYPE(WRFU_Time),                                           INTENT(IN   ) :: current_time  ! For use of IC:CG input
 
  REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LPI
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LPOS
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LNEG
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LNEU
+!
 ! Mandatory namelist inputs
  INTEGER, INTENT(IN   )    ::       lightning_option
  REAL,    INTENT(IN   )    ::       lightning_dt, lightning_start_seconds, flashrate_factor
@@ -294,6 +319,13 @@
 ! Scheme specific namelist inputs
  INTEGER, INTENT(IN   )    ::       cellcount_method                    ! used in CRM
  REAL,    INTENT(IN   )    ::       cldtop_adjustment                   ! used in CPM
+! Dynamic LIghtning namelist settings
+ REAL,    INTENT(IN   )    ::       coul_pos
+ REAL,    INTENT(IN   )    ::       coul_neg
+ REAL,    INTENT(IN   )    ::       coul_neu
+ REAL,    INTENT(IN   )    ::       j_pos
+ REAL,    INTENT(IN   )    ::       j_neg
+ REAL,    INTENT(IN   )    ::       j_neu
 
 ! Order dependent args for domain, mem, and tile dims
  INTEGER, INTENT(IN   )    ::       ids,ide, jds,jde, kds,kde
@@ -437,6 +469,50 @@
         WRITE(wrf_err_message, * ) ' lightning_driver: LPI option needs Microphysics Option with Graupel '
         CALL wrf_error_fatal ( wrf_err_message )
         ENDIF
+#endif
+#if (EM_CORE==1)
+    CASE( ltng_dyn_lightning )
+        CALL wrf_debug ( 100, ' lightning_driver: calling Dynamic Lightning Scheme' )
+        IF(F_QG) THEN
+        CALL   calc_dyn_pe(dx=dx,dy=dy,                         &
+                     W=w,                              &
+                     PI_PHY=pi_phy, RHO_PHY=rho,             &
+                     TH_PHY=TH_PHY,P_PHY=p_phy,                  &
+                     DZ8w=dz8w,                          &
+                     QC=moist(ims,kms,jms,P_QV),         &   
+                     QR=moist(ims,kms,jms,P_QR),         &  
+                     QI=moist(ims,kms,jms,P_QI),         & 
+                     QS=moist(ims,kms,jms,P_QS),         &
+                     QG=moist(ims,kms,jms,P_QG),         &
+                     light_pe=scalar(ims,kms,jms,P_light_pe), &
+                     light_ne=scalar(ims,kms,jms,P_light_ne), &
+                     light_neu=scalar(ims,kms,jms,P_light_neu),&
+                     dt=dt &
+                 ,coul_pos=coul_pos &
+                 ,coul_neg=coul_neg &
+                 ,coul_neu=coul_neu &
+                 ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
+                 ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
+                 ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte)
+        ELSE
+        WRITE(wrf_err_message, * ) ' lightning_driver: Dynamic Lightning option needs Microphysics Option with Graupel '
+        CALL wrf_error_fatal ( wrf_err_message )
+        END IF
+           CALL   calcstroke(dx=dx,dy=dy,                         &
+                     W=w,                              &
+                     PI_PHY=pi_phy, RHO_PHY=rho,             &
+                     TH_PHY=TH_PHY,P_PHY=p_phy,                  &
+                     DZ8w=dz8w,                          &
+                     light_pe=scalar(ims,kms,jms,P_light_pe), &
+                     light_ne=scalar(ims,kms,jms,P_light_ne), &
+                     light_neu=scalar(ims,kms,jms,P_light_neu),&
+                     lpos=lpos,lneg=lneg,lneu=lneu  &
+                 ,j_pos=j_pos &
+                 ,j_neg=j_neg &
+                 ,j_neu=j_neu &
+                 ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
+                 ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
+                 ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte)
 #endif
 !   CASE ( another_cpm_option)
 

--- a/phys/module_lightning_driver_add.F
+++ b/phys/module_lightning_driver_add.F
@@ -1,0 +1,744 @@
+!WRF:MEDIATION_LAYER:PHYSICS
+!
+! Contains initialization subroutine lightning_init and driver subroutine
+! lightning_driver.
+!
+! History:
+!   3.5?  - rewritten and added init, separate out flash rate
+!           parameterization from emission
+!   3.4.0 - Added cpm option
+!   3.3.x - lightning_driver written by M. Barth called in
+!           emission_driver in chem
+!
+! Contact: J. Wong <johnwong@ucar.edu>
+!
+!**********************************************************************
+
+ MODULE module_lightning_driver
+ CONTAINS
+
+!**********************************************************************
+!
+! SUBROUTINE lightning_init
+!
+! Performs compatibility checks and zero out flash arrays at first timestep.
+!
+!**********************************************************************
+
+ SUBROUTINE lightning_init ( &
+                              id, itimestep, restart, dt, dx           &
+                            ! Namelist control options
+                             ,cu_physics,mp_physics,do_radar_ref       &
+                             ,lightning_option, lightning_dt           &
+                             ,lightning_start_seconds                  &
+                             ,ltngacttime                              &
+                             ,iccg_prescribed_num, iccg_prescribed_den &
+                             ,cellcount_method                         &
+                            ! Order dependent args for domain, mem, and tile dims
+                             ,ids, ide, jds, jde, kds, kde             &
+                             ,ims, ime, jms, jme, kms, kme             &
+                             ,its, ite, jts, jte, kts, kte             &
+                            ! IC and CG flash rates and accumulated flash count
+                             ,ic_flashcount, ic_flashrate              &
+                             ,cg_flashcount, cg_flashrate              &
+#if ( WRF_CHEM == 1 )
+                             ,lnox_opt,lnox_passive                    &
+                            ! LNOx tracers (chemistry only)
+                             ,lnox_total, lnox_ic, lnox_cg             &
+#endif
+                            )
+!-----------------------------------------------------------------
+ USE module_state_description
+ USE module_wrf_error
+ IMPLICIT NONE
+!-----------------------------------------------------------------
+
+ INTEGER,  INTENT(IN)        :: id
+ INTEGER,  INTENT(IN)        :: itimestep
+ LOGICAL,  INTENT(IN)        :: restart
+ REAL,     INTENT(IN)        :: dt,dx
+ INTEGER,  INTENT(IN)        :: cu_physics,mp_physics,do_radar_ref,lightning_option
+ REAL,     INTENT(IN)        :: lightning_dt, lightning_start_seconds
+ REAL,     INTENT(INOUT)     :: ltngacttime
+ REAL,     INTENT(IN)        :: iccg_prescribed_num, iccg_prescribed_den
+ INTEGER,  INTENT(INOUT)     :: cellcount_method
+ INTEGER , INTENT(IN)        :: ids, ide, jds, jde, kds, kde,  &
+                                ims, ime, jms, jme, kms, kme,  &
+                                its, ite, jts, jte, kts, kte
+
+! Making these optional just in case qualitative lightning indices get implemented
+ REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme ), &
+                 INTENT(OUT) :: ic_flashcount, ic_flashrate, &
+                                cg_flashcount, cg_flashrate
+
+#if ( WRF_CHEM == 1 )
+ INTEGER, INTENT(IN)         :: lnox_opt
+ LOGICAL, INTENT(IN)         :: lnox_passive
+ REAL, OPTIONAL, DIMENSION( ims:ime,kms:kme,jms:jme ), &
+                 INTENT(OUT) :: lnox_total, lnox_ic, lnox_cg
+#endif
+
+ CHARACTER (LEN=80) :: message
+
+!-----------------------------------------------------------------
+
+!-- do not reset unless it is the first timestep or lightning_option is on
+ IF (lightning_option .eq. 0) THEN
+   return
+ ENDIF
+
+!-- check to see if lightning_dt is less than zero
+ IF ( lightning_dt <= 0. ) THEN
+    CALL nl_set_lightning_dt( id, dt )
+ ENDIF
+
+!-- restarting?  Code after this point is only executed on the very
+!                first time step of the simulation
+ IF (itimestep .gt. 0 ) THEN
+   return
+ ENDIF
+
+ ltngacttime = lightning_start_seconds
+
+!--  check to see if the prescribed IC:CG ratio is valid (0/0 and -1 are not allowed)
+ IF (iccg_prescribed_den .eq. 0. .and. iccg_prescribed_num .eq. 0.) THEN
+    CALL wrf_error_fatal (' lightning_init: iccg_prescribed cannot be 0.0/0.0')
+ ENDIF
+ IF (iccg_prescribed_den .ne. 0.) THEN
+    IF (iccg_prescribed_num/iccg_prescribed_den .eq. -1.) THEN
+        CALL wrf_error_fatal (' lightning_init: iccg_prescribed cannot be -1')
+    ENDIF
+ ENDIF
+
+!
+!-- check to see if lightning_option is valid
+!
+!   Add new schemes here so it is recognized and proper checks are performed
+!
+ ltng_select: SELECT CASE(lightning_option)
+
+    ! Convective resolved/permitted
+    CASE (ltng_crm_PR92w,ltng_crm_PR92z)
+        IF ( do_radar_ref .eq. 0 .or. mp_physics .eq. 0) THEN
+          CALL wrf_error_fatal( ' lightning_init: Selected lightning option requires microphysics and do_radar_ref=1' )
+        ENDIF
+
+        WRITE(message, * ) ' lightning_init: CRM lightning option used: ', lightning_option
+        CALL wrf_debug ( 100 , message )
+
+    ! Convective parameterized
+    CASE (ltng_cpm_PR92z)
+        IF ( cu_physics .ne. GDSCHEME .and. cu_physics .ne. G3SCHEME .and. cu_physics .ne. GFSCHEME  ) THEN
+          CALL wrf_error_fatal( ' lightning_init: Selected lightning option requires GD, G3, or GF convective parameterization' )
+        ENDIF
+
+        WRITE(message, * ) ' lightning_init: CPM lightning option selected: ', lightning_option
+        CALL wrf_debug ( 100 , message )
+
+#if (EM_CORE==1)
+    CASE (ltng_lpi)
+
+        WRITE(message, * ) ' lightning_init: LPIM lightning option selected: ', lightning_option
+        CALL wrf_debug ( 100 , message )
+#endif
+#if (EM_CORE==1)
+    CASE (ltng_dyn_lightning)
+
+        WRITE(message, * ) ' lightning_init: LPIM lightning option selected: ', lightning_option
+        CALL wrf_debug ( 100 , message )
+#endif
+    ! Non-existing options
+    CASE DEFAULT
+        CALL wrf_error_fatal ( ' lightning_init: invalid lightning_option')
+ END SELECT ltng_select
+
+!-- do not re-initialize for restarts
+ IF (restart) return
+
+!-- zero out arrays
+ IF ( PRESENT( ic_flashcount ) .and. PRESENT( ic_flashrate ) .and. &
+      PRESENT( cg_flashcount ) .and. PRESENT( cg_flashrate ) ) THEN
+    CALL wrf_debug ( 100 , ' lightning_init: flash initializing lightning flash arrays' )
+
+    ic_flashrate(:,:)  = 0.
+    ic_flashcount(:,:) = 0.
+    cg_flashrate(:,:)  = 0.
+    cg_flashcount(:,:) = 0.
+ ELSE
+    CALL wrf_error_fatal ( ' lightning_init: flash arrays not present' )
+ ENDIF
+
+!-- Resolve auto-cellcount method option (cellcount_method=0)
+ IF ( ( cellcount_method .eq. 0 ) .and. (lightning_option .eq. ltng_crm_PR92w )) THEN
+   IF ( (ime-ims+1)*dx .gt. 1E4 ) THEN ! use patch only if path size > 10 km
+     cellcount_method = 1
+     WRITE(message, * ) ' lightning_init: setting auto cellcount_method to patch (cellcount_method=1'
+   ELSE
+     cellcount_method = 2
+     WRITE(message, * ) ' lightning_init: setting auto cellcount_method to domain (cellcount_method=2'
+   ENDIF
+   CALL wrf_debug( 100, message )
+ ENDIF
+
+#if ( WRF_CHEM == 1 )
+
+ CALL wrf_debug( 100, ' lightning_init: initializing and validating WRF-Chem only arrays and settings')
+
+ IF ( lnox_opt .ne. lnox_opt_none .and. lightning_option .eq. 0 ) THEN
+   CALL wrf_error_fatal ( ' lightning_init: cannot set LNOx without lightning_option')
+ ENDIF
+
+ IF ( lnox_opt .eq. lnox_opt_decaria .and. ( do_radar_ref .eq. 0 .or. mp_physics .eq. 0 ) ) THEN
+   CALL wrf_error_fatal ( ' lightning_init: lnox_opt_decaria requires microphysics and do_radar_ref' )
+ ENDIF
+
+ IF (PRESENT( lnox_total )) lnox_total(:,:,:) = 0.
+ IF (PRESENT( lnox_cg    )) lnox_cg(:,:,:)    = 0.
+ IF (PRESENT( lnox_ic    )) lnox_ic(:,:,:)    = 0.
+
+#endif
+
+ CALL wrf_debug( 200, ' lightning_init: finishing')
+
+ END SUBROUTINE lightning_init
+
+
+!**********************************************************************
+!
+! SUBROUTINE lightning_driver
+!
+! Redirect to the appropriate lightning subroutine.
+!
+!**********************************************************************
+
+ SUBROUTINE lightning_driver ( &
+                          ! Frequently used prognostics
+                            curr_secs, dt, dx, dy,                &
+                            xlat, xlon, xland, ht,                &
+                            t_phy, p_phy, rho, u, v, w,           &
+                            th_phy, pi_phy,dz8w,                  &  
+                            z, moist,scalar,                      &
+                          ! Scheme specific prognostics
+                            ktop_deep,                            &
+                            refl,                                 &
+                            current_time,                         &
+                          ! Mandatory namelist inputs
+                            lightning_option,                     &
+                            lightning_dt,                         &
+                            lightning_start_seconds,              &
+                            ltngacttime,                          &
+                            flashrate_factor,                     &
+                          ! IC:CG namelist settings
+                            iccg_method,                          &
+                            iccg_prescribed_num,                  &
+                            iccg_prescribed_den,                  &
+                          ! IC:CG inputs
+                            iccg_in_num, iccg_in_den,             &
+                          ! Scheme specific namelist inputs
+                            cellcount_method,                     &
+                            cldtop_adjustment,                    &
+                         ! Dynamic Lightning Input
+                            coul_pos, &
+                            coul_neg, &
+                            coul_neu, &
+                            j_pos, &
+                            j_neg, &
+                            j_neu, &
+                          ! Dynamic Lightning output
+                            lpos,lneu,lneg, &
+                          ! Order dependent args for domain, mem, and tile dims
+                            ids, ide, jds, jde, kds, kde,         &
+                            ims, ime, jms, jme, kms, kme,         &
+                            its, ite, jts, jte, kts, kte,         &
+                          ! Mandatory outputs for all quantitative schemes
+                            ic_flashcount, ic_flashrate,          &
+                            cg_flashcount, cg_flashrate,           &
+                            lpi                                   &
+                          )
+!-----------------------------------------------------------------
+! Framework
+ USE module_state_description
+ USE module_utility
+
+! Model layer
+ USE module_model_constants
+ USE module_wrf_error
+
+! Parameterization options
+ USE module_ltng_crmpr92       ! lightning_option == 1,   ltng_crm_PR92w
+                               ! lightning_option == 2,   ltng_crm_PR92z
+ USE module_ltng_cpmpr92z      ! lightning_option == 11,  ltng_cpm_PR92z
+
+! IC:CG methods
+ USE module_ltng_iccg
+
+! LPI 
+#if (EM_CORE==1)
+  USE module_ltng_lpi
+#endif
+! Dynamic Lightning
+#if (EM_CORE==1)
+  USE module_ltng_pe
+  USE module_ltng_strokes
+#endif
+
+ IMPLICIT NONE
+!-----------------------------------------------------------------
+
+! Frequently used prognostics
+ REAL(8), INTENT(IN   )    ::       curr_secs
+ REAL,    INTENT(IN   )    ::       dt, dx, dy
+
+ REAL,    DIMENSION( ims:ime,          jms:jme ),           INTENT(IN   ) :: xlat, xlon, xland, ht
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: t_phy, p_phy, rho
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: th_phy, pi_phy, dz8w  
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: u, v, w, z
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, num_moist), INTENT(IN   ) :: moist
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, num_scalar), INTENT(INOUT   ) :: scalar
+
+! Scheme specific prognostics
+ INTEGER, DIMENSION( ims:ime,          jms:jme ),           INTENT(IN   ) :: ktop_deep     ! model LNB from cu_physics
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: refl          ! reflectivity from mp_physics
+ TYPE(WRFU_Time),                                           INTENT(IN   ) :: current_time  ! For use of IC:CG input
+
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LPI
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LPOS
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LNEG
+ REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT), OPTIONAL :: LNEU
+!
+! Mandatory namelist inputs
+ INTEGER, INTENT(IN   )    ::       lightning_option
+ REAL,    INTENT(IN   )    ::       lightning_dt, lightning_start_seconds, flashrate_factor
+ REAL,    INTENT(INOUT)    ::       ltngacttime
+
+! IC:CG namelist settings
+ INTEGER, INTENT(IN   )    ::       iccg_method
+ REAL,    INTENT(IN   )    ::       iccg_prescribed_num, iccg_prescribed_den
+ REAL,    DIMENSION( ims:ime, jms:jme, 12), INTENT(IN   ) :: iccg_in_num, iccg_in_den
+
+! Scheme specific namelist inputs
+ INTEGER, INTENT(IN   )    ::       cellcount_method                    ! used in CRM
+ REAL,    INTENT(IN   )    ::       cldtop_adjustment                   ! used in CPM
+! Dynamic LIghtning namelist settings
+ REAL,    INTENT(IN   )    ::       coul_pos
+ REAL,    INTENT(IN   )    ::       coul_neg
+ REAL,    INTENT(IN   )    ::       coul_neu
+ REAL,    INTENT(IN   )    ::       j_pos
+ REAL,    INTENT(IN   )    ::       j_neg
+ REAL,    INTENT(IN   )    ::       j_neu
+
+! Order dependent args for domain, mem, and tile dims
+ INTEGER, INTENT(IN   )    ::       ids,ide, jds,jde, kds,kde
+ INTEGER, INTENT(IN   )    ::       ims,ime, jms,jme, kms,kme
+ INTEGER, INTENT(IN   )    ::       its,ite, jts,jte, kts,kte
+
+! Mandatory outputs for all quantitative schemes
+ REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: ic_flashcount , cg_flashcount
+ REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(  OUT) :: ic_flashrate  , cg_flashrate
+
+
+! Local variables
+ REAL(8) :: LtngActivationTime
+ REAL(8) :: nextTime
+ REAL, DIMENSION( ims:ime, jms:jme ) :: total_flashrate
+ CHARACTER (LEN=80) :: message
+ LOGICAL :: do_ltng
+
+ REAL, PARAMETER            :: reflthreshold = 20. ! reflectivity threshold for CRM schemes
+ REAL, DIMENSION( kms:kme ) :: cellcount
+
+!-----------------------------------------------------------------
+
+ IF ( lightning_option .eq. 0 ) RETURN
+
+ nextTime = curr_secs + REAL(dt,8)
+ LtngActivationTime = REAL(ltngacttime,8)
+ do_ltng = LtngActivationTime >= curr_secs .and. LtngActivationTime <= nextTime
+
+ IF( .not. do_ltng ) THEN
+   RETURN
+ ENDIF
+
+!-----------------------------------------------------------------
+! This driver performs several steps in order to produce lightning
+! flash rate and flash count diagnostics:
+!
+! 1. Determine cloud extents for specific CRM schemes
+! 2. Total flash rate assignment to 2D array
+! 3. Partitioning of total lightning into IC & CG
+! 4. Scale flash rate by flashrate_factor and lightning_dt
+!
+!-----------------------------------------------------------------
+
+ IF ( lightning_option .eq. ltng_crm_PR92w .or. &
+      lightning_option .eq. ltng_crm_PR92z ) THEN
+   CALL wrf_debug ( 100, ' lightning_driver: determining cloud extents for CRM' )
+   CALL countCells( &
+          ! Inputs
+            refl, reflthreshold, cellcount_method,     &
+          ! Order dependent args for domain, mem, and tile dims
+            ids, ide, jds, jde, kds, kde,              &
+            ims, ime, jms, jme, kms, kme,              &
+            its, ite, jts, jte, kts, kte,              &
+          ! Outputs
+            cellcount )
+   WRITE(message, * ) ' lightning_driver: Max cell count = ', maxval(cellcount)
+   CALL wrf_debug ( 100, message )
+ ENDIF
+
+!-----------------------------------------------------------------
+
+ CALL wrf_debug ( 100, ' lightning_driver: calculating flash rate' )
+ flashrate_select: SELECT CASE(lightning_option)
+
+    ! CRM lightning options
+    CASE( ltng_crm_PR92w )
+        CALL wrf_debug ( 100, ' lightning_driver: calling Price and Rind 1992 (w_max, CRM)' )
+
+        CALL ltng_crmpr92w ( &
+                  ! Frequently used prognostics
+                    dx, dy, xland, ht, z, t_phy,          &
+                  ! Scheme specific prognostics
+                    w, refl, reflthreshold, cellcount,    &
+                  ! Scheme specific namelist inputs
+                    cellcount_method,                     &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,         &
+                    ims, ime, jms, jme, kms, kme,         &
+                    its, ite, jts, jte, kts, kte,         &
+                  ! Mandatory output for all quantitative schemes
+                    total_flashrate                       &
+                  )
+    CASE( ltng_crm_PR92z )
+        CALL wrf_debug ( 100, ' lightning_driver: calling Price and Rind 1992 (z_top, CRM)' )
+        CALL ltng_crmpr92z ( &
+                  ! Frequently used prognostics
+                    dx, dy, xland, ht, z, t_phy,          &
+                  ! Scheme specific prognostics
+                    refl, reflthreshold, cellcount,       &
+                  ! Scheme specific namelist inputs
+                    cellcount_method,                     &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,         &
+                    ims, ime, jms, jme, kms, kme,         &
+                    its, ite, jts, jte, kts, kte,         &
+                  ! Mandatory output for all quantitative schemes
+                    total_flashrate                       &
+                  )
+!   CASE ( another_crm_option)
+!       CALL ...
+
+    ! CPM lightning options
+    CASE( ltng_cpm_PR92z )
+        CALL wrf_debug ( 100, ' lightning_driver: calling Price and Rind 1992 (z_top, CPM)' )
+
+        CALL ltng_cpmpr92z ( &
+                  ! Frequently used prognostics
+                    dx, dy, xland, ht, z, t_phy,      &
+                    ktop_deep, cldtop_adjustment,     &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,     &
+                    ims, ime, jms, jme, kms, kme,     &
+                    its, ite, jts, jte, kts, kte,     &
+                  ! Mandatory output for all quantitative schemes
+                    total_flashrate                   &
+                  )
+
+    ! LPI lightning options
+#if (EM_CORE==1)
+    CASE( ltng_lpi )
+        CALL wrf_debug ( 100, ' lightning_driver: calling Light Potential Index' )
+        IF(F_QG) THEN
+        CALL   calclpi(W=w,                              &
+                     Z=z,                              &
+                     PI_PHY=pi_phy, RHO_PHY=rho,             &
+                     TH_PHY=TH_PHY,P_PHY=p_phy,                  &
+                     DZ8w=dz8w,                          &
+                     QV=moist(ims,kms,jms,P_QV),         &   !Qv=qv_curr,                         &
+                     QC=moist(ims,kms,jms,P_QC),         &   !Qc=qc_curr,                         &
+                     QR=moist(ims,kms,jms,P_QR),         &   !QR=qr_curr,                         &
+                     QI=moist(ims,kms,jms,P_QI),         &   !QI=qi_curr,                         &
+                     QS=moist(ims,kms,jms,P_QS),         &   !qs_curr,                         &
+                     QG=moist(ims,kms,jms,P_QG),         &   !qg_curr,                         &
+                     QH=moist(ims,kms,jms,P_QH),         &   !qh_curr,                         &
+                  lpi=lpi &
+                 ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
+                 ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
+                 ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte)
+        ELSE
+        WRITE(wrf_err_message, * ) ' lightning_driver: LPI option needs Microphysics Option with Graupel '
+        CALL wrf_error_fatal ( wrf_err_message )
+        ENDIF
+#endif
+#if (EM_CORE==1)
+    CASE( ltng_dyn_lightning )
+        CALL wrf_debug ( 100, ' lightning_driver: calling Dynamic Lightning Scheme' )
+        IF(F_QG) THEN
+        CALL   calc_dyn_pe(dx=dx,dy=dy,                         &
+                     W=w,                              &
+                     PI_PHY=pi_phy, RHO_PHY=rho,             &
+                     TH_PHY=TH_PHY,P_PHY=p_phy,                  &
+                     DZ8w=dz8w,                          &
+                     QC=moist(ims,kms,jms,P_QV),         &   
+                     QR=moist(ims,kms,jms,P_QR),         &  
+                     QI=moist(ims,kms,jms,P_QI),         & 
+                     QS=moist(ims,kms,jms,P_QS),         &
+                     QG=moist(ims,kms,jms,P_QG),         &
+                     light_pe=scalar(ims,kms,jms,P_light_pe), &
+                     light_ne=scalar(ims,kms,jms,P_light_ne), &
+                     light_neu=scalar(ims,kms,jms,P_light_neu),&
+                     dt=dt &
+                 ,coul_pos=coul_pos &
+                 ,coul_neg=coul_neg &
+                 ,coul_neu=coul_neu &
+                 ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
+                 ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
+                 ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte)
+        ELSE
+        WRITE(wrf_err_message, * ) ' lightning_driver: Dynamic Lightning option needs Microphysics Option with Graupel '
+        CALL wrf_error_fatal ( wrf_err_message )
+        END IF
+           CALL   calcstroke(dx=dx,dy=dy,                         &
+                     W=w,                              &
+                     PI_PHY=pi_phy, RHO_PHY=rho,             &
+                     TH_PHY=TH_PHY,P_PHY=p_phy,                  &
+                     DZ8w=dz8w,                          &
+                     light_pe=scalar(ims,kms,jms,P_light_pe), &
+                     light_ne=scalar(ims,kms,jms,P_light_ne), &
+                     light_neu=scalar(ims,kms,jms,P_light_neu),&
+                     lpos=lpos,lneg=lneg,lneu=lneu  &
+                 ,j_pos=j_pos &
+                 ,j_neg=j_neg &
+                 ,j_neu=j_neu &
+                 ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
+                 ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
+                 ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte)
+#endif
+!   CASE ( another_cpm_option)
+
+    ! Invalid lightning options
+    CASE DEFAULT
+        WRITE(wrf_err_message, * ) ' lightning_driver: The lightning option does not exist: lightning_opt = ', lightning_option
+        CALL wrf_error_fatal ( wrf_err_message )
+
+ END SELECT flashrate_select
+
+!-----------------------------------------------------------------
+
+ CALL wrf_debug ( 100, ' lightning_driver: partitioning IC:CG')
+ iccg_select: SELECT CASE(iccg_method)
+    ! Flash rate option defaults
+    CASE( 0 ) iccg_select
+        CALL wrf_debug( 100, ' lightning_driver: using option-default IC:CG method' )
+        iccg_method_default: SELECT CASE(lightning_option)
+
+            CASE( ltng_crm_PR92w, ltng_crm_PR92z, ltng_cpm_PR92z ) iccg_method_default
+                CALL iccg_boccippio( &
+                            xlat, xlon,                                &
+                            iccg_prescribed_num, iccg_prescribed_den,  &
+                          ! Order dependent args for domain, mem, and tile dims
+                            ids, ide, jds, jde, kds, kde,              &
+                            ims, ime, jms, jme, kms, kme,              &
+                            its, ite, jts, jte, kts, kte,              &
+                          ! Input
+                            total_flashrate,                           &
+                          ! Output
+                            ic_flashrate, cg_flashrate                 &
+                          )
+
+            CASE DEFAULT iccg_method_default
+                CALL wrf_debug ( 100, ' lightning_driver: no method-default IC:CG implemented, using user-prescribed constant')
+                CALL iccg_user_prescribed( &
+                            iccg_prescribed_num,                  &
+                            iccg_prescribed_den,                  &
+                          ! Order dependent args for domain, mem, and tile dims
+                            ids, ide, jds, jde, kds, kde,         &
+                            ims, ime, jms, jme, kms, kme,         &
+                            its, ite, jts, jte, kts, kte,         &
+                          ! Input
+                            total_flashrate,                      &
+                          ! Output
+                            ic_flashrate, cg_flashrate            &
+                          )
+
+        END SELECT iccg_method_default
+
+    ! Used-prescribed constant
+    CASE( 1 ) iccg_select
+        WRITE(message, * ) ' lightning_driver: using user-prescribed IC:CG ratio = ', iccg_prescribed_num, iccg_prescribed_den
+        CALL wrf_debug ( 100, message )
+        CALL iccg_user_prescribed( &
+                    iccg_prescribed_num,                  &
+                    iccg_prescribed_den,                  &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,         &
+                    ims, ime, jms, jme, kms, kme,         &
+                    its, ite, jts, jte, kts, kte,         &
+                  ! Input
+                    total_flashrate,                      &
+                  ! Output
+                    ic_flashrate, cg_flashrate            &
+                  )
+
+    ! Boccippio et al, 2001
+    CASE( 2 ) iccg_select
+        CALL wrf_debug ( 100, ' lightning_driver: using Boccippio 2001 IC:CG climatology')
+        CALL iccg_boccippio( &
+                    xlat, xlon,                                &
+                    iccg_prescribed_num, iccg_prescribed_den,  &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,              &
+                    ims, ime, jms, jme, kms, kme,              &
+                    its, ite, jts, jte, kts, kte,              &
+                  ! Input
+                    total_flashrate,                           &
+                  ! Output
+                    ic_flashrate, cg_flashrate                 &
+                  )
+
+    ! Price and Rind, 1993
+    CASE( 3 ) iccg_select
+        iccg_pr93_select: SELECT CASE(lightning_option)
+        CASE( ltng_crm_PR92w, ltng_crm_PR92z ) iccg_pr93_select
+            CALL wrf_debug ( 100, ' lightning_driver: using Price and Rind 1993 IC:CG ratio (CRM)')
+            CALL iccg_crm_pr93( &
+                    refl, reflthreshold, t_phy, z,             &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,              &
+                    ims, ime, jms, jme, kms, kme,              &
+                    its, ite, jts, jte, kts, kte,              &
+                  ! Input
+                    total_flashrate,                           &
+                  ! Output
+                    ic_flashrate, cg_flashrate                 &
+                )
+
+        CASE DEFAULT iccg_pr93_select
+            CALL wrf_debug ( 100, ' lightning_driver: using Price and Rind 1993 IC:CG ratio (CPM)')
+            CALL iccg_pr93( &
+                    ktop_deep, cldtop_adjustment, t_phy, z,    &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,              &
+                    ims, ime, jms, jme, kms, kme,              &
+                    its, ite, jts, jte, kts, kte,              &
+                  ! Input
+                    total_flashrate,                           &
+                  ! Output
+                    ic_flashrate, cg_flashrate                 &
+                )
+        END SELECT iccg_pr93_select
+
+    CASE( 4 ) iccg_select
+        CALL wrf_debug ( 100, ' lightning_driver: using input IC:CG ratio from iccg_in_(num|den)' )
+        CALL iccg_input( &
+                    iccg_prescribed_num, iccg_prescribed_den,  &
+                    iccg_in_num, iccg_in_den, current_time,    &
+                  ! Order dependent args for domain, mem, and tile dims
+                    ids, ide, jds, jde, kds, kde,              &
+                    ims, ime, jms, jme, kms, kme,              &
+                    its, ite, jts, jte, kts, kte,              &
+                  ! Input
+                    total_flashrate,                           &
+                  ! Output
+                    ic_flashrate, cg_flashrate                 &
+                  )
+
+    ! Invalid IC:CG method
+    CASE DEFAULT iccg_select
+        WRITE(wrf_err_message, * ) ' lightning_driver: Invalid IC:CG method (iccg_method) = ', lightning_option
+        CALL wrf_error_fatal ( wrf_err_message )
+
+ END SELECT iccg_select
+
+!-----------------------------------------------------------------
+
+ CALL wrf_debug( 200, ' lightning_driver: converting flash rates to flash counts')
+
+ ic_flashrate(its:ite,jts:jte) = ic_flashrate(its:ite,jts:jte) * flashrate_factor
+ cg_flashrate(its:ite,jts:jte) = cg_flashrate(its:ite,jts:jte) * flashrate_factor
+
+ ic_flashcount(its:ite,jts:jte) = ic_flashcount(its:ite,jts:jte) + ic_flashrate(its:ite,jts:jte) * lightning_dt
+ cg_flashcount(its:ite,jts:jte) = cg_flashcount(its:ite,jts:jte) + cg_flashrate(its:ite,jts:jte) * lightning_dt
+ 
+ do
+   if( REAL(ltngacttime,8) <= nextTime ) then
+     ltngacttime = ltngacttime + lightning_dt
+   else
+     exit
+   endif
+ enddo
+
+!-----------------------------------------------------------------
+
+ CALL wrf_debug ( 100, ' lightning_driver: returning from')
+
+ END SUBROUTINE lightning_driver
+
+
+!**********************************************************************
+!
+! SUBROUTINE countCells
+!
+! For counting number of cells where reflectivity exceeds a certain
+! threshold. Typically used by CRM schemes to redistribute lightning
+! within convective cores.
+!
+! Departure from original implementation:
+! Output includes domain-wide cellcounts if cellcount_method = 2
+!
+!**********************************************************************
+
+ SUBROUTINE countCells( &
+          ! Inputs
+            refl, reflthreshold, cellcount_method,     &
+          ! Order dependent args for domain, mem, and tile dims
+            ids, ide, jds, jde, kds, kde,              &
+            ims, ime, jms, jme, kms, kme,              &
+            its, ite, jts, jte, kts, kte,              &
+          ! Outputs
+            cellcount )
+
+ USE module_dm, only: wrf_dm_sum_real
+
+ IMPLICIT NONE
+!-----------------------------------------------------------------
+
+! Inputs
+ REAL,    DIMENSION( ims:ime,kms:kme,jms:jme ), INTENT(IN   ) :: refl
+ REAL,    INTENT(IN   ) :: reflthreshold
+ INTEGER, INTENT(IN   ) :: cellcount_method
+
+! Order dependent args for domain, mem, and tile dims
+ INTEGER, INTENT(IN   )    ::       ids,ide, jds,jde, kds,kde
+ INTEGER, INTENT(IN   )    ::       ims,ime, jms,jme, kms,kme
+ INTEGER, INTENT(IN   )    ::       its,ite, jts,jte, kts,kte
+
+
+! Outputs
+ REAL,    DIMENSION( kms:kme ), INTENT(  OUT) :: cellcount
+
+! Local vars
+ INTEGER :: i,k,j
+
+!-----------------------------------------------------------------
+
+ cellcount(kts:kte) = 0.
+ DO j=jts,jte
+   DO k=kts,kte
+     DO i=its,ite
+       IF ( refl(i,k,j) .gt. reflthreshold ) THEN
+         cellcount(k) = cellcount(k) + 1
+       ENDIF
+     ENDDO
+   ENDDO
+ ENDDO
+
+ IF ( cellcount_method .eq. 2 ) THEN
+   DO k=kts,kte
+     cellcount(k) = wrf_dm_sum_real(cellcount(k))
+   ENDDO
+ ENDIF
+
+ END SUBROUTINE
+
+ END MODULE module_lightning_driver

--- a/phys/module_ltng_pe.F
+++ b/phys/module_ltng_pe.F
@@ -1,0 +1,322 @@
+MODULE module_ltng_pe
+CONTAINS
+!https://journals.ametsoc.org/doi/10.1175/WAF-D-11-00144.1
+! coul_pos, etc, are charging constants, in units of Coulombs..
+! coul_pos, etc, now set in Registry.EM_COMMON; can be added to namelist.input
+! The values set work well for the NSSL scheme, and probably for Thompson
+! Aerosol Aware.  They are suggested values and  can be modified by the user  based on a set of  case study comparisons.
+! For the WSM6, it is suggested to double the values. 
+  SUBROUTINE calc_dyn_pe(dx,dy,qc, qr, qi, qs, qg                                &
+                 ,w,dz8w,pi_phy,th_phy,p_phy,rho_phy                    &
+                 ,light_pe &
+                 ,light_ne &
+                 ,light_neu &
+                 ,dt &
+                 ,coul_pos,coul_neg,coul_neu &
+                 ,ids,ide, jds,jde, kds,kde                        &
+                 ,ims,ime, jms,jme, kms,kme                        &
+                 ,its,ite, jts,jte, kts,kte                        &
+                                                                   )
+!-------------------------------------------------------------------
+  IMPLICIT NONE
+!-------------------------------------------------------------------
+!
+!
+  REAL,   INTENT(IN) ::  coul_pos,coul_neg,coul_neu
+  INTEGER,      INTENT(IN   )    ::   ids,ide, jds,jde, kds,kde , &
+                                      ims,ime, jms,jme, kms,kme , &
+                                      its,ite, jts,jte, kts,kte
+  REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                 &
+        INTENT(IN) ::                                          &
+                                                              qc, &
+                                                              qi, &
+                                                              qr, &
+                                                              qs, &
+                                                              qg
+  REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                 &
+        INTENT(INOUT) ::                                          &
+                                                      light_pe,&
+                                                      light_ne, &
+                                                      light_neu
+
+      REAL,INTENT(IN):: dx,dy
+      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                  &
+         INTENT(IN ) ::  w
+   REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                    &
+         INTENT(IN) ::                                         th_phy
+!
+
+!
+   REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                    &
+         INTENT(IN   ) ::                                             &
+                                                                rho_phy, &
+                                                                dz8w, &
+                                                              pi_phy, &
+                                                                   p_phy
+
+!     REAL, INTENT(INOUT),  DIMENSION(ims:ime,jms:jme)::      &
+!    &                      prec_ice,wqg_m15
+      REAL, DIMENSION(ims:ime,jms:jme)::      &
+     &                      LPI,LPOS,LNEG,LNEU,plpi,nlpi,neulpi
+!     REAL, DIMENSION(ims:ime,jms:jme)::      &
+!    &                      LPI,LPOS,LNEG,LNEU,plpi,nlpi,neulpi,prec_ice,wqg_m15
+
+
+
+
+      REAL, DIMENSION(kms:kme)::    tempk,rh,qtot,qitot
+      REAL, DIMENSION(kms:kme):: p1d,rho1d,qti1d
+      REAL, DIMENSION(kms:kme):: temp,qc1d,ql1d,qi1d,qs1d,qg1d,lpi1d
+      REAL, DIMENSION(0:kme):: w1d,height
+      REAL, DIMENSION(kms:kme):: e1d,height_t,w1d_t
+      REAL z_full,qrs,teten,RELHUM,LOC,Td_850,Td_700,PC_DWPT
+      INTEGER level
+      REAL :: dt,dxdy,t_base,t_top
+      INTEGER I_COLLAPSE
+      LOGICAL LOOK_T
+      real t_pos,t_neg,t_neu
+      INTEGER I_START,I_END,J_START,J_END
+
+
+  INTEGER ::               i,j,k
+!-------------------------------------------------------------------
+! !   print*,'ims,ime,jms,jme,kms,kme = ',ims,ime,jms,jme,kms,kme 
+!     print*,'its,ite,jts,jte,kts,kte = ',its,ite,jts,jte,kts,kte 
+!     parameter(t_pos=0.12,t_neg=0.06,t_neu=0.03) 
+!     note: t_pos is modified based on the height of the top of the cloud
+!     I believe that the value of 60000 m/s might be a typical speed
+!     See: https\://en.wikipedia.org/wiki/Lightning
+      t_pos=0.12
+      t_neg=0.06
+      t_neu=0.03
+      dxdy=dx*dy
+!     print*,'kte = ',kte
+!     return (1)
+      DO j = jts,jte
+      DO i = its,ite
+        z_full=0.
+        height(0)=z_full
+        w1d(0)=w(i,1,j)
+      DO k = kts,kte
+          if (k.lt.kte)then
+           w1d(k)=w(i,k+1,j)
+          else
+           w1d(k)=0.
+          end if
+          temp(k) = th_phy(i,k,j)*pi_phy(i,k,j)-273.16
+          tempk(k) = th_phy(i,k,j)*pi_phy(i,k,j)
+          p1d(k)=p_phy(i,k,j)
+          rho1d(k)=rho_phy(i,k,j)
+          z_full=z_full+dz8w(i,k,j)
+          height(k)=z_full
+          qc1d(k)=qc(i,k,j)
+          ql1d(k)=qc(i,k,j)+qr(i,k,j)
+          qi1d(k)=qi(i,k,j)
+!         qti1d(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)+qh(i,k,j)
+          qti1d(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)
+          qs1d(k)=qs(i,k,j)
+!         qg1d(k)=qg(i,k,j)+qh(i,k,j)
+          qg1d(k)=qg(i,k,j)
+!         qtot(k)=qc(i,k,j)+qr(i,k,j)+qi(i,k,j)+qs(i,k,j)+qg(i,k,j)+qh(i,k,j)
+          qtot(k)=qc(i,k,j)+qr(i,k,j)+qi(i,k,j)+qs(i,k,j)+qg(i,k,j)
+          qitot(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)
+!         qitot(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)+qh(i,k,j)
+! For conservative advection multiply by rho1d and divide by it below
+          qitot(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)
+      ENDDO
+      do k = kts,kte
+       height_t(k)=0.5*(height(k-1)+height(k))
+       w1d_t(k)=0.5*(w1d(k-1)+w1d(k))
+      end do
+      t_base=-10
+      t_top=-30
+      do k = kts,kte-1
+        e1d(k)=light_pe(i,k,j)*rho1d(k)
+      end do
+      call calc_lpi(ql1d,qi1d,qs1d,qg1d,w1d,temp,height,plpi(i,j),lpi1d,t_base,t_top,kme,kte)
+      look_t=.true.
+       do k=kte-1,kts,-1
+       if (look_t)then
+       if (temp(k).ge.-27.and.qtot(k).gt.0.00001.and.height(k).ge.4000)then
+        t_pos=height_t(k)/60000.
+!       print*,'height_t(k) = ',k,height_t(k)
+!       print*,'t_pos = ',t_pos
+        look_t=.false.
+       end if
+       end if
+       end do
+      call power_index(temp,qitot,rho1d,plpi(i,j),lpi1d,e1d,dt,dxdy,t_pos,t_base,t_top,coul_pos,kme,kte)
+      do k = kts,kte-1
+          light_pe(i,k,j)=e1d(k)
+      end do
+      do k = kts,kte-1
+        e1d(k)=light_ne(i,k,j)*rho1d(k)
+!     IF (ISNAN(e1d(k))) STOP 'BARRY WANTS TO STOP HERE 18'
+      end do
+      t_base=-0
+      t_top=-20
+      call calc_lpi(ql1d,qi1d,qs1d,qg1d,w1d,temp,height,nlpi(i,j),lpi1d,t_base,t_top,kme,kte)
+      lpi(i,j)=nlpi(i,j)
+! OLD 2
+       look_t=.true.
+       do k=kte-1,kts,-1
+       if (look_t)then
+       if (temp(k).ge.-2.and.qtot(k).gt.0.0001.and.height(k).ge.1000)then
+        t_neg=height_t(k)/60000.
+        look_t=.false.
+       end if
+       end if
+       end do
+      call power_index(temp,qitot,rho1d,nlpi(i,j),lpi1d,e1d,dt,dxdy,t_neg,t_base,t_top,coul_neg,kme,kte)
+      do k = kts,kte-1
+          light_ne(i,k,j)=e1d(k)
+      end do
+! OLD 3
+      do k = kts,kte-1
+        e1d(k)=light_neu(i,k,j)*rho1d(k)
+      end do
+      t_base=0.
+      t_top=-30.
+      call calc_lpi(ql1d,qi1d,qs1d,qg1d,w1d,temp,height,neulpi(i,j),lpi1d,t_base,t_top,kme,kte)
+       t_neu=0.5*(t_pos-t_neg)
+       if (abs(t_pos-t_neg).le.01)t_neu=0.01
+      call power_index(temp,qitot,rho1d,neulpi(i,j),lpi1d,e1d,dt,dxdy,t_neu,t_base,t_top,coul_neu,kme,kte)
+      do k = kts,kte-1
+          light_neu(i,k,j)=e1d(k)
+      end do
+
+
+      END DO
+      END DO
+      return
+      end subroutine calc_dyn_pe
+      subroutine &
+     &  calc_lpi(ql3d,qi3d,qs3d,qg3d,w3d,t3d,height,lpi,lpi1d,t_base,t_top,nk,nke)
+      implicit none
+      integer nk,nke
+      real t_base,t_top
+      real lpi1d(nk)
+      real ql3d(nk)
+      real qg3d(nk)
+      real qi3d(nk)
+      real qs3d(nk)
+      real w3d(0:nk)
+      real t3d(nk)
+      real height(0:nk)
+      real lpi,plpi
+      real del_z(nk)
+      real w_ave(nk)
+      integer ic,jc,icnt,i,j,k,i_collapse
+      real i_dist,j_dist,del_z_tot
+      real top, bot
+      real num,den,ave_z
+      real num_s,den_s
+      real num_i,den_i
+      real q_isg
+      icnt=0
+!     print*,'nke = ',nke
+      do k=1,nke
+        lpi1d(k)=0
+        top=height(k)
+        bot=height(k-1)
+        del_z(k)=top-bot
+        w_ave(k)=0.5*(w3d(k)+w3d(k-1))
+      end do
+      lpi1d(nk)=0
+!
+!     Check for collapsing cell
+      ave_z=0
+      del_z_tot=0
+      lpi=0
+      do k=1,nke-1
+!      print*,'k = ',k
+!      print*,'t3d(k) = ',t3d(k)
+!      print*,'t_base = ',t_base
+!      print*,'t_top = ',t_top
+
+       if (t3d(k).le.t_base.and.t3d(k).gt.t_top)then ! set temp range
+        
+        den_i = qi3d(k)+qg3d(k)     
+        den_s = qs3d(k)+qg3d(k)
+        if (qs3d(k).le.1.E-10.or.qg3d(k).le.1.E-10)then !checks for zeroes
+         den_s=10000.
+         num_s = 0.
+        else
+         num_s = sqrt(qs3d(k)*qg3d(k))   
+        end if
+!       print*,'qi3d(k) = ',qi3d(k)
+!       print*,'qg3d(k) = ',qg3d(k)
+        if (qi3d(k).le.1.E-10.or.qg3d(k).le.1.E-10)then
+         num_i = 0.
+         den_i = 10000
+        else
+         num_i = sqrt(qi3d(k)*qg3d(k))
+        end if
+!       print*,'num_i = ',num_i
+!       print*,'den_i = ',den_i
+!       print*,'num_s = ',num_s
+!       print*,'den_s = ',den_s
+
+        q_isg = qg3d(k)*(num_i/den_i+num_s/den_s)  ! ice "fract"-content
+
+        if (ql3d(k).le.1.E-10.or.q_isg.le.1.E-10)then
+          num=0
+          den=10000.
+        else
+         num = sqrt(ql3d(k)*q_isg)
+         den = ql3d(k)+q_isg
+        end if
+        del_z_tot=del_z_tot+del_z(k)
+        if (num.gt.0)then
+         ave_z=ave_z+del_z(k)*(2.*num/den)*w_ave(k)**2 ! power index J/unit-mass
+         lpi1d(k)=del_z(k)*(2.*num/den)*w_ave(k)**2 ! power index J/unit-mass
+        end if
+       end if
+      end do
+!
+      if (del_z_tot.eq.0)del_z_tot=100000
+      lpi=ave_z/del_z_tot
+       
+!
+      return
+      end subroutine calc_lpi
+      subroutine &
+     &  power_index(t3d,qitot,rho1d,lpi,lpi1d,le1d,dt,dxdy,t_pos,t_base,t_top,coul_value,nk,nke)
+      implicit none
+      integer nk,nke
+      real coul_value
+      real t_pos,t_top,t_base
+      real lpi1d(nk),lpi,dxdy
+      real le1d(nk)
+      real rho1d(nk)
+      real ql3d(nk)
+      real qitot(nk)
+      real qg3d(nk)
+      real qi3d(nk)
+      real qs3d(nk)
+      real w3d(nk)
+      real t3d(nk)
+      real del_z(nk)
+      real w_ave(nk)
+      real power
+      integer ic,jc,icnt,i,j,k,i_collapse
+      real i_dist,j_dist,del_z_tot
+      real top, bot
+      real num,den,ave_z
+      real num_s,den_s
+      real num_i,den_i
+      real q_isg
+      real dt
+      lpi=0
+      le1d(nk)=0
+!     print*,'t_pos = ',t_pos
+      do k=1,nke-1
+       if (t3d(k).le.t_base.and.t3d(k).gt.t_top)then ! set temp range
+        power=coul_value/t_pos*qitot(k)*rho1d(k)*lpi1d(k)
+        le1d(k)=le1d(k)+power*dt*dxdy
+        lpi = lpi+le1d(k)
+       end if
+      end do
+      return
+      end subroutine power_index
+  END MODULE module_ltng_pe

--- a/phys/module_ltng_pe_add.F
+++ b/phys/module_ltng_pe_add.F
@@ -1,6 +1,5 @@
 MODULE module_ltng_pe
 CONTAINS
-! Modified
 !https://journals.ametsoc.org/doi/10.1175/WAF-D-11-00144.1
 ! coul_pos, etc, are charging constants, in units of Coulombs..
 ! coul_pos, etc, now set in Registry.EM_COMMON; can be added to namelist.input

--- a/phys/module_ltng_strokes.F
+++ b/phys/module_ltng_strokes.F
@@ -1,5 +1,6 @@
 MODULE module_ltng_strokes
 !https://journals.ametsoc.org/doi/10.1175/WAF-D-11-00144.1
+!modified
 
 ! j_pos,j_neg,j_neu:Energy per flash; threshold values set in Registry.EM_COMMON
 ! Values can be modified through namelist.input

--- a/phys/module_ltng_strokes.F
+++ b/phys/module_ltng_strokes.F
@@ -1,0 +1,194 @@
+MODULE module_ltng_strokes
+!https://journals.ametsoc.org/doi/10.1175/WAF-D-11-00144.1
+
+! j_pos,j_neg,j_neu:Energy per flash; threshold values set in Registry.EM_COMMON
+! Values can be modified through namelist.input
+! Sample values used:  parameter (j_pos=5.E9,j_neg=1.E9,j_neu=1.E9)
+! References for this and accompanying program module_calc_lpi.F
+! Note, the calculation of lpi is different than in the published paper by Yair
+! et al., JGR:
+! https://scholar.google.co.il/citations?user=vzBSZmEAAAAJ&hl=en#d=gs_md_cita-d&u=%2Fcitations%3Fview_op%3Dview_citation%26hl%3Den%26user%3DvzBSZmEAAAAJ%26citation_for_view%3DvzBSZmEAAAAJ%3AULOm3_A8WrAC%26tzom%3D-120
+! Lynn, B. H., Y. Yair, C. Price, G. Kelman, A. Clark,
+! 2012: Predicting Cloud-to-Ground and Intracloud Lightning in Weather
+!Forecast Models.  Wea. Forecast.  27, 1470-1486.
+! Lynn, B. H., G. Kelman, and G. Ellrod, 2015: An Evaluation of the
+! Efficacy of Using Observed Lightning to Improve Convective Lightning Forecasts.
+! Wea. Forecasting, 30, 405–423. 
+! Lynn, B.H, 2016: The Usefulness and Economic Value of Total Lightning
+! Forecasts made with a "Dynamic" Lightning Scheme coupled with Lightning Data
+! Assimilation. Wea. Forecasting. 32, 645 – 663.
+! Contact: barry.lynn@weather-it-is.com or barry.h.lynn@gmail.com
+
+CONTAINS
+!===================================================================
+!
+  SUBROUTINE calcstroke(dx,dy &
+                 ,w,dz8w,pi_phy,th_phy,p_phy,rho_phy                    &
+                 ,light_pe &
+                 ,light_ne &
+                 ,light_neu &
+                 ,lpos,lneg,lneu&
+                 ,j_pos,j_neg,j_neu &
+                 ,ids,ide, jds,jde, kds,kde                        &
+                 ,ims,ime, jms,jme, kms,kme                        &
+                 ,its,ite, jts,jte, kts,kte                        &
+                                                                   )
+!-------------------------------------------------------------------
+  IMPLICIT NONE
+!-------------------------------------------------------------------
+!
+!
+  REAL, INTENT(IN):: j_pos,j_neg,j_neu
+  real j_sa ! scale aware
+  INTEGER,      INTENT(IN   )    ::   ids,ide, jds,jde, kds,kde , &
+                                      ims,ime, jms,jme, kms,kme , &
+                                      its,ite, jts,jte, kts,kte
+ 
+       REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                 &
+        INTENT(INOUT) ::                                          &
+                                                      light_pe,&
+                                                      light_ne, &
+                                                      light_neu
+      REAL,INTENT(IN):: dx,dy
+      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                  &
+         INTENT(IN ) ::  w
+      REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                    &
+         INTENT(IN) ::                                         th_phy
+!
+
+!
+       REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                    &
+         INTENT(IN   ) ::                                             &
+                                                                rho_phy, &
+                                                                dz8w, &
+                                                              pi_phy, &
+                                                                   p_phy
+
+      REAL, INTENT(INOUT),  DIMENSION(ims:ime,jms:jme)::      &
+     &                      LPOS,LNEG,LNEU
+!     REAL, INTENT(INOUT),  DIMENSION(ims:ime,jms:jme)::      &
+!    &                      LPI,LPOS,LNEG,LNEU,plpi,nlpi,neulpi        
+
+
+
+      REAL, DIMENSION(kms:kme)::    tempk,rh,qtot,qitot
+      REAL, DIMENSION(kms:kme):: qv1d,p1d,rho1d,qti1d
+      REAL, DIMENSION(kms:kme):: temp,qc1d,ql1d,qi1d,qs1d,qg1d,lpi1d
+      REAL, DIMENSION(0:kme):: w1d,height
+      REAL, DIMENSION(kms:kme):: e1d,height_t,w1d_t
+      REAL z_full
+      INTEGER level
+      INTEGER I_COLLAPSE
+      LOGICAL LOOK_T
+      real dxkm
+
+  INTEGER ::               i,j,k
+!-------------------------------------------------------------------
+
+! NOTE: dxkm is a "scale-aware" term.
+! The volume change from grid to grid depends on  the square of the area.
+! The vertical velocity, though, will increase, for example, by deltax
+! the ratio of  w to volume is deltax/deltax-sq or 1./delta_x
+! 4 km is the reference value for deltax (based on paper published in 2012).
+      dxkm = dx*1.E-3
+      DO j = jts,jte
+      DO i = its,ite
+       z_full=0.
+       height(0)=z_full
+       do k=kts,kte
+        z_full=z_full+dz8w(i,k,j)
+        height(k)=z_full
+        temp(k) = th_phy(i,k,j)*pi_phy(i,k,j)-273.16
+        rho1d(k)=rho_phy(i,k,j)
+       end do
+! note: light_neu, etc, are multiplied by rho in calc_lpi.F, for converting from
+! /kg to /m^3
+       e1d(kme) = 0
+       do k=kts,kte
+        e1d(k)=light_neu(i,k,j)
+       end do
+!      j_neu=1.E9
+       j_sa=j_neu*dxkm/4.
+       call flash(height,temp,e1d,j_sa,lneu(i,j),kme,kte)
+       do k=kts,kte
+        if (rho1d(k).le.1.E-10)rho1d(k) = 100000.
+        light_neu(i,k,j) = e1d(k)/rho1d(k)
+       end do
+       light_neu(i,kme,j) = 0
+       e1d(kme) = 0
+       do k = kts,kte
+        e1d(k)=light_ne(i,k,j)
+       end do
+       j_sa=j_neg*dxkm/4.
+       call flash(height,temp,e1d,j_sa,lneg(i,j),kme,kte)
+       do k = kts,kte
+        if (rho1d(k).le.1.E-10)rho1d(k) = 100000.
+        light_ne(i,k,j) = e1d(k)/rho1d(k)
+       end do
+       light_ne(i,kme,j) = 0
+!      j_pos=5.E9
+       j_sa=j_pos*dxkm/4.
+       e1d(kme) = 0
+       do k = kts,kte
+       e1d(k)=light_pe(i,k,j)
+       end do 
+       call flash(height,temp,e1d,j_sa,lpos(i,j),kme,kte)
+       do k = kts,kte
+        if (rho1d(k).le.1.E-10)rho1d(k) = 100000.
+          light_pe(i,k,j)=e1d(k)/rho1d(k)
+       end do
+       light_pe(i,kme,j) = 0
+      END DO
+      END DO
+
+
+      return
+      end subroutine calcstroke
+      subroutine &
+     & flash(height,t3d,pe1d,j_pos,lpos,nk,nke)
+      implicit none
+      integer nk,nke
+      real lpos,j_pos
+      real pe1d(nk)
+      integer i,j,k
+      integer num_ran
+      parameter (num_ran=2)
+      real ran_num(num_ran)
+      real    i_seed
+      real t3d(nk)
+      real height(0:nk)
+      real del_z(nk)
+      real top, bot
+      real n,ave_z,del_z_tot
+      real residual,e_p,e_n,e_neu,loss,e_min
+      del_z_tot=0
+      do k=1,nke-1
+        top=0.5*(height(k+1)+height(k))
+        bot=0.5*(height(k)+height(k-1))
+        del_z(k)=top-bot
+      end do
+!     plpi=0
+      e_p=0
+      do k=1,nke
+       e_p=pe1d(k)+e_p
+      end do
+! FLASHES AND LOSSES
+! POSITIVE
+      pe1d(1)=0
+      pe1d(nk)=0
+      pe1d(nke)=0
+      do k=2,nke-1
+        del_z_tot=del_z_tot+del_z(k)
+      end do
+       if (e_p.ge.j_pos)then
+        lpos=lpos+int(e_p/j_pos)
+        loss = int(e_p/j_pos)
+        residual=e_p-j_pos*loss
+        do k=2,nke-1
+          e_min=min(pe1d(k),e_p)
+          pe1d(k)=pe1d(k)-e_min+residual*del_z(k)/del_z_tot
+        end do
+       end if
+      return
+      end subroutine flash
+END MODULE  module_ltng_strokes

--- a/phys/module_ltng_strokes_add.F
+++ b/phys/module_ltng_strokes_add.F
@@ -1,0 +1,194 @@
+MODULE module_ltng_strokes
+!https://journals.ametsoc.org/doi/10.1175/WAF-D-11-00144.1
+
+! j_pos,j_neg,j_neu:Energy per flash; threshold values set in Registry.EM_COMMON
+! Values can be modified through namelist.input
+! Sample values used:  parameter (j_pos=5.E9,j_neg=1.E9,j_neu=1.E9)
+! References for this and accompanying program module_calc_lpi.F
+! Note, the calculation of lpi is different than in the published paper by Yair
+! et al., JGR:
+! https://scholar.google.co.il/citations?user=vzBSZmEAAAAJ&hl=en#d=gs_md_cita-d&u=%2Fcitations%3Fview_op%3Dview_citation%26hl%3Den%26user%3DvzBSZmEAAAAJ%26citation_for_view%3DvzBSZmEAAAAJ%3AULOm3_A8WrAC%26tzom%3D-120
+! Lynn, B. H., Y. Yair, C. Price, G. Kelman, A. Clark,
+! 2012: Predicting Cloud-to-Ground and Intracloud Lightning in Weather
+!Forecast Models.  Wea. Forecast.  27, 1470-1486.
+! Lynn, B. H., G. Kelman, and G. Ellrod, 2015: An Evaluation of the
+! Efficacy of Using Observed Lightning to Improve Convective Lightning Forecasts.
+! Wea. Forecasting, 30, 405–423. 
+! Lynn, B.H, 2016: The Usefulness and Economic Value of Total Lightning
+! Forecasts made with a "Dynamic" Lightning Scheme coupled with Lightning Data
+! Assimilation. Wea. Forecasting. 32, 645 – 663.
+! Contact: barry.lynn@weather-it-is.com or barry.h.lynn@gmail.com
+
+CONTAINS
+!===================================================================
+!
+  SUBROUTINE calcstroke(dx,dy &
+                 ,w,dz8w,pi_phy,th_phy,p_phy,rho_phy                    &
+                 ,light_pe &
+                 ,light_ne &
+                 ,light_neu &
+                 ,lpos,lneg,lneu&
+                 ,j_pos,j_neg,j_neu &
+                 ,ids,ide, jds,jde, kds,kde                        &
+                 ,ims,ime, jms,jme, kms,kme                        &
+                 ,its,ite, jts,jte, kts,kte                        &
+                                                                   )
+!-------------------------------------------------------------------
+  IMPLICIT NONE
+!-------------------------------------------------------------------
+!
+!
+  REAL, INTENT(IN):: j_pos,j_neg,j_neu
+  real j_sa ! scale aware
+  INTEGER,      INTENT(IN   )    ::   ids,ide, jds,jde, kds,kde , &
+                                      ims,ime, jms,jme, kms,kme , &
+                                      its,ite, jts,jte, kts,kte
+ 
+       REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                 &
+        INTENT(INOUT) ::                                          &
+                                                      light_pe,&
+                                                      light_ne, &
+                                                      light_neu
+      REAL,INTENT(IN):: dx,dy
+      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                  &
+         INTENT(IN ) ::  w
+      REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                    &
+         INTENT(IN) ::                                         th_phy
+!
+
+!
+       REAL, DIMENSION( ims:ime , kms:kme , jms:jme ),                    &
+         INTENT(IN   ) ::                                             &
+                                                                rho_phy, &
+                                                                dz8w, &
+                                                              pi_phy, &
+                                                                   p_phy
+
+      REAL, INTENT(INOUT),  DIMENSION(ims:ime,jms:jme)::      &
+     &                      LPOS,LNEG,LNEU
+!     REAL, INTENT(INOUT),  DIMENSION(ims:ime,jms:jme)::      &
+!    &                      LPI,LPOS,LNEG,LNEU,plpi,nlpi,neulpi        
+
+
+
+      REAL, DIMENSION(kms:kme)::    tempk,rh,qtot,qitot
+      REAL, DIMENSION(kms:kme):: qv1d,p1d,rho1d,qti1d
+      REAL, DIMENSION(kms:kme):: temp,qc1d,ql1d,qi1d,qs1d,qg1d,lpi1d
+      REAL, DIMENSION(0:kme):: w1d,height
+      REAL, DIMENSION(kms:kme):: e1d,height_t,w1d_t
+      REAL z_full
+      INTEGER level
+      INTEGER I_COLLAPSE
+      LOGICAL LOOK_T
+      real dxkm
+
+  INTEGER ::               i,j,k
+!-------------------------------------------------------------------
+
+! NOTE: dxkm is a "scale-aware" term.
+! The volume change from grid to grid depends on  the square of the area.
+! The vertical velocity, though, will increase, for example, by deltax
+! the ratio of  w to volume is deltax/deltax-sq or 1./delta_x
+! 4 km is the reference value for deltax (based on paper published in 2012).
+      dxkm = dx*1.E-3
+      DO j = jts,jte
+      DO i = its,ite
+       z_full=0.
+       height(0)=z_full
+       do k=kts,kte
+        z_full=z_full+dz8w(i,k,j)
+        height(k)=z_full
+        temp(k) = th_phy(i,k,j)*pi_phy(i,k,j)-273.16
+        rho1d(k)=rho_phy(i,k,j)
+       end do
+! note: light_neu, etc, are multiplied by rho in calc_lpi.F, for converting from
+! /kg to /m^3
+       e1d(kme) = 0
+       do k=kts,kte
+        e1d(k)=light_neu(i,k,j)
+       end do
+!      j_neu=1.E9
+       j_sa=j_neu*dxkm/4.
+       call flash(height,temp,e1d,j_sa,lneu(i,j),kme,kte)
+       do k=kts,kte
+        if (rho1d(k).le.1.E-10)rho1d(k) = 100000.
+        light_neu(i,k,j) = e1d(k)/rho1d(k)
+       end do
+       light_neu(i,kme,j) = 0
+       e1d(kme) = 0
+       do k = kts,kte
+        e1d(k)=light_ne(i,k,j)
+       end do
+       j_sa=j_neg*dxkm/4.
+       call flash(height,temp,e1d,j_sa,lneg(i,j),kme,kte)
+       do k = kts,kte
+        if (rho1d(k).le.1.E-10)rho1d(k) = 100000.
+        light_ne(i,k,j) = e1d(k)/rho1d(k)
+       end do
+       light_ne(i,kme,j) = 0
+!      j_pos=5.E9
+       j_sa=j_pos*dxkm/4.
+       e1d(kme) = 0
+       do k = kts,kte
+       e1d(k)=light_pe(i,k,j)
+       end do 
+       call flash(height,temp,e1d,j_sa,lpos(i,j),kme,kte)
+       do k = kts,kte
+        if (rho1d(k).le.1.E-10)rho1d(k) = 100000.
+          light_pe(i,k,j)=e1d(k)/rho1d(k)
+       end do
+       light_pe(i,kme,j) = 0
+      END DO
+      END DO
+
+
+      return
+      end subroutine calcstroke
+      subroutine &
+     & flash(height,t3d,pe1d,j_pos,lpos,nk,nke)
+      implicit none
+      integer nk,nke
+      real lpos,j_pos
+      real pe1d(nk)
+      integer i,j,k
+      integer num_ran
+      parameter (num_ran=2)
+      real ran_num(num_ran)
+      real    i_seed
+      real t3d(nk)
+      real height(0:nk)
+      real del_z(nk)
+      real top, bot
+      real n,ave_z,del_z_tot
+      real residual,e_p,e_n,e_neu,loss,e_min
+      del_z_tot=0
+      do k=1,nke-1
+        top=0.5*(height(k+1)+height(k))
+        bot=0.5*(height(k)+height(k-1))
+        del_z(k)=top-bot
+      end do
+!     plpi=0
+      e_p=0
+      do k=1,nke
+       e_p=pe1d(k)+e_p
+      end do
+! FLASHES AND LOSSES
+! POSITIVE
+      pe1d(1)=0
+      pe1d(nk)=0
+      pe1d(nke)=0
+      do k=2,nke-1
+        del_z_tot=del_z_tot+del_z(k)
+      end do
+       if (e_p.ge.j_pos)then
+        lpos=lpos+int(e_p/j_pos)
+        loss = int(e_p/j_pos)
+        residual=e_p-j_pos*loss
+        do k=2,nke-1
+          e_min=min(pe1d(k),e_p)
+          pe1d(k)=pe1d(k)-e_min+residual*del_z(k)/del_z_tot
+        end do
+       end if
+      return
+      end subroutine flash
+END MODULE  module_ltng_strokes

--- a/phys/my_test.file
+++ b/phys/my_test.file
@@ -1,0 +1,1 @@
+This is just a test.

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1022,6 +1022,9 @@ Namelist variables for lake module:
                                      = 2        ! PR92 based on 20 dBZ top, redistributes flashes within dBZ > 20 (for convection resolved runs; must also use 
 				     		  do_radar_ref = 1, and mp_physics = 2,4,6,7,8,10,14, or 16)
                                      = 3        ! Predicting the potential for lightning activity (based on Yair et al, 2010, J. Geophys. Res., 115, D04205, doi:10.1029/2008JD010868) 
+                                     = 4        !
+Lynn, B. H., Y. Yair, C. Price, G. Kelman, and A. J. Clark, 2012: Predicting cloud-to-ground and intracloud lightning in weather forecast models. Wea. Forecasting, 27, 1470–1488, doi:https://doi.org/10.1175/WAF-D-11-00144.1 -- note: Dynamic Lightning Scheme output of cloud to ground positive and negative events, and intra-cloud lightning, (LPOS, LNEG, AND LNEU, respectively) was verified against ENTLN event or stroke data in the US and Israel, and, is per grid-element. Adjust coul_pos, coul_neg, and coul_neu as required for different microphysics (must include Graupel). Suggested values: SBM 0.15 for each coul..., Thompson/NSSL 0.25, and WSM6 0.5. Must be called lightning_dt = 0.
+
                                      = 11       ! PR92 based on level of neutral buoyancy from convective parameterization (for scales
                                                   where a CPS is used, intended for use at 10 < dx < 50 km; must also use cu_physics = 5 or 93)
  lightning_dt  (max_dom)             = 0.       ! time interval (seconds) for calling lightning parameterization. Default uses model time step

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1,4 +1,5 @@
 Description of namelist variables
+!modified
 
 ---------------------------------
  

--- a/run/README.namelist_add
+++ b/run/README.namelist_add
@@ -1,0 +1,1760 @@
+Description of namelist variables
+
+---------------------------------
+ 
+For WRF-NMM users, please see Chapter 5 of the WRF-NMM User's Guide for 
+information on NMM specific settings (http://www.dtcenter.org/wrf-nmm/users)
+
+
+ Note: variables followed by (max_dom) indicate that this variable needs to
+       be defined for the nests when max_dom > 1.
+
+ &time_control
+ run_days                            = 0,	! run time in days
+ run_hours                           = 0,	! run time in hours
+                                                  Note: if it is more than 1 day, one may use both run_days and run_hours
+                                                  or just run_hours. e.g. if the total run length is 36 hrs, you may
+                                                  set run_days = 1, and run_hours = 12, or run_days = 0, and run_hours = 36
+ run_minutes                         = 0,	! run time in minutes
+ run_seconds                         = 0,	! run time in seconds
+ start_year (max_dom)                = 2001,	! four digit year of starting time
+ start_month (max_dom)               = 06,	! two digit month of starting time
+ start_day (max_dom)                 = 11,	! two digit day of starting time
+ start_hour (max_dom)                = 12,	! two digit hour of starting time
+ start_minute (max_dom)              = 00,	! two digit minute of starting time
+ start_second (max_dom)              = 00,	! two digit second of starting time
+                                                  Note: the start time is used to name the first wrfout file.
+                                                  It also controls the start time for nest domains, and the time to restart
+ tstart (max_dom)                    = 00,	! FOR NMM: starting hour of the forecast
+ end_year (max_dom)                  = 2001,	! four digit year of ending time
+ end_month (max_dom)                 = 06,	! two digit month of ending time
+ end_day (max_dom)                   = 12,	! two digit day of ending time
+ end_hour (max_dom)                  = 12,	! two digit hour of ending time
+ end_minute (max_dom)                = 00,	! two digit minute of ending time
+ end_second (max_dom)                = 00,	! two digit second of ending time
+                                                  It also controls when the nest domain integrations end
+                                                  All start and end times are used by real.exe.
+
+                                                  Note that one may use either run_days/run_hours etc. or 
+                                                  end_year/month/day/hour etc. to control the length of 
+                                                  model integration. But run_days/run_hours
+                                                  takes precedence over the end times. 
+                                                  Program real.exe uses start and end times only.
+
+ interval_seconds                    = 10800,	! time interval between incoming real data, which will be the interval
+                                                  between the lateral boundary condition file (in seconds)
+ input_from_file (max_dom)           = T,       ! whether nested run will have input files for domains other than 1
+ fine_input_stream (max_dom)         = 0,       ! field selection from nest input for its initialization
+                                                  0: all fields are used! 2: only static and time-varying, masked land 
+                                                  surface fields are used. In V3.2, this requires the use of 
+                                                  io_form_auxinput2
+ history_interval (max_dom)          = 60,  	! history output file interval in minutes
+ frames_per_outfile (max_dom)        = 1, 	! number of output times per history output file, 
+                                                  used to split output into multiple files 
+                                                  into smaller pieces
+ restart                             = F,	! whether this run is a restart run
+ cycling                             = F,       ! whether this run is a cycling run, if so, initializes look-up table for Thompson schemes only
+ restart_interval		     = 1440,	! restart output file interval in minutes
+ reset_simulation_start              = F,       ! whether to overwrite simulation_start_date with forecast start time
+ io_form_history                     = 2,       ! 2 = netCDF 
+ io_form_restart                     = 2,       ! 2 = netCDF 
+ io_form_input                       = 2,       ! 2 = netCDF
+ io_form_boundary                    = 2,       ! netCDF format
+                                     = 4,       ! PHD5 format
+                                     = 5,       ! GRIB1 format
+                                     = 10,      ! GRIB2 format
+                                     = 11,      ! pnetCDF format
+ ncd_nofill                          = .true.,  ! only a single write, not the write/read/write sequence, new in 3.6
+ frames_per_emissfile                = 12,      ! number of times in each chemistry emission file.
+ io_style_emiss                      = 1,       ! style to use for the chemistry emission files.
+                                                ! 0 = Do not read emissions from files.
+                                                ! 1 = Cycle between two 12 hour files (set frames_per_emissfile=12)
+                                                ! 2 = Dated files with length set by frames_per_emissfile
+ debug_level                         = 0, 	! 50,100,200,300 values give increasing prints
+ diag_print                          = 0, 	! print out time series of model diagnostics
+                                                  0 = no print
+                                                  1 = domain averaged 3-hourly hydrostatic surface pressure tendency 
+                                                      (Dpsfc/Dt), and dry-hydrostatic column pressure tendency (Dmu/Dt)
+                                                      will appear in stdout file
+                                                  2 = in addition to those above, domain averaged rainfall, 
+                                                      surface evaporation, and sensible and latent heat fluxes will be output
+ all_ic_times                        = .false., ! whether to write out wrfinput for all processing times
+ adjust_output_times                 = .false., ! adjust output times to the nearest hour
+ override_restart_timers             = .false., ! whether to change the alarms from what is previously set
+ write_hist_at_0h_rst                = .false., ! whether to output history file at the start of restart run
+ output_ready_flag		     = .true.,  ! asks the model to write-out an empty file with the name 'wrfoutReady_d<domain>_<date>.  
+                                                  Useful in production runs so that post-processing code can check on the 
+                                                  completeness of this file
+ force_use_old_data                  = .false., ! if set to .true., allow WRF Version 3 input data
+                                                  =.false., stop when WRF model detects Version 3 input data
+
+To choose between SI and WPS input to real for EM core:
+ auxinput1_inname                    = "met_em.d<domain>.<date>"             ! Input to real from WPS (default since 3.0)
+                                     = "wrf_real_input_em.d<domain>.<date>"  ! Input to real from SI
+
+To choose between SI and WPS input to real for NMM core:
+ auxinput1_inname                    = "met_nm.d<domain>.<date>"             ! Input to real from WPS
+                                     = "wrf_real_input_nm.d<domain>.<date>"  ! Input to real from SI
+
+Other output options:
+
+ auxhist2_outname                    = "rainfall" ! file name for extra output! if not specified,
+                                                    auxhist2_d<domain>_<date> will be used
+                                                    also note that to write variables in output other
+                                                    than the history file requires Registry.EM file change
+ auxhist2_interval (max_dom)         = 10,      ! interval in minutes
+ io_form_auxhist2                    = 2,       ! output in netCDF
+ frames_per_auxhist2                 = 1000,    ! number of output times in this file
+
+For SST updating (used only with sst_update=1):
+ 
+ auxinput4_inname                    = "wrflowinp_d<domain>" 
+ auxinput4_interval                  = 360      ! minutes generally matches time given by interval_seconds
+ io_form_auxinput4                   = 2        ! IO format, required in V3.2
+
+ nwp_diagnostics                     = 0        ! set to = 1 to add 7 history-interval max diagnostic fields
+
+For additional regional climate surface fields
+
+ output_diagnostics                  = 0        ! set to = 1 to add 36 surface diagnostic arrays (max/min/mean/std)
+ auxhist3_outname                    = 'wrfxtrm_d<domain>_<date>' ! file name for added diagnostics
+ io_form_auxhist3                    = 2        ! netcdf
+ auxhist3_interval                   = 1440     ! minutes between outputs (1440 gives daily max/min)
+ frames_per_auxhist3                 = 1        ! output times per file
+                                                  Note: do restart only at multiple of auxhist3_intervals
+
+For observation nudging:
+ auxinput11_interval                 = 10       ! interval in minutes for observation data. It should be 
+                                                  set as or more frequently as obs_ionf (with unit of 
+                                                  coarse domain time step).
+ auxinput11_end_h                    = 6        ! end of observation time in hours.
+
+Options for run-time IO:
+
+ iofields_filename (max_dom)         = "my_iofields_list.txt",
+                                       (example: +:h:21:rainc, rainnc, rthcuten)
+ ignore_iofields_warning             = .true.,  ! what to do when encountering an error in the user-specified files
+                                       .false., ! abort when encountering an error in iofields_filename file
+
+Additional settings when running WRFVAR:
+
+ write_input                         = t,       ! write input-formatted data as output
+ inputout_interval (max_dom)         = 180,     ! interval in minutes when writing input-formatted data 
+ input_outname                       = 'wrfinput_d<domain>_<date>' ! you may change the output file name
+ inputout_begin_y (max_dom)          = 0
+ inputout_begin_mo                   = 0
+ inputout_begin_d (max_dom)          = 0
+ inputout_begin_h (max_dom)          = 3
+ inputout_begin_m (max_dom)          = 0
+ inputout_begin_s (max_dom)          = 0
+ inputout_end_y (max_dom)            = 0
+ inputout_end_mo                     = 0
+ inputout_end_d (max_dom)            = 0
+ inputout_end_h (max_dom)            = 12
+ inputout_end_m (max_dom)            = 0
+ inputout_end_s (max_dom)            = 0        ! the above shows that the input-formatted data are output
+                                                  starting from hour 3 to hour 12 in 180 min interval.
+
+For automatic moving nests: requires special input data, and environment variable TERRAIN_AND_LANDUSE set at compile time
+                                     (This option will overwrite input_from_file for nest domains)
+ input_from_hires (max_dom)          = .true., 
+ rsmas_data_path                     = "path-to-terrain-and-landuse-dataset"
+
+ &domains
+ time_step                           = 60,	! time step for integration in integer seconds
+                                                  recommend 6*dx (in km) for typical real-data cases
+ time_step_fract_num                 = 0,	! numerator for fractional time step 
+ time_step_fract_den                 = 1,	! denominator for fractional time step 
+                                                  Example, if you want to use 60.3 sec as your time step,
+                                                  set time_step = 60, time_step_fract_num = 3, and 
+                                                  time_step_fract_den = 10
+ time_step_dfi                       = 60,	! time step for DFI, may be different from regular time_step
+ max_dom                             = 1,	! number of domains - set it to > 1 if it is a nested run
+ s_we (max_dom)                      = 1,	! start index in x (west-east) direction (leave as is)
+ e_we (max_dom)                      = 91,	! end index in x (west-east) direction (staggered dimension)
+ s_sn (max_dom)                      = 1,	! start index in y (south-north) direction (leave as is)
+ e_sn (max_dom)                      = 82,	! end index in y (south-north) direction (staggered dimension)
+ s_vert (max_dom)                    = 1,	! start index in z (vertical) direction (leave as is)
+ e_vert (max_dom)                    = 30,	! end index in z (vertical) direction (staggered dimension)
+                                                  Note: this refers to full levels including surface and top
+                                                  vertical dimensions need to be the same for all nests
+                                                  Note: most variables are unstaggered (= staggered dim - 1)
+ dx (max_dom)                        = 10000,	! grid length in x direction; ARW: unit in meters, NMM: unit in degrees (e.g. 0.667)
+ dy (max_dom)                        = 10000,	! grid length in y direction; ARW: unit in meters, NMM: unit in degrees (e.g. 0.0658) 
+ ztop (max_dom)                      = 19000.	! used in mass model for idealized cases
+ grid_id (max_dom)                   = 1,	! domain identifier
+ parent_id (max_dom)                 = 0,       ! id of the parent domain
+ i_parent_start (max_dom)            = 0,       ! starting LLC I-indices from the parent domain
+ j_parent_start (max_dom)            = 0,       ! starting LLC J-indices from the parent domain
+ parent_grid_ratio (max_dom)         = 1,       ! parent-to-nest domain grid size ratio: for real-data cases
+                                                  the ratio has to be odd! for idealized cases,
+                                                  the ratio can be even if feedback is set to 0. (NMM: must be 3)
+ parent_time_step_ratio (max_dom)    = 1,       ! parent-to-nest time step ratio! it can be different
+                                                  from the parent_grid_ratio (NMM: must be 3)
+ feedback                            = 1,       ! feedback from nest to its parent domain; 0 = no feedback
+ smooth_option                       = 2        ! smoothing option for parent domain, used only with feedback
+                                                  option on. 0: no smoothing; 1: 1-2-1 smoothing; 2: smoothing-desmoothing (default)
+
+Namelist variables specifically for the WPS input for real:
+
+ num_metgrid_soil_levels             = 4        ! number of vertical soil levels or layers input
+                                                  from WPS metgrid program
+ num_metgrid_levels                  = 27       ! number of vertical levels of 3d meteorological fields coming 
+                                                  from WPS metgrid program
+ interp_type                         = 2        ! vertical interpolation
+                                                  1 = linear in pressure
+                                                  2 = linear in log(pressure)
+ extrap_type                         = 2        ! vertical extrapolation of non-temperature fields
+                                                  1 = extrapolate using the two lowest levels
+                                                  2 = use lowest level as constant below ground
+ t_extrap_type                       = 2        ! vertical extrapolation for potential temperature
+                                                  1 = isothermal
+                                                  2 = -6.5 K/km lapse rate for temperature
+                                                  3 = constant theta
+ use_levels_below_ground             = .true.   ! in vertical interpolation, use levels below input surface level
+                                                  T = use input isobaric levels below input surface
+                                                  F = extrapolate when WRF location is below input surface value
+ use_surface                         = .true.   ! use the input surface level data in the vertical interp and extrap
+                                                  T = use the input surface data
+                                                  F = do not use the input surface data
+ lagrange_order                      = 2        ! vertical interpolation order
+                                                  1 = linear
+                                                  2 = quadratic
+                                                  9 = cubic spline
+ zap_close_levels                    = 500      ! ignore isobaric level above surface if delta p (Pa) < zap_close_levels
+ lowest_lev_from_sfc                 = .false.  ! place the surface value into the lowest eta location
+                                                ! T = use surface value as lowest eta (u,v,t,q)
+                                                ! F = use traditional interpolation
+ force_sfc_in_vinterp                = 1        ! use the surface level as the lower boundary when interpolating
+                                                  through this many eta levels
+                                                  0 = perform traditional trapping interpolation
+                                                  n = first n eta levels directly use surface level
+ maxw_horiz_pres_diff                = 5000     ! Pressure threshold (Pa).  For using the level of max winds, when the
+                                                  pressure difference between neighboring values exceeds this maximum,
+                                                  the variable is NOT inserted into the column for vertical interpolation.
+                                                  ARW real only.
+ trop_horiz_pres_diff                = 5000     ! Pressure threshold (Pa).  For using the tropopause level, when the
+                                                  pressure difference between neighboring values exceeds this maximum,
+                                                  the variable is NOT inserted into the column for vertical interpolation.
+                                                  ARW real only.
+ maxw_above_this_level               = 30000    ! Minimum height (actually it is pressure in Pa) to allow using the 
+                                                  level of max wind information in real.  With a value of 300 hPa, then
+                                                  a max wind value at 500 hPa will be ignored.
+                                                  ARW real only.
+ use_maxw_level                                   0=do not use max wind speed level in vertical interpolation inside
+                                                  of the ARW real program, 1 = use level
+ use_trop_level                                   as above, with tropopause level data
+ sfcp_to_sfcp                        = .false.  ! Optional method to compute model's surface pressure when incoming
+                                                  data only has surface pressure and terrain, but not SLP
+ smooth_cg_topo	                     = .false.  ! Smooth the outer rows and columns of domain 1's topography w.r.t.
+                                                  the input data
+ use_tavg_for_tsk                    = .false.  ! whether to use diurnally averaged surface temp as skin temp. The 
+                                                  diurnally averaged surface temp can be computed using WPS utility
+                                                  avg_tsfc.exe. May use this option when SKINTEMP is not present.
+ aggregate_lu                        = .false.  ! whether to aggregate the grass, shrubs, trees in dominant landuse;
+                                                  default is false.
+ rh2qv_wrt_liquid                    = .true.,  ! whether to compute RH with respect to water (true) or ice (false)
+ rh2qv_method                        = 1,       ! which method to use to computer mixing ratio from RH:
+                                                  default is option 1, the old MM5 method; option 2 uses a WMO 
+                                                  recommended method (WMO-No. 49, corrigendum, August 2000) - 
+                                                  there is a difference between the two methods though small
+ interp_theta                        = .false.  ! If set to .false., it will vertically interpolate temperature 
+                                                  instead of potential temperature, which may reduce bias when 
+                                                  compared with input data
+ hypsometric_opt                     = 2,       ! = 1: default method
+                                                  = 2: it uses an alternative way (less biased 
+                                                  when compared against input data) to compute height in program 
+                                                  real and pressure in model (ARW only). 
+ p_top_requested                     = 5000     ! p_top (Pa) to use in the model
+ ptsgm                               = 42000.   ! FOR NMM:  defines the pressure interface dividing
+                                                            the terrain following portion of the hybrid vertical
+                                                            coordinate (p > ptsgm) and the purely
+                                                            isobaric portion of the vertical coordinate (p < ptsgm)
+ vert_refine_fact                    = 1        ! vertical refinement factor for ndown, not used for concurrent vertical grid refinement
+ vert_refine_method (max_dom)        = 0        ! vertical refinement method (new in 3.7)
+                                                  0: no vertical refinement
+                                                  1: integer vertical refinement
+                                                  2: use specified or computed eta levels for vertical refinement
+
+Users may explicitly define full eta levels.  Given are two distributions for 28 and 35 levels.  The number
+of levels must agree with the number of eta surfaces allocated (e_vert).  Users may alternatively request 
+only the number of levels (with e_vert), and the real program will compute values.  From V4.0 there are
+two methods selected with auto_levels_opt = 1 (old) or 2 (new). The old computation assumes
+a known first several layers, then generates equi-height spaced levels up to the top of the model.
+The new method has surface and upper stretching factors (dz_stretch_s and dz_stretch_u) to stretch levels according to
+log p up to where it reaches the maximum thickness (max_dz) and starting from thickness dzbot.
+The stretching transitions from dzstretch_s to dzstretch_u by the time the thickness reaches max_dz/2.
+
+ max_dz                              = 1000.     ! maximum level thickness allowed (m)
+ auto_levels_opt                     = 1         ! old
+                                     = 2         ! new default (also set dzstretch_s, dzstretch_u, dzbot, max_dz)
+ dzbot                               = 50.       ! thickness of lowest layer (m) for auto_levels_opt=2
+ dzstretch_s                         = 1.3       ! surface stretch factor for auto_levels_opt=2
+ dzstretch_u                         = 1.1       ! upper stretch factor for auto_levels_opt=2
+
+ eta_levels                          = 1.000, 0.990, 0.978, 0.964, 0.946,
+                                       0.922, 0.894, 0.860, 0.817, 0.766,
+                                       0.707, 0.644, 0.576, 0.507, 0.444,
+                                       0.380, 0.324, 0.273, 0.228, 0.188,
+                                       0.152, 0.121, 0.093, 0.069, 0.048,
+                                       0.029, 0.014, 0.000,
+ eta_levels                          = 1.000, 0.993, 0.983, 0.970, 0.954,
+                                       0.934, 0.909, 0.880, 0.845, 0.807,
+                                       0.765, 0.719, 0.672, 0.622, 0.571,
+                                       0.520, 0.468, 0.420, 0.376, 0.335,
+                                       0.298, 0.263, 0.231, 0.202, 0.175,
+                                       0.150, 0.127, 0.106, 0.088, 0.070,
+                                       0.055, 0.040, 0.026, 0.013, 0.000
+
+                                     = 0,2,  ! this allows vertical nesting in the nest domain
+                                               Note that with vertical nesting one can only use RRTM and RRTMG radiation physics
+
+ An example to define vertical nested levels (in program real):
+                                       
+ e_vert                              = 35,    45,
+ eta_levels(1:35)                    = 1., 0.993, 0.983, 0.97, 0.954, 0.934, 0.909, 0.88, 0.8406663, 0.8013327,
+                                       0.761999, 0.7226653, 0.6525755, 0.5877361, 0.5278192, 0.472514,
+                                       0.4215262, 0.3745775, 0.3314044, 0.2917579, 0.2554026, 0.2221162,
+                                       0.1916888, 0.1639222, 0.1386297, 0.1156351, 0.09525016, 0.07733481,
+                                       0.06158983, 0.04775231, 0.03559115, 0.02490328, 0.0155102, 0.007255059, 0.
+ eta_levels(36:81)                   = 1.0000, 0.9946, 0.9875, 0.9789, 0.9685, 0.9562, 0.9413, 0.9238, 0.9037, 0.8813, 0.8514,
+                                       0.8210, 0.7906, 0.7602, 0.7298, 0.6812, 0.6290, 0.5796, 0.5333, 0.4901, 0.4493, 0.4109,
+                                       0.3746, 0.3412, 0.3098, 0.2802, 0.2524, 0.2267, 0.2028, 0.1803, 0.1593, 0.1398, 0.1219,
+                                       0.1054, 0.0904, 0.0766, 0.0645, 0.0534, 0.0433, 0.0341, 0.0259, 0.0185, 0.0118, 0.0056, 0.
+
+ ideal_init_method                   method to compute alb in idealized cases in start_em (new in 3.8)
+                                     = 1, alb from phb (default); = 2, alb from t_init
+
+Horizontal interpolation options, coarse grid to fine grid.  The default is to use
+the Smolarkiewicz "SINT" method.  However, this is known to break with the 
+implementation inside of WRF for large refinement ratios (such as 15:1).  For those
+extreme (and quite rare occurrences), other schemes are available.  For options
+1, 3, 4, and 12, the FG lateral boundaries use the same horizontal scheme for the
+lateral BC computations.
+ interp_method_type                  = 1 ! bi-linear interpolation
+                                     = 2 ! SINT, (default)
+                                     = 3 ! nearest neighbor - only to be used for 
+                                           testing purposes
+                                     = 4 ! overlapping quadratic
+                                     =12 ! again for testing, uses SINT horizontal
+                                           interpolation, and same scheme for 
+                                           computation of FG lateral boundaries
+
+Variables specifically for the 3d ocean initialization with a single profile. Set
+the ocean physics option to #2.  Specify a number of levels.  For each of those levels,
+provide a depth (m) below the surface.  At each depth provide a temperature (K) and
+a salinity (ppt).  The default is not to use the 3d ocean.  Even when the 3d ocean is
+activated, the user must specify a reasonable ocean.  Currently, this is the only way
+available to run the 3d ocean option.
+
+ &physics
+ sf_ocean_physics                    = activate ocean model (0=no, 1=1d mixed layer; 2=3D PWP, no bathymetry)
+
+ &domains
+ ocean_levels                        = 30,
+ ocean_z                             ; vertical profile of layer depths for ocean (in meters), e.g.:
+                                     =       5.,       15.,       25.,       35.,       45.,       55.,
+                                            65.,       75.,       85.,       95.,      105.,      115.,
+                                           125.,      135.,      145.,      155.,      165.,      175.,
+                                           185.,      195.,      210.,      230.,      250.,      270.,
+                                           290.,      310.,      330.,      350.,      370.,      390.
+ ocean_t                             ; vertical profile of ocean temps, e.g.:
+                                     = 302.3493,  302.3493,  302.3493,  302.1055,  301.9763,  301.6818,
+                                       301.2220,  300.7531,  300.1200,  299.4778,  298.7443,  297.9194,
+                                       297.0883,  296.1443,  295.1941,  294.1979,  293.1558,  292.1136,
+                                       291.0714,  290.0293,  288.7377,  287.1967,  285.6557,  284.8503,
+                                       284.0450,  283.4316,  283.0102,  282.5888,  282.1674,  281.7461
+ ocean_s                             ; vertical profile of salinity, e.g.:
+                                     =  34.0127,   34.0127,   34.0127,   34.3217,   34.2624,   34.2632,
+                                        34.3240,   34.3824,   34.3980,   34.4113,   34.4220,   34.4303,
+                                        34.6173,   34.6409,   34.6535,   34.6550,   34.6565,   34.6527,
+                                        34.6490,   34.6446,   34.6396,   34.6347,   34.6297,   34.6247,
+                                        34.6490,   34.6446,   34.6396,   34.6347,   34.6297,   34.6247
+
+Namelist variables for controlling the specified moving nest: 
+                   Note that this moving nest option needs to be activated at the compile time by adding -DMOVE_NESTS
+                   to the ARCHFLAGS. The maximum number of moves, max_moves, is set to 50 
+                   but can be modified in source code file frame/module_driver_constants.F.
+ num_moves                           = 0                 ! total number of moves
+ move_id(max_moves)                  = 2,2,2,2,          ! a list of nest domain id's, one per move
+ move_interval(max_moves)            = 60,120,150,180,   ! time in minutes since the start of this domain
+ move_cd_x(max_moves)                = 1,1,0,-1,         ! the number of parent domain grid cells to move in i direction
+ move_cd_y(max_moves)                = 1,0,-1,1,         ! the number of parent domain grid cells to move in j direction
+                                                           positive is to move in increasing i and j direction, and 
+                                                           negative is to move in decreasing i and j direction.
+                                                           0 means no move. The limitation now is to move only 1 grid cell
+                                                           at each move.
+
+Namelist variables for controlling the automatic moving nest: 
+                   Note that this moving nest option needs to be activated at the compile time by adding -DMOVE_NESTS
+                   and -DVORTEX_CENTER to the ARCHFLAGS. This option uses a mid-level vortex following algorithm to
+                   determine the nest move. This option is experimental.
+ vortex_interval(max_dom)            = 15       ! how often the new vortex position is computed
+ max_vortex_speed(max_dom)           = 40       ! used to compute the search radius for the new vortex position
+ corral_dist(max_dom)                = 8        ! how many coarse grid cells the moving nest is allowed to get
+                                                  near the mother domain boundary
+ track_level                         = 50000    ! pressure value in Pa where the vortex is tracked
+ time_to_move(max_dom)               = 0.       ! time (in minutes) to start the moving nests     
+
+ tile_sz_x                           = 0,       ! number of points in tile x direction
+ tile_sz_y                           = 0,       ! number of points in tile y direction
+                                                  can be determined automatically
+ numtiles                            = 1,       ! number of tiles per patch (alternative to above two items)
+ nproc_x                             = -1,      ! number of processors in x for decomposition
+ nproc_y                             = -1,      ! number of processors in y for decomposition
+                                                  -1: code will do automatic decomposition
+                                                  >1: for both: will be used for decomposition
+
+Namelist variables for controlling the adaptive time step option:
+                   These options are only valid for the ARW core.  
+ use_adaptive_time_step              = .false.  ! T/F use adaptive time stepping, ARW only
+ step_to_output_time                 = .true.   ! if adaptive time stepping, T/F modify the
+                                                  time steps so that the exact history time is reached
+ target_cfl(max_dom)                 = 1.2,1.2  ! vertical and horizontal CFL <= to this value implies
+                                                  no reason to reduce the time step, and to increase it
+ target_hcfl(max_dom)                = .84,.84  ! horizontal CFL <= to this value implies
+ max_step_increase_pct(max_dom)      = 5,51     ! percentage of previous time step to increase, if the
+                                                  max(vert cfl, horiz cfl) <= target_cfl, then the time
+                                                  will increase by max_step_increase_pct. Use something 
+                                                  large for nests (51% suggested)
+ starting_time_step(max_dom)         = -1,-1    ! flag = -1 implies use 6 * dx (defined in start_em), 
+                                                  starting_time_step = 100 means the starting time step
+                                                  for the coarse grid is 100 s
+ max_time_step(max_dom)              = -1,-1    ! flag = -1 implies max time step is 3 * starting_time_step,
+                                                  max_time_step = 100 means that the time step will not
+                                                  exceed 100 s
+ min_time_step(max_dom)              = -1,-1    ! flag = -1 implies max time step is 0.5 * starting_time_step,
+                                                  min_time_step = 100 means that the time step will not
+                                                  be less than 100 s
+ adaptation_domain                   = 1        ! default, all fine grid domains adaptive dt driven by coarse-grid
+                                                  2 = Fine grid domain #2 determines the fundamental adaptive dt.
+
+ &dfi_control
+ dfi_opt                             = 0        ! which DFI option to use (3 is recommended)
+                                                    0 = no digital filter initialization
+                                                    1 = digital filter launch (DFL)
+                                                    2 = diabatic DFI (DDFI)
+                                                    3 = twice DFI (TDFI)
+ dfi_nfilter                         = 7        ! digital filter type to use (7 is recommended)
+                                                    0 = uniform
+                                                    1 = Lanczos
+                                                    2 = Hamming
+                                                    3 = Blackman
+                                                    4 = Kaiser
+                                                    5 = Potter
+                                                    6 = Dolph window
+                                                    7 = Dolph
+                                                    8 = recursive high-order
+ dfi_write_filtered_input            = .true.   ! whether to write wrfinput file with filtered 
+                                                    model state before beginning forecast
+ dfi_write_dfi_history               = .false.  ! whether to write wrfout files during filtering integration
+ dfi_cutoff_seconds                  = 3600     ! cutoff period, in seconds, for the filter
+ dfi_time_dim                        = 1000     ! maximum number of time steps for filtering period
+                                                    this value can be larger than necessary
+ dfi_bckstop_year                    = 2004     ! four-digit year of stop time for backward DFI integration
+ dfi_bckstop_month                   = 03       ! two-digit month of stop time for backward DFI integration
+ dfi_bckstop_day                     = 14       ! two-digit day of stop time for backward DFI integration
+ dfi_bckstop_hour                    = 12       ! two-digit hour of stop time for backward DFI integration
+ dfi_bckstop_minute                  = 00       ! two-digit minute of stop time for backward DFI integration
+ dfi_bckstop_second                  = 00       ! two-digit second of stop time for backward DFI integration
+ dfi_fwdstop_year                    = 2004     ! four-digit year of stop time for forward DFI integration
+ dfi_fwdstop_month                   = 03       ! two-digit month of stop time for forward DFI integration
+ dfi_fwdstop_day                     = 13       ! two-digit month of stop time for forward DFI integration
+ dfi_fwdstop_hour                    = 12       ! two-digit month of stop time for forward DFI integration
+ dfi_fwdstop_minute                  = 00       ! two-digit month of stop time for forward DFI integration
+ dfi_fwdstop_second                  = 00       ! two-digit month of stop time for forward DFI integration
+ dfi_radar                           = 0        ! DFI radar da switch
+
+ &physics
+
+ Note: even the physics options can be different in different nest domains, 
+       caution must be used as what options are sensible to use
+
+ chem_opt (max_dom)                  = 0,       ! chemistry option - use WRF-Chem
+ mp_physics (max_dom)                microphysics option
+                                     = 0, no microphysics
+                                     = 1, Kessler scheme
+                                     = 2, Lin et al. scheme
+                                     = 3, WSM 3-class simple ice scheme
+                                     = 4, WSM 5-class scheme
+                                     = 5, Ferrier (new Eta) microphysics, operational High-Resolution Window version
+                                     = 6, WSM 6-class graupel scheme
+                                     = 7, Goddard 4-ice scheme
+                                     = 8, Thompson scheme
+                                     = 9, Milbrandt-Yau 2-moment scheme
+                                     = 10, Morrison (2 moments)
+                                     = 11, CAM 5.1 microphysics
+                                     = 13, SBU_YLIN scheme
+                                     = 14, WDM 5-class scheme
+                                     = 16, WDM 6-class scheme
+                                     = 17, NSSL 2-moment 4-ice scheme (steady background CCN)
+                                     = 18, NSSL 2-moment 4-ice scheme with predicted CCN (better for idealized than real cases)
+                                           to set a global CCN value, use
+                                           nssl_cccn  = 0.7e9   ; CCN for NSSL scheme (18). 
+                                           Also sets same value to ccn_conc for mp_physics=18
+                                     = 19, NSSL 1-moment (7 class: qv,qc,qr,qi,qs,qg,qh; predicts graupel density)
+                                     = 21, NSSL 1-moment, (6-class), very similar to Gilmore et al. 2004
+                                           Can set intercepts and particle densities in physics namelist, e.g., nssl_cnor
+                                       For NSSL 1-moment schemes, intercept and particle densities can be set for snow, 
+                                       graupel, hail, and rain. For the 1- and 2-moment schemes, the shape parameters 
+                                       for graupel and hail can be set.
+                                       nssl_alphah  = 0.    ! shape parameter for graupel
+                                       nssl_alphahl = 2.    ! shape parameter for hail
+                                       nssl_cnoh    = 4.e5  ! graupel intercept
+                                       nssl_cnohl   = 4.e4  ! hail intercept
+                                       nssl_cnor    = 8.e5  ! rain intercept
+                                       nssl_cnos    = 3.e6  ! snow intercept
+                                       nssl_rho_qh  = 500.  ! graupel density
+                                       nssl_rho_qhl = 900.  ! hail density
+                                       nssl_rho_qs  = 100.  ! snow density
+                                     = 28, aerosol-aware Thompson scheme with water- and ice-friendly aerosol climatology 
+                                           (new for V3.6)
+                                       This option has two climatological aerosol input options:
+                                       use_aero_icbc = .F. : use constant values
+                                       use_aero_icbc = .T. : use input from WPS
+                                     = 30, HUJI (Hebrew University of Jerusalem, Israel) spectral bin microphysics,
+                                           fast version
+                                     = 32, HUJI spectral bin microphysics, full version
+                                     = 40, Morrison (2 moments) with consideration of CESM-NCSU RCP4.5 climatological aerosol 
+                                     = 50, P3 1-category
+                                     = 51, P3 1-category plus double-moment cloud water
+                                     = 95, Ferrier (old Eta) microphysics, operational NAM (WRF NMM) version
+                                     = 97, Goddard GCE scheme (also uses gsfcgce_hail, gsfcgce_2ice)
+
+ For non-zero mp_physics options, to keep Qv .GE. 0, and to set the other moisture
+ fields .LT. a critical value to zero
+
+ mp_zero_out                         = 0,      ! no action taken, no adjustment to any moist field
+                                     = 1,      ! except for Qv, all other moist arrays are set to zero
+                                                 if they fall below a critical value
+                                     = 2,      ! Qv is .GE. 0, all other moist arrays are set to zero
+                                                 if they fall below a critical value
+ mp_zero_out_thresh                  = 1.e-8   ! critical value for moist array threshold, below which
+                                                 moist arrays (except for Qv) are set to zero (kg/kg)
+
+ gsfcgce_hail                        = 0       ! for running gsfcgce microphysics with graupel
+                                     = 1       ! for running gsfcgce microphysics with hail
+                                                 default value = 0
+ gsfcgce_2ice                        = 0       ! for running with snow, ice and graupel/hail
+                                     = 1       ! for running with only ice and snow
+                                     = 2       ! for running with only ice and graupel
+                                                 (only used in very extreme situation)
+                                                 default value = 0
+                                                 gsfcgce_hail is ignored if gsfcgce_2ice is set to 1 or 2.
+ hail_opt                            = 0       ! hail switch for WSM6 and WDM6 : 0 - off, 1 - on (new in 3.6.1)
+ morr_rimed_ice                      = 1       ! hail switch for Morrison schemes (mp_physics=10 and 40: 0 - off, 1 - on (new in 4.0)
+ clean_atm_diag                      = 0       ! if set to =1, turns on clean sky diagnostics (for chem); default is 0=off
+ progn (max_dom)                     = 0       ! switch to use mix-activate scheme (Only for Morrison, WDM6, WDM5, 
+                                                 and NSSL_2MOMCCN/NSSL_2MOM
+ ccn_conc                            = 1.E8    ! CCN concentration, used by WDM schemes (new in 3.6.1)
+
+ no_mp_heating                       = 0       ! normal
+                                     = 1       ! turn off latent heating from a microphysics scheme
+ use_mp_re                           = 1       ! whether to use effective radii computed in mp schemes in RRTMG (new in 3.8).
+                                                 0: do not use; 1: use effective radii
+                                                 (The mp schemes that compute effective radii are 3,4,6,8,14,16,17-21,28)
+
+ ra_lw_physics (max_dom)             longwave radiation option
+                                     = 0, no longwave radiation
+                                     = 1, rrtm scheme 
+                                       (Default values for GHG in V3.5: co2vmr=379.e-6, n2ovmr=319.e-9, ch4vmr=1774.e-9;
+                                        Values used in previous versions: co2vmr=330.e-6, n2ovmr=0., ch4vmr=0.)
+                                     = 3, cam scheme
+                                          also requires levsiz, paerlev, cam_abs_dim1/2 (see below)
+                                     = 4, rrtmg scheme
+                                       (Default values for GHG in V3.5: co2vmr=379.e-6, n2ovmr=319.e-9, ch4vmr=1774.e-9)
+                                     = 14, rrtmg-k scheme from KIAPS
+                                     = 24, fast rrtmg scheme for GPU and MIC (since 3.7)
+                                     = 5, Goddard longwave scheme
+                                     = 7, FLG (UCLA) scheme 
+                                     = 31, Earth Held-Suarez forcing
+                                     = 99, GFDL (Eta) longwave (semi-supported)
+                                          also must use co2tf = 1 for ARW
+
+ ra_sw_physics (max_dom)             shortwave radiation option
+                                     = 0, no shortwave radiation
+                                     = 1, Dudhia scheme
+                                     = 2, Goddard short wave
+                                     = 3, cam scheme
+                                          also must set levsiz, paerlev, cam_abs_dim1/2 (see below)
+                                     = 4, rrtmg scheme
+                                     = 14, rrtmg-k scheme from KIAPS
+                                     = 24, fast rrtmg scheme for GPU and MIC (since 3.7)
+                                     = 5, Goddard shortwave scheme
+                                     = 7, FLG (UCLA) scheme
+                                     = 99, GFDL (Eta) longwave (semi-supported)
+                                          also must use co2tf = 1 for ARW
+
+ radt (max_dom)                      = 30,  ! minutes between radiation physics calls
+                                              recommend 1 min per km of dx (e.g. 10 for 10 km);
+                                              use the same value for all nests.                      
+ cldovrlp                            = 2,   ! cloud overlapping option for RRTMG only. 1=random, 2=maximum-random (default), 
+                                              3=maximum, 4=exponential, 5=exponential-random
+
+ nrads (max_dom)                     = FOR NMM: number of fundamental timesteps between 
+                                                calls to shortwave radiation; the value
+                                                is set in Registry.NMM but is overridden
+                                                by namelist value; radt will be computed
+                                                from this.
+
+ nradl (max_dom)                     = FOR NMM: number of fundamental timesteps between 
+                                                calls to longwave radiation; the value
+                                                is set in Registry.NMM but is overridden
+                                                by namelist value.
+
+ co2tf                               CO2 transmission function flag only for GFDL radiation
+                                     = 0,  ! read CO2 function data from pre-generated file
+                                     = 1,  ! generate CO2 functions internally in the forecast
+
+ ra_call_offset                      radiation call offset
+                                     = 0   ! (=0, no offset; =-1, old offset)
+ swint_opt                                  Interpolation of short-wave radiation based on the updated solar zenith angle 
+                                            between SW call
+                                     = 0,  ! no interpolation
+                                     = 1,  ! use interpolation
+ cam_abs_freq_s                      = 21600  ! default CAM clearsky longwave absorption calculation frequency
+                                                (recommended minimum value to speed scheme up)
+ levsiz                              = 59     ! for CAM radiation input ozone levels, set automatically
+ paerlev                             = 29     ! for CAM radiation input aerosol levels, set automatically 
+ cam_abs_dim1                        = 4      ! for CAM absorption save array, set automatically 
+ cam_abs_dim2                        = value of e_vert for CAM 2nd absorption save array, set automatically
+
+ o3input                             = ozone input option for radiation (currently rrtmg only)
+                                     = 0, ! using profile inside the code
+                                     = 2, ! using CAM ozone data (ozone.formatted)
+ aer_opt                             = aerosol input option for radiation (currently rrtmg only)
+                                     = 0,  ! none
+                                     = 1,  ! using Tegen (1997) data, 
+                                     = 2,  ! using J. A. Ruiz-Arias method (see other aer_* options) 
+                                     = 3,  ! using G. Thompson's water/ice friendly climatological aerosol 
+ alevsiz                             = 12  ! for Tegen aerosol input levels, set automatically 
+ no_src_types                        = 6   ! for Tegen aerosols: organic and black carbon, sea salt, sulfalte, dust,
+                                             and stratospheric aerosol (volcanic ashes - currently 0), set automatically
+
+ The following aerosol options allow RRTMG and new Goddard radiation schemes to see it, but the aerosols are
+     constant during the model integration.
+ aer_aod550_opt (max_dom)            = [1,2] 
+                                       1 = input constant value for AOD at 550 nm from namelist.
+                                           In this case, the value is read from aer_aod550_val;
+                                       2 = input value from auxiliary input 15. It is a time-varying 2D grid in netcdf 
+                                           wrf-compatible format. The default is aer_aod550_opt=1 and aer_aod550_val=0.12
+ aer_aod550_val (max_dom)            = 0.12
+ aer_angexp_opt (max_dom)            = [1,2,3] :
+                                       1 = input constant value for Angstrom exponent from namelist. In this case, 
+                                           the value is read from aer_angexp_val;
+                                       2 = input value from auxiliary input 15, as in aer_aod550_opt;
+                                       3 = Angstrom exponent value estimated from the aerosol type defined in aer_type, and modulated
+                                           with the RH in WRF. Default operation is aer_angexp_opt = 1, and aer_angexp_val=1.3.
+ aer_angexp_val (max_dom)            = 1.3   
+ aer_ssa_opt (max_dom)               = [1,2,3] similar to aer_angexp_opt.
+ aer_ssa_val (max_dom)               = 0.85
+ aer_asy_opt (max_dom)               = [1,2,3] similar to aer_angexp_opt.
+ aer_asy_val (max_dom)               = 0.9
+ aer_type (max_dom)                  = [1,2,3] : 1 for rural, 2 is urban and 3 is maritime.
+
+ sf_sfclay_physics (max_dom)         surface-layer option (old bl_sfclay_physics option)
+                                     = 0, no surface-layer
+                                     = 1, Revised MM5 Monin-Obukhov scheme (Jimenez, renamed in v3.6)
+                                     = 2, Monin-Obukhov (Janjic) scheme
+                                     = 3, NCEP Global Forecast System scheme 
+                                     = 4, QNSE surface layer
+                                     = 5, MYNN surface layer
+                                     = 7, Pleim-Xiu surface layer (ARW only)
+                                     = 10, TEMF surface layer (ARW only)
+                                     = 91, Old MM5 scheme (previously option 1)
+
+ sf_surface_physics (max_dom)        land-surface option (old bl_surface_physics option)
+                                     = 0, no surface temp prediction
+                                     = 1, thermal diffusion scheme
+                                     = 2, Unified Noah land-surface model
+                                     = 3, RUC land-surface model
+                                     = 4, Noah-MP land-surface model (see additional &noah_mp namelist)
+                                     = 5, Community Land Model version 4 (CLM4), adapted from CAM
+                                     = 7, Pleim-Xiu LSM (ARW)
+                                     = 8, Simplified Simple Biosphere Model (SSiB) 
+                                          - can be used with Dudhia/RRTM, CAM or RRTMG radiation options
+
+ sf_urban_physics(max_dom)           = 0, ! activate urban canopy model (in Noah and Noah-MP LSMs only)
+                                     = 0: no
+                                     = 1: Single-layer, UCM 
+                                     = 2: Multi-layer, Building Environment Parameterization (BEP) scheme 
+                                          (works only with MYJ and BouLac PBL)
+                                     = 3: Multi-layer, Building Environment Model (BEM) scheme 
+                                          (works only with MYJ and BouLac PBL)
+
+ num_urban_ndm                       = 1! (=  2 if BEP or BEM active) maximum number of street dimensions (ndm in BEP or BEM header)
+ num_urban_ng                        = 1! (= 10 if BEP or BEM active) number of grid levels in the ground (ng_u in BEP or BEM header)
+ num_urban_nwr                       = 1! (= 10 if BEP or BEM active) number of grid levels in the walls or roof (nwr_u in BEP or BEM header)
+ num_urban_nz                        = 1! (= 18 if BEP or BEM active) maximum number of vertical levels in the urban grid (nz_um in BEP or BEM header)
+ num_urban_ngb                       = 1! (= 10 if BEM active)        number of grid levels in the ground below building (ngb_u in BEM header)
+ num_urban_nf                        = 1! (= 10 if BEM active)        number of grid levels in the floors (nf_u in BEM header)
+ num_urban_nbui                      = 1! (= 15 if BEM active)        maximum number of types of buildings in an urban class (nbui_max in BEM header)
+
+
+ bl_pbl_physics (max_dom)            boundary-layer option
+                                     = 0, no boundary-layer 
+                                     = 1, YSU scheme
+                                     = 2, Mellor-Yamada-Janjic TKE scheme
+                                     = 3, Hybrid EDMF GFS scheme 
+                                     = 4, Eddy-diffusivity Mass Flux, Quasi-Normal Scale Elimination PBL
+                                     = 5, MYNN 2.5 level TKE scheme, works with
+                                          sf_sfclay_physics=1 or 2 as well as 5
+                                     = 6, MYNN 3rd level TKE scheme, works only
+                                          MYNNSFC (sf_sfclay_physics = 5)
+                                     = 7, ACM2 (Pleim) PBL (ARW)
+                                     = 8, Bougeault and Lacarrere (BouLac) PBL
+                                     = 9, UW boundary layer scheme from CAM5 (CESM 1_0_1)
+                                     = 10, TEMF (Total Energy Mass Flux) scheme (ARW only)
+                                          sf_sfclay_physics=10
+                                     = 11, Shin-Hong 'scale-aware' PBL scheme
+                                     = 12, Grenier-Bretherton-McCaa scheme (ARW only)
+                                     = 93, 2015 GFS scheme (NMM only)
+                                     = 99, MRF scheme
+
+ bldt (max_dom)                      = 0,       ! minutes between boundary-layer physics calls
+
+ grav_settling (max_dom)             gravitational settling of fog/cloud droplets (Now works for any PBL scheme)
+ 				     = 0, No settling of cloud droplets
+				     = 1, Settling from Dyunkerke 1991 (in atmos and at surface)
+				     = 2, Fogdes (vegetation & wind speed dependent; Katata et al. 2008) at surface 
+                                          and Dyunkerke in the atmos.
+
+ nphs (max_dom)                      = FOR NMM: number of fundamental timesteps between
+                                                calls to turbulence and microphysics;
+                                                the value is set in Registry.NMM but is
+                                                overridden by namelist value; bldt will
+                                                be computed from this.
+ ysu_topdown_pblmix                  = 0,  ! whether to turn on top-down, radiation-driven mixing (1=yes)
+ mfshconv (max_dom)                  = 1,  ! whether to turn on new day-time EDMF QNSE (0=no)
+ topo_wind (max_dom)                 = 0,  ! turn off, 
+                                     = 1,    turn on topographic surface wind correction from Jimenez 
+                                             (YSU PBL only, and require extra input from geogrid)
+                                     = 2,    turn on topographic surface wind correction from Mass (YSU PBL only)
+
+ bl_mynn_tkebudget (max_dom)         = 0,       ! default off; = 1 adds MYNN tke budget terms to output
+ bl_mynn_tkeadvect (max_dom)         = .false., ! default off; = .true. do MYNN tke advection
+ icloud_bl                                        option to couple the subgrid-scale clouds from the PBL scheme (MYNN only) 
+                                                  to radiation schemes 
+                                     0:  no coupling; 1: activate coupling to radiation (default)
+ bl_mynn_cloudmix (max_dom)          = 0 ! default off; =1 activates mixing of qc and qi in MYNN
+                                     0: no mixing of qc & qi; 1: mixing activated (default). 
+                                        Note qnc and qni are mixed when scalar_pblmix =1.
+ bl_mynn_mixlength                   option to change mixing length formulation in MYNN
+                                     0: original as in Nakanishi and Niino 2009, 
+                                     1: RAP/HRRR (including BouLac in free atmosphere), 
+                                     2: experimental (default; includes cloud-specific mixing length and a scale-aware mixing 
+                                        length, following Ito et al. 2015, BLM). Option 2 has been well tested with 
+                                        the edmf options.
+ bl_mynn_cloudpdf                    option to switch to different cloud PDFs to represent subgrid clouds
+                                     0: original (Sommeria and Deardorf 1977); 
+                                     1: Kuwano et al 2010, similar to option 0, but uses resolved scale gradients 
+                                        as opposed to higher order moments ; 
+                                     2: from Chaboureau and Bechtold (2002, JAS, with mods, default) 
+ bl_mynn_edmf (max_dom)              = 0,  ! default; = 1 activates mass-flux scheme in MYNN 
+                                       1:  ! (default) for StEM; 2: for TEMF; 0: just regular MYNN. 
+                                             Related (hidden) options: 
+ bl_mynn_edmf_mom (max_dom)          = 1   ! - activates momentum transport in MYNN mass-flux scheme 
+                                           (assuming bl_mynn_edmf > 0); 0=off (default)
+                                       0    no momentum transport; 1: momentum transport activated (default)
+ bl_mynn_edmf_tke (max_dom)          = 0,  ! default; = 1 activates TKE transport in MYNN mass-flux scheme 
+                                            (assuming bl_mynn_edmf > 0)
+                                       0    no TKE transport (default);1: activate TKE transport
+
+ scalar_pblmix (max_dom)             = 1 ! mix scalar fields consistent with PBL option (exch_h)
+ tracer_pblmix (max_dom)             = 1 ! mix tracer fields consistent with PBL option (exch_h)
+ shinhong_tke_diag (max_dom)         = 0 ! diagnostic TKE and mixing length from Shin-Hong PBL
+ opt_thcnd                                 option to treat thermal conductivity in Noah LSM (new in 3.8)
+                                     = 1,  original (default)
+                                     = 2,  McCumber and Pielke for silt loam and sandy loam
+ sf_surface_mosaic                   option to mosaic landuse categories for Noah LSM            
+                                     = 0 ! default; use dominant category only
+                                     = 1 ! use mosaic landuse categories
+ mosaic_cat                          = 3 ! number of mosaic landuse categories in a grid cell
+ mosaic_lu                           = 0, ! default ;  set to = 1 to use mosaic landuse categories in RUC
+ mosaic_soil                         = 0, ! default ;  set to = 1 to use mosaic soil categories in RUC
+
+ cu_physics (max_dom)                cumulus option
+                                     = 0, no cumulus
+                                     = 1, Kain-Fritsch (new Eta) scheme
+                                     = 2, Betts-Miller-Janjic scheme
+                                     = 3, Grell-Freitas ensemble scheme
+                                     = 4, Scale-aware GFS Simplified Arakawa-Schubert (SAS) scheme 
+                                     = 5, Grell 3D ensemble scheme
+                                     = 6, Modifed Tiedtke scheme (ARW only)
+                                     = 7, Zhang-McFarlane scheme from CAM5 (CESM 1_0_1)
+                                     = 10, Modified Kain-Fritsch scheme with trigger function based on PDFs (ARW only)
+                                     = 11, Multi-scale Kain-Fritsch scheme
+                                     = 14, A modified  GFS simplified Arakawa-Schubert scheme that enables NSAS to work 
+                                           in various model grids across gray-zone resolutions (from KIAPS,ARW only)
+                                     = 16, A newer Tiedtke scheme
+                                     = 94, 2015 GFS Simplified Arakawa-Schubert scheme (HWRF) 
+                                     = 95, Previous GFS Simplified Arakawa-Schubert scheme (HWRF) 
+                                     = 96, Previous NEW GFS simplified Arakawa-Schubert scheme from YSU (ARW only)
+                                     = 93, Grell-Devenyi ensemble scheme
+                                     = 99, previous Kain-Fritsch scheme
+
+ shcu_physics (max_dom)              independent shallow cumulus option (not tied to deep convection)
+                                     = 0, no independent shallow cumulus
+                                     = 1, Grell 3D ensemble scheme (use with cu_physics=93 or 5) (PLACEHOLDER: SWITCH NOT YET IMPLEMENTED--use ishallow)
+                                     = 2, Park and Bretherton shallow cumulus from CAM5 (CESM 1_0_1)
+                                     = 3, GRIMS shallow cumulus from YSU group
+                                     = 5, Deng cumulus scheme (including both shallow and deep convections) from PSU and WRF-Solar.
+                                          However the deep part isn't very active. Not recommended to use alone for deep convection 
+                                          case. Could work well for grid sizes 3-9 km.
+                                          This scheme only works with MYJ or MYNN PBL schemes 
+
+ ishallow                            = 0, !  = 1 turns on shallow convection, used with Grell 3D ensemble schemes (cu_physics = 3 or 5)
+ clos_choice                         = 0, !  closure choice (place holder only)
+ cu_diag (max_dom)                   = 0, !  additional t-averaged stuff for cu physics (cu_phys = 3, 5, 10, and 93 only)
+ kf_edrates (max_dom)                = 0, !  Add entrainment/detrainment rates and convective timescale output variables for KF-based 
+                                             cumulus schemes (cu_phys = 1, 11 and 99 only) (new in 3.8)
+                                     = 0,  !  no output; = 1, additional output
+ convtrans_avglen_m                  = 30, !  averaging time for variables used by convective transport (call cu_phys options)  and radiation routines (only cu_phys=3,5 and 93) (minutes) 
+ cu_rad_feedback (max_dom)           = .false.  ! sub-grid cloud effect to the optical depth in radiation
+                                                  currently it works only for GF, G3, GD and KF scheme
+                                                  One also needs to set cu_diag = 1 for GF, G3, KF-CuP, and GD schemes
+ cudt (max_dom)                      = 0,       ! minutes between cumulus physics calls
+ kfeta_trigger                       KF trigger option (cu_physics=1 only):
+                                     = 1, default option
+                                     = 2, moisture-advection based trigger (Ma and Tan [2009]) - ARW only
+                                     = 3, RH-dependent additional perturbation to option 1 (JMA)
+ cugd_avedx                          ; number of grid boxes over which subsidence is spread.
+                                     = 1, default, for large grid distances
+                                     = 3, for small grid distances (DX < 5 km)
+ nsas_dx_factor                      = 0, ! default option
+                                     = 1,   NSAS grid-distance dependent option (new in 3.6)
+ For KF-CuP scheme: recommended to use with cu_rad_feedback
+ shallowcu_forced_ra(max_dom)        radiative impact of shallow Cu by a prescribed maximum cloud fraction
+                                     = .false., option off, default
+                                     = .true., radiative impact of shallow cu with a cloud fraction value of 0.36
+ numbins(max_dom)                    number of perturbations for potential temperature and mixing ratio in the CuP PDF,
+                                     should be an odd number (21 is a recommended value)
+ thBinSize(max_dom)                  bin size of potential temperature perturbation increment (0.01 K)
+ rBinSize(max_dom)                   bin size of mixing ratio perturbation increment (1.0e-4 kg/kg)
+ minDeepFreq(max_dom)                minimum frequency required before deep convection is allowed (0.333)
+ minShallowFreq(max_dom)             minimum frequency required before shallow convection is allowed (1.0e-2)
+ shcu_aerosols_opt(max_dom)          whether aerosols in shcu:  0=none, 2=prognostic (run with WRF-Chem), 
+
+ For MSKF scheme:
+ aercu_opt                           option to control aerosol interaction in MSKF and Morrison microphysics (mp_physics=40)
+                                     = 0: no aerosol interaction
+                                     = 1: aerosol interaction with MSKF only
+                                     = 2: aerosol interaction with both MSKF and Morrison
+ aercu_fct                           factor to multiply with aerosol amount
+                                     = 1.       ! default value
+ no_src_types_cu                     = 1        ! number of aerosol species in global aerosol data: 10 for CESM input,
+                                                  set automatically
+ alevsiz_cu                          = 1        ! number of levels in global aerosol data: 30 for CESM input,
+                                                  set automatically
+
+ ncnvc (max_dom)                     = FOR NMM: number of fundamental timesteps between
+                                                calls to convection; the value is set in Registry.NMM
+                                                but is overridden by namelist value; cudt will be
+                                                computed from this.
+
+ tprec (max_dom)                     = FOR NMM: number of hours in precipitation bucket
+ theat (max_dom)                     = FOR NMM: number of hours in latent heating bucket
+ tclod (max_dom)                     = FOR NMM: number of hours in cloud fraction average
+ trdsw (max_dom)                     = FOR NMM: number of hours in short wave buckets
+ trdlw (max_dom)                     = FOR NMM: number of hours in long wave buckets
+ tsrfc (max_dom)                     = FOR NMM: number of hours in surface flux buckets
+ pcpflg (max_dom)                    = FOR NMM: logical switch for precipitation assimilation
+
+ isfflx                              = 1,	! heat and moisture fluxes from the surface
+                                                  (only works for sf_sfclay_physics = 1,5,7,11)
+                                                  1 = with fluxes from the surface 
+                                                  0 = no flux from the surface
+                                                      with bl_pbl_physics=0 this uses tke_drag_coefficient
+                                                      and tke_heat_flux in vertical diffusion
+                                                  2 = use drag from sf_sfclay_physics and heat flux from
+                                                      tke_heat_flux with bl_pbl_physics=0
+ ideal_xland                         = 1,       ! sets XLAND (1=land,2=water) for ideal cases with no input land-use
+                                                      run-time switch for wrf.exe physics_init (default 1 as before)
+ ifsnow                              = 1,	! snow-cover effects
+                                                  (only works for sf_surface_physics = 1)
+                                                  1 = with snow-cover effect
+                                                  0 = without snow-cover effect
+ icloud                              = 1,	! cloud effect to the optical depth in radiation
+                                                  (only works for ra_sw_physics = 1,4 and ra_lw_physics = 1,4)
+                                                  Since 3.6, this also controls the cloud fraction options
+                                                  1 = with cloud effect, and use cloud fraction option 1
+                                                      (Xu-Randall method) 
+                                                  0 = without cloud effect
+                                                  2 = with cloud effect, and use cloud fraction option 2 (0/1 based
+                                                      on threshold
+                                                  3 = with cloud effect, and use cloud fraction option 3, based on
+                                                      Sundqvist et al. (1989) (since 3.7)
+ swrad_scat                          = 1.       ! scattering tuning parameter (default 1. is 1.e-5 m2/kg)
+                                                  (works for ra_sw_physics = 1 option only)
+ surface_input_source                = 3,	! where landuse and soil category data come from:
+                                                  1 = WPS/geogrid but with dominant categories recomputed
+                                                  2 = GRIB data from another model (only possible
+                                                      (VEGCAT/SOILCAT are in met_em files from WPS)
+                                                  3 = use dominant land and soil categories from WPS/geogrid (default since 3.8)
+
+ num_soil_layers                     = 5,	! number of soil layers in land surface model
+                                                  = 5: thermal diffusion scheme
+                                                  = 4: Noah landsurface model
+                                                  = 6 or 9: RUC landsurface model
+                                                  = 10: CLM4 landsurface model
+                                                  = 2: Pleim-Xu landsurface model
+                                                  = 3: SSiB landsurface model
+ num_land_cat                        = 21,      ! number of land categories in input data.
+                                                  24 - for USGS (default); 20 for MODIS
+                                                  28 - for USGS if including lake category
+                                                  21 - for MODIS if including lake category (default since 3.8)
+						  40 - for NCLD
+ num_soil_cat                        = 16,      ! number of soil categories in input data
+
+ pxlsm_smois_init(max_dom)           = 1        ! PXLSM Soil moisture initialization option 
+                                                   0 - From analysis, 1 - From moisture availability
+                                                   or SLMO in LANDUSE.TBL
+ pxlsm_modis_veg                     = 1,       ! PX LSM LAI and VEGFRA 
+                                                   0 - Old PX method that uses PX landuse look-up table
+                                                   1 - Use VEGFRA and LAI in wrflowinp_d0* file
+                                                   Note: Values used are called VEGF_PX and LAI_PX in output.
+
+ maxiens                             = 1,       ! Grell-Devenyi only
+ maxens                              = 3,       ! G-D only
+ maxens2                             = 3,       ! G-D only
+ maxens3                             = 16       ! G-D only
+ ensdim                              = 144      ! G-D only
+                                                  These are recommended numbers. If you would like to use
+                                                  any other number, consult the code, know what you are doing.
+ seaice_threshold                    = 100.     ! tsk < seaice_threshold, if water point and 5-layer slab
+                                                  scheme, set to land point and permanent ice; if water point
+                                                  and Noah scheme, set to land point, permanent ice, set temps
+                                                  from 2 m to surface, and set smois and sh2o. The default value has changed
+                                                  from 271 to 100 K in v3.5.1 to avoid mixed-up use with fractional seaice input
+                                                  Used by land model option 1,2,3,4 and 8
+ sst_update                          = 0        ! time-varying sea-surface temp (0=no, 1=yes). If selected real 
+                                                  puts SST, XICE, ALBEDO and VEGFRA in wrflowinp_d01 file, and wrf updates 
+                                                  these from it at same interval as boundary file. Also requires
+                                                  namelists in &time_control: auxinput4_interval, auxinput4_end_h,
+                                                  auxinput4_inname = "wrflowinp_d<domain>", 
+                                                  and in V3.2 io_form_auxinput4
+ usemonalb                           = .false.  ! use monthly albedo map instead of table value
+                                                  (must be set to true for NMM, and recommended for sst_update=1)
+ rdmaxalb                            = .true.   ! use snow albedo from geogrid; false means using values from table
+ rdlai2d                             = .false.  ! use LAI from input; false means using values from table
+                                                  if sst_update=1, LAI will also be in wrflowinp file
+ dust_emis                           = 0        ! Enable (0=no, 1=yes) surface dust emission scheme to enter mp_physics=28 QNIFA (ice-friendly aerosol variable)
+ erosion_dim                         = 3        ! In conjunction with dust_emis=1, this value can only be set equal to 3 (erodibility information)
+ bucket_mm                           = -1.      ! bucket reset value for water accumulations (value in mm, -1.=inactive)
+ bucket_J                            = -1.      ! bucket reset value for energy accumulations (value in J, -1.=inactive)
+ tmn_update                          = 0        ! update deep soil temperature (1, yes; 0, no)
+ lagday                              = 150      ! days over which tmn is computed using skin temperature
+ sst_skin                            = 0        ! calculate skin SST
+ slope_rad (max_dom)                 = 0        ! slope effects for solar radiation (1=on, 0=off)
+ topo_shading (max_dom)              = 0        ! neighboring-point shadow effects for solar radiation (1=on, 0=off)
+ shadlen                             = 25000.   ! max shadow length in meters for topo_shading=1
+ sf_ocean_physics                    = 0        ! activate ocean model (0=no, 1=1d mixed layer; 2=3D PWP, no bathymetry)
+ oml_hml0                            = 50       ! oml model can be initialized with a constant depth everywhere (m)
+ oml_gamma                           = 0.14     ! oml deep water lapse rate (K m-1)
+ oml_relaxation_time                 = 0.       ! Relaxation time (in second) of mixed layer ocean model back to original values 
+                                                  (an example value is 259200 sec. (3 days)) (new in 3.8)
+ omdt                                = 1.       ! 3D PWP time step (min).  It can be set to be the same as WRF time step 
+                                                  in corresponding nested grids, but omdt should be no less than 1.0 minute.
+ ocean_levels                        = 30       ! number of vertical levels in 3DPWP. Note that the depth of each ocean 
+                                                  model layers is specified in OM_DEPTH in wrfinput_d01
+ traj_opt                            = 0        ! Forward trajectory calculation (Lee and Chen 2013)
+ num_traj                            = 1000     ! number of trajectories to be released
+ isftcflx                            = 0        ! alternative Ck, Cd formulation for tropical storm application 
+                                                  sf_sfclay=1 and 11
+                                                  0=default
+                                                  1=Donelan Cd + const z0q 
+                                                  2=Donelan Cd + Garratt 
+                                                  sf_sfclay=5
+                                                  (default) =0: z0, zt, and zq from COARE3.0 (Fairall et al 2003)
+                                                            =1: z0 from Davis et al (2008), zt & zq from COARE3.0
+                                                            =2: z0 from Davis et al (2008), zt & zq from Garratt (1992)
+ fractional_seaice                   = 0        ! treat sea-ice as fractional field (1) or ice/no-ice flag (0)
+                                                  works for sf_sfclay_physics=1,2,3,4,5,7,and 91 
+                                                  If fractional_seaice = 1, also set seaice_threshold = 0.
+ seaice_albedo_opt                   = 0        ! option to set albedo over sea ice
+                                                ! 0 = seaice albedo is a constant value from namelist option seaice_albedo_default
+                                                ! 1 = seaice albedo is f(Tair,Tskin,Snow) following Mills (2011) for Arctic Ocean
+                                                ! 2 = seaice albedo read in from input variable ALBSI
+ seaice_albedo_default               =  0.65    ! default value of seaice albedo for seaice_albedo_opt=0
+ seaice_snowdepth_opt                = 0        ! method for treating snow depth on sea ice
+                                                ! 0 = snow depth on sea ice is bounded by seaice_snowdepth_min and seaice_snowdepth_max
+                                                ! 1 = snow depth on sea ice read in from input array SNOWSI (bounded by 
+                                                ;     seaice_snowdepth_min and seaice_snodepth_max)
+ seaice_snowdepth_max                = 1.E10    ! maximum allowed accumulation of snow (m) on sea ice
+ seaice_snowdepth_min                = 0.001    ! minimum snow depth (m) on sea ice
+ seaice_thickness_opt                = 0        ! option for treating seaice thickness
+                                                ! 0 = seaice thickness is uniform value taken from namelist variable seaice_thickness_default
+                                                ! 1 = seaice_thickness is read in from input variable ICEDEPTH
+ seaice_thickness_default            = 3.0      ! default value of seaice thickness for seaice_thickness_opt=0
+ tice2tsk_if2cold                    = .false.  ! set Tice to Tsk to avoid unrealistically low sea ice temperatures
+ iz0tlnd                             = 0        ! thermal roughness length for sfclay (0 = old, 1 = veg dependent Chen-Zhang Czil,
+                                                      2 = Zilitinkevitch (czil=0.1))
+                                                      for mynn sfc (0=Zilitinkevitch (def),1=Chen-Zhang,2=mod Yang,3=const zt)
+ mp_tend_lim                         = 10.,     ! limit on temp tendency from mp latent heating from radar data assimilation
+ prec_acc_dt (max_dom)               = 0.,      ! number of minutes in precipitation bucket (ARW only) - will add three
+                                                  new 2d output fields: prec_acc_c, prec_acc_nc and snow_acc_nc
+ topo_wind (max_dom)                 = 0,       ! 1 = improve effect of topography for surface winds.
+ ua_phys                             = .false.  ! Option to activate UA Noah changes: a different snow-cover physics in
+                                                  Noah, aimed particularly toward improving treatment of snow as it relates 
+                                                  to the vegetation canopy. Also uses new columns added in VEGPARM.TBL
+ do_radar_ref			     = 0, 	! 1 = allows radar reflectivity to be computed using mp-scheme-specific
+ 						  parameters.  Currently works for mp_physics = 2,4,6,7,8,10,14,16,28
+ hailcast_opt (max_dom)              = 0, 	! 1 = 1-D hail growth model which predicts 1st-5th rank-ordered hail diameters, mean hail 
+                                                  diameter and standard deviation of hail diameter. (Adams-Selin and Ziegler, MWR Dec 2016.) 
+                                                  Updated in V3.9, replacing afwa_hailcast_opt in previous versions.
+ haildt (max_dom)                    = 0.,      ! seconds between WRF-HAILCAST calls (s)
+				
+Namelist variables for lake module: 
+
+ sf_lake_physics(max_dom)            = 1,       ! lake model on/off 
+ lakedepth_default(max_dom)          = 50,      ! default lake depth (If there is no lake_depth information in the input data, then lake depth 
+                                                  is assumed to be 50m)  
+ lake_min_elev(max_dom)              = 5,       ! minimum elevation of lakes. May be used to determine whether a water point is a lake in the absence of lake
+                                                  category. If the landuse type includes 'lake' (i.e. Modis_lake and USGS_LAKE), this variable is of no effects. 
+ use_lakedepth (max_dom)             = 1,       ! option to use lake depth data. Lake depth data is available from 3.6 geogrid program. If one didn't process
+                                                  the lake depth data, but this switch is set to 1, the program will stop and tell one to go back to geogrid
+                                                  program. 
+                                                  = 0, do not use lake depth data.
+ lightning_option (max_dom)                       Lightning parameterization option to allow flash rate prediction without chemistry
+                                     = 0        ! off
+                                     = 1        ! PR92 based on maximum w, redistributes flashes within dBZ > 20 (for convection resolved runs; must also use 
+				     		  do_radar_ref = 1, and mp_physics = 2,4,6,7,8,10,14, or 16)
+                                     = 2        ! PR92 based on 20 dBZ top, redistributes flashes within dBZ > 20 (for convection resolved runs; must also use 
+				     		  do_radar_ref = 1, and mp_physics = 2,4,6,7,8,10,14, or 16)
+                                     = 3        ! Predicting the potential for lightning activity (based on Yair et al, 2010, J. Geophys. Res., 115, D04205, doi:10.1029/2008JD010868) 
+                                     = 4        !
+Lynn, B. H., Y. Yair, C. Price, G. Kelman, and A. J. Clark, 2012: Predicting cloud-to-ground and intracloud lightning in weather forecast models. Wea. Forecasting, 27, 1470–1488, doi:https://doi.org/10.1175/WAF-D-11-00144.1 -- note: Dynamic Lightning Scheme output of cloud to ground positive and negative events, and intra-cloud lightning, (LPOS, LNEG, AND LNEU, respectively) was verified against ENTLN event or stroke data in the US and Israel, and, is per grid-element. Adjust coul_pos, coul_neg, and coul_neu as required for different microphysics (must include Graupel). Suggested values: SBM 0.15 for each coul..., Thompson/NSSL 0.25, and WSM6 0.5. Must be called lightning_dt = 0.
+
+                                     = 11       ! PR92 based on level of neutral buoyancy from convective parameterization (for scales
+                                                  where a CPS is used, intended for use at 10 < dx < 50 km; must also use cu_physics = 5 or 93)
+ lightning_dt  (max_dom)             = 0.       ! time interval (seconds) for calling lightning parameterization. Default uses model time step
+ lightning_start_seconds (max_dom)   = 0.       ! Start time for calling lightning parameterization. Recommends at least 10 minutes for spin-up.
+ flashrate_factor  (max_dom)         = 1.0      ! Factor to adjust the predicted number of flashes. Recommends 1.0 for lightning_option = 11
+                                                  between dx=10 and 50 km. Manual tuning recommended for all other options independently
+                                                  for each nest.
+ cellcount_method (max_dom)                       Method for counting storm cells. Used by CRM options (lightning_options=1,2).
+                                     = 0,       ! model determines method used
+                                     = 1,       ! tile-wide, appropriate for large domains
+                                     = 2,       ! domain-wide, appropriate for sing-storm domains
+ cldtop_adjustment (max_dom)         = 0.       ! Adjustment from LNB in km. Used by lightning_option=11. Default is 0, but recommends 2 km
+ iccg_method (max_dom)                            IC:CG partitioning method (IC: intra-cloud; CG: cloud-to-ground)
+                                     = 0        ! Default method depending on lightning option, currently all options use iccg_method=2 by default
+                                     = 1        ! Constant everywhere, set with namelist options iccg_prescribed (num|den)#, default is 0./1. (all CG).
+                                     = 2        ! Coarsely prescribed 1995-1999 NLDN/OTD climatology based on Boccippio et al. (2001)
+                                     = 3        ! Parameterization by Price and Rind (1993) based on cold-cloud depth
+                                     = 4        ! Gridded input via arrays iccg_in_(num|den) from wrfinput for monthly mapped ratios. 
+                                                  Points with 0/0 values use ratio defined by iccg_prescribed_(num|den)
+ iccg_prescribed_num (max_dom)       = 0.       ! Numerator of user-specified prescribed IC:CG
+ iccg_prescribed_den (max_dom)       = 1.       ! Denominator of user-specified prescribed IC:CG
+
+Options for wind turbine drag parameterization:
+
+ windfarm_opt (max_dom)             = 0         ! 1 = Simulates the effects of wind turbines in the atmospheric evolution
+ windfarm_ij                        = 0         ! whether to use lat-lon or i-j coordinate as wind turbine locations    
+                                                ! 0 = The coordinate of the turbines are defined in terms of lat-lon
+                                                ! 1 = The coordinate of the turbines are defined in terms of grid points
+
+
+Stochastic parameterization schemes:
+
+&stoch
+; Random perturbation field (rand_perturb=1) 
+ rand_perturb (max_dom)               = 1        ! Generate array with random perturbations for user-determined use, 1: on
+ gridpt_stddev_rand_pert (max_dom)    = 0.03     ! Standard deviation of random perturbation field at each gridpoint.
+                                                   Determines amplitude of random perturbations
+ lengthscale_rand_pert (max_dom)      = 500000.0 ! Perturbation lengthscale (in m).
+ timescale_rand_pert (max_dom)        = 21600.0  ! Temporal decorrelation of random field (in s).
+ stddev_cutoff_rand_pert (max_dom)    = 3.0      ! Cutoff tails of perturbation pattern above this threshold standard deviation.
+ rand_pert_vertstruc                  = 0        ! Vertical structure for random perturbation field: 0=constant; 1=random phase with tilt
+ iseed_rand_pert                                   Seed for random number stream for rand_perturb. Will be
+                                                   combined with seed nens signifying ensemble member number and initial
+                                                   start time to ensure different random number streams for forecasts
+                                                   starting from different initial times and for different ensemble members.
+
+; Stochastically perturbed physics tendencies (SPPT) (sppt=1)
+ sppt (max_dom)                       = 0        ! Stochastically perturbed physics tendencies (SPPT), 0: off, 1: on
+ gridpt_stddev_sppt (max_dom)         = 0.5      ! Standard deviation of random perturbation field at each gridpoint.
+                                                   Determines amplitude of random perturbations
+ lengthscale_sppt (max_dom)           = 150000.0 ! Perturbation lengthscale (in m).
+ timescale_sppt (max_dom)             = 21600.0  ! Temporal decorrelation of random field (in s).
+ stddev_cutoff_sppt (max_dom)         = 2.0      ! Cutoff tails of perturbation pattern above this threshold standard deviation.
+ iseed_sppt                                        Seed for random number stream for sppt. Will be
+                                                   combined with seed nens signifying ensemble member number and initial
+                                                   start time to ensure different random number streams for forecasts
+                                                   starting from different initial times and for different ensemble members.
+
+; Stochastic kinetic-energy backscatter scheme (SKEBS)(skebs=1):
+
+ skebs (max_dom)                    = 0         ! stochastic kinetic-energy backscatter scheme, 0: off, 1: on
+ tot_backscat_psi (max_dom)         = 1.0E-05   ! Controls amplitude of rotational wind perturbations
+ tot_backscat_t (max_dom)           = 1.0E-06   ! Controls amplitude of potential temperature perturbations
+ ztau_psi                           = 10800.0   ! decorr. time of noise for psi perturb
+ ztau_t                             = 10800.0   ! decorr. time of noise for theta perturb
+ rexponent_psi                      = -1.83     ! spectral slope of forcing for psi
+ rexponent_t                        = -1.83     ! spectral slope of forcing for theta
+ zsigma2_eps                        = 0.0833    ! variance of noise for psi perturb
+ zsigma2_eta                        = 0.0833    ! variance of noise for theta perturb
+ kminforc                           = 1         ! min. forcing wavenumber in lon. for psi perturb
+ lminforc                           = 1         ! min. forcing wavenumber in lat. for psi perturb
+ kminforct                          = 1         ! min. forcing wavenumber in lon. for theta perturb
+ lminforct                          = 1         ! min. forcing wavenumber in lat. for theta perturb
+ kmaxforc                           = 1000000   ! max. forcing wavenumber in lon. for psi perturb
+ lmaxforc                           = 1000000   ! max. forcing wavenumber in lat. for psi perturb
+ kmaxforct                          = 1000000   ! max. forcing wavenumber in lon. for theta perturb
+ lmaxforct                          = 1000000   ! max. forcing wavenumber in lat. for theta perturb
+ skebs_vertstruc                    = 0         ! Vertical structure for random perturbation field: 0=constant; 1=random phase with tilt
+
+Stochastically perturbed parameter scheme (SPP) (spp=1)
+ sppt (max_dom)                      = 0        ! Stochastically perturbed parameter (SPP) scheme for
+                                                ; GF convection scheme, MYNN boundary layer scheme and RUC LSM. 0: off, 1: on
+ spp_conv (max_dom)                  = 0        ! Perturb parameters of GF convection scheme only
+ gridpt_stddev_spp_conv (max_dom)    = 0.3      ! Standard deviation of random perturbation field at each gridpoint.
+                                                  Determines amplitude of random perturbations
+ lengthscale_spp_conv (max_dom)      = 150000.0 ! Perturbation lengthscale (in m).
+ timescale_spp_conv (max_dom)        = 21600.0  ! Temporal decorrelation of random field (in s).
+ stddev_cutoff_spp_conv (max_dom)    = 3.0      ! Cutoff tails of perturbation pattern above this threshold standard deviation.
+ iseed_spp_conv                                   Seed for random number stream for spp_conv. Will be
+                                                  combined with seed nens signifying ensemble member number and initial
+                                                  start time to ensure different random number streams for forecasts
+                                                  starting from different initial times and for different ensemble members.
+ spp_pbl (max_dom)                   = 0        ! Perturb parameters of MYNN PBL scheme only
+ gridpt_stddev_spp_pbl (max_dom)     = 0.15     ! Standard deviation of random perturbation field at each gridpoint.
+                                                  Determines amplitude of random perturbations
+ lengthscale_spp_pbl (max_dom)       = 70000.0  ! Perturbation lengthscale (in m).
+ timescale_spp_pbl (max_dom)         = 21600.0  ! Temporal decorrelation of random field (in s).
+ stddev_cutoff_spp_pbl (max_dom)     = 2.0      ! Cutoff tails of perturbation pattern above this threshold standard deviation.
+ iseed_spp_pbl                                    Seed for random number stream for spp_pbl . Will be
+                                                  combined with seed nens signifying ensemble member number and initial
+                                                  start time to ensure different random number streams for forecasts
+                                                  starting from different initial times and for different ensemble members.
+ spp_lsm (max_dom)                   = 0        ! Perturb parameters of RUC LSM
+ gridpt_stddev_spp_lsm (max_dom)     = 0.3      ! Standard deviation of random perturbation field at each gridpoint.
+                                                ; Determines amplitude of random perturbations
+ lengthscale_spp_lsm (max_dom)       = 50000.0  ! Perturbation lengthscale (in m).
+ timescale_spp_lsm (max_dom)         = 86400.0  ! Temporal decorrelation of random field (in s).
+ stddev_cutoff_spp_lsm (max_dom)     = 3.0      ! Cutoff tails of perturbation pattern above this threshold standard deviation.
+ iseed_spp_lsm                                    Seed for random number stream for spp_lsm . Will be
+                                                  combined with seed nens signifying ensemble member number and initial
+                                                  start time to ensure different random number streams for forecasts
+                                                  starting from different initial times and for different ensemble members.
+
+; Stochastic Perturbations to the boundary conditions?| (perturb_bdy)
+ perturb_bdy                        = 0         ! No boundary perturbations
+                                      1           Use SKEBS pattern for boundary perturbations
+                                      2           Use other user-provided pattern for boundary perturbations
+
+; Stochastic perturbations to the boundary tendencies in WRF-CHEM (perturb_chem_bdy)
+ perturb_chem_bdy                                 Options for perturbing lateral boundaries of chemical tracers:
+                                                  0 = off; 1 = on with RAND_PERTURB pattern
+
+; Common to all stochastic schemes
+  nens                                =1        ! Seed for random number stream. For ensemble forecasts this parameter needs to be
+                                                  different for each member. The seed is a function of initial start time
+                                                  to ensure different random number streams for forecasts starting from
+                                                  different initial times. Changing this seed changes the random number
+                                                  streams for all activated stochastic parameterization schemes.
+
+
+Options for use with the Noah-MP Land Surface Model:
+
+&noah_mp
+ dveg                               = 4,        ! Noah-MP Dynamic Vegetation option:
+                                                     1 = Off (LAI from table; FVEG = shdfac)
+                                                     2 = On  (LAI predicted;  FVEG calculated)
+                                                     3 = Off (LAI from table; FVEG calculated)
+                                                     4 = Off (LAI from table; FVEG = maximum veg. fraction)
+                                                     5 = On  (LAI predicted;  FVEG = maximum veg. fraction)
+                                                     6 = On  (use FVEG = SHDFAC from input)
+                                                     7 = Off (use input LAI; use FVEG = SHDFAC from input)
+                                                     8 = Off (use input LAI; calculate FVEG)
+                                                     9 = Off (use input LAI; use maximum vegetation fraction)
+ opt_crs                            = 1,        ! Noah-MP Stomatal Resistance option:
+                                                     1 = Ball-Berry
+                                                     2 = Jarvis
+ opt_sfc                            = 1         ! Noah-MP surface layer drag coefficient calculation
+                                                     1 = Monin-Obukhov
+                                                     2 = original Noah (Chen97)
+ opt_btr                            = 1,        ! Noah-MP Soil Moisture Factor for Stomatal Resistance
+                                                     1 = Noah
+                                                     2 = CLM
+                                                     3 = SSiB
+ opt_run                            = 3,        ! Noah-MP Runoff and Groundwater option
+                                                     1 = TOPMODEL with groundwater
+                                                     2 = TOPMODEL with equilibrium water table
+                                                     3 = original surface and subsurface runoff (free drainage) - default
+                                                     4 = BATS surface and subsurface runoff (free drainage)
+                                                     5 = Miguez-Macho & Fan groundwater scheme (Miguez-Macho et al. 2007 JGR; Fan et al. 2007 JGR)
+                                                           geogrid must have been run with GEOGRID.TBL.ARW.noahmp, use with caution
+ opt_frz                            = 1,        ! Noah-MP Supercooled Liquid Water option
+                                                     1 = No iteration
+                                                     2 = Koren's iteration
+ opt_inf                            = 1,        ! Noah-MP Soil Permeability option
+                                                     1 = Linear effects, more permeable
+                                                     2 = Non-linear effects, less permeable
+ opt_rad                            = 3,        ! Noah-MP Radiative Transfer option
+                                                     1 = Modified two-stream (known to cause problems when vegetation fraction is small)
+                                                     2 = Two-stream applied to grid-cell
+                                                     3 = Two-stream applied to vegetated fraction
+ opt_alb                            = 2,        ! Noah-MP Ground Surface Albedo option
+                                                     1 = BATS
+                                                     2 = CLASS
+ opt_snf                            = 1,        ! Noah-MP Precipitation Partitioning between snow and rain
+                                                     1 = Jordan (1991)
+                                                     2 = BATS:  Snow when SFCTMP < TFRZ+2.2
+                                                     3 = Snow when SFCTMP < TFRZ
+                                                     4 = Use WRF precipitation partitioning
+ opt_tbot                           = 2,        ! Noah-MP Soil Temperature Lower Boundary Condition
+                                                     1 = Zero heat flux
+                                                     2 = TBOT at 8 m from input file
+ opt_stc                            = 1,        ! Noah-MP Snow/Soil temperature time scheme
+                                                     1 = semi-implicit
+                                                     2 = full-implicit
+                                                     3 = semi-implicit where Ts uses snow cover fraction
+ opt_gla                            = 1,        ! Noah-MP glacier treatment option (new in 3.8)
+                                                     1 = includes phase change
+                                                     2 = slab ice (Noah)
+ opt_rsf                            = 1,        ! Noah-MP surface evaporation resistance option (new in 3.8)
+                                                     1 -> Sakaguchi and Zeng, 2009
+                                                     2 -> Sellers (1992)
+                                                     3 -> adjusted Sellers to decrease RSURF for wet soil
+                                                     4 -> option 1 for non-snow; rsurf = rsurf_snow for snow (set in MPTABLE)
+ opt_soil                           = 1,        ! Noah-MP options for defining soil properties
+                                                           geogrid must have been run with GEOGRID.TBL.ARW.noahmp, use with caution
+                                                     1 -> use input dominant soil texture
+                                                     2 -> use input soil texture that varies with depth
+                                                     3 -> use soil composition (sand, clay, orgm) and pedotransfer functions (OPT_PEDO)
+                                                     4 -> use input soil properties (BEXP_3D, SMCMAX_3D, etc.) (not valid in WRF)
+ opt_pedo                           = 1,        ! Noah-MP options for pedotransfer functions (used when OPT_SOIL = 3)
+                                                          geogrid must have been run with GEOGRID.TBL.ARW.noahmp, use with caution
+                                                  1 -> Saxton and Rawls (2006)
+ opt_crop                           = 0,        !  options for crop model
+                                                           geogrid must have been run with GEOGRID.TBL.ARW.noahmp, use with caution
+                                                     0 -> No crop model, will run default dynamic vegetation
+                                                     1 -> Liu, et al. 2016
+                                                     2 -> Gecros (Genotype-by-Environment interaction on CROp growth Simulator) Yin and van Laar, 2005
+ /
+
+ &fdda
+ grid_fdda (max_dom)                 = 1        ! grid-nudging fdda on (=0 off) for each domain
+                                     = 2        ! spectral nudging
+ gfdda_inname                        = "wrffdda_d<domain>" ! defined name in real
+ gfdda_interval_m (max_dom)          = 360      ! time interval (in min) between analysis times (must use minutes)
+ gfdda_end_h (max_dom)               = 6        ! time (in hours) to stop nudging after start of forecast
+ io_form_gfdda                       = 2        ! analysis data io format (2 = netCDF)
+ fgdt (max_dom)                      = 0        ! calculation frequency (minutes) for grid-nudging (0=every step)
+ if_no_pbl_nudging_uv (max_dom)      = 0        ! 1= no nudging of u and v in the pbl, 0=nudging in the pbl
+ if_no_pbl_nudging_t (max_dom)       = 0        ! 1= no nudging of temp in the pbl, 0=nudging in the pbl
+ if_no_pbl_nudging_q (max_dom)       = 0        ! 1= no nudging of qvapor in the pbl, 0=nudging in the pbl
+ if_zfac_uv (max_dom)                = 0        ! 0= nudge u and v in all layers, 1= limit nudging to levels above k_zfac_uv
+  k_zfac_uv (max_dom)                = 10       ! 10=model level below which nudging is switched off for u and v
+ if_zfac_t (max_dom)                 = 0        ! 0= nudge temp in all layers, 1= limit nudging to levels above k_zfac_t
+  k_zfac_t (max_dom)                 = 10       ! 10=model level below which nudging is switched off for temp
+ if_zfac_q (max_dom)                 = 0        ! 0= nudge qvapor in all layers, 1= limit nudging to levels above k_zfac_q
+  k_zfac_q (max_dom)                 = 10       ! 10=model level below which nudging is switched off for qvapor
+ guv (max_dom)                       = 0.0003   ! nudging coefficient for u and v (sec-1)
+ gt (max_dom)                        = 0.0003   ! nudging coefficient for temp (sec-1)
+ gq (max_dom)                        = 0.00001  ! nudging coefficient for qvapor (sec-1)
+ if_ramping                          = 0        ! 0= nudging ends as a step function, 1= ramping nudging down at end of period
+ dtramp_min                          = 0        ! time (min) for ramping function 
+ grid_sfdda (max_dom)                = 0        ! surface fdda switch
+                                                  0: off; 
+                                                  1: nudging selected surface fields; 
+                                                  2: FASDAS (flux-adjusting surface data assimilation system)
+ sgfdda_inname                       = "wrfsfdda_d<domain>" ! defined name for sfc nudgingi in input file (from program obsgrid) 
+ sgfdda_end_h (max_dom)              = 6        ! time (in hours) to stop sfc nudging after start of forecast
+ sgfdda_interval_m (max_dom)         = 180      ! time interval (in min) between sfc analysis times (must use minutes)
+ io_form_sgfdda                      = 2        ! sfc analysis data io format (2 = netCDF)
+ guv_sfc (max_dom)                   = 0.0003   ! nudging coefficient for sfc u and v (sec-1)
+ gt_sfc (max_dom)                    = 0.0003   ! nudging coefficient for sfc temp (sec-1)
+ gq_sfc (max_dom)                    = 0.00001  ! nudging coefficient for sfc qvapor (sec-1)
+ rinblw (max_dom)                    = 0.       ! radius of influence used to determine the confidence (or weights) for
+                                                  the analysis, which is based on the distance between the grid point to the nearest
+                                                  obs. The analysis without nearby observation is used at a reduced weight.
+
+ pxlsm_soil_nudge(max_dom)           = 1        ! PXLSM Soil nudging option (requires wrfsfdda file)
+
+The following are for spectral nudging:
+ fgdtzero (max_dom)                  = 0,       ! 1= nudging tendencies are set to zero in between fdda calls
+ if_no_pbl_nudging_uv (max_dom)      = 0,       ! 1= no nudging of uv in the pbl, 0= nudging in the pbl
+ if_no_pbl_nudging_t  (max_dom)      = 0,       ! 1= no nudging of t in the pbl, 0= nudging in the pbl
+ if_no_pbl_nudging_ph (max_dom)      = 0,       ! 1= no nudging of ph in the pbl, 0= nudging in the pbl
+ if_no_pbl_nudging_q  (max_dom)      = 0,       ! 1= no nudging of q in the pbl, 0= nudging in the pbl
+ if_zfac_uv (max_dom)                = 0,       ! 0= nudge uv in all layers, 1= limit nudging to levels above k_zfac_uv
+  k_zfac_uv (max_dom)                = 0,       ! 0= model level below which nudging is switched off for uv
+ dk_zfac_uv (max_dom)                = 1,       ! depth in k between k_zfac_X to dk_zfac_X where nudging increases
+                                                ; linearly to full strength
+ if_zfac_t  (max_dom)                = 0,       ! 0= nudge t in all layers, 1= limit nudging to levels above k_zfac_t
+  k_zfac_t  (max_dom)                = 0,       ! 0= model level below which nudging is switched off for t
+ dk_zfac_t  (max_dom)                = 1,       ! depth in k between k_zfac_X to dk_zfac_X where nudging increases
+                                                  linearly to full strength
+ if_zfac_ph (max_dom)                = 0,       ! 0= nudge ph in all layers, 1= limit nudging to levels above k_zfac_ph
+  k_zfac_ph (max_dom)                = 0,       ! 0= model level below which nudging is switched off for ph
+ dk_zfac_ph  (max_dom)               = 1,       ! depth in k between k_zfac_X to dk_zfac_X where nudging increases
+                                                  linearly to full strength
+ if_zfac_q  (max_dom)                = 0,       ! 0= nudge q in all layers, 1= limit nudging to levels above k_zfac_q
+  k_zfac_q  (max_dom)                = 0,       ! 0= model level below which nudging is switched off for q
+ dk_zfac_q  (max_dom)                = 1,       ! depth in k between k_zfac_X to dk_zfac_X where nudging increases
+ gph (max_dom)                       = 0.0003,
+ ktrop                               = 0,       ! layer nominally representing tropopause for limiting nudging to q and t
+                                     		; setting ktrop = 0 allows nudging to extend to the top of the atmosphere
+ xwavenum (max_dom)                  = 3,       ! top wave number to nudge in x direction
+ ywavenum (max_dom)                  = 3,       ! top wave number to nudge in y direction
+
+The following are for observation nudging:
+ obs_nudge_opt (max_dom)             = 1        ! obs-nudging fdda on (=0 off) for each domain
+                                                  also need to set auxinput11_interval and auxinput11_end_h
+                                                  in time_control namelist
+ max_obs                             = 0        ! max number of observations used on a domain during any 
+                                                  given time window
+ fdda_start (max_dom)                = 0        ! obs nudging start time in minutes
+ fdda_end (max_dom)                  = 0        ! obs nudging end time in minutes
+ obs_nudge_wind (max_dom)            = 1        ! whether to nudge wind: (=0 off)
+ obs_coef_wind (max_dom)             = 0,       ! nudging coefficient for wind, unit: s-1
+ obs_nudge_temp (max_dom)            = 0,       ! set to = 1 to turn to nudge temperature (default = 0; off) 
+ obs_coef_temp (max_dom)             = 0,       ! nudging coefficient for temperature, unit: s-1
+ obs_nudge_mois (max_dom)            = 1        ! whether to nudge water vapor mixing ratio: (=0 off)
+ obs_coef_mois (max_dom)             = 0,       ! nudging coefficient for water vapor mixing ratio, unit: s-1
+ obs_nudge_pstr (max_dom)            = 0        ! whether to nudge surface pressure (not used)
+ obs_coef_pstr (max_dom)             = 0.       ! nudging coefficient for surface pressure, unit: s-1 (not used)
+ obs_rinxy (max_dom)                 = 0.       ! horizonal radius of influence in km
+ obs_rinsig                          = 0        ! vertical radius of influence in eta
+ obs_twindo (max_dom)                = 0.66667  ! half-period time window over which an observation 
+                                                  will be used for nudging (hours)
+ obs_npfi                            = 0,       ! freq in coarse grid timesteps for diagnostic prints
+ obs_ionf (max_dom)                  = 2        ! freq in coarse grid timesteps for obs input and err calc
+ obs_idynin                          = 0        ! for dynamic initialization using a ramp-down function to gradually
+                                                  turn off the FDDA before the pure forecast (=1 on)
+ obs_dtramp                          = 0        ! time period in minutes over which the nudging is ramped down 
+                                                  from one to zero.
+ obs_prt_freq (max_dom)              = 10,      ! Frequency in obs index for diagnostic printout
+ obs_prt_max                         = 1000,    ! Maximum allowed obs entries in diagnostic printout
+ obs_ipf_in4dob                      = .true.   ! print obs input diagnostics (=.false. off)
+ obs_ipf_errob                       = .true.   ! print obs error diagnostics (=.false. off)
+ obs_ipf_nudob                       = .true.   ! print obs nudge diagnostics (=.false. off)
+ obs_ipf_init                        = .true.   ! Enable obs init warning messages
+
+ obs_no_pbl_nudge_uv (max_dom)       = 0        ! 1=no wind-nudging within pbl
+ obs_no_pbl_nudge_t (max_dom)        = 0        ! 1=no temperature-nudging within pbl
+ obs_no_pbl_nudge_q (max_dom)        = 0        ! 1=no moisture-nudging within pbl
+ obs_sfc_scheme_horiz                = 0        ! horizontal spreading scheme for surf obs;
+                                                ; 0=wrf scheme, 1=original mm5 scheme
+ obs_sfc_scheme_vert                 = 0        ! vertical spreading scheme for surf obs
+                                                  0=regime vif scheme, 1=original simple scheme
+ obs_max_sndng_gap                   = 20       ! Max pressure gap between soundings, in cb
+ obs_nudgezfullr1_uv                 = 50       ! Vert infl full weight  height for lowest model level (LML) obs, regime 1, winds
+ obs_nudgezrampr1_uv                 = 50       ! Vert infl ramp-to-zero height for LML obs, regime 1, winds
+ obs_nudgezfullr2_uv                 = 50       ! Vert infl full weight  height for LML obs, regime 2, winds
+ obs_nudgezrampr2_uv                 = 50       ! Vert infl ramp-to-zero height for LML obs, regime 2, winds
+ obs_nudgezfullr4_uv                 = -5000    ! Vert infl full weight  height for LML obs, regime 4, winds
+ obs_nudgezrampr4_uv                 = 50       ! Vert infl ramp-to-zero height for LML obs, regime 4, winds
+ obs_nudgezfullr1_t                  = 50       ! Vert infl full weight  height for LML obs, regime 1, temperature
+ obs_nudgezrampr1_t                  = 50       ! Vert infl ramp-to-zero height for LML obs, regime 1, temperature
+ obs_nudgezfullr2_t                  = 50       ! Vert infl full weight  height for LML obs, regime 2, temperature
+ obs_nudgezrampr2_t                  = 50       ! Vert infl ramp-to-zero height for LML obs, regime 2, temperature
+ obs_nudgezfullr4_t                  = -5000    ! Vert infl full weight  height for LML obs, regime 4, temperature
+ obs_nudgezrampr4_t                  = 50       ! Vert infl ramp-to-zero height for LML obs, regime 4, temperature
+ obs_nudgezfullr1_q                  = 50       ! Vert infl full weight  height for LML obs, regime 1, moisture
+ obs_nudgezrampr1_q                  = 50       ! Vert infl ramp-to-zero height for LML obs, regime 1, moisture
+ obs_nudgezfullr2_q                  = 50       ! Vert infl full weight  height for LML obs, regime 2, moisture
+ obs_nudgezrampr2_q                  = 50       ! Vert infl ramp-to-zero height for LML obs, regime 2, moisture
+ obs_nudgezfullr4_q                  = -5000    ! Vert infl full weight  height for LML obs, regime 4, moisture
+ obs_nudgezrampr4_q                  = 50       ! Vert infl ramp-to-zero height for LML obs, regime 4, moisture
+ obs_nudgezfullmin                   = 50       ! Min depth through which vertical infl fcn remains 1.0
+ obs_nudgezrampmin                   = 50       ! Min depth (m) through which vert infl fcn decreases from 1 to 0
+ obs_nudgezmax                       = 3000     ! Max depth (m) in which vert infl function is nonzero
+ obs_sfcfact                         = 1.0      ! Scale factor applied to time window for surface obs
+ obs_sfcfacr                         = 1.0      ! Scale factor applied to horiz radius of influence for surface obs
+ obs_dpsmx                           = 7.5      ! Max pressure change (cb) allowed within horiz radius of influence
+
+ obs_scl_neg_qv_innov                = 0        ! 1 = prevent to nudge toward negative QV 
+ /
+
+ &scm
+ scm_force                           = 1,       ! switch for single column forcing (=0 off)
+ scm_force_dx                        = 4000.    ! DX for SCM forcing (in meters)
+ num_force_layers                    = 8        ! number of SCM input forcing layers
+ scm_lu_index                        = 2        ! SCM landuse category (2 is dryland, cropland and pasture)
+ scm_isltyp                          = 4        ! SCM soil category (4 is silt loam)
+ scm_vegfra                          = 0.5      ! SCM vegetation fraction
+ scm_canwat                          = 0.0      ! SCM canopy water
+ scm_lat                             = 36.605   ! SCM latitude
+ scm_lon                             = -97.485  ! SCM longitude
+ scm_th_adv                          = .true.   ! turn on theta advection in SCM
+ scm_wind_adv                        = .true.   ! turn on wind advection in SCM
+ scm_qv_adv                          = .true.   ! turn on moisture advection in SCM
+ scm_ql_adv                          = .true.   ! turn on cloud liquid water advection in SCM
+ scm_vert_adv                        = .true.   ! turn on vertical advection in SCM
+ num_force_soil_layers               = 5,       ! Number of SCM soil forcing layer 
+ scm_soilT_force                     = .false.  ! Turn on soil temp forcing in SCM
+ scm_soilq_force                     = .false.  ! Turn on soil moisture forcing in SCM
+ scm_force_th_largescale             = .false.  ! Turn on large scale theta forcing in SCM
+ scm_force_qv_largescale             = .false.  ! Turn on large scale qv forcing in SCM
+ scm_force_ql_largescale             = .false.  ! Turn on large scale cloud water forcing in SCM
+ scm_force_wind_largescale           = .false.  ! Turn on large scale wind forcing in SCM
+
+ &dynamics
+ hybrid_opt                          = 2,       ! default; Klemp cubic form with etac
+                                                  0 = original WRF terrain-following coordinate (through V3)
+ etac                                = 0.2      ! znw(k) < etac, eta surfaces are isobaric, 0.2 is a good default (Pa/Pa)
+ rk_ord                              = 3,	! time-integration scheme option:
+                                                  2 = Runge-Kutta 2nd order
+                                                  3 = Runge-Kutta 3rd order
+ diff_opt(max_dom)                   = 0,	! turbulence and mixing option:
+                                                  0 = no turbulence or explicit
+                                                      spatial numerical filters (km_opt IS IGNORED).
+                                                  1 = evaluates 2nd order
+                                                      diffusion term on coordinate surfaces.
+                                                      uses kvdif for vertical diff unless PBL option
+                                                      is used. may be used with km_opt = 1 and 4.
+                                                      (= 1, recommended for real-data cases)
+                                                  2 = evaluates mixing terms in
+                                                      physical space (stress form) (x,y,z).
+                                                      turbulence parameterization is chosen
+                                                      by specifying km_opt.
+ km_opt(max_dom)                     = 1,	! eddy coefficient option
+                                                  1 = constant (use khdif kvdif)
+                                                  2 = 1.5 order TKE closure (3D)
+                                                  3 = Smagorinsky first order closure (3D)
+                                                      Note: option 2 and 3 are not recommended for DX > 2 km
+                                                  4 = horizontal Smagorinsky first order closure
+                                                      (recommended for real-data cases)
+ damp_opt                            = 0,	! upper level damping flag 
+                                                  0 = without damping
+                                                  1 = with diffusive damping, maybe used for real-data cases 
+                                                      (dampcoef nondimensional ~0.01-0.1)
+                                                  2 = with Rayleigh  damping (dampcoef inverse time scale [1/s] e.g. .003; idealized case only
+                                                      not for real-data cases)
+                                                  3 = with w-Rayleigh damping (dampcoef inverse time scale [1/s] e.g. .2; 
+                                                      for real-data cases)
+ use_theta_m                         = 1        ! 1: use theta_m=theta(1+1.61Qv)
+                                                  0: use dry theta in dynamics
+ use_q_diabatic                      = 0        ! whether to include QV and QC tendencies in advection (new in 3.7)
+                                                  0 = default, old behavior
+                                                  1 = include QV and QC tendencies - this helps to produce correct solution
+                                                      in an idealized 'moist benchmark' test case (Bryan, 2014).
+                                                      In real data testing, time step needs to be reduce to maintain stable solution
+ c_s (max_dom)                       = 0.25     ! Smagorinsky coeff
+ c_k (max_dom)                       = 0.15     ! TKE coeff
+ diff_6th_opt (max_dom)              = 0,       ! 6th-order numerical diffusion
+                                                  0 = no 6th-order diffusion (default)
+                                                  1 = 6th-order numerical diffusion (not recommended)
+                                                  2 = 6th-order numerical diffusion but prohibit up-gradient diffusion
+ diff_6th_factor (max_dom)           = 0.12,    ! 6th-order numerical diffusion non-dimensional rate (max value 1.0
+                                                      corresponds to complete removal of 2dx wave in one timestep)
+ diff_6th_slopeopt (max_dom)         = 0        ! if set to =1, turns on 6th-order numerical diffusion - terrain-slope tapering. default is 0=off
+ diff_6th_thresh (max_dom)           = 0.10     ! slope threshold (m/m) that turns off 6th order diff in steep terrain
+ dampcoef (max_dom)                  = 0.,	! damping coefficient (see above)
+ zdamp (max_dom)                     = 5000.,	! damping depth (m) from model top
+ w_damping                           = 0,       ! vertical velocity damping flag (for operational use)
+                                                  0 = without damping
+                                                  1 = with    damping
+ base_temp                           = 290.,    ! real-data, em ONLY, base sea-level temp (K)
+ base_pres                           = 10^5     ! real-data, em ONLY, base sea-level pres (Pa), DO NOT CHANGE
+ base_lapse                          = 50.,     ! real-data, em ONLY, lapse rate (K), DO NOT CHANGE
+ iso_temp                            = 200.,    ! real-data, em ONLY, reference temp in stratosphere, US Standard atmosphere 216.5 K
+ base_pres_strat                     = 0.       ! real-data, em ONLY, base state pressure (Pa) at bottom of the stratosphere, 
+                                                  US Standard atmosphere 55 hPa
+ base_lapse_strat                    = -11.     ! real-data, em ONLY, base state lapse rate ( dT / d(lnP) ) in stratosphere, 
+                                                  approx to US Standard atmosphere -12 K
+ use_baseparam_fr_nml                = .f.,     ! whether to use base state parameters from the namelist
+ use_input_w                         = .f.,     ! whether to use vertical velocity from input file
+ khdif (max_dom)                     = 0,	; horizontal diffusion constant (m^2/s). A typical value should be 0.1*DX in meters.
+ kvdif (max_dom)                     = 0,	! vertical diffusion constant (m^2/s). A typical value should be 100.
+ smdiv (max_dom)                     = 0.1,	! divergence damping (0.1 is typical)
+ emdiv (max_dom)                     = 0.01,	! external-mode filter coef for mass coordinate model
+                                                  (0.01 is typical for real-data cases)
+ epssm (max_dom)                     = .1,	! time off-centering for vertical sound waves
+ non_hydrostatic (max_dom)           = .true.,	! whether running the model in hydrostatic or non-hydro mode
+ pert_coriolis (max_dom)             = .false.,	! Coriolis only acts on wind perturbation (idealized)
+ top_lid (max_dom)                   = .false., ! Zero vertical motion at top of domain
+ mix_full_fields(max_dom)            = .true.,  ! used with diff_opt = 2; value of ".true." is recommended, except for
+                                                  highly idealized numerical tests; damp_opt must not be 1 if ".true."
+                                                  is chosen. .false. means subtract 1-d base-state profile before mixing
+ mix_isotropic(max_dom)              = 0        ! 0=anisotropic vertical/horizontal diffusion coeffs, 1=isotropic
+ mix_upper_bound(max_dom)            = 0.1      ! non-dimensional upper limit for diffusion coeffs
+ tke_drag_coefficient(max_dom)       = 0.,      ! surface drag coefficient (Cd, dimensionless) for diff_opt=2 only
+ tke_heat_flux(max_dom)              = 0.,      ! surface thermal flux (H/(rho*cp), K m/s) for diff_opt=2 only
+ h_mom_adv_order (max_dom)           = 5,       ! horizontal momentum advection order (5=5th, etc.)
+ v_mom_adv_order (max_dom)           = 3,       ! vertical momentum advection order
+ h_sca_adv_order (max_dom)           = 5,       ! horizontal scalar advection order
+ v_sca_adv_order (max_dom)           = 3,       ! vertical scalar advection order
+
+ momentum_adv_opt(max_dom)           = 1,       ! advection options for momentum variables: 
+                                                  1=original, 3 = 5th-order WENO
+                                                  advection options for scalar variables: 0=simple, 1=positive definite,
+                                                  2=monotonic, 3=5th order WENO, 4=5th-order WENO with positive definite filter
+ moist_adv_opt (max_dom)             = 1        ! for moisture
+ moist_adv_dfi_opt (max_dom)         = 0        ! positive-definite RK3 transport switch. Default is 0=off
+ scalar_adv_opt (max_dom)            = 1        ! for scalars
+ chem_adv_opt (max_dom)              = 1        ! for chem variables
+ tracer_adv_opt (max_dom)            = 1        ! for tracer variables (WRF-Chem activated)
+ tke_adv_opt (max_dom)               = 1        ! for tke
+ moist_mix2_off (max_dom)            = .false.  ! if set to T, deactivate 2nd-order horizontal mixing for moisture. default is F.
+ chem_mix2_off (max_dom)             = .false.  ! if set to T, deactivate 2nd-order horizontal mixing for chem species. default is F.
+ tracer_mix2_off (max_dom)           = .false.  ! if set to T, deactivate 2nd-order horizontal mixing for tracers. default is F. 
+ scalar_mix2_off (max_dom)           = .false.  ! if set to T, deactivate 2nd-order horizontal mixing for scalars. default is F.
+ tke_mix2_off (max_dom)              = .false.  ! if set to T, deactivate 2nd-order horizontal mixing for tke. default is F.
+ moist_mix6_off (max_dom)            = .false.  ! if set to T, deactivate 6th-order horizontal mixing for moisture. default is F.
+ chem_mix6_off (max_dom)             = .false.  ! if set to T, deactivate 6th-order horizontal mixing for chem species. default is F.
+ tracer_mix6_off (max_dom)           = .false.  ! if set to T, deactivate 6th-order horizontal mixing for tracers. default is F.
+ scalar_mix6_off (max_dom)           = .false.  ! if set to T, deactivate 6th-order horizontal mixing for scalars. default is F.
+ tke_mix6_off (max_dom)              = .false.  ! if set to T, deactivate 6th-order horizontal mixing for tke. default is F.
+
+
+ time_step_sound (max_dom)           = 4 /	! number of sound steps per time-step (0=set automatically)
+                                                  (if using a time_step much larger than 6*dx (in km),
+                                                  proportionally increase number of sound steps - also
+                                                  best to use even numbers)
+ do_avgflx_em (max_dom)               = 0,       ! whether to output time-averaged mass-coupled advective velocities
+                                                  0 = no (default)
+                                                  1 = yes
+ do_avgflx_cugd (max_dom)             = 0,       ! whether to output time-averaged convective mass-fluxes from Grell-Devenyi ensemble scheme
+                                                  0 = no (default)
+                                                  1 = yes (only takes effect if do_avgflx_em=1 and cu_physics= 93
+ do_coriolis (max_dom)               = .true.,	! whether to do Coriolis calculations (idealized) (inactive)
+ do_curvature (max_dom)              = .true.,	! whether to do curvature calculations (idealized) (inactive)
+ do_gradp (max_dom)                  = .true.,	! whether to do horizontal pressure gradient calculations (idealized) (inactive)
+ fft_filter_lat                      = 91.      ! the latitude above which the polar filter is turned on (degrees) - 45 degrees is a 
+                                                  reasonable latitude to start using polar filters
+ coupled_filtering                   = .true.   ! T/F mu coupled scalar arrays are run through the polar filters
+ pos_def                             = .false.  ! T/F remove negative values of scalar arrays by setting minimum value to zero
+ swap_pole_with_next_j               = .false.  ! T/F replace the entire j=1 (jds-1) with the values from j=2 (jds-2)
+ actual_distance_average             = .false.  ! T/F average the field at each i location in the j-loop with a number of grid points based on a map-factor ratio
+ gwd_opt                             = 0       ! for running without gravity wave drag
+                                     = 1       ; for running the WRF-ARW with its gravity wave drag
+                                     = 2       ; for running the WRF-NMM with its gravity wave drag
+ sfs_opt (max_dom)                   = 0       ! nonlinear backscatter and anisotropy (NBA) off
+                                     = 1       ! NBA1 using diagnostic stress terms (km_opt=2,3 for scalars)
+                                     = 2       ! NBA2 using tke-based stress terms (km_opt=2 needed)
+ m_opt (max_dom)                     = 0       ! no added output
+                                     = 1       ! adds output of Mij stress terms when NBA is not used
+ tracer_opt(max_dom)                 = 0       ! 
+
+ &bdy_control
+ spec_bdy_width                      = 5,       ! total number of rows for specified boundary value nudging
+ spec_zone                           = 1,       ! number of points in specified zone (spec b.c. option)
+ relax_zone                          = 4,       ! number of points in relaxation zone (spec b.c. option)
+ specified (max_dom)                 = .false., ! specified boundary conditions (only can be used for domain 1)
+                                                  the above 4 are used for real-data runs
+ spec_exp                            = 0.       ! exponential multiplier for relaxation zone ramp for specified=.t.
+                                                  (0.=linear ramp default, e.g. 0.33=~3*dx exp decay factor)
+ constant_bc                         = .false.  ! constant boundary condition used with DFI
+ spec_bdy_final_mu                   = 1,       ! whether to call spec_bdy_final for mu (this may cause different restart results in V3.8): 
+                                                  = 0, no call; = 1: call (this may cause different restart results)
+
+ periodic_x (max_dom)                = .false., ! periodic boundary conditions in x direction
+ symmetric_xs (max_dom)              = .false., ! symmetric boundary conditions at x start (west)
+ symmetric_xe (max_dom)              = .false., ! symmetric boundary conditions at x end (east)
+ open_xs (max_dom)                   = .false., ! open boundary conditions at x start (west)
+ open_xe (max_dom)                   = .false., ! open boundary conditions at x end (east)
+ periodic_y (max_dom)                = .false., ! periodic boundary conditions in y direction
+ symmetric_ys (max_dom)              = .false., ! symmetric boundary conditions at y start (south)
+ symmetric_ye (max_dom)              = .false., ! symmetric boundary conditions at y end (north)
+ open_ys (max_dom)                   = .false., ! open boundary conditions at y start (south)
+ open_ye (max_dom)                   = .false., ! open boundary conditions at y end (north)
+ nested (max_dom)                    = .false., ! nested boundary conditions (must be used for nests)
+ polar (max_dom)                     = .false., ! polar boundary condition
+                                                  (v=0 at polarward-most v-point)
+ have_bcs_moist (max_dom)            = .false., ! model run after ndown only: do not use microphysics variables in bdy file
+                                     = .true. , ! use microphysics variables in bdy file
+ have_bcs_scalar (max_dom)           = .false., ! model run after ndown only: do not use scalar variables in bdy file
+                                     = .true. , ! use scalar variables in bdy file
+
+ euler_adv                           = .false., ! conservative Eulerian passive advection (NMM only)
+ idtadt                              = 1,       ! fundamental timesteps between calls to Euler advection, dynamics (NMM only)
+ idtadc                              = 1        ! fundamental timesteps between calls to Euler advection, chemistry (NMM only)
+
+ &ideal
+ ideal_case                          = 0        ! ideal case number. Option selects CASEs within module_initialize_ideal.F
+                                                  realcase       ideal_case=0
+                                                  hill2d_x       ideal_case=1
+                                                  quarter_ss     ideal_case=2
+                                                  convrad        ideal_case=3
+                                                  squall2d_x     ideal_case=4
+                                                  squall2d_y     ideal_case=5
+                                                  grav2d_x       ideal_case=6
+                                                  b_wave         ideal_case=7
+                                                  seabreeze2d_x  ideal_case=8
+                                                  les            ideal_case=9
+
+ &tc                                            ; controls for tc_em.exe ONLY, no impact on real, ndown, or model
+
+ insert_bogus_storm                  = .false.  ! T/F for inserting a bogus tropical storm (TC)
+ remove_storm                        = .false.  ! T/F for only removing the original TC
+ num_storm                           = 1        ! Number of bogus TC
+ latc_loc                            = -999.    ! center latitude of the bogus TC
+ lonc_loc                            = -999.    ! center longitude of the bogus TC
+ vmax_meters_per_second(max_bogus)   = -999.    ! vmax of bogus storm in meters per second
+ rmax                                = -999.    ! maximum radius outward from storm center
+ vmax_ratio(max_bogus)               = -999.    ! ratio for representative maximum winds, 0.75 for 45 km grid, and 
+                                                  0.9 for 15 km grid.
+ rankine_lid                         = -999.    ! top pressure limit for the tc bogus scheme
+
+ &namelist_quilt    This namelist record controls asynchronized I/O for MPI applications. 
+
+ nio_tasks_per_group                 = 0,       ! default value is 0: no quilting; > 0 quilting I/O
+ nio_groups                          = 1,       ! default 1. May be set to higher value for nesting IO 
+                                                  or history and restart IO
+
+
+ &grib2:
+ background_proc_id                  = 255,	! Background generating process identifier, typically defined
+                                                  by the originating center to identify the background data that
+                                                  was used in creating the data. This is octet 13 of Section 4 
+                                                  in the grib2 message
+ forecast_proc_id                    = 255,	! Analysis or generating forecast process identifier, typically
+                                                  defined by the originating center to identify the forecast process
+                                                  that was used to generate the data. This is octet 14 of Section
+                                                  4 in the grib2 message
+ production_status                   = 255,     ! Production status of processed data in the grib2 message. 
+                                                  See Code Table 1.3 of the grib2 manual. This is octet 20 of
+                                                  Section 1 in the grib2 record
+ compression                         = 40,      ! The compression method to encode the output grib2 message.
+                                                  Only 40 for jpeg2000 or 41 for PNG are supported
+
+
+By default the pressure and height level data goes into stream 23 and 22, respectively. Using
+the vertical interpolation options requires the user to define an io_form and interval for
+the requested stream.  See examples.namelist.
+
+ &diags:
+ p_lev_diags                         = 1,       ! Vertically interpolate diagnostics to p-levels
+                                                  0=NO, 1=YES
+ num_press_levels                    = 0,       ! Number of pressure levels to interpolate to, for example,
+                                                  could be 2
+ press_levels                        = 0,       ! Which pressure levels (Pa) to interpolate to, for example
+                                                  could be 85000, 70000
+ use_tot_or_hyd_p                    = 2        ! Which half level pressure to use: 1=total (p+pb); 2=hydrostatic
+                                                  (p_hyd).  The p_hyd option is the default and less noisy.  Total
+                                                  pressure is consistent with what is done in various post-proc
+                                                  packages.
+ z_lev_diags                         = 0,       ! Vertically interpolate diagnostics to z-levels
+                                                  0=NO, 1=YES
+ num_z_levels                        = 2,       ! Number of height levels to interpolate to
+ z_levels                            = 0,       ! List of height values (m) to interpolate data to. 
+                                                  Positive numbers are for height above mean sea level (i.e. a flight level)
+                                                  Negative numbers are for levels above ground
+ /
+
+AFWA diagnostics:
+&afwa
+afwa_diag_opt (max_dom)              = 0,       ! AFWA Diagnostic option, 1: on
+afwa_ptype_opt (max_dom)             = 0,       ! Precip type option, 1: on
+afwa_vil_opt (max_dom)               = 0,       ! Vert Int Liquid option, 1: on
+afwa_radar_opt (max_dom)             = 0,       ! Radar option, 1: on
+afwa_severe_opt (max_dom)            = 0,       ! Severe Wx option, 1: on
+afwa_icing_opt (max_dom)             = 0,       ! Icing option, 1: on
+afwa_vis_opt (max_dom)               = 0,       ! Visibility option, 1: on
+afwa_cloud_opt (max_dom)             = 0,       ! Cloud option, 1: on
+afwa_therm_opt (max_dom)             = 0,       ! Thermal indices option, 1: on
+afwa_turb_opt (max_dom)              = 0,       ! Turbulence option, 1: on
+afwa_buoy_opt (max_dom)              = 0,       ! Buoyancy option, 1: on
+afwa_ptype_ccn_tmp                   = 264.15,  ! CCN temperature for precipitation type calculation
+afwa_ptype_tot_melt                  = 50,      ! Total melting energy for precipitation type calculation
+
+
+
+
+Add an extra set of 3d arrays for vertical interpolation to the
+processing for the real program.  Typically, this extra data set
+is to include monthly aerosol data.  The vertical coordinate of the
+aerosol data is able to be separate from the input meteorological
+data.  To introduce new data sets, mods are required in the Registry
+and in module_initialize_real.F.  There is a space-holder/practice
+set-up for "GCA".  The actual data set for Thompson mp=28 (WIF) that 
+utilizes QNWFA and QNIFA (water and ice friendly aerosols) has 
+been tested.
+
+&domains
+ num_wif_levels                      = 30    
+ wif_input_opt                       = 1
+/
+ num_gca_levels                      = 13    
+ gca_input_opt                       = 1     
+
+
+Introduction of physics suite specification since v3.9:
+
+Starting with V3.9, there is a way to specify physics suite to use in the model. The physics suite
+specifies physics options 
+
+ mp_physics
+ cu_physics
+ ra_lw_physics
+ ra_sw_physics
+ bl_pbl_physics
+ sf_sfclay_physics
+ sf_surface_physics
+
+with a new namelist physics_suite = 'X'. Two suites are available in V3.9:
+
+ physics_suite = 'CONUS'
+
+ or 
+
+ physics_suite = 'tropical'
+
+where 'CONUS' is equivalent to
+
+ mp_physics         = 8,
+ cu_physics         = 6,
+ ra_lw_physics      = 4,
+ ra_sw_physics      = 4,
+ bl_pbl_physics     = 2,
+ sf_sfclay_physics  = 2,
+ sf_surface_physics = 2,
+
+and 'tropical' is equivalent to
+
+ mp_physics         = 6,
+ cu_physics         = 16,
+ ra_lw_physics      = 4,
+ ra_sw_physics      = 4,
+ bl_pbl_physics     = 1,
+ sf_sfclay_physics  = 91,
+ sf_surface_physics = 2,
+
+One can use physics_suite, and overwrite one or more options by explicitly including the physics 
+namelists.
+
+To overwrite an option for a nest, one can have
+
+ &physics
+ physics_suite                       = 'tropical'
+ cu_physics                          = -1,    -1,     0,
+ ...
+
+here '-1' means to use option specified by the suite, and '0' modifies the cumulus option from the 
+suite option 16 to 0 (turning cumulus off).
+
+
+Hybrid Vertical Coordinate (HVC) vs Terrain Following (TF)
+
+1. To turn ON the HVC
+&dynamics
+ hybrid_opt         = 2,
+
+2. To turn OFF the HVC
+&dynamics
+ hybrid_opt         = 0,
+
+
+
+Traditional / full fields model output
+
+The ARW WRF model output may be modified at run-time to also include a stream that contains
+more traditional fields: temperature, pressure, geopotential height, etc. The flag needs to 
+be activated in the namelist (diag_nwp2 = 1). In the registry.trad_fields, the output stream 
+is "h1", so that stream needs to be explicitly requested in the namelist.input file.
+
+ &diags
+ diag_nwp2 = 1
+ /
+
+ &time_control
+ io_form_auxhist1                    = 2
+ auxhist1_interval                   = 180,  30,   30,
+ frames_per_auxhist1                 = 1,     1,    1,
+ auxhist1_outname                    = "wrf_trad_fields_d<domain>_<date>"
+ /
+

--- a/run/namelist.input
+++ b/run/namelist.input
@@ -62,6 +62,9 @@
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  lightning_option                    = 4,     4,     4,
+ coul_pos = 0.000025, 0.000025,0.000025,
+ coul_neg = 0.000025, 0.000025,0.000025,
+ coul_neu = 0.000025, 0.000025,0.000025,
  /
 
  &fdda

--- a/run/namelist.input
+++ b/run/namelist.input
@@ -1,0 +1,100 @@
+ &time_control
+ run_days                            = 0,
+ run_hours                           = 12,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2000, 2000, 2000,
+ start_month                         = 01,   01,   01,
+ start_day                           = 24,   24,   24,
+ start_hour                          = 12,   12,   12,
+ end_year                            = 2000, 2000, 2000,
+ end_month                           = 01,   01,   01,
+ end_day                             = 25,   25,   25,
+ end_hour                            = 12,   12,   12,
+ interval_seconds                    = 21600
+ input_from_file                     = .true.,.true.,.true.,
+ history_interval                    = 180,  60,   60,
+ frames_per_outfile                  = 1000, 1000, 1000,
+ restart                             = .false.,
+ restart_interval                    = 7200,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ /
+
+ &domains
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 1,
+ e_we                                = 74,    112,   94,
+ e_sn                                = 61,    97,    91,
+ e_vert                              = 33,    33,    33,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 32,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     31,    30,
+ j_parent_start                      = 1,     17,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ physics_suite                       = 'CONUS'
+ mp_physics                          = -1,    -1,    -1,
+ cu_physics                          = -1,    -1,     0,
+ ra_lw_physics                       = -1,    -1,    -1,
+ ra_sw_physics                       = -1,    -1,    -1,
+ bl_pbl_physics                      = -1,    -1,    -1,
+ sf_sfclay_physics                   = -1,    -1,    -1,
+ sf_surface_physics                  = -1,    -1,    -1,
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ icloud                              = 1,
+ num_land_cat                        = 21,
+ sf_urban_physics                    = 0,     0,     0,
+ lightning_option                    = 4,     4,     4,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ hybrid_opt                          = 2, 
+ w_damping                           = 0,
+ diff_opt                            = 1,      1,      1,
+ km_opt                              = 4,      4,      4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 3,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,     
+ gwd_opt                             = 1,
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ specified                           = .true.
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/test/em_real/README.namelist
+++ b/test/em_real/README.namelist
@@ -1,0 +1,1 @@
+../../run/README.namelist


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: lightning

SOURCE: Barry Lynn (Weather It Is, LTD; barry.h.lynn@gmail.com)

DESCRIPTION OF CHANGES: 
The Dynamic Lightning Scheme forecasts cloud-to-ground (+/-) and Intra-cloud lightning. 
It also outputs the "Electric Potential Energy" as 4-D variable. The program requires calls to two subroutines, phys/module_ltng_pe.F and phys/module_ltng_strokes.F.  The program needs to be run with a microphysical scheme that forecasts both liquid water, small ice, snow, and graupel. Hail is not included because it is not clear that hail (wet-hail) contributes to charging.  The scheme can be run with any grid-spacing, but it is designed for grid-spacings of 4 km (convection-allowing) or smaller. It was originally designed for 4 km grid spacing, but a factor term was added to reduce the required threshold for lightning to occur after the buildup of electric potential energy (reducing the threshold for smaller grid-spacings).  Please see the comment in README.namelist about modifying coul_pos, coul_neg, and coul_neu, which are charging constants set by the user. 

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
A       Registry/Registry.EM_COMMON_add (not needed)
A       branch_check.file
M       dyn_em/module_after_all_rk_steps.F
M       phys/Makefile
M       phys/module_diagnostics_driver.F
M       phys/module_lightning_driver.F
A       phys/module_ltng_pe.F
A       phys/module_ltng_strokes.F
A       phys/my_test.file
M       run/README.namelist
A       run/README.namelist_add (not needed)
A       run/namelist.input
A       test/em_real/README.namelist

TESTS CONDUCTED: 
Checked that the model produced reasonable lightning values. 

RELEASE NOTE: Predicting Cloud-to-Ground and Intracloud Lightning in Weather Forecast Models. Barry Lynn,  Yoav Yair, Colin Price, Guy Kelman, and Adam Clark
https://journals.ametsoc.org/doi/full/10.1175/WAF-D-11-00144.1
