### PR TITLE
Fire: fix vert index for half-levels

### DIFF
--- a/phys/module_fr_fire_util.F
+++ b/phys/module_fr_fire_util.F
@@ -1370,7 +1370,7 @@ js=ifval(jstag.ne.0,1,0)
 
 lsum=0
 do j=jps,jpe1
-  do k=kps,kpe1
+  do k=kps,kpe1-1
     do i=ips,ipe1
       rel=a(i,k,j)
       lsum=ieor(lsum,iel)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: fire, bounds check, vertical index

SOURCE: Internal

DESCRIPTION OF CHANGES:
A bounds check indicated a half-level variable was accessed with
the vertical index at the top full-level. Only a single array is
in the DO loop. The vertical index is reduced by one.

LIST OF MODIFIED FILES:
modified:   phys/module_fr_fire_util.F

TESTS CONDUCTED:
 - [x] Without mod, the WRF Fire code built with bounds checking activated
throws an error.
 - [x] With mod, the WRF Fire code built with bounds checking activated
completes the simulation without any troubles.