### PR TITLE
Fix broken NMM build caused by FARMS mods

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -308,10 +308,13 @@ BENCH_START(rad_driver_tim)
      &        ,CAM_ABS_FREQ_S=grid%cam_abs_freq_s                         &
      &        ,XTIME=grid%xtime                                                &
               ,CURR_SECS=curr_secs, ADAPT_STEP_FLAG=adapt_step_flag       &
+!dave
+#if ( EM_CORE == 1)
      &        ,mut=grid%mut,dnw=grid%dnw                                  & ! FARMS coupling
      &        ,swdown2=grid%swdown2, swddni2=grid%swddni2                 & ! FARMS coupling
      &        ,swddif2=grid%swddif2, swddir2=grid%swddir2                 & ! FARMS coupling
      &        ,swdownc2=grid%swdownc2, swddnic2=grid%swddnic2             & ! FARMS coupling
+#endif
 !BSINGH - For WRFCuP scheme
      &        ,CU_PHYSICS=config_flags%cu_physics                         & !CuP, wig 5-Oct-2006
      &        ,SHALLOWCU_FORCED_RA=config_flags%shallowcu_forced_ra       & !CuP, wig

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -308,7 +308,6 @@ BENCH_START(rad_driver_tim)
      &        ,CAM_ABS_FREQ_S=grid%cam_abs_freq_s                         &
      &        ,XTIME=grid%xtime                                                &
               ,CURR_SECS=curr_secs, ADAPT_STEP_FLAG=adapt_step_flag       &
-!dave
 #if ( EM_CORE == 1)
      &        ,mut=grid%mut,dnw=grid%dnw                                  & ! FARMS coupling
      &        ,swdown2=grid%swdown2, swddni2=grid%swddni2                 & ! FARMS coupling

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -472,8 +472,8 @@ CONTAINS
                                                            HBOTR, &
                                                            CUPPT
      ! FARMS coupling
-   REAL, DIMENSION( ims:ime , jms:jme ),  INTENT(IN) ::  MUT
-   REAL , DIMENSION( kms:kme ) , INTENT(IN   ) :: DNW
+   REAL, DIMENSION( ims:ime , jms:jme ),  INTENT(IN), OPTIONAL ::  MUT
+   REAL , DIMENSION( kms:kme ) , INTENT(IN   ), OPTIONAL :: DNW
 
    !BSINGH - For WRFCuP scheme
    REAL, DIMENSION( ims:ime, jms:jme ), OPTIONAL,                 &
@@ -615,7 +615,7 @@ CONTAINS
 
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)  ::   SWDOWN
      ! PAJ: FARMS coupling
-   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)  ::   SWDOWN2, SWDDNI2, SWDDIF2, SWDDIR2, SWDOWNC2, SWDDNIC2
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT), OPTIONAL  ::   SWDOWN2, SWDDNI2, SWDDIF2, SWDDIR2, SWDOWNC2, SWDDNIC2
 
 ! ------------------------------------------------------------------------------ jararias 2013/08/10 -----------
    REAL, DIMENSION( ims:ime, jms:jme ),  INTENT(OUT) :: swddir, & ! All-sky SW broadband surface direct irradiance
@@ -2745,31 +2745,41 @@ CONTAINS
  end if
 
    ! Coupling with FARMS
- if (swint_opt == 2) then
-    call wrf_debug(100,'SW surface irradiance calculated with FARMS')
-
-    if (aer_opt == 1) then
-      DO j=jts,jte
-        DO i=its,ite
-          aod5502d(i, j) = aodtot(i, j)
-        ENDDO
-      ENDDO
+!dave
+ if( present(mut      ) .and. &
+     present(dnw      ) .and. &
+     present(swdown2  ) .and. &
+     present(swddir2  ) .and. &
+     present(swddni2  ) .and. &
+     present(swddif2  ) .and. &
+     present(swdownc2 ) .and. &
+     present(swddnic2 ) ) then
+    if (swint_opt == 2) then
+       call wrf_debug(100,'SW surface irradiance calculated with FARMS')
+   
+       if (aer_opt == 1) then
+         DO j=jts,jte
+           DO i=its,ite
+             aod5502d(i, j) = aodtot(i, j)
+           ENDDO
+         ENDDO
+       end if
+   
+       !---------------
+       !$OMP PARALLEL DO   &
+       !$OMP PRIVATE ( ij ,i,j,k,its,ite,jts,jte)
+       do ij = 1,num_tiles
+         its = i_start(ij)
+         ite = i_end(ij)
+         jts = j_start(ij)
+         jte = j_end(ij)
+         call farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte, &
+              p8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
+              coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
+              julian, mut, dnw, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+       enddo
+       !$OMP END PARALLEL DO
     end if
-
-    !---------------
-    !$OMP PARALLEL DO   &
-    !$OMP PRIVATE ( ij ,i,j,k,its,ite,jts,jte)
-    do ij = 1,num_tiles
-      its = i_start(ij)
-      ite = i_end(ij)
-      jts = j_start(ij)
-      jte = j_end(ij)
-      call farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte, &
-           p8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
-           coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-           julian, mut, dnw, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
-    enddo
-    !$OMP END PARALLEL DO
  end if
 
      accumulate_lw_select: SELECT CASE(lw_physics)

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2745,7 +2745,6 @@ CONTAINS
  end if
 
    ! Coupling with FARMS
-!dave
  if( present(mut      ) .and. &
      present(dnw      ) .and. &
      present(swdown2  ) .and. &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, NMM

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The NMM HWRF code would not build after the FARMS commit. A few variables passed 
into the radiation driver are ARW specific, so the call from the NMM core did not have:
MUT or DNW (both input associated with ARW only), or the six additional computed 
radiation output fields (sw*2).

Solution:
1. Make the ARW-specific input fields and the additional radiation output fields OPTIONAL.
2. Use an IF(PRESENT(xxx)) before using any of the fields.

These problems were introduced with commit 3c71dd1de6e0df0, PR #1025 "Adding a fast 
surface shortwave parameterization (FARMS)".

LIST OF MODIFIED FILES:
modified:   phys/module_radiation_driver.F
modified:   dyn_em/module_first_rk_step_part1.F

TESTS CONDUCTED:
1. Without mods, NMM HWRF cannot build.
2. With mods, NMM HWRF builds and runs successfully.
3. With mods, ARW still works.