### PR TITLE
Add WSM7 and WDM7 to README.namelist

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -508,6 +508,8 @@ Namelist variables for controlling the adaptive time step option:
                                        nssl_rho_qh  = 500.  ! graupel density
                                        nssl_rho_qhl = 900.  ! hail density
                                        nssl_rho_qs  = 100.  ! snow density
+                                     = 24, WSM 7-class scheme (separate hail and graupel categories)
+                                     = 26, WDM 7-class scheme (separate hail and graupel categories)
                                      = 28, aerosol-aware Thompson scheme with water- and ice-friendly aerosol climatology 
                                            (new for V3.6)
                                        This option has two climatological aerosol input options:


### PR DESCRIPTION
TYPE: text only

KEYWORDS: WSM7, WDM7, README

SOURCE: internal

DESCRIPTION OF CHANGES: 
Microphysics options WSM7 and WDM7 were introduced in 4.1, but not added to README.namelist file. This PR adds them.

LIST OF MODIFIED FILES: 
M   run/README.namelist

TESTS CONDUCTED: 
No test needed.

RELEASE NOTE: 