### PR TITLE
Increase max_eta from 1001 to 10001

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7049,7 +7049,7 @@ print *,'p sfc = ',psfc(i,j)
 #if 0
 program foo
 
-integer , parameter :: max_eta = 1000
+integer , parameter :: max_eta = 10001
 
 INTEGER :: ids , ide , jds , jde , kds , kde , &
            ims , ime , jms , jme , kms , kme , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7049,6 +7049,7 @@ print *,'p sfc = ',psfc(i,j)
 #if 0
 program foo
 
+!  Make this the same as frame/module_driver_constants.F max_eta
 integer , parameter :: max_eta = 10001
 
 INTEGER :: ids , ide , jds , jde , kds , kde , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7049,7 +7049,7 @@ print *,'p sfc = ',psfc(i,j)
 #if 0
 program foo
 
-!  Make this the same as frame/module_driver_constants.F max_eta
+!  Make this the same as frame/module_driver_constants.F MAX_ETA
 integer , parameter :: max_eta = 10001
 
 INTEGER :: ids , ide , jds , jde , kds , kde , &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7049,7 +7049,8 @@ print *,'p sfc = ',psfc(i,j)
 #if 0
 program foo
 
-!  Make this the same as frame/module_driver_constants.F MAX_ETA
+!  Make this local variable have the same value as in 
+!  frame/module_driver_constants.F: MAX_ETA
 integer , parameter :: max_eta = 10001
 
 INTEGER :: ids , ide , jds , jde , kds , kde , &

--- a/frame/module_driver_constants.F
+++ b/frame/module_driver_constants.F
@@ -46,13 +46,8 @@ MODULE module_driver_constants
    INTEGER , PARAMETER :: max_moves       =   50
 
    !  The maximum number of eta levels
-   !DJW 140701 Increased from 501 to 1001 since I can imagine using more than
-   !501 total vertical levels across multiple nested domains. Now that the
-   !code is modified to allow specification of all domains eta_levels using a
-   !array of length max_eta, this will need to be larger.  I'll also add a check
-   !in module_initialize_real to ensure we don't exceed this value.
 
-   INTEGER , PARAMETER :: max_eta         =   1001
+   INTEGER , PARAMETER :: max_eta         =   10001
 
    !  The maximum number of ocean levels in the 3d U Miami ocean.
 

--- a/frame/module_driver_constants.F
+++ b/frame/module_driver_constants.F
@@ -45,7 +45,8 @@ MODULE module_driver_constants
 
    INTEGER , PARAMETER :: max_moves       =   50
 
-   !  The maximum number of eta levels
+   !  The maximum number of eta levels. With vertical refinement defining
+   !  each domain separately, the aggregated number of levels could be large.
 
    INTEGER , PARAMETER :: max_eta         =   10001
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: eta, levels

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
The real program fails when the number of vertical levels is more than a thousand.

Solution:
There is a single PARAMETER in the frame directory that is used to allocate space for the namelist
read and the eta computation in the real program. We absolutely need a parameter for 
allocating space for the namelist variables. The original value for the maximum number of eta 
levels was 1001. The 10x increase in size (from 1001 to 10001) impacts only a couple of 1d
arrays, so the WRF memory footprint is not dramatically increased.

The mods to the real program are for a stand-alone program buried in the source, and therefore
do not impact the traditional processing of either the real program or the WRF model.

LIST OF MODIFIED FILES: 
modified:   dyn_em/module_initialize_real.F
modified:   frame/module_driver_constants.F

TESTS CONDUCTED: 
 - [x] Original version with 1100 eta levels fails with bound check on Mac.
 - [x] New mods, real on Mac with 1100 eta levels works OK.
```
Full level index =    1     Height =     0.0 m
Full level index =    2     Height =    50.0 m      Thickness =   50.0 m
Full level index =    3     Height =    73.0 m      Thickness =   23.1 m
Full level index =    4     Height =    96.1 m      Thickness =   23.1 m
Full level index =    5     Height =   119.2 m      Thickness =   23.1 m
Full level index =    6     Height =   142.2 m      Thickness =   23.0 m
Full level index =    7     Height =   165.2 m      Thickness =   23.0 m
Full level index =    8     Height =   188.3 m      Thickness =   23.0 m
Full level index =    9     Height =   211.3 m      Thickness =   23.0 m
Full level index =   10     Height =   234.3 m      Thickness =   23.0 m

Full level index = 1090     Height = 19738.8 m      Thickness =   15.9 m
Full level index = 1091     Height = 19754.7 m      Thickness =   15.9 m
Full level index = 1092     Height = 19770.7 m      Thickness =   15.9 m
Full level index = 1093     Height = 19786.6 m      Thickness =   15.9 m
Full level index = 1094     Height = 19802.5 m      Thickness =   15.9 m
Full level index = 1095     Height = 19818.4 m      Thickness =   15.9 m
Full level index = 1096     Height = 19834.4 m      Thickness =   15.9 m
Full level index = 1097     Height = 19850.3 m      Thickness =   15.9 m
Full level index = 1098     Height = 19866.2 m      Thickness =   15.9 m
Full level index = 1099     Height = 19882.2 m      Thickness =   15.9 m
Full level index = 1100     Height = 19898.3 m      Thickness =   16.1 m

d01 2000-01-25_12:00:00 real_em: SUCCESS COMPLETE REAL_EM INIT
```

RELEASE NOTE: The number of vertical levels for the WRF model was increased from 1001 to 10001. Certainly 10000 vertical levels is very large. However, 3 domains with increasing numbers of eta levels (from vertical refinement) of 250, 350, 450 eta levels would previously have exceed the 1001 maximum value.
