### PR TITLE
Changing gwd_opt to a domain-dependent namelist

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2156,6 +2156,7 @@ rconfig   integer fft_used                derived               1             0 
 rconfig   integer cu_used                 derived               1             0       -     "cu_used"   "turn on if any cumulus scheme is used"
 rconfig   integer shcu_used               derived               1             0       -     "shcu_used" "turn on if any shallow cumulus scheme is used"
 rconfig   integer cam_used                derived               1             0       -     "cam_used"  "turn on if one of the following CAM schemes is used: MP, PBL, SHCU"
+rconfig   integer gwd_used                derived               1             0       -     "gwd_used"  "turn on if gwd_opt is on on any domains"
 rconfig   integer alloc_qndropsource      derived               1             0       -     "alloc_qndropsource"  "allocate qndropsource if CHEM==1 or if progn=1"
 
 rconfig   integer   num_moves       namelist,domains    1                0
@@ -2965,7 +2966,9 @@ package   aeropt2        aer_opt==2                 -              state:aod5503
 package   aercuopt       aercu_used==1              -              state:aeromcu,CU_UAF,EFCS,EFIS,EFSS,qr_cu,qs_cu,nc_cu,ni_cu,nr_cu,ns_cu,ccn_cu,aerovar;aerocu:cu_sulfate,cu_seasalt,cu_dust1,cu_dust2,cu_dust3,cu_dust4,cu_phoocar,cu_phiocar,cu_phobcar,cu_phibcar
 
 package   slopeopt       slope_rad==1               -              -
-package   gwdopt         gwd_opt==1                 -              state:oc12d,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4,dtaux3d,dtauy3d,dusfcg,dvsfcg
+package   gwd_used       gwd_used==1                -              state:oc12d,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4,dtaux3d,dtauy3d,dusfcg,dvsfcg
+package   nogwdopt       gwd_opt==0                 -              -
+package   gwdopt         gwd_opt==1                 -              -
 package   omlscheme      sf_ocean_physics==1        -              state:tml,t0ml,hml,h0ml,huml,hvml,tmoml
 package   pwp3dscheme    sf_ocean_physics==2        -              state:tml,t0ml,hml,h0ml,huml,hvml,tmoml,om_tmp,om_s,om_depth,om_u,om_v,om_lat,om_lon,om_ml,om_tini,om_sini
 

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2599,7 +2599,7 @@ rconfig   integer km_opt                  namelist,dynamics	max_domains   -1    
 rconfig   integer km_opt_dfi              namelist,dynamics	max_domains   1       irh    "km_opt_dfi"            ""      ""
 rconfig   integer damp_opt                namelist,dynamics	1             0       irh    "damp_opt"              ""      ""
 rconfig   integer rad_nudge               namelist,dynamics	1             0       irh    "rad_nudge"             ""      ""
-rconfig   integer gwd_opt                 namelist,dynamics     1             0       irh    "gwd_opt"              ""      ""
+rconfig   integer gwd_opt                 namelist,dynamics     max_domains   0       irh    "gwd_opt"              ""      ""
 rconfig   real    max_rot_angle_gwd       namelist,dynamics     1             22.5    irh    "max_rot_angle_gwd"    "max projection rotation angle permitted for gwd_opt=1"      ""
 rconfig   real    zdamp                   namelist,dynamics	max_domains    5000.   h    "zdamp"         ""      ""
 rconfig   real    dampcoef                namelist,dynamics     max_domains    0.      h    "dampcoef"              ""      ""

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1525,7 +1525,7 @@ The following are for observation nudging:
  pos_def                             = .false.  ! T/F remove negative values of scalar arrays by setting minimum value to zero
  swap_pole_with_next_j               = .false.  ! T/F replace the entire j=1 (jds-1) with the values from j=2 (jds-2)
  actual_distance_average             = .false.  ! T/F average the field at each i location in the j-loop with a number of grid points based on a map-factor ratio
- gwd_opt                             = 0       ! for running without gravity wave drag
+ gwd_opt (max_dom)                   = 0       ! for running without gravity wave drag
                                      = 1       ; for running the WRF-ARW with its gravity wave drag
                                      = 2       ; for running the WRF-NMM with its gravity wave drag
  sfs_opt (max_dom)                   = 0       ! nonlinear backscatter and anisotropy (NBA) off

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1426,6 +1426,28 @@
          END IF
 
 !-----------------------------------------------------------------------
+! Make sure icloud_bl is only used when MYNN is chosen.
+!-----------------------------------------------------------------------
+
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec%icloud_bl .eq. 1) THEN
+           IF ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
+                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) THEN
+              !CORRECTLY CONFIGURED
+           ELSE
+              model_config_rec%icloud_bl = 0
+              oops = oops + 1
+           END IF
+         END IF
+      ENDDO      ! Loop over domains
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = 'Need MYNN PBL for icloud_bl = 1, resetting to 0'
+         CALL wrf_debug ( 1, wrf_err_message )
+      END IF
+
+!-----------------------------------------------------------------------
 !  We need to know if any of the cumulus schemes are active. This
 !  allows the model to allocate space.
 !-----------------------------------------------------------------------
@@ -1452,26 +1474,17 @@
       ENDDO
 
 !-----------------------------------------------------------------------
-! Make sure icloud_bl is only used when MYNN is chosen.
+!  We need to know if the orographic gravity wave drag scheme is active 
+!  on any domains. This allows the model to allocate space.
 !-----------------------------------------------------------------------
 
-      oops = 0
+      model_config_rec%gwd_used = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( model_config_rec%icloud_bl .eq. 1) THEN
-           IF ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
-                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) THEN
-              !CORRECTLY CONFIGURED
-           ELSE
-              model_config_rec%icloud_bl = 0
-              oops = oops + 1
-           END IF
+         IF ( model_config_rec%gwd_opt(i) .NE. NOGWDOPT ) THEN
+            model_config_rec%gwd_used = 1
          END IF
-      ENDDO      ! Loop over domains
-      IF ( oops .GT. 0 ) THEN
-         wrf_err_message = 'Need MYNN PBL for icloud_bl = 1, resetting to 0'
-         CALL wrf_debug ( 1, wrf_err_message )
-      END IF
+      ENDDO
 
 !-----------------------------------------------------------------------
 ! Make sure microphysics option without QICE array cannot be used with icloud=3

--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -82,7 +82,7 @@
  non_hydrostatic                     = .true., .true., .true.,
  moist_adv_opt                       = 1,      1,      1,     
  scalar_adv_opt                      = 1,      1,      1,     
- gwd_opt                             = 1,
+ gwd_opt                             = 1,      1,      0,
  /
 
  &bdy_control

--- a/test/em_real/namelist.input.global
+++ b/test/em_real/namelist.input.global
@@ -82,7 +82,7 @@
  tke_adv_opt                         = 0,      0,      0,     
  fft_filter_lat                      = 45.,
  w_damping                           = 1,
- gwd_opt                             = 1,
+ gwd_opt                             = 1,      1,      1,
  /
 
  &bdy_control

--- a/test/em_real/namelist.input.jan00
+++ b/test/em_real/namelist.input.jan00
@@ -82,7 +82,7 @@
  non_hydrostatic                     = .true., .true., .true.,
  moist_adv_opt                       = 1,      1,      1,     
  scalar_adv_opt                      = 1,      1,      1,     
- gwd_opt                             = 1,
+ gwd_opt                             = 1,      1,      0,
  /
 
  &bdy_control

--- a/test/em_real/namelist.input.jun01
+++ b/test/em_real/namelist.input.jun01
@@ -82,7 +82,7 @@
  non_hydrostatic                     = .true., .true., .true.,
  moist_adv_opt                       = 1,      1,      1,     
  scalar_adv_opt                      = 1,      1,      1,     
- gwd_opt                             = 1,
+ gwd_opt                             = 1,      0,      0,
  /
 
  &bdy_control


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: GWD, domain dependent

SOURCE: internal

DESCRIPTION OF CHANGES: 
To assist the possibility that a user may turn off GWD in a nest, this PR make gwd_opt domain-dependent.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       share/module_check_a_mundo.F
M       run/README.namelist
M       test/em_real/namelist.input
M       test/em_real/namelist.input.global
M       test/em_real/namelist.input.jan00
M       test/em_real/namelist.input.jun01

TESTS CONDUCTED: 
Code tested with gwd_opt set to 1,1 and 1,0. The code behaves as expected. It passed automatic jenkins test.

RELEASE NOTE: 
The gwd_opt namelist has been changed to domain-dependent namelist. Hence one may turn off the option in a high-resolution domain.
