### PR TITLE
Fixing sms_3dtke km_opt=5 which breaks km_opt=2

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2915,7 +2915,10 @@ package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
 
 #SMS-3DTKE
-package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+#jm deleting from package sms_3dtke variables used elsewhere
+# l_scale 
+package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+#package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 
 # dfi
 package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2915,7 +2915,7 @@ package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
 
 #SMS-3DTKE
-#jm package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 
 # dfi
 package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2918,7 +2918,8 @@ package   pbl_cloud      icloud_bl==1                -             state:cldfra_
 #jm deleting from package sms_3dtke variables used elsewhere
 # l_scale
 # th_h_tend
-package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+# tke_diffusion_h_tend
+package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_z_tend
 #package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 
 # dfi

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2915,7 +2915,7 @@ package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
 
 #SMS-3DTKE
-package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+#jm package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 
 # dfi
 package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2916,8 +2916,9 @@ package   pbl_cloud      icloud_bl==1                -             state:cldfra_
 
 #SMS-3DTKE
 #jm deleting from package sms_3dtke variables used elsewhere
-# l_scale 
-package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+# l_scale
+# th_h_tend
+package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 #package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 
 # dfi

--- a/phys/module_fr_fire_util.F
+++ b/phys/module_fr_fire_util.F
@@ -1361,9 +1361,9 @@ character(len=256)msg
 
 if(fire_print_msg.le.0)return
 
-ipe1=ifval(ipe.eq.ide.and.istag.ne.0,ipe+1,ipe)
-kpe1=ifval(kpe.eq.kde.and.kstag.ne.0,kpe+1,kpe)
-jpe1=ifval(jpe.eq.jde.and.jstag.ne.0,jpe+1,jpe)
+ipe1=min(ime,ifval(ipe.eq.ide.and.istag.ne.0,ipe+1,ipe))
+kpe1=min(kme,ifval(kpe.eq.kde.and.kstag.ne.0,kpe+1,kpe))
+jpe1=min(jme,ifval(jpe.eq.jde.and.jstag.ne.0,jpe+1,jpe))
 is=ifval(istag.ne.0,1,0)
 ks=ifval(kstag.ne.0,1,0)
 js=ifval(jstag.ne.0,1,0)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: 3DTKE, Fire

SOURCE: Jan Mandel

DESCRIPTION OF CHANGES:

Removed variables  l_scale, th_h_tend, and tke_diffusion_h_tend included in registry package sms_3dtke for km_opt=5 which are used outside of km_opt=5 but should not be and broke km_opt=2. 

When running with bound checks  on, I also found and fixed an index overrun in vertical staggering I originally made in https://github.com/openwfm/WRF-Fire-merge/commit/be6d402373151a5f66d7757bc6321a984c63fc99  The memory allocated in the vertical grid direction is by one one less than what I thought. The fix is, do not allow the index exceed the end memory index.

LIST OF MODIFIED FILES: 
Registry/Registry.EM_COMMON | 7 ++++++-
 phys/module_fr_fire_util.F  | 6 +++---


TESTS CONDUCTED: Jenkins, test/em_fire/two_fires serial (build option 13) only 

RELEASE NOTE: 

Symptoms: /compile em_fire; cd test/em_fire/two_fires; ./ideal.exe; ./wrf.exe failed with error message FIRE:crash: NaN detected

Tested with 
-fpe0 -check noarg_temp_created,bounds,format,output_conversion,pointers,uninit -ftrapuv -unroll0 -u
uncommened in configure.wrf

It is possible that more variables need to be removed from sms_3dtke for other values of km_opt.