### PR TITLE
Add year dependent CO2 function as default for RRTMG only

### DIFF
--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11744,9 +11744,9 @@ CONTAINS
 #else
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv)
+! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
     real :: co2
-    data co2 / 379.e-6 / 
+!   data co2 / 379.e-6 / 
 ! methane (1774 ppbv)
     real :: ch4
     data ch4 / 1774.e-9 / 
@@ -11887,6 +11887,9 @@ CONTAINS
 ! All fields are ordered vertically from bottom to top
 ! Pressures are in mb
 !
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+
 !ccc Read time-varying trace gases concentrations and interpolate them to run date.
 !
 #ifdef CLWRFGHG

--- a/phys/module_ra_rrtmg_lwf.F
+++ b/phys/module_ra_rrtmg_lwf.F
@@ -15496,9 +15496,9 @@ integer,external :: omp_get_thread_num
 #else
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv)
+! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
     real :: co2
-    data co2 / 379.e-6 / 
+!   data co2 / 379.e-6 /
 ! methane (1774 ppbv)
     real :: ch4
     data ch4 / 1774.e-9 / 
@@ -15638,6 +15638,8 @@ integer,external :: omp_get_thread_num
 !                                                              
 ! All fields are ordered vertically from bottom to top
 ! Pressures are in mb
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 !
 !ccc Read time-varying trace gases concentrations and interpolate them to run date.
 !

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -9962,7 +9962,7 @@ CONTAINS
                        tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
                        swddir, swddni, swddif,                    & ! jararias 2013/08
                        swdownc, swddnic, swddirc,                 & ! PAJ
-                       xcoszen,julian                             & ! jararias 2013/08
+                       xcoszen,yr,julian                          & ! jararias 2013/08
                                                                   )
 !------------------------------------------------------------------
    IMPLICIT NONE
@@ -10035,6 +10035,7 @@ CONTAINS
             swddnic, & ! Clear ski DNI
             swddirc    ! Clear ski direct horizontal irradiance
 
+   integer, intent(in)        :: yr
    real, optional, intent(in) :: &
             julian      ! julian day (1-366)
    real, dimension(ims:ime,jms:jme), intent(in) :: &
@@ -10242,9 +10243,9 @@ CONTAINS
     real:: corr
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv)
+! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
     real :: co2
-    data co2 / 379.e-6 / 
+!   data co2 / 379.e-6 /
 ! methane (1774 ppbv)
     real :: ch4
     data ch4 / 1774.e-9 / 
@@ -10315,6 +10316,8 @@ CONTAINS
     REAL :: da, eot ! jararias, 14/08/2013
 
 !------------------------------------------------------------------
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then
       IF ( .NOT. &

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11256,7 +11256,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
                        tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
                        swddir, swddni, swddif,                    & ! jararias 2013/08
                        swdownc, swddnic, swddirc,                 & ! PAJ
-                       xcoszen,julian                             & ! jararias 2013/08
+                       xcoszen,yr,julian                          & ! jararias 2013/08
                                                                   )
 !------------------------------------------------------------------
       IMPLICIT NONE
@@ -11327,6 +11327,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
          swdownc, & ! Clear sky GHI
          swddnic, & ! Clear ski DNI
          swddirc    ! Clear ski direct horizontal irradiance
+   integer, intent(in)        :: yr
    real, optional, intent(in) :: &
          julian      ! julian day (1-366)
    real, dimension(ims:ime,jms:jme), optional, intent(in) :: &
@@ -11522,9 +11523,9 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
     real:: corr
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv)
+! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
     real :: co2
-    data co2 / 379.e-6 / 
+!   data co2 / 379.e-6 /
 ! methane (1774 ppbv)
     real :: ch4
     data ch4 / 1774.e-9 / 
@@ -11604,6 +11605,8 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
 !    REAL, DIMENSION( ims:ime, jms:jme ) ::         SWDB, SWUT
 
 !------------------------------------------------------------------
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then
       IF ( .NOT. &

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2378,7 +2378,7 @@ CONTAINS
                      asyaer3d_sw=asyaer_sw,                             & ! jararias 2013/11
                      swddir=swddir,swddni=swddni,swddif=swddif,         & ! jararias 2013/08/10
                      swdownc=swdownc, swddnic=swddnic, swddirc=swddirc, & ! PAJ
-                     xcoszen=coszen,julian=julian,mp_physics=mp_physics ) ! jararias 2013/08/14
+                     xcoszen=coszen,yr=yr,julian=julian,mp_physics=mp_physics ) ! jararias 2013/08/14
 
              DO j=jts,jte
              DO k=kts,kte
@@ -2459,7 +2459,7 @@ CONTAINS
                      asyaer3d_sw=asyaer_sw,                             & ! jararias 2013/11
                      swddir=swddir,swddni=swddni,swddif=swddif,         & ! jararias 2013/08/10
                      swdownc=swdownc, swddnic=swddnic, swddirc=swddirc, & ! PAJ
-                     xcoszen=coszen,julian=julian                       ) ! jararias 2013/08/14
+                     xcoszen=coszen,yr=yr,julian=julian                 ) ! jararias 2013/08/14
 
              DO j=jts,jte
              DO k=kts,kte


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: CO2, RTTMG longwave and shortwave

SOURCE: internal

DESCRIPTION OF CHANGES: 
CO2 is changing as a function of year. The default RRTMG value is 379 ppm valid in 2005. 
Current values exceed 400 ppm. A simple exponential function fits the past century to about 1%.
The function applied is CO2(ppm) = 280 + 90 exp (0.02 (year-2000)). Below are two plots 
using this function. 

The first figure shows the analytic function and measured values, as a function of time.
<img width="744" alt="Screen Shot 2020-01-23 at 9 44 40 AM" src="https://user-images.githubusercontent.com/17932284/73015483-59ae1580-3dd9-11ea-87c7-a89fa4113ad5.png">

The second figure shows the difference in the analytic and measured values for CO2.
<img width="487" alt="Screen Shot 2020-01-23 at 10 10 25 AM" src="https://user-images.githubusercontent.com/17932284/73015493-5fa3f680-3dd9-11ea-9f55-34967414c876.png">

This PR partially replaces #705 "User defined values for CO2 content in RRTMG and NOAH-MP".
The modifications are only to RRTMG (and the fast version).

LIST OF MODIFIED FILES: 
module_ra_rrtmg_lw.F
module_ra_rrtmg_sw.F
module_ra_rrtmg_lwf.F
module_ra_rrtmg_swf.F

TESTS CONDUCTED: 
With and without change. 2001 test case has 372 ppm versus 379 ppm default. T2 difference.
<img width="1650" alt="Screen Shot 2020-01-23 at 12 00 56 PM" src="https://user-images.githubusercontent.com/17932284/73016982-30db4f80-3ddc-11ea-9372-194c04bd9028.png">

RELEASE NOTE: RRTMG (and fast version) longwave and shortwave CO2 value is now a function of year, which replaces the outdated constant value of 379 ppm (applies to 2005).