### PR TITLE
Allow MSKF scheme to run with more PBL schemes

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1258,7 +1258,7 @@ BENCH_START(cu_driver_tim)
      &             ,QI_CURR=moist(ims,kms,jms,P_QI), F_QI=F_QI            &
      &             ,QS_CURR=moist(ims,kms,jms,P_QS), F_QS=F_QS            &
      &             ,QG_CURR=moist(ims,kms,jms,P_QG), F_QG=F_QG            &
-     &             ,ZOL=grid%ZOL,WSTAR=grid%wstar_ysu                     & !ckay
+     &             ,ZOL=grid%ZOL                                          & !ckay
 ! Variables for Tiedtke and NSAS schemes
      &             ,ZNU=grid%znu                                          &
      &             ,MP_PHYSICS=config_flags%mp_physics                    &

--- a/phys/module_cu_mskf.F
+++ b/phys/module_cu_mskf.F
@@ -3437,7 +3437,7 @@ CONTAINS
              ,UDR_KF,DDR_KF                                  &
              ,UER_KF,DER_KF                                  &
              ,TIMEC_KF,KF_EDRATES                            & 
-             ,ZOL,WSTAR,UST,PBLH                             &   !ckay
+             ,ZOL,HFX,UST,PBLH                               &   !ckay
              ,aerocu,no_src_types_cu,aercu_fct,aercu_opt     & !PSH/TWG
              ,EFCS,EFIS,EFSS)
 !
@@ -3569,7 +3569,7 @@ CONTAINS
 !ckay
    REAL, DIMENSION( ims:ime, jms:jme )                     , &
          INTENT(   IN) ::                               ZOL, &
-                                                      WSTAR, &
+                                                        HFX, &
                                                         UST, &
                                                        PBLH
 !ckaywup
@@ -3922,7 +3922,7 @@ CONTAINS
                  UDR_KF,DDR_KF,                     &
                  UER_KF,DER_KF,                     &
                  TIMEC_KF,KF_EDRATES,               &                 
-                 ZOL,WSTAR,UST,PBLH,                &
+                 ZOL,HFX,UST,PBLH,                  &
                  aerocu,no_src_types_cu,aercu_fct,  &
                  aercu_opt,EFCS,EFIS,EFSS) !PSH/TWG
 
@@ -3988,7 +3988,7 @@ CONTAINS
                       UDR_KF,DDR_KF,                       &
                       UER_KF,DER_KF,                       &
                       TIMEC_KF,KF_EDRATES,                 &
-                      ZOL,WSTAR,UST,PBLH,                  &
+                      ZOL,HFX,UST,PBLH,                    &
                       aerocu,no_src_types_cu,aercu_fct,    &
                       aercu_opt,EFCS,EFIS,EFSS) !PSH/TWG
 
@@ -4038,7 +4038,7 @@ CONTAINS
 !ckay
       REAL, DIMENSION( ims:ime, jms:jme ),                 &
             INTENT(   IN) ::                          ZOL, &
-                                                    WSTAR, &
+                                                      HFX, &
                                                       UST, &
                                                      PBLH
 !
@@ -4175,7 +4175,7 @@ CONTAINS
 
 !ckaywup
    REAL    :: envEsat, envQsat, envRH, envRHavg, denSplume
-   REAL    :: updil, Drag
+   REAL    :: updil, Drag, WST, thetav
 !TWG Mar 2017
    REAL, PARAMETER :: P1_HU10 = 7.6725
    REAL, PARAMETER :: P2_HU10 = 1.0118
@@ -5545,7 +5545,19 @@ updraft:    DO NK=K,KL-1
          TIMEC = TIMEC*Scale_Fac
 
 !ckay SCLvel = SubCloudLayerVELOCITY = Wsb
-         SCLvel = WSTAR(I,J)**3
+!ckay estimate WSTAR to allow most of the PBL schemes here...
+         densPlume = P0(1)/R/T0(1)
+         WST = HFX(I,J)/densPlume/CP  ! hfx in kinematic units  CKAY
+         WST = amax1(0.,WST)  ! +ve hfx only
+         WST = G*PBLH(I,J)*WST
+         thetav = (1.E5/P0(1))**(R/CP)
+         thetav = T0(1) * thetav
+         eps1u = 0.622
+         thetav = thetav*(1.+Q0(1)*eps1u)
+         WST = WST/thetav
+         WST = WST**0.3333
+
+         SCLvel = WST**3
          ZLCL_KAY = amax1(ZLCL,Z0(KPBL))
          SCLvel = SCLvel/PBLH(I,J)
          SCLvel = SCLvel*ZLCL_kay   

--- a/phys/module_cumulus_driver.F
+++ b/phys/module_cumulus_driver.F
@@ -22,7 +22,7 @@ CONTAINS
                      ,QC_CU,QI_CU                                     &
                      ,z,z_at_w,dz8w,mavail,pblh,p8w,psfc,tsk          &
                      ,tke_pbl, ust                                    &
-                     ,ZOL,WSTAR                                       &  !ckay
+                     ,ZOL                                             & !ckay
                      ,forcet,forceq,w0avg,stepcu,gsw                  &
                      ,cldefi,lowlyr,xland,cu_act_flag,warm_rain       &
                      ,hfx,qfx,cldfra,cldfra_mp_all,tpert2d            &
@@ -493,11 +493,9 @@ CONTAINS
         PRATEC,MAVAIL,PBLH,PSFC,TSK,TPERT2D,UST,HFX,QFX
    REAL, DIMENSION( ims:ime , jms:jme ),INTENT(INOUT)          :: &
                                                       HPBL_HOLD
-
 !ckay
    REAL, DIMENSION( ims:ime , jms:jme ),                         &
-         OPTIONAL, INTENT(INOUT) ::                         ZOL  &
-                                                    ,     WSTAR
+         OPTIONAL, INTENT(INOUT) ::                         ZOL
 
    REAL, DIMENSION( ims:ime , jms:jme ) :: tmppratec
                                                     
@@ -1054,7 +1052,7 @@ CONTAINS
                ,UDR_KF=udr_kf,DDR_KF=ddr_kf                     & !kf_edrates
                ,UER_KF=uer_kf,DER_KF=der_kf                     & 
                ,TIMEC_KF=timec_kf,KF_EDRATES=kf_edrates         & 
-               ,ZOL=zol,WSTAR=wstar,UST=ust,PBLH=pblh           & !ckay
+               ,ZOL=zol,HFX=hfx,UST=ust,PBLH=pblh               & !ckay
                ,AEROCU=aerocu,NO_SRC_TYPES_CU=no_src_types_cu   &
                ,AERCU_FCT=aercu_fct,AERCU_OPT=aercu_opt        &
                ,EFCS=EFCS,EFIS=EFIS,EFSS=EFSS)

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -993,13 +993,17 @@
       oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( ( model_config_rec%bl_pbl_physics(i) .NE. YSUSCHEME ) .AND. &
+         IF ( ( model_config_rec%bl_pbl_physics(i) .EQ. QNSEPBLSCHEME   .or. &
+                model_config_rec%bl_pbl_physics(i) .EQ. MYJPBLSCHEME    .or. &
+                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2  .or. &
+                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 )  &
+                                                                  .AND.   &
               ( model_config_rec%cu_physics(i) .EQ. MSKFSCHEME ) ) THEN
             oops = oops + 1
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- ERROR: bl_pbl_physics must be set to 1 for cu_physics = 11 '
+         wrf_err_message = '--- ERROR: bl_pbl_physics cannot be set to 4, 5, or 6 for cu_physics = 11 '
          CALL wrf_message ( wrf_err_message )
          wrf_err_message = '--- Fix bl_pbl_physics in namelist.input OR use another cu_physics option '
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1003,7 +1003,7 @@
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- ERROR: bl_pbl_physics cannot be set to 4, 5, or 6 for cu_physics = 11 '
+         wrf_err_message = '--- ERROR: bl_pbl_physics cannot be set to 2, 4, 5, or 6 for cu_physics = 11 '
          CALL wrf_message ( wrf_err_message )
          wrf_err_message = '--- Fix bl_pbl_physics in namelist.input OR use another cu_physics option '
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: MSKF, PBLs

SOURCE: Kiran Alapaty (EPA)

DESCRIPTION OF CHANGES: 
By computing convective velocity inside MSKF scheme, it allows the scheme to work with more PBL options.

LIST OF MODIFIED FILES: list of changed files 
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_cu_mskf.F
M       phys/module_cumulus_driver.F
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
regtest pending..

RELEASE NOTE: 
MSKF is now working with six other PBL schemes in addition to YSU.
