### PR TITLE
Fix for Deng shallow combined with other subgrid cloud options

### DIFF
--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1601,7 +1601,6 @@ CONTAINS
         DO k=kts,kte
         DO i=its,ite
            cldfra(I,K,J) = max(cldfra_sh(I,K,J), cldfra(I,K,J))
-           qc_save(I,K,J)=qc(I,K,J)
            qc(I,K,J)=cw_rad(I,K,J)+qc(I,K,J)
         ENDDO
         ENDDO


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: Deng shallow, radiation-driver clouds

SOURCE: internal and Pedro Jimenez

DESCRIPTION OF CHANGES: 
Line qc_save = qc must be removed from Deng shallow section of radiation driver because it may save qc that is already updated by other physics that have radiation feedback, e.g. icloud, cu or bl. Leads to error when combining Deng shallow with such options (already not recommended with cumulus scheme). qc_save was already set for all options earlier.

LIST OF MODIFIED FILES: 
phys/module_radiation_driver.F

TESTS CONDUCTED: 
This fix has been tested by Pedro in WRF-Solar.
No regtests yet.
Test shows impact when Deng shcu is run with sub-grid clouds from MYNN icloud_bl=1. Left fixed, right old. Higher cloud fraction which leads to reduced surface shortwave compared to corrected code.
[Note that a later bug fix will not allow this combination, but fix applies to Deng shcu with sub-grid clouds from cumulus schemes and icloud=3 too].
<img width="1122" alt="Screen Shot 2019-12-18 at 1 39 55 PM" src="https://user-images.githubusercontent.com/17932284/71130543-62467700-21af-11ea-913e-d51b4bb80c55.png">

RELEASE NOTE: 
Deng shallow scheme fix for when combined with other sub-grid cloud schemes (e.g. non-microphysics options that have radiation feedback). This would have added these clouds to microphysics at each step instead of removing them after radiation. (provided by Pedro Jimenez).