### PR TITLE
YSU Modify Comment at Top to Match Unified Physics and MPAS

### DIFF
--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -1,12 +1,5 @@
 !=================================================================================================================
-!module_bl_ysu.F was originally copied from ./phys/module_bl_ysu.F from WRF version 3.8.1.
-!Laura D. Fowler (laura@ucar.edu) / 2016-10-26.
-
-!modifications to sourcecode for MPAS:
-!   * calculated the dry hydrostatic pressure using the dry air density.
-!   * added outputs of the vertical diffusivity coefficients.
-!     Laura D. Fowler (laura@ucar.edu) / 2016-10-26.
-
+!module_bl_ysu.F was modified to accomodate both the WRF and MPAS models / 2018-12-7 
 !=================================================================================================================
 !WRF:model_layer:physics
 !


### PR DESCRIPTION
TYPE: text only

KEYWORDS: YSU, bl, module_bl_ysu, unified_physics, MPAS

SOURCE: internal

DESCRIPTION OF CHANGES: 
In an effort to ensure the develop branch and unified_physics branches are identical (which
is to keep the WRF and MPAS physics repositories with identical source code for the
targeted suites), the comment at the top of the YSU PBL file was modified to the more 
recent comment found in both the MPAS code and the code from the WRF
unified_physics branch. The unified_physics branch was cut off of the develop branch, which 
has had YSU updates from commits 3fd6cb1d (YSU fix for WSM3 and Kessler no-ice test) 
and 89208e9 (YSU update to include unified_physics branch mods on develop branch), 
meaning this file now differs from the unified_physics branch. 

LIST OF MODIFIED FILES:
M    phys/module_bl_ysu.F

TESTS CONDUCTED: 
1. Verified mods build okay with GNU. 
2. Automated Jenkins test OK.