### PR TITLE
Handle possible locations for rpc/types.h

### DIFF
--- a/configure
+++ b/configure
@@ -983,6 +983,24 @@ if [ $retval -ne 0 ] ; then
   echo "*****************************************************************************"
 fi
 
+# testing for location of rpc/types.h file, used in landuse
+if [ -f /usr/include/rpc/types.h ] ; then
+  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=1/' configure.wrf > configure.wrf.edit
+  mv configure.wrf.edit configure.wrf
+echo standard location of RPC
+elif [ -f /usr/include/tirpc/rpc/types.h ] ; then
+  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=2/' configure.wrf > configure.wrf.edit
+  mv configure.wrf.edit configure.wrf
+echo newer location of RPC
+else
+  echo "************************** W A R N I N G ************************************"
+  echo " "
+  echo "The moving nest option is not available due to missing rpc/types.h file."
+  echo "Copy landread.c.dist to landread.c in share directory to bypass compile error."
+  echo " "
+  echo "*****************************************************************************"
+fi
+
 # testing for netcdf4 IO features
 if [ -n "$NETCDF4" ] ; then
   if [ $NETCDF4 -eq 1 ] ; then

--- a/share/landread.c
+++ b/share/landread.c
@@ -65,8 +65,13 @@ int GET_LANDUSE (        float *adx,
 #ifndef MS_SUA
 # include <stdio.h>
 #endif
-#include <rpc/types.h>
-#include <rpc/xdr.h>
+#if (RPC_TYPES == 1)
+# include <rpc/types.h>
+# include <rpc/xdr.h>
+#elif (RPC_TYPES == 2)
+# include <tirpc/rpc/types.h>
+# include <tirpc/rpc/xdr.h>
+#endif
 #include <math.h>
 #ifndef MACOS
 # include <malloc.h>


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: type.h, rpc, tirpc

SOURCE: Reported on WRF Forum, fixed internally

DESCRIPTION OF CHANGES:
Problem:
The C header file `rpc/types.h` may be located in a directory other than 
`/usr/include`. If the WRF code cannot find this file, the source code for 
`landread.c` does not compile, and the WRF code fails to build.

Mentioned on WRF Forum as "Problem Compiling WRFV4.0 on Fedora 28"
https://forum.mmm.ucar.edu/phpBB3/viewtopic.php?f=37&t=61&p=15718#p15718

Solution:
Refer to the discussion:
https://forums.gentoo.org/viewtopic-t-1076270-start-0.html

The likely other location for this header file is `/usr/include/tirpc`. During
the `configure` stage, a test is made to determine which of these two 
candidate directories is the correct location of this header file. A cpp flag 
is added to `ARCH_LOCAL` so that the correct location is `#include`d into the 
source code of `landread.c`.

LIST OF MODIFIED FILES:
modified:   configure
modified:   share/landread.c

TESTS CONDUCTED:
1. Automatic jenkins regression test OK, with expected failures due to fixes that are currently
only on the release-v4.1.4 branch (not yey merged to develop):
```
output_2:2 = STATUS test_002m hwrf nmm_real 34 1NE
output_2:2 = STATUS test_002m hwrf nmm_real 34 2NE
output_9:9 = STATUS test_009o fire em_fire 33 01
```
2. Tested with a simple print statement that the code still builds as expected
for OS / glibc versions that did not exhibit this trouble (no harm done).