### PR TITLE
A fix for conservation of enthalpy in BMJ cumulus scheme

### DIFF
--- a/phys/module_cu_bmj.F
+++ b/phys/module_cu_bmj.F
@@ -18,7 +18,7 @@
      &                 ,EPSNTP=.0001,EPSNTT=.0001,EPSPR=1.E-7           &
      &                 ,EPSUP=1.00                                      &
      &                 ,FR=1.00,FSL=0.85,FSS=0.85                       &
-     &                 ,FUP=0.                                          &
+     &                 ,FUP=0.,CRMN=0.14                                &
      &                 ,PBM=13000.,PFRZ=15000.,PNO=1000.                &
      &                 ,PONE=2500.,PQM=20000.                           &
      &                 ,PSH=20000.,PSHU=45000.                          &
@@ -126,6 +126,7 @@ CONTAINS
       INTEGER :: LBOT,LPBL,LTOP
 !
       REAL :: DTCNVC,LANDMASK,PCPCOL,PSFC,PTOP
+      REAL :: PWCOL,DQCOL,DQCOLMIN
 ! 
       REAL,DIMENSION(KTS:KTE) :: DPCOL,DQDT,DTDT,PCOL,QCOL,TCOL
 !
@@ -169,9 +170,12 @@ CONTAINS
             DTDT(K)=0.
           ENDDO
 !
+          DQCOL=0.
+          PWCOL=0.
+          PCPCOL=0.
+          DQCOLMIN=0.
           RAINCV(I,J)=0.
           PRATEC(I,J)=0.
-          PCPCOL=0.
           PSFC=PINT(I,LOWLYR(I,J),J)
           PTOP=PINT(I,KTE+1,J)      ! KTE+1=KME
 !
@@ -212,6 +216,7 @@ CONTAINS
           CALL BMJ(ITIMESTEP,I,J,DTCNVC,LMH,LANDMASK,CLDEFI(I,J)        &
      &            ,DPCOL,PCOL,QCOL,TCOL,PSFC,PTOP                       &
      &            ,DQDT,DTDT,PCPCOL,LBOT,LTOP,LPBL                      &
+     &            ,PWCOL,DQCOL,DQCOLMIN                                 &
      &            ,CP,R,ELWV,ELIV,G,TFRZ,D608                           &   
      &            ,PRINT_DIAG                                           &   
      &            ,IDS,IDE,JDS,JDE,KDS,KDE                              &     
@@ -288,6 +293,7 @@ CONTAINS
      & (ITIMESTEP,I,J,DTCNVC,LMH,SM,CLDEFI                              &
      & ,DPRS,PRSMID,Q,T,PSFC,PT                                         &
      & ,DQDT,DTDT,PCPCOL,LBOT,LTOP,LPBL                                 &
+     & ,PWCOL,DQCOL,DQCOLMIN                                            &
      & ,CP,R,ELWV,ELIV,G,TFRZ,D608                                      &
      & ,PRINT_DIAG                                                      &   
      & ,IDS,IDE,JDS,JDE,KDS,KDE                                         &
@@ -309,7 +315,7 @@ CONTAINS
 !
       REAL,DIMENSION(KTS:KTE),INTENT(IN) :: DPRS,PRSMID,Q,T
 !
-      REAL,INTENT(INOUT) :: CLDEFI,PCPCOL
+      REAL,INTENT(INOUT) :: CLDEFI,PCPCOL,PWCOL,DQCOL,DQCOLMIN
 !
       REAL,DIMENSION(KTS:KTE),INTENT(INOUT) :: DQDT,DTDT
 !
@@ -348,7 +354,7 @@ CONTAINS
      &            ,PART1,PART2,PART3,PBOT,PBOTFC,PBTK                   &
      &            ,PK0,PKB,PKL,PKT,PKXXXX,PKXXXY                        &
      &            ,PLMH,PELEVFC,PBTmx,plo,POTSUM,PP1,PPK,PRECK          &
-     &            ,PRESK,PSP,PSUM,PTHRS,PTOP,PTPK,PUP                   &
+     &            ,PRWD,PDQD,PRESK,PSP,PSUM,PTHRS,PTOP,PTPK,PUP         &
      &            ,QBT,QKL,QNEW,QOTSUM,QQ1,QQK,QRFKL                    &
      &            ,QRFTP,QSP,QSUM,QUP,RDP0T                             &
      &            ,RDPSUM,RDTCNVC,RHH,RHL,RHMAX,ROTSUM,RTBAR,RHAVG      &
@@ -406,7 +412,10 @@ CONTAINS
 !-----------------------------PREPARATIONS------------------------------
 !-----------------------------------------------------------------------
       LBOT=LMH
+      DQCOL=0.
+      PWCOL=0.
       PCPCOL=0.
+      DQCOLMIN=0.
       TREF(KTS)=T(KTS)
 !
       DO L=KTS,LMH
@@ -799,7 +808,8 @@ CONTAINS
         LTOP=KTE
         PBOT=PRSMID(LMH)
         PTOP=PBOT
-        CLDEFI=AVGEFI*SM+STEFI*(1.-SM)
+!        CLDEFI=AVGEFI*SM+STEFI*(1.-SM)
+        CLDEFI=(EFIMN-0.2)*SM+(1.+0.2)*(1.-SM)
         GO TO 800
       ENDIF
 !
@@ -812,6 +822,7 @@ CONTAINS
         DEEP=.TRUE.
       ELSE
         SHALLOW=.TRUE.
+        CLDEFI=(EFIMN-0.1)*SM+(1.+0.1)*(1.-SM)
         GO TO 600
       ENDIF
 !
@@ -1005,10 +1016,13 @@ CONTAINS
           DO L=LTOP,LB
             SUMDE=((TK(L)-TREFK(L))*CP+(QK(L)-QREFK(L))*EL(L))*DPRS(L)  &
      &            +SUMDE
+            DHDT=(QREFK(L)*A23M4L/((TREFK(L)*APEK(L)/APESK(L))-A4)**2+CP)*DPRS(L) &
+     &            +DHDT
             SUMDP=SUMDP+DPRS(L)
           ENDDO
 !
           HCORR=SUMDE/(SUMDP-DPRS(LTOP))
+          DHDT=DHDT/(SUMDP-DPRS(LTOP))
           LCOR=LTOP+1
 !***
 !***  FIND LQM
@@ -1030,8 +1044,6 @@ CONTAINS
 !***  BELOW LQM CORRECT BOTH TEMPERATURE AND MOISTURE
 !***
           DO L=LCOR,LB
-            TSKL=TREFK(L)*APEK(L)/APESK(L)
-            DHDT=QREFK(L)*A23M4L/(TSKL-A4)**2+CP
             TREFK(L)=HCORR/DHDT+TREFK(L)
             THSKL=TREFK(L)*APEK(L)
             QREFK(L)=PQ0/PSK(L)*EXP(A2*(THSKL-A3*APESK(L))              &
@@ -1046,6 +1058,8 @@ CONTAINS
 !-----------------------------------------------------------------------
         AVRGT=0.
         PRECK=0.
+        PDQD=0.
+        PRWD=0.
         DSQ=0.
         DST=0.
 !
@@ -1059,6 +1073,8 @@ CONTAINS
           DSQ=DIFQL*EL(L)*DPOT+DSQ
           AVRGT=AVRGTL*DPRS(L)+AVRGT
           PRECK=DIFTL*DPRS(L)+PRECK
+          PDQD=(QK(L)-QREFK(L))*DPRS(L)+PDQD
+          PRWD=QK(L)*DPRS(L)+PRWD
           DIFT(L)=DIFTL
           DIFQ(L)=DIFQL
         ENDDO
@@ -1096,6 +1112,9 @@ CONTAINS
 !
         CUP=PRECK*CPRLG
         PCPCOL=CUP
+        DQCOL=PDQD/G
+        PWCOL=PRWD/G
+        DQCOLMIN=(CRMN*TREL)/(FEFI*86400.)
 !
         DO L=LTOP,LB
           DTDT(L)=DIFT(L)*FEFI*RDTCNVC
@@ -1120,7 +1139,8 @@ CONTAINS
 !        ENDIF
 !
 !        CLDEFI=AVGEFI
-         CLDEFI=EFIMN*SM+STEFI*(1.-SM)
+!        CLDEFI=EFIMN*SM+STEFI*(1.-SM)
+         CLDEFI=(EFIMN-0.1)*SM+(1.+0.1)*(1.-SM)
 !***
 !***  SEARCH FOR SHALLOW CLOUD TOP
 !***

--- a/phys/module_cu_bmj.F
+++ b/phys/module_cu_bmj.F
@@ -18,7 +18,7 @@
      &                 ,EPSNTP=.0001,EPSNTT=.0001,EPSPR=1.E-7           &
      &                 ,EPSUP=1.00                                      &
      &                 ,FR=1.00,FSL=0.85,FSS=0.85                       &
-     &                 ,FUP=0.,CRMN=0.14                                &
+     &                 ,FUP=0.                                          &
      &                 ,PBM=13000.,PFRZ=15000.,PNO=1000.                &
      &                 ,PONE=2500.,PQM=20000.                           &
      &                 ,PSH=20000.,PSHU=45000.                          &
@@ -126,7 +126,6 @@ CONTAINS
       INTEGER :: LBOT,LPBL,LTOP
 !
       REAL :: DTCNVC,LANDMASK,PCPCOL,PSFC,PTOP
-      REAL :: PWCOL,DQCOL,DQCOLMIN
 ! 
       REAL,DIMENSION(KTS:KTE) :: DPCOL,DQDT,DTDT,PCOL,QCOL,TCOL
 !
@@ -170,12 +169,9 @@ CONTAINS
             DTDT(K)=0.
           ENDDO
 !
-          DQCOL=0.
-          PWCOL=0.
-          PCPCOL=0.
-          DQCOLMIN=0.
           RAINCV(I,J)=0.
           PRATEC(I,J)=0.
+          PCPCOL=0.
           PSFC=PINT(I,LOWLYR(I,J),J)
           PTOP=PINT(I,KTE+1,J)      ! KTE+1=KME
 !
@@ -216,7 +212,6 @@ CONTAINS
           CALL BMJ(ITIMESTEP,I,J,DTCNVC,LMH,LANDMASK,CLDEFI(I,J)        &
      &            ,DPCOL,PCOL,QCOL,TCOL,PSFC,PTOP                       &
      &            ,DQDT,DTDT,PCPCOL,LBOT,LTOP,LPBL                      &
-     &            ,PWCOL,DQCOL,DQCOLMIN                                 &
      &            ,CP,R,ELWV,ELIV,G,TFRZ,D608                           &   
      &            ,PRINT_DIAG                                           &   
      &            ,IDS,IDE,JDS,JDE,KDS,KDE                              &     
@@ -293,7 +288,6 @@ CONTAINS
      & (ITIMESTEP,I,J,DTCNVC,LMH,SM,CLDEFI                              &
      & ,DPRS,PRSMID,Q,T,PSFC,PT                                         &
      & ,DQDT,DTDT,PCPCOL,LBOT,LTOP,LPBL                                 &
-     & ,PWCOL,DQCOL,DQCOLMIN                                            &
      & ,CP,R,ELWV,ELIV,G,TFRZ,D608                                      &
      & ,PRINT_DIAG                                                      &   
      & ,IDS,IDE,JDS,JDE,KDS,KDE                                         &
@@ -315,7 +309,7 @@ CONTAINS
 !
       REAL,DIMENSION(KTS:KTE),INTENT(IN) :: DPRS,PRSMID,Q,T
 !
-      REAL,INTENT(INOUT) :: CLDEFI,PCPCOL,PWCOL,DQCOL,DQCOLMIN
+      REAL,INTENT(INOUT) :: CLDEFI,PCPCOL
 !
       REAL,DIMENSION(KTS:KTE),INTENT(INOUT) :: DQDT,DTDT
 !
@@ -354,7 +348,7 @@ CONTAINS
      &            ,PART1,PART2,PART3,PBOT,PBOTFC,PBTK                   &
      &            ,PK0,PKB,PKL,PKT,PKXXXX,PKXXXY                        &
      &            ,PLMH,PELEVFC,PBTmx,plo,POTSUM,PP1,PPK,PRECK          &
-     &            ,PRWD,PDQD,PRESK,PSP,PSUM,PTHRS,PTOP,PTPK,PUP         &
+     &            ,PRESK,PSP,PSUM,PTHRS,PTOP,PTPK,PUP                   &
      &            ,QBT,QKL,QNEW,QOTSUM,QQ1,QQK,QRFKL                    &
      &            ,QRFTP,QSP,QSUM,QUP,RDP0T                             &
      &            ,RDPSUM,RDTCNVC,RHH,RHL,RHMAX,ROTSUM,RTBAR,RHAVG      &
@@ -412,10 +406,7 @@ CONTAINS
 !-----------------------------PREPARATIONS------------------------------
 !-----------------------------------------------------------------------
       LBOT=LMH
-      DQCOL=0.
-      PWCOL=0.
       PCPCOL=0.
-      DQCOLMIN=0.
       TREF(KTS)=T(KTS)
 !
       DO L=KTS,LMH
@@ -808,8 +799,7 @@ CONTAINS
         LTOP=KTE
         PBOT=PRSMID(LMH)
         PTOP=PBOT
-!        CLDEFI=AVGEFI*SM+STEFI*(1.-SM)
-        CLDEFI=(EFIMN-0.2)*SM+(1.+0.2)*(1.-SM)
+        CLDEFI=AVGEFI*SM+STEFI*(1.-SM)
         GO TO 800
       ENDIF
 !
@@ -822,7 +812,6 @@ CONTAINS
         DEEP=.TRUE.
       ELSE
         SHALLOW=.TRUE.
-        CLDEFI=(EFIMN-0.1)*SM+(1.+0.1)*(1.-SM)
         GO TO 600
       ENDIF
 !
@@ -1058,8 +1047,6 @@ CONTAINS
 !-----------------------------------------------------------------------
         AVRGT=0.
         PRECK=0.
-        PDQD=0.
-        PRWD=0.
         DSQ=0.
         DST=0.
 !
@@ -1073,8 +1060,6 @@ CONTAINS
           DSQ=DIFQL*EL(L)*DPOT+DSQ
           AVRGT=AVRGTL*DPRS(L)+AVRGT
           PRECK=DIFTL*DPRS(L)+PRECK
-          PDQD=(QK(L)-QREFK(L))*DPRS(L)+PDQD
-          PRWD=QK(L)*DPRS(L)+PRWD
           DIFT(L)=DIFTL
           DIFQ(L)=DIFQL
         ENDDO
@@ -1112,9 +1097,6 @@ CONTAINS
 !
         CUP=PRECK*CPRLG
         PCPCOL=CUP
-        DQCOL=PDQD/G
-        PWCOL=PRWD/G
-        DQCOLMIN=(CRMN*TREL)/(FEFI*86400.)
 !
         DO L=LTOP,LB
           DTDT(L)=DIFT(L)*FEFI*RDTCNVC
@@ -1139,8 +1121,7 @@ CONTAINS
 !        ENDIF
 !
 !        CLDEFI=AVGEFI
-!        CLDEFI=EFIMN*SM+STEFI*(1.-SM)
-         CLDEFI=(EFIMN-0.1)*SM+(1.+0.1)*(1.-SM)
+         CLDEFI=EFIMN*SM+STEFI*(1.-SM)
 !***
 !***  SEARCH FOR SHALLOW CLOUD TOP
 !***

--- a/phys/module_cu_bmj.F
+++ b/phys/module_cu_bmj.F
@@ -981,9 +981,10 @@ CONTAINS
 !***
 !***  HUMIDITY PROFILE
 !***
+          PSK(L)=PK(L)+DSP
+          APESK(L)=(1.E5/PSK(L))**CAPA
+
           IF(PK(L)>PQM)THEN
-            PSK(L)=PK(L)+DSP
-            APESK(L)=(1.E5/PSK(L))**CAPA
             THSK(L)=TREFK(L)*APEK(L)
             QREFK(L)=PQ0/PSK(L)*EXP(A2*(THSK(L)-A3*APESK(L))            &
      &                                /(THSK(L)-A4*APESK(L)))
@@ -1001,6 +1002,7 @@ CONTAINS
 !
           SUMDE=0.
           SUMDP=0.
+          DHDT =0.
 !
           DO L=LTOP,LB
             SUMDE=((TK(L)-TREFK(L))*CP+(QK(L)-QREFK(L))*EL(L))*DPRS(L)  &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: BMJ, conservation of enthalpy

SOURCE: Tieh-Yong Koh (Earth Observatory of Singapore, Nanyang Technological University, Singapore); Ricardo Fonseca (Earth Observatory of Singapore, Nanyang Technological University, Singapore); Chee-Kiat Teo (Temasek Laboratories, Nanyang Technological University, Singapore); Tengfei Zhang (Earth Observatory of Singapore, Nanyang Technological University, Singapore)

DESCRIPTION OF CHANGES: 
This PR separates out a bug fix from PR#921 so that even if a user would not want to use the precipitation convective cloud (PCC) option, the benefit of bug fix can be utilized. The fix corrects an error with conservation of enthalpy. The DHDT term is corrected, which should be an integral from p_bot to p_top and not computed at every level as done in the original version of the code. For more detail, refer to the following paper:
https://www.geosci-model-dev.net/8/2915/2015/

The plot below shows the difference in convective rainfall for a mid-latitude convection case. The left plot is with the fix, and the right one is the diff plot, all at forecast hour 12. The fixed code produces less rain.

![diff_bugfix_12h](https://user-images.githubusercontent.com/12705680/74184298-c9a70300-4c03-11ea-86a3-1053fdff0a52.png)

The original bug fix used part of an array (APESK) that is not defined. This is corrected here. The plot above is also updated.

LIST OF MODIFIED FILES: 
M       phys/module_cu_bmj.F

TESTS CONDUCTED: 
Individual case test. Passed jenkins test which tests the BMJ cumulus scheme.

RELEASE NOTE: The bug fix corrects an error with conservation of enthalpy and more detail can be found in the following paper: https://www.geosci-model-dev.net/8/2915/2015/. The fixed code produces less surface rain.
