### PR TITLE
Fixing the problem that km_opt=5 package breaks km_opt=2

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -342,15 +342,12 @@ state    real  nlflux          ikj     dyn_em        1         Z      -      "NL
 state    real  gamu            ij      dyn_em        1         -      r      "GAMU"            "NONLOCAL U GAMMA TERM IN 3DTKE SCHEME"         "s-1"
 state    real  gamv            ij      dyn_em        1         -      r      "GAMV"            "NONLOCAL V GAMMA TERM IN 3DTKE SCHEME"         "s-1"
 state    real  dlk             ikj     dyn_em        1         -      -      "DLK"             "TURBULENT LENGTH SCALE"     "m"
-state    real  l_scale         ikj     dyn_em        1         -      -      "L_SCALE"         "DISSIPATION LENGTH SCALE"   "m"
+state    real  l_diss          ikj     dyn_em        1         -      -      "L_DISS"          "DISSIPATION LENGTH SCALE"   "m"
 state    real  elmin           ikj     dyn_em        1         -      -      "ELMIN"           "FREE ATMOS LENGTH SCALE (FROM BOULAC SCHEME)"  "m"
 state    real  xkmv_meso       ikj     dyn_em        1         -      -      "XKMV_MESO"       "XKMV AT MESOSCALE LIMIT"    "m2 s-1"
 state    real  xkmh_t          ikj     dyn_em        1         -      -      "XKMH_T"          "HORIZONTAL DIFFUSIVITY BASED ON 1.5-ORDER TKE" "m2 s-1"
-state    real  U_H_TEND        ikj     dyn_em        1         X      -      "U_H_TEND"        "X WIND HORIZONTAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
 state    real  U_Z_TEND        ikj     dyn_em        1         X      -      "U_Z_TEND"        "X WIND VERTICAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
-state    real  V_H_TEND        ikj     dyn_em        1         Y      -      "V_H_TEND"        "Y WIND HORIZONTAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
 state    real  V_Z_TEND        ikj     dyn_em        1         Y      -      "V_Z_TEND"        "Y WIND VERTICAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
-state    real  W_H_TEND        ikj     dyn_em        1         Z      -      "W_H_TEND"        "W WIND HORIZONTAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
 state    real  W_Z_TEND        ikj     dyn_em        1         Z      -      "W_Z_TEND"        "W WIND VERTICAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
 state    real  TH_H_TEND       ikj     dyn_em        1         -      -      "TH_H_TEND"       "TH HORIZONTAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
 state    real  TH_Z_TEND       ikj     dyn_em        1         -      -      "TH_Z_TEND"       "TH VERTICAL TENDENCY IN 3DTKE SCHEME"  "m s-2"
@@ -2914,8 +2911,7 @@ package   mynn_tkebudget bl_mynn_tkebudget==1        -             state:qSHEAR,
 package   mynn_dmp_edmf  bl_mynn_edmf==1            -              state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,ktop_shallow,maxmf,nupdraft
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl
 
-#package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_scale,elmin,xkmv_meso,xkmh_t,u_h_tend,u_z_tend,v_h_tend,v_z_tend,w_h_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
-package   sms_3dtke      km_opt==5                   -             -
+package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_diss,elmin,xkmv_meso,xkmh_t,u_z_tend,v_z_tend,w_z_tend,th_h_tend,th_z_tend,tke_buoy_tend,tke_shear_tend,tke_production_tend,tke_diffusion_h_tend,tke_diffusion_z_tend
 
 # dfi
 package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2869,7 +2869,7 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                     msftx, msfty, xkmh, xkhh,km_opt,           &
                                     rdx, rdy, rdz, rdzw, fnm, fnp,             &
                                     cf1, cf2, cf3, zx, zy, dn, dnw, rho,       &
-                                    th_h_tend, tke_diffusion_h_tend,           & ! XZ
+                                    th_h_tend, tke_diffusion_h_tend,           &
                                     ids, ide, jds, jde, kds, kde,              &
                                     ims, ime, jms, jme, kms, kme,              &
                                     its, ite, jts, jte, kts, kte               )

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2111,7 +2111,7 @@ END SUBROUTINE smag2d_km
 !
 ! Local variables.
 
-    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )  &   !XZ
+    REAL, DIMENSION( its:ite, kts:kte, jts:jte )  &  
     :: l_scale
 
     REAL, DIMENSION( its:ite, kts:kte, jts:jte )  &
@@ -2360,7 +2360,7 @@ END SUBROUTINE smag2d_km
     REAL, INTENT( IN )  &
     :: dx, dy
 
-    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( OUT )  &  !XZ
+    REAL, DIMENSION( its:ite, kts:kte, jts:jte ), INTENT( OUT )  & 
     :: l_scale
 
     REAL , DIMENSION( ims:ime, jms:jme), INTENT(IN   ) ::     msftx, &
@@ -2869,8 +2869,7 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                     msftx, msfty, xkmh, xkhh,km_opt,           &
                                     rdx, rdy, rdz, rdzw, fnm, fnp,             &
                                     cf1, cf2, cf3, zx, zy, dn, dnw, rho,       &
-                                    u_h_tend,v_h_tend,w_h_tend,th_h_tend,      & ! XZ
-                                    tke_diffusion_h_tend,                      & ! XZ
+                                    th_h_tend, tke_diffusion_h_tend,           & ! XZ
                                     ids, ide, jds, jde, kds, kde,              &
                                     ims, ime, jms, jme, kms, kme,              &
                                     its, ite, jts, jte, kts, kte               )
@@ -2909,9 +2908,6 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                                                 tke_tendf
 ! XZ
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) ::th_h_tend,&
-                                                                  u_h_tend,&
-                                                                  v_h_tend,&
-                                                                  w_h_tend,&
                                                       tke_diffusion_h_tend
 !
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme, n_moist),                 &
@@ -2989,7 +2985,6 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
 ! Call diffusion subroutines.
 
     CALL horizontal_diffusion_u_2( ru_tendf, config_flags,                 &
-                                   u_h_tend,                               &! XZ
                                    defor11, defor12, div,                  &
                                    nba_mij, n_nba_mij,                     &
                                    tke(ims,kms,jms),                       &
@@ -3000,7 +2995,6 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                    its, ite, jts, jte, kts, kte           )
 
     CALL horizontal_diffusion_v_2( rv_tendf, config_flags,                 &
-                                   v_h_tend,                               &! XZ
                                    defor12, defor22, div,                  &
                                    nba_mij, n_nba_mij,                     &
                                    tke(ims,kms,jms),                       &
@@ -3011,7 +3005,6 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                    its, ite, jts, jte, kts, kte           )
 
     CALL horizontal_diffusion_w_2( rw_tendf, config_flags,                 &
-                                   w_h_tend,                               &! XZ
                                    defor13, defor23, div,                  &
                                    nba_mij, n_nba_mij,                     &
                                    tke(ims,kms,jms),                       &
@@ -3137,7 +3130,6 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
 !=======================================================================
 
 SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
-                                     u_h_tend,                            & ! XZ
                                      defor11, defor12, div,               &
                                      nba_mij, n_nba_mij,                  &
                                      tke,                                 &
@@ -3168,7 +3160,6 @@ SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
 
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) ::tendency
 
-   REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) ::u_h_tend ! XZ
 
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(IN   ) ::   rdzw, &
                                                                      rho
@@ -3216,9 +3207,6 @@ SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
 
    REAL :: term1, term2, term3
 
-   LOGICAL :: output_tend  ! XZ
-   
-   output_tend = .false.    ! XZ
 ! End declarations.
 !-----------------------------------------------------------------------
 
@@ -3343,33 +3331,12 @@ SUBROUTINE horizontal_diffusion_u_2( tendency, config_flags,              &
    ENDDO
    ENDDO
 
-! XZ
-   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
-      DO j = j_start, j_end
-      DO k = kts,ktf
-      DO i = i_start, i_end
- 
-         mrdx=msfux(i,j)*rdx
-         mrdy=msfuy(i,j)*rdy
- 
-         tmpdz = (1./rdzw(i,k,j)+1./rdzw(i-1,k,j))/2.
-         u_h_tend(i,k,j) =  g*tmpdz/dnw(k) *                                            &
-              (mrdx*(titau1(i,k,j  ) - titau1(i-1,k,j)) +                               &
-               mrdy*(titau2(i,k,j+1) - titau2(i  ,k,j)) -                               &
-               msfux(i,j)*zx_at_u(i,k,j)*(titau1avg(i,k+1,j)-titau1avg(i,k,j)) /tmpdz - &
-               msfuy(i,j)*zy_at_u(i,k,j)*(titau2avg(i,k+1,j)-titau2avg(i,k,j)) /tmpdz   &
-                                                                  )
-      ENDDO
-      ENDDO
-      ENDDO
-   ENDIF
 END SUBROUTINE horizontal_diffusion_u_2
 
 !=======================================================================
 !=======================================================================
 
 SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
-                                     v_h_tend,                            & ! XZ
                                      defor12, defor22, div,               &           
                                      nba_mij, n_nba_mij,                  &
                                      tke,                                 &
@@ -3399,8 +3366,6 @@ SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
                                                                    msfvy
 
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) :: tendency
-
-   REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) :: v_h_tend ! XZ
 
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(IN   ) ::defor12, &
                                                                  defor22, &
@@ -3442,8 +3407,6 @@ SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
    REAL :: mrdx, mrdy, rcoup
    REAL :: tmpdz
    REAL :: tmpzx, tmpzeta_z
-   LOGICAL :: output_tend  ! XZ
-   output_tend = .false.    ! XZ
 ! End declarations.
 !-----------------------------------------------------------------------
 
@@ -3563,34 +3526,12 @@ SUBROUTINE horizontal_diffusion_v_2( tendency, config_flags,              &
    ENDDO
    ENDDO
 
-! XZ
-   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
-      DO j = j_start, j_end
-      DO k = kts,ktf
-      DO i = i_start, i_end
- 
-         mrdx=msfvx(i,j)*rdx
-         mrdy=msfvy(i,j)*rdy
-         tmpdz = (1./rdzw(i,k,j)+1./rdzw(i,k,j-1))/2.
-         v_h_tend(i,k,j) =               g*tmpdz/dnw(k) *                                &
-              (mrdy*(titau2(i,k,j  ) - titau2(i,k,j-1)) +                                &
-               mrdx*(titau1(i+1,k,j) - titau1(i  ,k,j)) -                                &
-               msfvx(i,j)*zx_at_v(i,k,j)*(titau1avg(i,k+1,j)-titau1avg(i,k,j)) / tmpdz - &
-               msfvy(i,j)*zy_at_v(i,k,j)*(titau2avg(i,k+1,j)-titau2avg(i,k,j)) / tmpdz   &
-                                                                  )
- 
-      ENDDO
-      ENDDO
-      ENDDO
-   ENDIF
-!
 END SUBROUTINE horizontal_diffusion_v_2
 
 !=======================================================================
 !=======================================================================
 
 SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
-                                     w_h_tend,                            & ! XZ
                                      defor13, defor23, div,               &
                                      nba_mij, n_nba_mij,                  &
                                      tke,                                 &
@@ -3620,8 +3561,6 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
                                                                    msfty
 
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) :: tendency
-
-   REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(INOUT) :: w_h_tend  !XZ
 
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme), INTENT(IN   ) ::defor13, &
                                                                  defor23, &
@@ -3663,9 +3602,6 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
    REAL :: mrdx, mrdy, rcoup
 
    REAL :: tmpzx, tmpzy, tmpzeta_z
-!XZ
-   LOGICAL :: output_tend  
-   output_tend = .false.  
 ! 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -3782,27 +3718,6 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
    ENDDO
    ENDDO
 
-! XZ
-   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
-      DO j = j_start, j_end
-      DO k = kts+1,ktf
-      DO i = i_start, i_end
- 
-          mrdx=msftx(i,j)*rdx
-          mrdy=msfty(i,j)*rdy
- 
-          w_h_tend(i,k,j) =    g/(dn(k)*rdz(i,k,j)) *                                        &
-               (mrdx*(titau1(i+1,k,j)-titau1(i,k,j))+                                        &
-                mrdy*(titau2(i,k,j+1)-titau2(i,k,j))-                                        &
-                msfty(i,j)*rdz(i,k,j)*(zx_at_w(i,k,j)*(titau1avg(i,k,j)-titau1avg(i,k-1,j))+ &
-                                       zy_at_w(i,k,j)*(titau2avg(i,k,j)-titau2avg(i,k-1,j))  &
-                                      )                                                      &
-                )
-      ENDDO
-      ENDDO
-      ENDDO
-   ENDIF
-!
 END SUBROUTINE horizontal_diffusion_w_2
 
 !=======================================================================
@@ -3883,9 +3798,6 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags,                &
    REAL    :: mrdx, mrdy, rcoup
    REAL    :: tmpzx, tmpzy, tmpzeta_z, rdzu, rdzv
    INTEGER :: ktes1,ktes2
-!XZ
-   LOGICAL :: output_tend  
-   output_tend = .false.  
 !
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -4092,7 +4004,7 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags,                &
    ENDDO
 
 ! XZ
-   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
+   IF ( config_flags%km_opt .EQ. 5 ) THEN
       DO j = j_start, j_end
       DO k = kts,ktf
       DO i = i_start, i_end
@@ -4124,7 +4036,7 @@ SUBROUTINE horizontal_diffusion_s (tendency, config_flags,                &
    ENDIF
 
 ! XZ
-   IF ( ( output_tend ) .AND. ( config_flags%km_opt .EQ. 5 ) ) THEN
+   IF ( config_flags%km_opt .EQ. 5 ) THEN
       IF ( doing_tke ) THEN
        DO j = j_start, j_end
        DO k = kts,ktf
@@ -6226,7 +6138,7 @@ END SUBROUTINE phy_bc
                         rdz, rdzw, dn, dnw, isotropic,          &
                         hfx, qfx, qv, ust, rho,                 &
                         tke_production_tend,tke_buoy_tend,      & !XZ
-                        tke_shear_tend,l_scale,                 & !XZ
+                        tke_shear_tend,l_diss,                  & !XZ
                         nlflux, hpbl, dlk,  xkmh_t,             & !XZ
                         ids, ide, jds, jde, kds, kde,           &
                         ims, ime, jms, jme, kms, kme,           &
@@ -6277,7 +6189,7 @@ END SUBROUTINE phy_bc
     :: tke_production_tend, tke_buoy_tend, tke_shear_tend
     
     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( OUT )  &
-    :: l_scale   
+    :: l_diss   
 
     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT ( IN ) &
     :: nlflux, dlk
@@ -6323,7 +6235,7 @@ END SUBROUTINE phy_bc
                        tke, bn2, theta, p8w, t8w, z,          &
                        dx, dy,rdz, rdzw, isotropic,           &
                        msftx, msfty,                          &
-                       hpbl, dlk,  l_scale,                   & ! XZ
+                       hpbl, dlk,  l_diss,                    & ! XZ
                        ids, ide, jds, jde, kds, kde,          &
                        ims, ime, jms, jme, kms, kme,          &
                        its, ite, jts, jte, kts, kte           )
@@ -6552,7 +6464,7 @@ END SUBROUTINE phy_bc
                            tke, bn2, theta, p8w, t8w, z,      &
                            dx, dy, rdz, rdzw, isotropic,      &
                            msftx, msfty,                      &
-                           hpbl, dlk,  l_scale,               & !XZ
+                           hpbl, dlk, l_diss,                 & !XZ
                            ids, ide, jds, jde, kds, kde,      &
                            ims, ime, jms, jme, kms, kme,      &
                            its, ite, jts, jte, kts, kte       )
@@ -6606,15 +6518,15 @@ END SUBROUTINE phy_bc
     :: dlk 
  
     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(OUT) & 
-    :: l_scale
+    :: l_diss
 !
 ! Local variables.
 
     REAL, DIMENSION( its:ite, kts:kte, jts:jte )  &
     :: dthrdn
 
-!    REAL, DIMENSION( its:ite, kts:kte, jts:jte )  &
-!    :: l_scale
+    REAL, DIMENSION( its:ite, kts:kte, jts:jte )  &
+    :: l_scale
 
     REAL, DIMENSION( its:ite )  &
     :: sumtke,  sumtkez
@@ -6679,7 +6591,7 @@ END SUBROUTINE phy_bc
           delxy = SQRT(dx/msftx(i,j)*dy/msfty(i,j))
           pu1 = pu(delxy,hpbl(i,j))
           coefc_m = 0.285 
-          l_scale(i,k,j) = (1.0-pu1)*l_scale(i,k,j)/coefc + pu1*dlk(i,k,j)/coefc_m
+          l_diss(i,k,j) = (1.0-pu1)*l_scale(i,k,j)/coefc + pu1*dlk(i,k,j)/coefc_m
         ELSE 
           tendency(i,k,j) = tendency(i,k,j) - &
                            (c1(k)*mu(i,j)+c2(k)) * coefc * tketmp**1.5 / l_scale(i,k,j)
@@ -7869,7 +7781,7 @@ END SUBROUTINE phy_bc
 !=======================================================================
 !=======================================================================
     SUBROUTINE update_tke_implicit( config_flags,tke_old,               &
-                            tke,xkhv,rdz,rdzw,l_scale,                  &
+                            tke,xkhv,rdz,rdzw,l_diss,                   &
                             dnw, rdnw, c1h, c2h,                        & 
                             tke_adv_h_tend,tke_adv_z_tend,              &
                             tke_production_tend,                        &
@@ -7907,7 +7819,7 @@ END SUBROUTINE phy_bc
 
     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( INOUT ) :: tke, tke_old
 
-    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( IN ) :: l_scale
+    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( IN ) :: l_diss
 
     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( IN ) ::           &
                                                             tke_adv_h_tend, &
@@ -8024,7 +7936,7 @@ END SUBROUTINE phy_bc
              muu = c1h(k)*muold(i,j) + c2h(k)
              rdz_w = -g/(dnw(k)*muu) 
              temp = xkxavg(i,k,j)*dt*rdz_w
-             beta = 1.5*sqrt(tke_old(i,k,j))/l_scale(i,k,j)
+             beta = 1.5*sqrt(tke_old(i,k,j))/l_diss(i,k,j)
  
              a(k) = - 2.0*temp*rdz(i,k,j)  
              b(k) =   1.0 + 2.0*dt*rdz_w*(rdz(i,k,j)*xkxavg(i,k,j)    &
@@ -8034,7 +7946,7 @@ END SUBROUTINE phy_bc
  
              d(k) =  (tke_diffusion_h_tend(i,k,j)+advect_h_tend(i,k,j)+tke_production_tend(i,k,j) + advect_z_tend(i,k,j))*dt  &
                     + muu*tke_old(i,k,j)                              &
-                    + 0.5*dt*muu*tke_old(i,k,j)**1.5/l_scale(i,k,j)
+                    + 0.5*dt*muu*tke_old(i,k,j)**1.5/l_diss(i,k,j)
           ENDDO
  
              a(ktf) = -1. 

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -851,7 +851,7 @@ BENCH_START(tke_rhs_tim)
                          grid%hfx, grid%qfx, moist(ims,kms,jms,P_QV), &
                          grid%ustm, grid%rho,                         &
                          grid%tke_production_tend,grid%tke_buoy_tend, & !XZ
-                         grid%tke_shear_tend, grid%l_scale,           & !XZ
+                         grid%tke_shear_tend, grid%l_diss,            & !XZ
                          grid%nlflux, grid%pblh, grid%dlk,            & !XZ 
                          grid%xkmh_t,                                 & !XZ
                          ids, ide, jds, jde, kds, kde,                &
@@ -1042,7 +1042,6 @@ BENCH_START(hor_diff_tim)
                                       grid%rdx, grid%rdy, grid%rdz, grid%rdzw,                   &
                                       grid%fnm, grid%fnp, grid%cf1, grid%cf2, grid%cf3,          &
                                       grid%zx, grid%zy, grid%dn, grid%dnw, grid%rho,             &
-                                      grid%u_h_tend, grid%v_h_tend, grid%w_h_tend,               & !XZ
                                       grid%th_h_tend, grid%tke_diffusion_h_tend,                 & !XZ
                                       ids, ide, jds, jde, kds, kde,          &
                                       ims, ime, jms, jme, kms, kme,          &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -2373,7 +2373,7 @@ BENCH_START(tke_adv_tim)
          IF(rk_step == rk_order.and.config_flags%km_opt .eq. 5 ) THEN
           CALL update_tke_implicit( config_flags,grid%tke_1,              &
                                     grid%tke_2,grid%xkhv,                 &
-                                    grid%rdz,grid%rdzw,grid%l_scale,      &
+                                    grid%rdz,grid%rdzw,grid%l_diss,       &
                                     grid%dnw,grid%rdnw,grid%c1h,grid%c2h, &
                                     h_tendency,z_tendency,                &
                                     grid%tke_production_tend,             &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: SMS-3DTKE, package 

SOURCE: Xu Zhang (Shanghai Typhoon Institute)

DESCRIPTION OF CHANGES:
1. Redefined the variable "l_scale" using a new name "l_diss", which does not conflict with 
variables used in km_opt=2. 
2. Packaged the variables used in the km_opt=5.
3. Deleted some diagnostic variables "u_h_tend", "v_h_tend", "w_h_tend" that are seldomly used 
by most users, and cleaned up the related code.

LIST OF MODIFIED FILES:
Registry/Registry.EM_COMMON
dyn_em/module_diffusion_em.F
dyn_em/module_first_rk_step_part2.F
dyn_em/solve_em.F

TESTS CONDUCTED:
1. em_fire test with km_opt=2. 
2. em_les tests with km_opt=2 and km_opt=5.