### PR TITLE
Bug fix for calculating effective radius of rain, snow, and graupel

### DIFF
--- a/var/da/da_radiance/da_cld_eff_radius.inc
+++ b/var/da/da_radiance/da_cld_eff_radius.inc
@@ -142,13 +142,13 @@ subroutine da_cld_eff_radius(t,rho,qci,qrn,qsn,qgr,snow,xice,xland,method, &
 !
    piover6 = pi/6.
    if ( qrn > limit ) then
-      lamda_rain = (piover6*rho_w*n0_rain*rho/qrn)**0.25
+      lamda_rain = (piover6*rho_w*n0_rain/(rho*qrn))**0.25
    end if
    if ( qsn > limit ) then
-      lamda_snow = (piover6*rho_snow*n0_snow*rho/qsn)**0.25
+      lamda_snow = (piover6*rho_snow*n0_snow/(rho*qsn))**0.25
    end if
    if ( qgr > limit ) then
-      lamda_grau = (piover6*rho_grau*n0_grau*rho/qgr)**0.25
+      lamda_grau = (piover6*rho_grau*n0_grau/(rho*qgr))**0.25
    end if
    sum1_rain = 0.0
    sum2_rain = 0.0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: effective radius, lamda calculation

SOURCE: Yali Wu (NCAR)

DESCRIPTION OF CHANGES: Subroutine `da_cld_eff_radius` uses exponential distribution for calculating the effective radius of different hydrometeor particles. 

Slope parameters should be calculated following:
```
sqrt(sqrt(piover6*rho_x*n0_x/(rho*qx)))
```
but this was incorrectly typed, so that rho is in the numerator:
```
sqrt(sqrt(piover6*rho_x*n0_x*rho/qx)))
```
where, x denotes rain, snow, and graupel.

LIST OF MODIFIED FILES: 
M       var/da/da_radiance/da_cld_eff_radius.inc

TESTS CONDUCTED: Conducted tests before and after bugfix on Cheyenne. The model simulated MW radiances were slightly improved for a typhoon case, while the simulated IR radiances seemed to have no difference. 

![image](https://user-images.githubusercontent.com/43388239/70094592-148f1380-15e0-11ea-8066-ce8be9de2cb3.png)



