### PR TITLE
WDM scheme minor bug fixes

### DIFF
--- a/phys/module_mp_wdm5.F
+++ b/phys/module_mp_wdm5.F
@@ -1563,8 +1563,8 @@ CONTAINS
 ! (NC->NCCN)
 !----------------------------------------------------------------------
           if(pcond(i,k).eq.-qci(i,k,1)/dtcld) then
-            ncr(i,k,2) = 0.
             ncr(i,k,1) = ncr(i,k,1)+ncr(i,k,2)
+            ncr(i,k,2) = 0.
           endif
 !
           q(i,k) = q(i,k)-pcond(i,k)*dtcld

--- a/phys/module_mp_wdm6.F
+++ b/phys/module_mp_wdm6.F
@@ -905,8 +905,6 @@
                          +precs2*work2(i,k)*coeres)/den(i,k)                  
               psmlt(i,k) = min(max(psmlt(i,k)*dtcld/mstep(i),-qrs(i,k,2)     &
                          /mstep(i)),0.)
-              qrs(i,k,2) = qrs(i,k,2) + psmlt(i,k)
-              qrs(i,k,1) = qrs(i,k,1) - psmlt(i,k)
 !-------------------------------------------------------------------
 ! nsmlt: melting of snow [LH A27]
 !       (T>T0: ->NR)
@@ -915,6 +913,9 @@
                 sfac = rslope(i,k,2)*n0s*n0sfac(i,k)/qrs(i,k,2)
                 ncr(i,k,3) = ncr(i,k,3) - sfac*psmlt(i,k)
               endif
+! error correction based on Lei et al., (JGR, 2020)
+              qrs(i,k,2) = qrs(i,k,2) + psmlt(i,k)
+              qrs(i,k,1) = qrs(i,k,1) - psmlt(i,k)
               t(i,k) = t(i,k) + xlf/cpm(i,k)*psmlt(i,k)
             endif
 !---------------------------------------------------------------
@@ -928,8 +929,6 @@
                            /den(i,k)                                          
               pgmlt(i,k) = min(max(pgmlt(i,k)*dtcld/mstep(i),                &
                           -qrs(i,k,3)/mstep(i)),0.)
-              qrs(i,k,3) = qrs(i,k,3) + pgmlt(i,k)
-              qrs(i,k,1) = qrs(i,k,1) - pgmlt(i,k)
 !-------------------------------------------------------------------
 ! ngmlt: melting of graupel [LH A28]
 !       (T>T0: ->NR)
@@ -938,6 +937,9 @@
                 gfac = rslope(i,k,3)*n0g/qrs(i,k,3)
                 ncr(i,k,3) = ncr(i,k,3) - gfac*pgmlt(i,k)
               endif
+! error correction based on Lei et al., (JGR, 2020)
+              qrs(i,k,3) = qrs(i,k,3) + pgmlt(i,k)
+              qrs(i,k,1) = qrs(i,k,1) - pgmlt(i,k)
               t(i,k) = t(i,k) + xlf/cpm(i,k)*pgmlt(i,k)
             endif
           endif
@@ -1982,8 +1984,9 @@
 ! (NC->NCCN) 
 !----------------------------------------------------------------
           if(pcond(i,k).eq.-qci(i,k,1)/dtcld) then
-            ncr(i,k,2) = 0.
             ncr(i,k,1) = ncr(i,k,1)+ncr(i,k,2)
+! error correction based on Lei et al. (JGR, 2020)
+            ncr(i,k,2) = 0.
           endif
 !
           q(i,k) = q(i,k)-pcond(i,k)*dtcld

--- a/phys/module_mp_wdm7.F
+++ b/phys/module_mp_wdm7.F
@@ -917,8 +917,6 @@ CONTAINS
                          +precs2*work2(i,k)*coeres)/den(i,k)                  
               psmlt(i,k) = min(max(psmlt(i,k)*dtcld/mstep(i),-qrs(i,k,2)     &
                          /mstep(i)),0.)
-              qrs(i,k,2) = qrs(i,k,2) + psmlt(i,k)
-              qrs(i,k,1) = qrs(i,k,1) - psmlt(i,k)
 !
 ! nsmlt: melting of snow [LH A27]
 !       (T>T0: ->NR)
@@ -927,6 +925,8 @@ CONTAINS
                 sfac = rslope(i,k,2)*n0s*n0sfac(i,k)/qrs(i,k,2)
                 ncr(i,k,3) = ncr(i,k,3) - sfac*psmlt(i,k)
               endif
+              qrs(i,k,2) = qrs(i,k,2) + psmlt(i,k)
+              qrs(i,k,1) = qrs(i,k,1) - psmlt(i,k)
               t(i,k) = t(i,k) + xlf/cpm(i,k)*psmlt(i,k)
             endif
 !
@@ -940,8 +940,6 @@ CONTAINS
                            /den(i,k)                                          
               pgmlt(i,k) = min(max(pgmlt(i,k)*dtcld/mstep(i),                &
                           -qrs(i,k,3)/mstep(i)),0.)
-              qrs(i,k,3) = qrs(i,k,3) + pgmlt(i,k)
-              qrs(i,k,1) = qrs(i,k,1) - pgmlt(i,k)
 !
 ! ngmlt: melting of graupel [LH A28]
 !       (T>T0: ->NR)
@@ -950,6 +948,8 @@ CONTAINS
                 gfac = rslope(i,k,3)*n0g/qrs(i,k,3)
                 ncr(i,k,3) = ncr(i,k,3) - gfac*pgmlt(i,k)
               endif
+              qrs(i,k,3) = qrs(i,k,3) + pgmlt(i,k)
+              qrs(i,k,1) = qrs(i,k,1) - pgmlt(i,k)
               t(i,k) = t(i,k) + xlf/cpm(i,k)*pgmlt(i,k)
             endif
 !
@@ -2277,8 +2277,8 @@ CONTAINS
 ! (NC->NCCN) 
 !
           if(pcond(i,k).eq.-qci(i,k,1)/dtcld) then
-            ncr(i,k,2) = 0.
             ncr(i,k,1) = ncr(i,k,1)+ncr(i,k,2)
+            ncr(i,k,2) = 0.
           endif
 !
           q(i,k) = q(i,k)-pcond(i,k)*dtcld


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WDM5, WDM6, WDM7

SOURCE: Kyo-Sun Lim (Kyungpook National University) and Sooya Bae (KIAPS).

DESCRIPTION OF CHANGES: 
Error correction based on Lei et al. (JGR, 2020)
1. Melting of snow/graupel :
-Problem: melting processes of snow/graupel mass and number concentration do not occur 
at the same time.
-Correction: melting of snow/graupel changes the snow/graupel/rain mass and rain number 
concentration at the same time.
-Effect: Generation of rain number concentrations would decrease.
2. Regeneration of CCN number concentration due to the cloud water evaporation:
-Problem: Cloud water number concentration does not add into the CCN number concentration.
-Correction: Adding the cloud water number concentration into the CCN number concentration.
- Effect: CCN number concentration would increase.

ISSUE: none

LIST OF MODIFIED FILES: 
module_mp_wdm5.F
module_mp_wdm6.F
module_mp_wdm7.F

TESTS CONDUCTED: 
Passed Jenkins
WDM6 tested versus master. Diffs small for surface fields including rainfall after 12 hrs of June 2001 test case (shown).
<img width="1682" alt="Screen Shot 2020-02-04 at 12 39 13 PM" src="https://user-images.githubusercontent.com/17932284/73780409-a8e63580-474b-11ea-87ec-695d874c1b04.png">


RELEASE NOTE:  Melting of snow/graupel changes the snow/graupel/rain mass and rain number 
concentration at the same time in all WDM schemes provided by Kyo-Sun Lim (Korea).
