### PR TITLE
sfclayrev fix for divide by zero

### DIFF
--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1119,6 +1119,8 @@ CONTAINS
       fx1=zolri2(x1,ri,z,z0)
       fx2=zolri2(x2,ri,z,z0)
       Do While (abs(x1 - x2) > 0.01)
+! check added for potential divide by zero (2019/11)
+      if(fx1.eq.fx2)return
       if(abs(fx2).lt.abs(fx1))then
         x1=x1-fx1/(fx2-fx1)*(x2-x1)
         fx1=zolri2(x1,ri,z,z0)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: sfclayrev scheme, divide by zero

SOURCE: internal (reported by CH Liu)

DESCRIPTION OF CHANGES: 
During iterative solution for z/L there are rare cases where the same bit-for-bit value is returned for slightly different inputs to function zolri2 resulting in a divide by zero. This appears to be rare.
Fix is to return when these are found equal because solution is converged already.

LIST OF MODIFIED FILES: 
phys/module_sf_sfclayrev.F 

TESTS CONDUCTED: 
Fix works for case that stopped.
Test on standard June case is bit-for-bit as expected
No regtests yet (Jenkins?)

RELEASE NOTE: 
Fix for occasional divide-by-zero error in sfclayrev option.
