### PR TITLE
Fix comments in hybrid coordinate registry

### DIFF
--- a/Registry/registry.hyb_coord
+++ b/Registry/registry.hyb_coord
@@ -40,17 +40,17 @@
 
 #<Table> <Type>   <Sym>         <Dims>   <Use>           <NumTLev> <Stagger>        <IO>            <DNAME>                        <DESCRIP>                            <UNITS>
 
-state    real      c1h             k     misc                1         -     i02rh0{22}{23}{24}      "C1H"       "half levels, c1h = d bf / d eta, using znw"         "Dimensionless"
-state    real      c2h             k     misc                1         -     i02rh0{22}{23}{24}      "C2H"       "half levels, c2h = (1-c1h)*(p0-pt)"                 "Pa"
+state    real      c1h             k     misc                1         -     i02rh0{22}{23}{24}      "C1H"       "half levels, c1h = d bf / d eta, using znw"        "Dimensionless"
+state    real      c2h             k     misc                1         -     i02rh0{22}{23}{24}      "C2H"       "half levels, c2h = (1-c1h)*(p0-pt)"                "Pa"
 
-state    real      c1f             k     misc                1         Z     i02rh0{22}{23}{24}      "C1F"       "full levels, c1f = d bf / d eta, using znu"         "Dimensionless"
-state    real      c2f             k     misc                1         Z     i02rh0{22}{23}{24}      "C2F"       "full levels, c2f = (1-c1f)*(p0-pt)"                 "Pa"
+state    real      c1f             k     misc                1         Z     i02rh0{22}{23}{24}      "C1F"       "full levels, c1f = d bf / d eta, using znu"        "Dimensionless"
+state    real      c2f             k     misc                1         Z     i02rh0{22}{23}{24}      "C2F"       "full levels, c2f = (1-c1f)*(p0-pt)"                "Pa"
 
 state    real      c3h             k     misc                1         -     i02rh0{22}{23}{24}      "C3H"       "half levels, c3h = bh"                             "Dimensionless"
-state    real      c4h             k     misc                1         -     i02rh0{22}{23}{24}      "C4H"       "half levels, c4h = (eta-bh)*(p0-pt)+pt, using znu" "Pa"
+state    real      c4h             k     misc                1         -     i02rh0{22}{23}{24}      "C4H"       "half levels, c4h = (eta-bh)*(p0-pt), using znu"    "Pa"
 
 state    real      c3f             k     misc                1         Z     i02rh0{22}{23}{24}      "C3F"       "full levels, c3f = bf"                             "Dimensionless"
-state    real      c4f             k     misc                1         Z     i02rh0{22}{23}{24}      "C4F"       "full levels, c4f = (eta-bf)*(p0-pt)+pt, using znw" "Pa"
+state    real      c4f             k     misc                1         Z     i02rh0{22}{23}{24}      "C4F"       "full levels, c4f = (eta-bf)*(p0-pt), using znw"    "Pa"
 
 state    real      pcb            ij    dyn_em               1         -     irhdus                  "PCB"       "base state dry air mass in column"                 "Pa"
 state    real      pc             ijb   dyn_em               2         -     irhusdf=(bdy_interp:dt) "PC"        "perturbation dry air mass in column"               "Pa"

--- a/Registry/registry.hyb_coord
+++ b/Registry/registry.hyb_coord
@@ -1,7 +1,7 @@
 #	Dry pressure, Pd
 #	Dry surface pressure = Pds
 #	Model top pressure = Pt
-#	Mass in column, Pc = Pds - Pt
+#	Dry mass in column (base + perturbation), Pcb + Pc = Pds - Pt
 #	1d column weighting term, B: BF is full levels, BH is half levels
 
 #	Total dry pressure


### PR DESCRIPTION
TYPE: text only

KEYWORDS: hybrid comments

SOURCE: Found by Kezhen Chong (Georgia Institute of Technology), fixed internally

DESCRIPTION OF CHANGES: 
Modify the comments in registry.hyb_coord to correctly define c4f and c4h. Originally, the value
of the pressure at the model lid (ptop) was included in the description of the computation of
the C4F and C4H 1d arrays as an added term. Following is the source code showing no such term.

```
   !  c4 is a function of c3 and eta.

   DO k=1, kde
      c4f(k) = ( znw(k) - c3f(k) ) * ( p1000mb - p_top )
   ENDDO

   !  Now on half levels, just add up and divide by 2 (for c3h).  Use (eta-c3)*(p00-pt) for c4 on half levels.

   DO k=1, kde-1
      c4h(k) = ( znu(k) - c3h(k) ) * ( p1000mb - p_top )
   ENDDO
```

ISSUE: 
Fixes #1050

LIST OF MODIFIED FILES: 
modified:   Registry/registry.hyb_coord

TESTS CONDUCTED: 
 - [x] Text only in comment in a registry file, no tests required.