### PR TITLE
Remove pop/push communicator on non MPI runs

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -2528,6 +2528,7 @@ END MODULE module_dm
    SUBROUTINE pop_communicators_for_domain
       USE module_dm
       IMPLICIT NONE
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IF ( communicator_stack_cursor .LT. 1 ) CALL wrf_error_fatal("pop_communicators_for_domain on empty stack")
       current_id = id_stack(communicator_stack_cursor)
       local_communicator = local_communicator_stack( communicator_stack_cursor )
@@ -2542,6 +2543,7 @@ END MODULE module_dm
       mytask_x = mytask_x_stack( communicator_stack_cursor )
       mytask_y = mytask_y_stack( communicator_stack_cursor )
       communicator_stack_cursor = communicator_stack_cursor - 1
+#endif
    END SUBROUTINE pop_communicators_for_domain
    SUBROUTINE instate_communicators_for_domain( id )
       USE module_dm

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -2507,6 +2507,7 @@ END MODULE module_dm
    SUBROUTINE push_communicators_for_domain( id )
       USE module_dm
       INTEGER, INTENT(IN) :: id   ! if specified also does an instate for grid id
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IF ( communicator_stack_cursor .GE. max_domains ) CALL wrf_error_fatal("push_communicators_for_domain would excede stacksize")
       communicator_stack_cursor = communicator_stack_cursor + 1
 
@@ -2524,6 +2525,7 @@ END MODULE module_dm
       mytask_y_stack( communicator_stack_cursor )       =    mytask_y
 
       CALL instate_communicators_for_domain( id )
+#endif
    END SUBROUTINE push_communicators_for_domain
    SUBROUTINE pop_communicators_for_domain
       USE module_dm
@@ -2547,6 +2549,7 @@ END MODULE module_dm
    END SUBROUTINE pop_communicators_for_domain
    SUBROUTINE instate_communicators_for_domain( id )
       USE module_dm
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: id
       INTEGER ierr
@@ -2562,9 +2565,11 @@ END MODULE module_dm
       ntasks_y       = ntasks_y_store( id )
       mytask_x       = mytask_x_store( id )
       mytask_y       = mytask_y_store( id )
+#endif
    END SUBROUTINE instate_communicators_for_domain
    SUBROUTINE store_communicators_for_domain( id )
       USE module_dm
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: id
       local_communicator_store( id )    =    local_communicator
@@ -2578,6 +2583,7 @@ END MODULE module_dm
       mytask_store( id )        =    mytask
       mytask_x_store( id )      =    mytask_x
       mytask_y_store( id )      =    mytask_y
+#endif
    END SUBROUTINE store_communicators_for_domain
 
 !=========================================================================

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -2507,6 +2507,7 @@ END MODULE module_dm
    SUBROUTINE push_communicators_for_domain( id )
       USE module_dm
       INTEGER, INTENT(IN) :: id   ! if specified also does an instate for grid id
+!  Only required for distrbuted memory parallel runs
 #if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IF ( communicator_stack_cursor .GE. max_domains ) CALL wrf_error_fatal("push_communicators_for_domain would excede stacksize")
       communicator_stack_cursor = communicator_stack_cursor + 1
@@ -2550,6 +2551,7 @@ END MODULE module_dm
    END SUBROUTINE pop_communicators_for_domain
    SUBROUTINE instate_communicators_for_domain( id )
       USE module_dm
+!  Only required for distrbuted memory parallel runs
 #if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: id
@@ -2570,6 +2572,7 @@ END MODULE module_dm
    END SUBROUTINE instate_communicators_for_domain
    SUBROUTINE store_communicators_for_domain( id )
       USE module_dm
+!  Only required for distrbuted memory parallel runs
 #if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: id


### PR DESCRIPTION
TYPE:bug fix

KEYWORDS: fire, pop, push, communicator

SOURCE: internal

DESCRIPTION OF CHANGES: 
Problem:
WRF gets into a state where the code tries to pop or push a stack of communicators. This should 
not happen when doing a Serial or OpenMP build.

Here is the example error message we get with a push on OpenMP:
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    5489
pop_communicators_for_domain on empty stack
-------------------------------------------
```

And here is the example error message with a pop with OpenMP:
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    5464
push_communicators_for_domain would excede stacksize
-------------------------------------------
```

Solution:
This problem only occurs with Serial or OpenMP builds. The communicators are only required for 
distributed memory MPI jobs. Therefore, put an ifdef around the routine that handles pops 
and pushes of the the communicator stack.

LIST OF MODIFIED FILES: 
modified:   external/RSL_LITE/module_dm.F

TESTS CONDUCTED: 
 - [x] Auto regression is HAPPY!