### PR TITLE
Bug fixes for DA stand-alone gen_be_v3 utility in develop branch

### DIFF
--- a/var/gen_be_v3/README.gen_be_v3
+++ b/var/gen_be_v3/README.gen_be_v3
@@ -1,7 +1,7 @@
 
-*** gen_be_b3.F90 is a user-contribute program and is provided as it is. ***
-*** gen_be_b3.F90 is for univariate processing only. ***
-*** gen_be_b3.F90 is for bin_type=5 (domain-average BE statistics) only. ***
+*** gen_be_v3.F90 is a user-contribute program and is provided as it is. ***
+*** gen_be_v3.F90 is for univariate processing only. ***
+*** gen_be_v3.F90 is for bin_type=5 (domain-average BE statistics) only. ***
 
 1. To compile:
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, gen_be_v3

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
1. fix the allocation/initialization/deallocation of some arrays.
Some arrays should be initialized inside the loops for variables.
The improper initialized arrays led to incorrect scalelength values for the non-first variables.
2. fix typos in README.gen_be_v3

LIST OF MODIFIED FILES:
M       var/gen_be_v3/README.gen_be_v3
M       var/gen_be_v3/gen_be_v3.F90

TESTS CONDUCTED:
When single variable is set in the namelist, the results are identical before and after the fix.
When multiple variables are set in the namelist, the result of the first variable remains the same before and after the fix,
and the results of the other variables are now the same as when they are run alone.