### PR TITLE
Add missing "IF km_opt==5" tests for diag computations

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -3344,7 +3344,7 @@ SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
    ENDDO
 
 ! XZ
-   IF (output_tend) THEN
+   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
       DO j = j_start, j_end
       DO k = kts,ktf
       DO i = i_start, i_end
@@ -3564,7 +3564,7 @@ SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
    ENDDO
 
 ! XZ
-   IF (output_tend) THEN
+   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
       DO j = j_start, j_end
       DO k = kts,ktf
       DO i = i_start, i_end
@@ -3783,7 +3783,7 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
    ENDDO
 
 ! XZ
-   IF (output_tend) THEN
+   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
       DO j = j_start, j_end
       DO k = kts+1,ktf
       DO i = i_start, i_end
@@ -3885,7 +3885,7 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags,                &
    INTEGER :: ktes1,ktes2
 !XZ
    LOGICAL :: output_tend  
-   output_tend = .true.  
+   output_tend = .false.  
 !
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -4092,7 +4092,7 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags,                &
    ENDDO
 
 ! XZ
-   IF (output_tend) THEN
+   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
       DO j = j_start, j_end
       DO k = kts,ktf
       DO i = i_start, i_end
@@ -4124,7 +4124,7 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags,                &
    ENDIF
 
 ! XZ
-   IF(output_tend) THEN
+   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
       IF ( doing_tke ) THEN
        DO j = j_start, j_end
        DO k = kts,ktf


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: sms3dtke, km_opt==5

SOURCE: Internal

DESCRIPTION OF CHANGES:
Each location where the optional diagnostics for km_opt==5 are computed,
instead of only using a local IF test, now a combination of the same local
IF test (T/F do the computation) is used in conjunction with and a test
for if the diagnostic is permitted (is km_opt==5).

The km_opt==5 scheme originally had (and hopefully, will eventually again have) 
specified arrays via the package capability in the Registry. Those fields need to be 
protected from accidental use when km_opt==2.

LIST OF MODIFIED FILES:
modified:   dyn_em/module_diffusion_em.F

TESTS CONDUCTED:
 - [x] Without mods, there are attempts to compute km_opt==5 diags when km_opt==2.
 - [x] With mods, no attempts to compute km_opt==5 diags when km_opt==2.