### PR TITLE
HWRF fixes: build = replicated symbol; run = link in look-up tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -880,7 +880,7 @@ nmm_real : nmm_wrf
 	( cd test/nmm_real ; /bin/rm -f ETAMPNEW_DATA.expanded_rain ETAMPNEW_DATA RRTM_DATA ;    \
 	     ln -sf ../../run/ETAMPNEW_DATA . ;                     \
 	     ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;       \
-	     ln -sf ../../run/RRTM_DATA . ;                         \
+             ln -sf ../../run/RRTM_DATA . ;                         \
              ln -sf ../../run/RRTMG_LW_DATA . ;                     \
              ln -sf ../../run/RRTMG_SW_DATA . ;                     \
              ln -sf ../../run/CAM_ABS_DATA . ;                      \

--- a/Makefile
+++ b/Makefile
@@ -879,8 +879,52 @@ nmm_real : nmm_wrf
 	( cd test/nmm_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd test/nmm_real ; /bin/rm -f ETAMPNEW_DATA.expanded_rain ETAMPNEW_DATA RRTM_DATA ;    \
 	     ln -sf ../../run/ETAMPNEW_DATA . ;                     \
-	     ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;                     \
+	     ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;       \
 	     ln -sf ../../run/RRTM_DATA . ;                         \
+             ln -sf ../../run/RRTMG_LW_DATA . ;                     \
+             ln -sf ../../run/RRTMG_SW_DATA . ;                     \
+             ln -sf ../../run/CAM_ABS_DATA . ;                      \
+             ln -sf ../../run/CAM_AEROPT_DATA . ;                   \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP4.5 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP6   . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 CAMtr_volume_mixing_ratio ;   \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.A1B    . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.A2     . ;  \
+             ln -sf ../../run/CLM_ALB_ICE_DFS_DATA . ;              \
+             ln -sf ../../run/CLM_ALB_ICE_DRC_DATA . ;              \
+             ln -sf ../../run/CLM_ASM_ICE_DFS_DATA . ;              \
+             ln -sf ../../run/CLM_ASM_ICE_DRC_DATA . ;              \
+             ln -sf ../../run/CLM_DRDSDT0_DATA . ;                  \
+             ln -sf ../../run/CLM_EXT_ICE_DFS_DATA . ;              \
+             ln -sf ../../run/CLM_EXT_ICE_DRC_DATA . ;              \
+             ln -sf ../../run/CLM_KAPPA_DATA . ;                    \
+             ln -sf ../../run/CLM_TAU_DATA . ;                      \
+             ln -sf ../../run/ozone.formatted . ;                   \
+             ln -sf ../../run/ozone_lat.formatted . ;               \
+             ln -sf ../../run/ozone_plev.formatted . ;              \
+             ln -sf ../../run/aerosol.formatted . ;                 \
+             ln -sf ../../run/aerosol_lat.formatted . ;             \
+             ln -sf ../../run/aerosol_lon.formatted . ;             \
+             ln -sf ../../run/aerosol_plev.formatted . ;            \
+             ln -sf ../../run/capacity.asc . ;                      \
+             ln -sf ../../run/coeff_p.asc . ;                       \
+             ln -sf ../../run/coeff_q.asc . ;                       \
+             ln -sf ../../run/constants.asc . ;                     \
+             ln -sf ../../run/masses.asc . ;                        \
+             ln -sf ../../run/termvels.asc . ;                      \
+             ln -sf ../../run/kernels.asc_s_0_03_0_9 . ;            \
+             ln -sf ../../run/kernels_z.asc . ;                     \
+             ln -sf ../../run/bulkdens.asc_s_0_03_0_9 . ;           \
+             ln -sf ../../run/bulkradii.asc_s_0_03_0_9 . ;          \
+             ln -sf ../../run/CCN_ACTIVATE.BIN . ;                  \
+             ln -sf ../../run/p3_lookup_table_1.dat-v4.1 . ;        \
+             ln -sf ../../run/p3_lookup_table_2.dat-v4.1 . ;        \
+             ln -sf ../../run/HLC.TBL . ;                           \
+             ln -sf ../../run/wind-turbine-1.tbl . ;                \
+             ln -sf ../../run/ishmael-gamma-tab.bin . ;             \
+             ln -sf ../../run/ishmael-qi-qc.bin . ;                 \
+             ln -sf ../../run/ishmael-qi-qr.bin . ;                 \
+             ln -sf ../../run/BROADBAND_CLOUD_GODDARD.bin . ;       \
 	     if [ $(RWORDSIZE) -eq 8 ] ; then                       \
 	        ln -sf ../../run/ETAMPNEW_DATA_DBL ETAMPNEW_DATA ;  \
                 ln -sf ../../run/ETAMPNEW_DATA.expanded_rain_DBL ETAMPNEW_DATA.expanded_rain ;   \

--- a/Makefile
+++ b/Makefile
@@ -878,8 +878,8 @@ nmm_real : nmm_wrf
 	( cd test/nmm_real ; /bin/rm -f real_nmm.exe ; ln -s ../../main/real_nmm.exe . )
 	( cd test/nmm_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd test/nmm_real ; /bin/rm -f ETAMPNEW_DATA.expanded_rain ETAMPNEW_DATA RRTM_DATA ;    \
-	     ln -sf ../../run/ETAMPNEW_DATA . ;                     \
-	     ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;       \
+             ln -sf ../../run/ETAMPNEW_DATA . ;                     \
+             ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;       \
              ln -sf ../../run/RRTM_DATA . ;                         \
              ln -sf ../../run/RRTMG_LW_DATA . ;                     \
              ln -sf ../../run/RRTMG_SW_DATA . ;                     \

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -6334,9 +6334,9 @@ IF ( grid%active_this_task ) THEN
                                 cims, cime, cjms, cjme, ckms, ckme,    &
                                 cips, cipe, cjps, cjpe, ckps, ckpe    )
 
-     smoother: if(config_flags%smooth_option/=0) then
+     smoothr: if(config_flags%smooth_option/=0) then
 #include "nest_feedbackup_smooth.inc"
-     endif smoother
+     endif smoothr
 
     CALL pop_communicators_for_domain
 END IF


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: HWRF, build, run

SOURCE: internal

DESCRIPTION OF CHANGES: 
To get the HWRF code to build and run the regression test cases, two changes are required:

### Build
There is a replicated symbol in subroutine feedback_domain_nmm_part2: SMOOTHER. This
named symbol cannot be both a LABEL and the name of a called SUBROUTINE within 
a single subprogram unit (subroutine or function). Just a quick misspelling of SMOOTHR works
wonders.

### Run
Link in (ln -sf) all of the look-up tables to the test/nmm_real directory in the last step of the build
process. Most of the run-time-required links to physics data files were not originally in place.

LIST OF MODIFIED FILES:
modified:   Makefile
modified:   external/RSL_LITE/module_dm.F

TESTS CONDUCTED: 
 - [x] Without build mod (replicated symbol), code does not build with GNU
 - [x] Without run mod (linked-in look-up tables), the code does not run regression tests
 - [x] With both mods, the code builds and runs.
 - [x] Regression test is now in place for HWRF. 