### PR TITLE
Output standard U10/V10 from MYJSFC and QNSESFC schemes

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2862,7 +2862,7 @@ package   nosfcscheme        sf_sfclay_physics==0        -             -
 package   sfclayrevscheme    sf_sfclay_physics==1        -             -
 package   myjsfcscheme       sf_sfclay_physics==2        -             state:tke_pbl,u10e,v10e
 package   gfssfcscheme       sf_sfclay_physics==3        -             -
-package   qnsesfcscheme      sf_sfclay_physics==4        -             -
+package   qnsesfcscheme      sf_sfclay_physics==4        -             state:u10e,v10e
 package   mynnsfcscheme      sf_sfclay_physics==5        -             -
 package   pxsfcscheme        sf_sfclay_physics==7        -             -
 package   temfsfcscheme      sf_sfclay_physics==10       -             state:wm_temf

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -965,6 +965,9 @@ state   real   QSFC             ij     misc        1         -      r        "QS
 state   real   AKHS             ij     misc        1         -      r        "AKHS"                  "SFC EXCH COEFF FOR HEAT"                      "m s-1"    
 state   real   AKMS             ij     misc        1         -      r        "AKMS"                  "SFC EXCH COEFF FOR MOMENTUM"                  "m s-1"    
 state   integer KPBL            ij     misc        1         -     r         "KPBL"                  "LEVEL OF PBL TOP"                             ""
+state   real   U10E             ij     misc        1         -     irhdu     "U10E"                  "Special U at 10 M from MYJSFC"         "m s-1"
+state   real   V10E             ij     misc        1         -     irhdu     "V10E"                  "Special V at 10 M from MYJSFC"         "m s-1"
+
 #BSINGH - For CuP
 #~wig: added real pbl level index for output tests
 state   real   AKPBL            ij     misc        1         -      r        "AKPBL"                  "LEVEL OF PBL TOP"                             ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -965,8 +965,8 @@ state   real   QSFC             ij     misc        1         -      r        "QS
 state   real   AKHS             ij     misc        1         -      r        "AKHS"                  "SFC EXCH COEFF FOR HEAT"                      "m s-1"    
 state   real   AKMS             ij     misc        1         -      r        "AKMS"                  "SFC EXCH COEFF FOR MOMENTUM"                  "m s-1"    
 state   integer KPBL            ij     misc        1         -     r         "KPBL"                  "LEVEL OF PBL TOP"                             ""
-state   real   U10E             ij     misc        1         -     irhdu     "U10E"                  "Special U at 10 M from MYJSFC"         "m s-1"
-state   real   V10E             ij     misc        1         -     irhdu     "V10E"                  "Special V at 10 M from MYJSFC"         "m s-1"
+state   real   U10E             ij     misc        1         -     hdu       "U10E"                  "Special U at 10 M from MYJSFC"         "m s-1"
+state   real   V10E             ij     misc        1         -     hdu       "V10E"                  "Special V at 10 M from MYJSFC"         "m s-1"
 
 #BSINGH - For CuP
 #~wig: added real pbl level index for output tests

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2860,7 +2860,7 @@ package   gfdlswscheme    ra_sw_physics==99          -             -
 
 package   nosfcscheme        sf_sfclay_physics==0        -             -
 package   sfclayrevscheme    sf_sfclay_physics==1        -             -
-package   myjsfcscheme       sf_sfclay_physics==2        -             state:tke_pbl
+package   myjsfcscheme       sf_sfclay_physics==2        -             state:tke_pbl,u10e,v10e
 package   gfssfcscheme       sf_sfclay_physics==3        -             -
 package   qnsesfcscheme      sf_sfclay_physics==4        -             -
 package   mynnsfcscheme      sf_sfclay_physics==5        -             -

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -447,6 +447,8 @@ state  real   deep      ij    dyn_nmm   1    -     r        "DEEP"     "Deep con
 state  real   rf        ij    dyn_nmm   1    -     r
 state  real   th10      ij    dyn_nmm   1    -     rh023d=(DownCopy)       "TH10"     "10-m potential temperature from MYJ"  "K"
 state  real   q10       ij    dyn_nmm   1    -     rh023d=(DownCopy)       "Q10"      "10-m specific humidity from MYJ"      "kg kg-1"
+state  real   u10e      ij    dyn_nmm   1    -     rhd=(DownCopy)          "U10E"     "Special 10-m U from MYJ"      "m s-1"
+state  real   v10e      ij    dyn_nmm   1    -     rhd=(DownCopy)          "V10E"     "Special 10-m V from MYJ"      "m s-1"
 state  real   pshltr    ij    dyn_nmm   1    -     rh023d=(DownCopy)       "PSHLTR"   "2-m pressure from MYJ"                "Pa"
 state  real   tshltr    ij    dyn_nmm   1    -     rh023d=(DownCopy)       "TSHLTR"   "2-m potential temperature from MYJ"    "K"
 state  real   qshltr    ij    dyn_nmm   1    -     rh023d=(DownCopy)       "QSHLTR"   "2-m specific humidity from MYJ"       "kg kg-1"

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -526,6 +526,7 @@ BENCH_START(surf_driver_tim)
      &        ,URATX=grid%uratx        ,VRATX=grid%vratx   ,TRATX=grid%tratx        &
      &        ,UDRUNOFF=grid%udrunoff  ,UST=grid%ust       ,UZ0=grid%uz0            &
      &        ,U_FRAME=grid%u_frame    ,U_PHY=grid%u_phy   ,V10=grid%v10            &
+     &        ,U10E=grid%u10e          ,V10E=grid%v10e                              &
      &        ,UOCE=grid%uoce          ,VOCE=grid%voce                              &
      &        ,VEGFRA=grid%vegfra      ,VZ0=grid%vz0       ,V_FRAME=grid%v_frame    &
      &        ,V_PHY=grid%v_phy        ,WARM_RAIN=grid%warm_rain                    &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1067,7 +1067,8 @@ endif
                       grid%DX,grid%DY,grid%f_ice_phy,grid%f_rain_phy,grid%f_rimef_phy, &
                       grid%mp_restart_state,grid%tbpvs_state,grid%tbpvs0_state,&
                       allowed_to_read, grid%moved, start_of_simulation,               &
-                      grid%LAGDAY, &
+                      grid%LAGDAY,                            &
+                      grid%U10,grid%V10,grid%U10E,grid%V10E,  &
                       ids, ide, jds, jde, kds, kde,           &
                       ims, ime, jms, jme, kms, kme,           &
                       grid%i_start(ij), grid%i_end(ij), grid%j_start(ij), grid%j_end(ij), kts, kte, &

--- a/dyn_nmm/module_PHYSICS_CALLS.F
+++ b/dyn_nmm/module_PHYSICS_CALLS.F
@@ -1465,6 +1465,7 @@
      &          ,TMN=TG,TSHLTR=TSHLTR,TSK=TSFC,TSLB=STC,T_PHY=T_PHY     &
      &          ,U10=U10,UDRUNOFF=BGROFF,UST=USTAR,UZ0=UZ0H             &
      &          ,U_FRAME=U_FRAME,U_PHY=U_PHY,V10=V10,VEGFRA=VGFRCK      &
+     &          ,U10E=grid%U10E,V10E=grid%V10E                          &
      &          ,UOCE=UOCE,VOCE=VOCE                                    &
      &          ,VZ0=VZ0H,V_FRAME=V_FRAME,V_PHY=V_PHY                   &
      &          ,WARM_RAIN=WARM_RAIN,WSPD=WSPD,XICE=SICE,XICEM=SICE     &

--- a/dyn_nmm/start_domain_nmm.F
+++ b/dyn_nmm/start_domain_nmm.F
@@ -2171,6 +2171,7 @@
      &             ,grid%mp_restart_state,grid%tbpvs_state,grid%tbpvs0_state           &
      &             ,ALLOWED_TO_READ,grid%moved,START_OF_SIMULATION                    &
      &             ,1                                                   & ! lagday
+     &             ,grid%U10,grid%V10,grid%U10E,grid%V10E               &
      &             ,IDS, IDE, JDS, JDE, KDS, KDE                        &
      &             ,IMS, IME, JMS, JME, KMS, KME                        &
      &             ,ITS, ITE, JTS, JTE, KTS, KTE                        &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -1173,9 +1173,10 @@ CONTAINS
    end if
 #endif
 
-!  Initializing special output from myjsfc
+!  Initializing special output from myjsfc and qnsesfc
 
-   if ( config_flags%sf_sfclay_physics .EQ. MYJSFCSCHEME ) THEN
+   if ( config_flags%sf_sfclay_physics .EQ. MYJSFCSCHEME .OR. &
+        config_flags%sf_sfclay_physics .EQ. QNSESFCSCHEME ) THEN
       do j=jts,jtf
          do i=its,itf
             u10e(i,j) = u10(i,j)

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -81,6 +81,7 @@ CONTAINS
                          mp_restart_state,tbpvs_state,tbpvs0_state,&
                          allowed_to_read, moved, start_of_simulation,&
                          LAGDAY,                                 &
+                         u10,v10,u10e,v10e,                      &
                          ids, ide, jds, jde, kds, kde,           &
                          ims, ime, jms, jme, kms, kme,           &
                          its, ite, jts, jte, kts, kte,           &
@@ -357,7 +358,12 @@ CONTAINS
    INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
             INTENT(INOUT)    ::                         IVGTYP, &
                                                         ISLTYP
-
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            OPTIONAL, INTENT(IN)    ::                     U10, &
+                                                           V10
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            OPTIONAL, INTENT(OUT)    ::                   U10E, &
+                                                          V10E
 #if ( EM_CORE == 1 )
    !BSINGH - For WRFCuP scheme
    REAL, DIMENSION( ims:ime, jms:jme )                        , &
@@ -1166,6 +1172,17 @@ CONTAINS
       end do
    end if
 #endif
+
+!  Initializing special output from myjsfc
+
+   if ( config_flags%sf_sfclay_physics .EQ. MYJSFCSCHEME ) THEN
+      do j=jts,jtf
+         do i=its,itf
+            u10e(i,j) = u10(i,j)
+            v10e(i,j) = v10(i,j)
+         end do
+      end do
+   end if
 
    CALL wrf_debug ( 200 , 'module_start: phy_init: Before call to landuse_init' )
 

--- a/phys/module_sf_myjsfc.F
+++ b/phys/module_sf_myjsfc.F
@@ -73,7 +73,7 @@ CONTAINS
      &                 ,CHS,CHS2,CQS2,HFX,QFX,FLX_LH,FLHC,FLQC         &
      &                 ,QGH,CPM,CT                                     &
      &                 ,U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR          &
-     &                 ,P1000mb                                        &
+     &                 ,P1000mb,U10E,V10E                              &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE)
@@ -105,7 +105,8 @@ CONTAINS
       REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(OUT) :: FLX_LH,HFX,PSHLTR &
      &                                              ,QFX,Q10,QSHLTR    &
      &                                              ,TH10,TSHLTR,T02   &
-     &                                              ,U10,V10,TH02,Q02
+     &                                              ,U10,V10,TH02,Q02  &
+     &                                              ,U10E,V10E
 !
       REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: AKHS,AKMS       &
      &                                                ,PBLH,QSFC
@@ -315,6 +316,7 @@ CONTAINS
      &               ,ZSL,PLOW                                         &
      &               ,U10(I,J),V10(I,J),TSHLTR(I,J),TH10(I,J)          &
      &               ,QSHLTR(I,J),Q10(I,J),PSHLTR(I,J)                 &
+     &               ,U10E(I,J),V10E(I,J)                              &
      &               ,IDS,IDE,JDS,JDE,KDS,KDE                          &
      &               ,IMS,IME,JMS,JME,KMS,KME                          &
      &               ,ITS,ITE,JTS,JTE,KTS,KTE,i,j,ZHK(LMH+1))
@@ -364,6 +366,7 @@ CONTAINS
      &                 ,ULOW,VLOW,TLOW,THLOW,THELOW,QLOW,CWMLOW        &
      &                 ,ZSL,PLOW                                       &
      &                 ,U10,V10,TH02,TH10,Q02,Q10,PSHLTR               &
+     &                 ,U10E,V10E                                      &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE,i,j,ZSFC)
@@ -390,7 +393,7 @@ CONTAINS
 !
       REAL,INTENT(OUT) :: CHS,CHS2,CPM,CQS2,CT,FLHC,FLQC,FLX_LH,HFX    &
      &                   ,PSHLTR,Q02,Q10,QFX,QGH,RIB,RLMO              &
-     &                   ,TH02,TH10,U10,V10
+     &                   ,TH02,TH10,U10,V10,U10E,V10E
 !
       REAL,INTENT(INOUT) :: AKHS,AKMS,QZ0,THZ0,USTAR,UZ0,VZ0,Z0,QS
 !----------------------------------------------------------------------
@@ -412,7 +415,7 @@ CONTAINS
 !
       REAL :: AKHS02,AKHS10,AKMS02,AKMS10,EKMS10,QSAT10,QSAT2          &
      &       ,RLNT02,RLNT10,RLNU10,SIMH02,SIMH10,SIMM10,T02,T10        &
-     &       ,TERM1,RLOW,U10E,V10E,WSTAR,XLT02,XLT024,XLT10            &
+     &       ,TERM1,RLOW,WSTAR,XLT02,XLT024,XLT10            &
      &       ,XLT104,XLU10,XLU104,XU10,XU104,ZT02,ZT10,ZTAT02,ZTAT10   &
      &       ,ZTAU,ZTAU10,ZU10,ZUUZ
 !----------------------------------------------------------------------
@@ -1016,8 +1019,8 @@ CONTAINS
 
       ENDIF
 !
-      U10=U10E
-      V10=V10E
+!     U10=U10E
+!     V10=V10E
 !
 !----------------------------------------------------------------------
 !***  SET OTHER WRF DRIVER ARRAYS

--- a/phys/module_sf_qnsesfc.F
+++ b/phys/module_sf_qnsesfc.F
@@ -75,6 +75,7 @@ CONTAINS
      &                 ,CHS,CHS2,CQS2,HFX,QFX,FLX_LH,FLHC,FLQC         &
      &                 ,QGH,CPM,CT                                     &
      &                 ,U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR          &
+     &                 ,U10E,V10E                                      &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE,SCM_FORCE_FLUX  )
@@ -103,6 +104,7 @@ CONTAINS
       REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(OUT) :: PSHLTR,Q10,QSHLTR &
      &                                              ,TH10,TSHLTR,T02   &
      &                                              ,U10,V10,TH02,Q02
+      REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(OUT) :: U10E,V10E
       REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: FLX_LH,HFX,QFX 
 !
       REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: AKHS,AKMS       &
@@ -297,6 +299,7 @@ CONTAINS
      &               ,ZSL,PLOW                                         &
      &               ,U10(I,J),V10(I,J),TSHLTR(I,J),TH10(I,J)          &
      &               ,QSHLTR(I,J),Q10(I,J),PSHLTR(I,J)                 &
+     &               ,U10E(I,J),V10E(I,J)                              &
      &               ,IDS,IDE,JDS,JDE,KDS,KDE                          &
      &               ,IMS,IME,JMS,JME,KMS,KME                          &
      &               ,ITS,ITE,JTS,JTE,KTS,KTE,i,j,ZHK(LMH+1)           &
@@ -348,6 +351,7 @@ CONTAINS
      &                 ,ULOW,VLOW,TLOW,THLOW,THELOW,QLOW,CWMLOW        &
      &                 ,ZSL,PLOW                                       &
      &                 ,U10,V10,TH02,TH10,Q02,Q10,PSHLTR               &
+     &                 ,U10E,V10E                                      &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE,i,j,ZSFC,SCM_FORCE_FLUX)
@@ -373,6 +377,8 @@ CONTAINS
 !
       REAL,INTENT(OUT) :: CHS,CHS2,CPM,CQS2,CT,FLHC,FLQC,    &
      &                   PSHLTR,Q02,Q10,QGH,RIB,RLMO,TH02,TH10,U10,V10
+
+      REAL,INTENT(OUT) :: U10E,V10E
 !
       REAL,INTENT(INOUT) :: FLX_LH,HFX,QFX  
 !
@@ -398,7 +404,7 @@ CONTAINS
 !
       REAL :: AKHS02,AKHS10,AKMS02,AKMS10,EKMS10,QSAT10,QSAT2          &
      &       ,RLNT02,RLNT10,RLNU10,SIMH02,SIMH10,SIMM10,T02,T10        &
-     &       ,TERM1,RLOW,U10E,V10E,WSTAR,XLT02,XLT024,XLT10            &
+     &       ,TERM1,RLOW,WSTAR,XLT02,XLT024,XLT10                      &
      &       ,XLT104,XLU10,XLU104,XU10,XU104,ZT02,ZT10,ZTAT02,ZTAT10   &
      &       ,ZTAU,ZTAU10,ZU10,ZUUZ
 !----------------------------------------------------------------------
@@ -956,8 +962,8 @@ CONTAINS
 
       ENDIF
 !
-      U10=U10E
-      V10=V10E
+!     U10=U10E
+!     V10=V10E
 !
 !----------------------------------------------------------------------
 !***  SET OTHER WRF DRIVER ARRAYS

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -31,7 +31,7 @@ CONTAINS
      &          ,th10,th2,thz0,th_phy,tmn,tshltr,tsk,tslb             &
      &          ,tyr,tyra,tdly,tlag,lagday,nyear,nday,tmn_update,yr   &
      &          ,t_phy,u10,udrunoff,ust,uz0                           &
-     &          ,u_frame,u_phy,v10,vegfra,uoce,voce                   &
+     &          ,u_frame,u_phy,v10,vegfra,u10e,v10e,uoce,voce         &
      &          ,vz0,v_frame,v_phy,warm_rain,wspd,xice,xland,z,znt    &
      &          ,max_edom,cplmask                                     &
 #if (HWRF==1)
@@ -817,6 +817,8 @@ CONTAINS
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   TSHLTR
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   U10
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   V10
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   U10E
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   V10E
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   UOCE
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   VOCE
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   PSFC
@@ -2066,7 +2068,7 @@ CONTAINS
                 br,                                                 &
                 chs,chs2,cqs2,hfx,qfx,lh,flhc,flqc,qgh,cpm,ct,       &
                 u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,               &
-                p1000mb,                                             &
+                p1000mb,u10e,v10e,                                   &
                 ids,ide, jds,jde, kds,kde,                           &
                 ims,ime, jms,jme, kms,kme,                           &
                 i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte    )
@@ -2083,7 +2085,7 @@ CONTAINS
               br,                                                 &
               chs,chs2,cqs2,hfx,qfx,lh,flhc,flqc,qgh,cpm,ct,       &
               u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,               &
-              p1000mb,                                             &
+              p1000mb,u10e,v10e,                                   &
               ids,ide, jds,jde, kds,kde,                           &
               ims,ime, jms,jme, kms,kme,                           &
               i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte    )
@@ -4151,7 +4153,7 @@ CONTAINS
         &     CHS,CHS2,CQS2,HFX,QFX,FLX_LH,FLHC,FLQC,     &
         &     QGH,CPM,CT,                                 &
         &     U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR,          &
-        &     P1000,                                        &
+        &     P1000,U10E,V10E,                            &
         &     IDS,IDE,JDS,JDE,KDS,KDE,                        &
         &     IMS,IME,JMS,JME,KMS,KME,                        &
         &     ITS,ITE,JTS,JTE,KTS,KTE )
@@ -4224,6 +4226,8 @@ CONTAINS
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: CT
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: U10
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: V10
+     REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: U10E
+     REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: V10E
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: T02
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: TH02
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: TSHLTR
@@ -4246,6 +4250,8 @@ CONTAINS
      REAL, DIMENSION( ims:ime, jms:jme ) :: ct_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: u10_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: v10_sea
+     REAL, DIMENSION( ims:ime, jms:jme ) :: u10e_sea
+     REAL, DIMENSION( ims:ime, jms:jme ) :: v10e_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: t02_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: th02_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: tshltr_sea
@@ -4384,7 +4390,7 @@ CONTAINS
           &        QGH, CPM, CT, U10, V10, T02,                    &  ! 0,0,0,0,0,0,
           &        TH02, TSHLTR, TH10, Q02,                        &  ! 0,0,0,0,
           &        QSHLTR, Q10, PSHLTR,                            &  ! 0,0,0,
-          &        P1000,                                        &  ! I
+          &        P1000, U10E, V10E,                              &  ! I
           &        ids,ide, jds,jde, kds,kde,                      &
           &        ims,ime, jms,jme, kms,kme,                      &
           &        its,ite, jts,jte, kts,kte    )
@@ -4438,7 +4444,7 @@ CONTAINS
           &        CHS_SEA, CHS2_SEA, CQS2_SEA, HFX_SEA, QFX_SEA, FLX_LH_SEA, FLHC_SEA,        & ! 0,0,0,0,0,0,0,
           &        FLQC_SEA, QGH_SEA, CPM_SEA, CT_SEA, U10_SEA, V10_SEA, T02_SEA, TH02_SEA,    & ! 0,0,0,0,0,0,0,0,
           &        TSHLTR_SEA, TH10_SEA, Q02_SEA, QSHLTR_SEA, Q10_SEA, PSHLTR_SEA,             & ! 0,0,0,0,0,0,
-          &        p1000,                                                                    & ! I
+          &        p1000, u10e_sea,  v10e_sea,                                                 & ! I
           &        ids,ide, jds,jde, kds,kde,                                                  &
           &        ims,ime, jms,jme, kms,kme,                                                  &
           &        its,ite, jts,jte, kts,kte    )
@@ -4474,6 +4480,8 @@ CONTAINS
               T02(i,j)    = T02(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * T02_SEA(i,j)
               U10(i,j)    = U10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * U10_SEA(i,j)
               V10(i,j)    = V10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * V10_SEA(i,j)
+              U10E(i,j)   = U10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * U10E_SEA(i,j)
+              V10E(i,j)   = V10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * V10E_SEA(i,j)
 
               ! INTENT(INOUT):  updated by MYJSFC
               ! QSFC:  wait

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -4482,8 +4482,8 @@ CONTAINS
               T02(i,j)    = T02(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * T02_SEA(i,j)
               U10(i,j)    = U10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * U10_SEA(i,j)
               V10(i,j)    = V10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * V10_SEA(i,j)
-              U10E(i,j)   = U10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * U10E_SEA(i,j)
-              V10E(i,j)   = V10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * V10E_SEA(i,j)
+              U10E(i,j)   = U10(i,j)
+              V10E(i,j)   = V10(i,j)
 
               ! INTENT(INOUT):  updated by MYJSFC
               ! QSFC:  wait

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -4849,8 +4849,8 @@ CONTAINS
               T02(i,j)    = T02(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * T02_SEA(i,j)
               U10(i,j)    = U10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * U10_SEA(i,j)
               V10(i,j)    = V10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * V10_SEA(i,j)
-              U10E(i,j)   = U10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * U10E_SEA(i,j)
-              V10E(i,j)   = V10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * V10E_SEA(i,j)
+              U10E(i,j)   = U10(i,j)
+              V10E(i,j)   = V10(i,j)
 
               ! INTENT(INOUT):  updated by QNSESFC
               ! QSFC:  wait

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2160,7 +2160,8 @@ CONTAINS
                 akhs,akms,                                           &
                 br,                                                 &
                 chs,chs2,cqs2,hfx,qfx,lh,flhc,flqc,qgh,cpm,ct,       &
-                u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,               &
+                u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,     &
+                u10e,v10e,                                           &
                 ids,ide, jds,jde, kds,kde,                           &
                 ims,ime, jms,jme, kms,kme,                           &
                 i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,SCM_FORCE_FLUX    )
@@ -2176,7 +2177,8 @@ CONTAINS
               akhs,akms,                                           &
               br,                                                 &
               chs,chs2,cqs2,hfx,qfx,lh,flhc,flqc,qgh,cpm,ct,       &
-              u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,               &
+              u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,     &
+              u10e,v10e,                                           &
               ids,ide, jds,jde, kds,kde,                           &
               ims,ime, jms,jme, kms,kme,                           &
               i_start(ij),i_end(ij), j_start(ij),j_end(ij),     &
@@ -4524,6 +4526,7 @@ CONTAINS
         &     CHS,CHS2,CQS2,HFX,QFX,FLX_LH,FLHC,FLQC,     &
         &     QGH,CPM,CT,                                 &
         &     U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR,          &
+        &     U10E,V10E,                                  &
         &     IDS,IDE,JDS,JDE,KDS,KDE,                        &
         &     IMS,IME,JMS,JME,KMS,KME,                        &
         &     ITS,ITE,JTS,JTE,KTS,KTE,SCM_FORCE_FLUX )
@@ -4593,6 +4596,8 @@ CONTAINS
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: CT
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: U10
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: V10
+     REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: U10E
+     REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: V10E
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: T02
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: TH02
      REAL,DIMENSION(IMS:IME,JMS:JME),        INTENT(OUT)   :: TSHLTR
@@ -4615,6 +4620,8 @@ CONTAINS
      REAL, DIMENSION( ims:ime, jms:jme ) :: ct_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: u10_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: v10_sea
+     REAL, DIMENSION( ims:ime, jms:jme ) :: u10e_sea
+     REAL, DIMENSION( ims:ime, jms:jme ) :: v10e_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: t02_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: th02_sea
      REAL, DIMENSION( ims:ime, jms:jme ) :: tshltr_sea
@@ -4752,6 +4759,7 @@ CONTAINS
           &        QGH, CPM, CT, U10, V10,T02,TH02,                    &  ! 0,0,0,0,0,0,0
           &        TSHLTR, TH10, Q02,                    &  ! 0,0,0
           &        QSHLTR, Q10, PSHLTR,                            &  ! 0,0,0,
+          &        U10E, V10E,                                     &  ! 0,0,0,
           &        ids,ide, jds,jde, kds,kde,                      &
           &        ims,ime, jms,jme, kms,kme,                      &
           &        its,ite, jts,jte, kts,kte, SCM_FORCE_FLUX    )
@@ -4805,6 +4813,7 @@ CONTAINS
           &        CHS_SEA, CHS2_SEA, CQS2_SEA, HFX_SEA, QFX_SEA, FLX_LH_SEA, FLHC_SEA,        & ! 0,0,0,0,0,0,0,
           &        FLQC_SEA, QGH_SEA, CPM_SEA, CT_SEA, U10_SEA, V10_SEA,T02_SEA,TH02_SEA,   & ! 0,0,0,0,0,0,0,0
           &        TSHLTR_SEA, TH10_SEA, Q02_SEA, QSHLTR_SEA, Q10_SEA, PSHLTR_SEA,             & ! 0,0,0,0,0,0
+          &        U10E, V10E,                                                                 &
           &        ids,ide, jds,jde, kds,kde,                                                  &
           &        ims,ime, jms,jme, kms,kme,                                                  &
           &        its,ite, jts,jte, kts,kte, SCM_FORCE_FLUX    )
@@ -4840,6 +4849,8 @@ CONTAINS
               T02(i,j)    = T02(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * T02_SEA(i,j)
               U10(i,j)    = U10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * U10_SEA(i,j)
               V10(i,j)    = V10(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * V10_SEA(i,j)
+              U10E(i,j)   = U10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * U10E_SEA(i,j)
+              V10E(i,j)   = V10E(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * V10E_SEA(i,j)
 
               ! INTENT(INOUT):  updated by QNSESFC
               ! QSFC:  wait


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: u10, v10, myjsfc, qnsesfc

SOURCE: reported by Rob Fovell and others, fixed internally

DESCRIPTION OF CHANGES: 
The U10/V10 output when MYJ and QNSE surface layer schemes is used is non-standard over land, which produces higher values. This PR retains the value computed using standard MO 
theory, and moves the modified U10/V10 to U10E/V10E. 

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       Registry/Registry.NMM
M       dyn_em/module_first_rk_step_part1.F
M       dyn_em/start_em.F
M       dyn_nmm/module_PHYSICS_CALLS.F
M       dyn_nmm/start_domain_nmm.F
M       phys/module_physics_init.F
M       phys/module_sf_myjsfc.F
M       phys/module_sf_qnsesfc.F
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
1. Compiled. 
2. Tested with MYJSFC on and off. 
   * When MYJSFC is on, both U10/U10E, V10/V10E are in output.
   * When MYJSFC is not used, only U10/V10 are in output.
3. Has passed jenkins test

RELEASE NOTE: 
The U10/v10 diagnostic variables output from the MYJ and QNSE surface layer schemes have been replaced. The standard fields from MO theory are now output as U10/V10, and the original MYJ SFC scheme diagnostic values of U10/V10 are output with the names U10E/V10E. For those using the MYJ surface layer scheme, this change will modify the resultant U10/V10 values that are used inside of the diagnostics and the time series options.