### PR TITLE
TESTING - DO NOT MERGE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -878,9 +878,53 @@ nmm_real : nmm_wrf
 	( cd test/nmm_real ; /bin/rm -f real_nmm.exe ; ln -s ../../main/real_nmm.exe . )
 	( cd test/nmm_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
 	( cd test/nmm_real ; /bin/rm -f ETAMPNEW_DATA.expanded_rain ETAMPNEW_DATA RRTM_DATA ;    \
-	     ln -sf ../../run/ETAMPNEW_DATA . ;                     \
-	     ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;                     \
-	     ln -sf ../../run/RRTM_DATA . ;                         \
+             ln -sf ../../run/ETAMPNEW_DATA . ;                     \
+             ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;       \
+             ln -sf ../../run/RRTM_DATA . ;                         \
+             ln -sf ../../run/RRTMG_LW_DATA . ;                     \
+             ln -sf ../../run/RRTMG_SW_DATA . ;                     \
+             ln -sf ../../run/CAM_ABS_DATA . ;                      \
+             ln -sf ../../run/CAM_AEROPT_DATA . ;                   \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP4.5 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP6   . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 CAMtr_volume_mixing_ratio ;   \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.A1B    . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.A2     . ;  \
+             ln -sf ../../run/CLM_ALB_ICE_DFS_DATA . ;              \
+             ln -sf ../../run/CLM_ALB_ICE_DRC_DATA . ;              \
+             ln -sf ../../run/CLM_ASM_ICE_DFS_DATA . ;              \
+             ln -sf ../../run/CLM_ASM_ICE_DRC_DATA . ;              \
+             ln -sf ../../run/CLM_DRDSDT0_DATA . ;                  \
+             ln -sf ../../run/CLM_EXT_ICE_DFS_DATA . ;              \
+             ln -sf ../../run/CLM_EXT_ICE_DRC_DATA . ;              \
+             ln -sf ../../run/CLM_KAPPA_DATA . ;                    \
+             ln -sf ../../run/CLM_TAU_DATA . ;                      \
+             ln -sf ../../run/ozone.formatted . ;                   \
+             ln -sf ../../run/ozone_lat.formatted . ;               \
+             ln -sf ../../run/ozone_plev.formatted . ;              \
+             ln -sf ../../run/aerosol.formatted . ;                 \
+             ln -sf ../../run/aerosol_lat.formatted . ;             \
+             ln -sf ../../run/aerosol_lon.formatted . ;             \
+             ln -sf ../../run/aerosol_plev.formatted . ;            \
+             ln -sf ../../run/capacity.asc . ;                      \
+             ln -sf ../../run/coeff_p.asc . ;                       \
+             ln -sf ../../run/coeff_q.asc . ;                       \
+             ln -sf ../../run/constants.asc . ;                     \
+             ln -sf ../../run/masses.asc . ;                        \
+             ln -sf ../../run/termvels.asc . ;                      \
+             ln -sf ../../run/kernels.asc_s_0_03_0_9 . ;            \
+             ln -sf ../../run/kernels_z.asc . ;                     \
+             ln -sf ../../run/bulkdens.asc_s_0_03_0_9 . ;           \
+             ln -sf ../../run/bulkradii.asc_s_0_03_0_9 . ;          \
+             ln -sf ../../run/CCN_ACTIVATE.BIN . ;                  \
+             ln -sf ../../run/p3_lookup_table_1.dat-v4.1 . ;        \
+             ln -sf ../../run/p3_lookup_table_2.dat-v4.1 . ;        \
+             ln -sf ../../run/HLC.TBL . ;                           \
+             ln -sf ../../run/wind-turbine-1.tbl . ;                \
+             ln -sf ../../run/ishmael-gamma-tab.bin . ;             \
+             ln -sf ../../run/ishmael-qi-qc.bin . ;                 \
+             ln -sf ../../run/ishmael-qi-qr.bin . ;                 \
+             ln -sf ../../run/BROADBAND_CLOUD_GODDARD.bin . ;       \
 	     if [ $(RWORDSIZE) -eq 8 ] ; then                       \
 	        ln -sf ../../run/ETAMPNEW_DATA_DBL ETAMPNEW_DATA ;  \
                 ln -sf ../../run/ETAMPNEW_DATA.expanded_rain_DBL ETAMPNEW_DATA.expanded_rain ;   \

--- a/Registry/registry.hyb_coord
+++ b/Registry/registry.hyb_coord
@@ -1,7 +1,7 @@
 #	Dry pressure, Pd
 #	Dry surface pressure = Pds
 #	Model top pressure = Pt
-#	Mass in column, Pc = Pds - Pt
+#	Dry mass in column (base + perturbation), Pcb + Pc = Pds - Pt
 #	1d column weighting term, B: BF is full levels, BH is half levels
 
 #	Total dry pressure
@@ -40,17 +40,17 @@
 
 #<Table> <Type>   <Sym>         <Dims>   <Use>           <NumTLev> <Stagger>        <IO>            <DNAME>                        <DESCRIP>                            <UNITS>
 
-state    real      c1h             k     misc                1         -     i02rh0{22}{23}{24}      "C1H"       "half levels, c1h = d bf / d eta, using znw"         "Dimensionless"
-state    real      c2h             k     misc                1         -     i02rh0{22}{23}{24}      "C2H"       "half levels, c2h = (1-c1h)*(p0-pt)"                 "Pa"
+state    real      c1h             k     misc                1         -     i02rh0{22}{23}{24}      "C1H"       "half levels, c1h = d bf / d eta, using znw"        "Dimensionless"
+state    real      c2h             k     misc                1         -     i02rh0{22}{23}{24}      "C2H"       "half levels, c2h = (1-c1h)*(p0-pt)"                "Pa"
 
-state    real      c1f             k     misc                1         Z     i02rh0{22}{23}{24}      "C1F"       "full levels, c1f = d bf / d eta, using znu"         "Dimensionless"
-state    real      c2f             k     misc                1         Z     i02rh0{22}{23}{24}      "C2F"       "full levels, c2f = (1-c1f)*(p0-pt)"                 "Pa"
+state    real      c1f             k     misc                1         Z     i02rh0{22}{23}{24}      "C1F"       "full levels, c1f = d bf / d eta, using znu"        "Dimensionless"
+state    real      c2f             k     misc                1         Z     i02rh0{22}{23}{24}      "C2F"       "full levels, c2f = (1-c1f)*(p0-pt)"                "Pa"
 
 state    real      c3h             k     misc                1         -     i02rh0{22}{23}{24}      "C3H"       "half levels, c3h = bh"                             "Dimensionless"
-state    real      c4h             k     misc                1         -     i02rh0{22}{23}{24}      "C4H"       "half levels, c4h = (eta-bh)*(p0-pt)+pt, using znu" "Pa"
+state    real      c4h             k     misc                1         -     i02rh0{22}{23}{24}      "C4H"       "half levels, c4h = (eta-bh)*(p0-pt), using znu"    "Pa"
 
 state    real      c3f             k     misc                1         Z     i02rh0{22}{23}{24}      "C3F"       "full levels, c3f = bf"                             "Dimensionless"
-state    real      c4f             k     misc                1         Z     i02rh0{22}{23}{24}      "C4F"       "full levels, c4f = (eta-bf)*(p0-pt)+pt, using znw" "Pa"
+state    real      c4f             k     misc                1         Z     i02rh0{22}{23}{24}      "C4F"       "full levels, c4f = (eta-bf)*(p0-pt), using znw"    "Pa"
 
 state    real      pcb            ij    dyn_em               1         -     irhdus                  "PCB"       "base state dry air mass in column"                 "Pa"
 state    real      pc             ijb   dyn_em               2         -     irhusdf=(bdy_interp:dt) "PC"        "perturbation dry air mass in column"               "Pa"

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7049,7 +7049,9 @@ print *,'p sfc = ',psfc(i,j)
 #if 0
 program foo
 
-integer , parameter :: max_eta = 1000
+!  Make this local variable have the same value as in 
+!  frame/module_driver_constants.F: MAX_ETA
+integer , parameter :: max_eta = 10001
 
 INTEGER :: ids , ide , jds , jde , kds , kde , &
            ims , ime , jms , jme , kms , kme , &

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -2507,6 +2507,8 @@ END MODULE module_dm
    SUBROUTINE push_communicators_for_domain( id )
       USE module_dm
       INTEGER, INTENT(IN) :: id   ! if specified also does an instate for grid id
+!  Only required for distrbuted memory parallel runs
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IF ( communicator_stack_cursor .GE. max_domains ) CALL wrf_error_fatal("push_communicators_for_domain would excede stacksize")
       communicator_stack_cursor = communicator_stack_cursor + 1
 
@@ -2524,10 +2526,13 @@ END MODULE module_dm
       mytask_y_stack( communicator_stack_cursor )       =    mytask_y
 
       CALL instate_communicators_for_domain( id )
+#endif
    END SUBROUTINE push_communicators_for_domain
    SUBROUTINE pop_communicators_for_domain
       USE module_dm
       IMPLICIT NONE
+      !  Only required for distrbuted memory parallel runs
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IF ( communicator_stack_cursor .LT. 1 ) CALL wrf_error_fatal("pop_communicators_for_domain on empty stack")
       current_id = id_stack(communicator_stack_cursor)
       local_communicator = local_communicator_stack( communicator_stack_cursor )
@@ -2542,9 +2547,12 @@ END MODULE module_dm
       mytask_x = mytask_x_stack( communicator_stack_cursor )
       mytask_y = mytask_y_stack( communicator_stack_cursor )
       communicator_stack_cursor = communicator_stack_cursor - 1
+#endif
    END SUBROUTINE pop_communicators_for_domain
    SUBROUTINE instate_communicators_for_domain( id )
       USE module_dm
+!  Only required for distrbuted memory parallel runs
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: id
       INTEGER ierr
@@ -2560,9 +2568,12 @@ END MODULE module_dm
       ntasks_y       = ntasks_y_store( id )
       mytask_x       = mytask_x_store( id )
       mytask_y       = mytask_y_store( id )
+#endif
    END SUBROUTINE instate_communicators_for_domain
    SUBROUTINE store_communicators_for_domain( id )
       USE module_dm
+!  Only required for distrbuted memory parallel runs
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: id
       local_communicator_store( id )    =    local_communicator
@@ -2576,6 +2587,7 @@ END MODULE module_dm
       mytask_store( id )        =    mytask
       mytask_x_store( id )      =    mytask_x
       mytask_y_store( id )      =    mytask_y
+#endif
    END SUBROUTINE store_communicators_for_domain
 
 !=========================================================================

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -6346,9 +6346,9 @@ IF ( grid%active_this_task ) THEN
                                 cims, cime, cjms, cjme, ckms, ckme,    &
                                 cips, cipe, cjps, cjpe, ckps, ckpe    )
 
-     smoother: if(config_flags%smooth_option/=0) then
+     smoothr: if(config_flags%smooth_option/=0) then
 #include "nest_feedbackup_smooth.inc"
-     endif smoother
+     endif smoothr
 
     CALL pop_communicators_for_domain
 END IF

--- a/frame/module_driver_constants.F
+++ b/frame/module_driver_constants.F
@@ -45,14 +45,10 @@ MODULE module_driver_constants
 
    INTEGER , PARAMETER :: max_moves       =   50
 
-   !  The maximum number of eta levels
-   !DJW 140701 Increased from 501 to 1001 since I can imagine using more than
-   !501 total vertical levels across multiple nested domains. Now that the
-   !code is modified to allow specification of all domains eta_levels using a
-   !array of length max_eta, this will need to be larger.  I'll also add a check
-   !in module_initialize_real to ensure we don't exceed this value.
+   !  The maximum number of eta levels. With vertical refinement defining
+   !  each domain separately, the aggregated number of levels could be large.
 
-   INTEGER , PARAMETER :: max_eta         =   1001
+   INTEGER , PARAMETER :: max_eta         =   10001
 
    !  The maximum number of ocean levels in the 3d U Miami ocean.
 

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1601,7 +1601,6 @@ CONTAINS
         DO k=kts,kte
         DO i=its,ite
            cldfra(I,K,J) = max(cldfra_sh(I,K,J), cldfra(I,K,J))
-           qc_save(I,K,J)=qc(I,K,J)
            qc(I,K,J)=cw_rad(I,K,J)+qc(I,K,J)
         ENDDO
         ENDDO


### PR DESCRIPTION
### Not for merging

This is using the current (and ready) v4.1.4 PRs to verify a regression test on the cumulative mods.

```
> git branch
  master
* release-v4.1.4

> git checkout -b COMBO
Switched to a new branch 'COMBO'

> git merge davegill/MAX_ETA
Merge made by the 'recursive' strategy.
 dyn_em/module_initialize_real.F |  4 +++-
 frame/module_driver_constants.F | 12 ++++--------
 2 files changed, 7 insertions(+), 9 deletions(-)

> git merge davegill/fire_pops
Merge made by the 'recursive' strategy.
 external/RSL_LITE/module_dm.F | 12 ++++++++++++
 1 file changed, 12 insertions(+)

> git merge dudhia/dengfix2
Merge made by the 'recursive' strategy.
 phys/module_radiation_driver.F | 1 -
 1 file changed, 1 deletion(-)

> git merge davegill/HWRF
Auto-merging external/RSL_LITE/module_dm.F
Merge made by the 'recursive' strategy.
 Makefile                      | 50 +++++++++++++++++++++++++++++++++++++++++++++++---
 external/RSL_LITE/module_dm.F |  4 ++--
 2 files changed, 49 insertions(+), 5 deletions(-)

> git merge davegill/hyb_comments
Merge made by the 'recursive' strategy.
 Registry/registry.hyb_coord | 14 +++++++-------
 1 file changed, 7 insertions(+), 7 deletions(-)
```

Supposed to get:
```
 WRF Scala Jenkins AWS Automated GitHub Testing                                               
 ==============================================                                               
 Number of Tests        : 10                                                          
 Number of Builds       : 23                                                         
 Number of Simulations  : 65                                                           
 Number of Comparisons  : 39
```
... and that is what I got from the auto Jenkins regtest

Bit wise comparisons:
```
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_03FD status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_03FD vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_03FD status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_10 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_10 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_11 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_11 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_20NE vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_20NE status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_20NE vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_20NE status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_conus vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_conus status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_conus vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_conus status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_tropical vs SUCCESS_RUN_WRF_d01_em_real_33_em_real_tropical status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real_tropical vs SUCCESS_RUN_WRF_d01_em_real_34_em_real_tropical status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_1 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_1 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_2 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_2 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_chem_5 vs SUCCESS_RUN_WRF_d01_em_real_34_em_chem_5 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_02NE vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss_02NE status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_02NE vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss_02NE status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_03 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss_03 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_03 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss_03 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_03NE vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss_03NE status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_03NE vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss_03NE status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_04 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss_04 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss_04 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss_04 status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_1NE vs SUCCESS_RUN_WRF_d01_em_b_wave_33_em_b_wave_1NE status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_1NE vs SUCCESS_RUN_WRF_d01_em_b_wave_34_em_b_wave_1NE status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_2 vs SUCCESS_RUN_WRF_d01_em_b_wave_33_em_b_wave_2 status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_2 vs SUCCESS_RUN_WRF_d01_em_b_wave_34_em_b_wave_2 status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_2NE vs SUCCESS_RUN_WRF_d01_em_b_wave_33_em_b_wave_2NE status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_2NE vs SUCCESS_RUN_WRF_d01_em_b_wave_34_em_b_wave_2NE status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_3 vs SUCCESS_RUN_WRF_d01_em_b_wave_33_em_b_wave_3 status = 0
SUCCESS_RUN_WRF_d01_em_b_wave_32_em_b_wave_3 vs SUCCESS_RUN_WRF_d01_em_b_wave_34_em_b_wave_3 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real8_14 vs SUCCESS_RUN_WRF_d01_em_real_33_em_real8_14 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real8_14 vs SUCCESS_RUN_WRF_d01_em_real_34_em_real8_14 status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real8_17AD vs SUCCESS_RUN_WRF_d01_em_real_33_em_real8_17AD status = 0
SUCCESS_RUN_WRF_d01_em_real_32_em_real8_17AD vs SUCCESS_RUN_WRF_d01_em_real_34_em_real8_17AD status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss8_06 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss8_06 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss8_06 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss8_06 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss8_08 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss8_08 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss8_08 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss8_08 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss8_09 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_33_em_quarter_ss8_09 status = 0
SUCCESS_RUN_WRF_d01_em_quarter_ss_32_em_quarter_ss8_09 vs SUCCESS_RUN_WRF_d01_em_quarter_ss_34_em_quarter_ss8_09 status = 0
SUCCESS_RUN_WRF_d01_em_fire_32_em_fire_01 vs SUCCESS_RUN_WRF_d01_em_fire_33_em_fire_01 status = 0
SUCCESS_RUN_WRF_d01_em_fire_32_em_fire_01 vs SUCCESS_RUN_WRF_d01_em_fire_34_em_fire_01 status = 0
Mon Jan 13 21:15:02 UTC 2020
```
