### PR TITLE
add description for LANDUSE variables

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1593,6 +1593,16 @@ CONTAINS
 
    REAL :: xice_threshold
 !---------------------------------------------------------------------
+!
+! Variable Description:
+!  ALBD: Surface albedo
+!  SLMO: Moisture availability
+!  SFEM: Emissivity
+!  SFZ0: Roughness length
+!  THERIN: Thermal inertia (only used in SLAB)
+!  SFHC: Soil heat capacity (not used)
+!  SCFX: Snow cover effect (not used)
+!
 ! Local
    CHARACTER*256 LUTYPE
    CHARACTER*512 :: message

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1601,7 +1601,7 @@ CONTAINS
 !  SFZ0: Roughness length
 !  THERIN: Thermal inertia (only used in SLAB)
 !  SFHC: Soil heat capacity (not used)
-!  SCFX: Snow cover effect (not used)
+!  SCFX: Snow cover effect (dependent on SNOWC)
 !
 ! Local
    CHARACTER*256 LUTYPE

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1594,7 +1594,7 @@ CONTAINS
    REAL :: xice_threshold
 !---------------------------------------------------------------------
 !
-! Variable Description:
+! Input Variable Description:
 !  ALBD: Surface albedo
 !  SLMO: Moisture availability
 !  SFEM: Emissivity


### PR DESCRIPTION
TYPE: text only

KEYWORDS: landuse variables

SOURCE: internal

DESCRIPTION OF CHANGES: Add descriptions

LIST OF MODIFIED FILES: 
M  phys/module_physics_init.F

TESTS CONDUCTED: 
Text only.