### PR TITLE
SMS3dTKE: Remove broken packaging for km_opt=5

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2915,7 +2915,8 @@ package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
 
 #SMS-3DTKE
-package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+#package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
+package   sms_3dtke      km_opt==5                   -             -
 
 # dfi
 package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2914,7 +2914,6 @@ package   mynn_tkebudget bl_mynn_tkebudget==1        -             state:qSHEAR,
 package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,ktop_shallow,maxmf,nupdraft
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
 
-#SMS-3DTKE
 #package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 package   sms_3dtke      km_opt==5                   -             -
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: packaging, sms3dtke

SOURCE: Internal

DESCRIPTION OF CHANGES:

The existing packaging in combination with the logic added in the
code for PR #972 (Add a scale-adaptive 3DTKE parameterization scheme as a subgrid 
mixing option) d059afe1e646f7 causes segmentation faults for most model
simulations that use km_opt=2.

The packaging is important, but we have a broken repository. The
packaging will be removed, developers will fix the problem, and
then put the packaging back into the Registry file for this option.

Jan Mandel states:
> "found that l_scale, th_h_tend, and tke_diffusion_h_tend made my km_opt=2 test case fail, 
and with them removed from the package it did not fail. But I do not know if sms_3dtke even 
with the packaging removed does not break something in a different way."

Perhaps these are the variables to start the seg fault investigation to re-introduce 
packaging for this option.

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON

TESTS CONDUCTED:
 - [x] With original packaging, all tests with km_opt=2 failed
 - [x] With mods (removing km_opt=5 packaging), km_opt=2 and km_opt=5 tests pass