### PR TITLE
Improve memory usage for DA gen_be_v3 and add another output reformatting tool

### DIFF
--- a/var/gen_be_v3/README.gen_be_v3
+++ b/var/gen_be_v3/README.gen_be_v3
@@ -70,6 +70,9 @@
 
       For cv_options=7 purpose, util/combine_be_cv7.f90 can be used to combine be_[T/U/V/RH/PSFC].dat into be.dat that WRFDA can read.
 
+      For cv_options=7 and cloud_cv_options=2 purpose, util/combine_be_cv7_ccv2.f90 can be used to
+          combine be_[T/U/V/RH/PSFC/QCLOUD/QRAIN/QICE/QSNOW/QGRAUP/W].dat into be.dat that WRFDA can read.
+
       pert1.* files are intermediate output that can be removed after the successful execution.
 
       pertv_* files are intermediate pert1_read_opt=2 output that can be removed after the successful execution.

--- a/var/gen_be_v3/README.gen_be_v3
+++ b/var/gen_be_v3/README.gen_be_v3
@@ -14,7 +14,7 @@
             Either a list of WRF ensembles,
             or a list of WRF forecasts with proper forecast lengths (for example: 24-h and 12-h forecasts).
       (3) Execute gen_be_v3.exe
-            The code can be built and run with MPI, however seriel code should have good enough
+            The code can be built and run with MPI, however serial code should have good enough
             performance by submitting/running each variable separately (in different working directory).
 
 (a) namelist.gen_be_v3 for generating ensemble perturbations to be used in WRFDA
@@ -55,6 +55,11 @@
                               ! 2: laplacian method (recommended)
    do_eof_transform = .true.  ! .true.: statistics on EOF space for WRFDA runs
                               ! .false.: statistics on physical model levels for diagnostics
+   pert1_read_opt = 1         ! specify how the program accesses the pert1 data (output of do_pert_calc=.true.)
+                              ! 1: (default) read and store all cases in memory at once
+                              ! 2: read from pert1 file when need it
+                              !    This option writes out additional vertical-mode-projected fields when do_eof_transform=.true.
+                              ! Set pert1_read_opt=2 for large number of cases and large domain sizes that encounter memory insufficiency.
 /
 &ens_nml
 /
@@ -66,3 +71,5 @@
       For cv_options=7 purpose, util/combine_be_cv7.f90 can be used to combine be_[T/U/V/RH/PSFC].dat into be.dat that WRFDA can read.
 
       pert1.* files are intermediate output that can be removed after the successful execution.
+
+      pertv_* files are intermediate pert1_read_opt=2 output that can be removed after the successful execution.

--- a/var/gen_be_v3/gen_be_v3.F90
+++ b/var/gen_be_v3/gen_be_v3.F90
@@ -55,7 +55,7 @@ program gen_be_v3
 
    namelist /gen_be_nml/ nc_list_file, be_method, varnames, outnames, &
       do_pert_calc, do_eof_transform, do_slen_calc, slen_opt, stride, yr_cutoff, &
-      verbose, level_start, level_end, aux_file, write_be_dat_r8
+      verbose, level_start, level_end, aux_file, write_be_dat_r8, pert1_read_opt
    namelist /ens_nml/ nens, write_ep, write_ens_stdv, ep_format, nproc_out
 
    character(len=filename_len) :: nc_list_file  ! the text file that contains a list of netcdf files to process
@@ -80,6 +80,9 @@ program gen_be_v3
    integer :: nproc_out              ! number of processors to decompose for ep_format=3
 
    integer :: level_start, level_end ! for do_slen_calc=true. Can be set to be other than 1 and nvert for quick debugging/testing
+   integer :: pert1_read_opt         ! how to access pert1 data for compute_bv_sl
+                                     ! 1: read and store all cases in memory at once
+                                     ! 2: read from pert1 file when need it
    logical :: write_pert0
    logical :: write_pert1
    logical :: write_be_dat_r8        ! if writing out be.dat in real*8
@@ -188,6 +191,7 @@ program gen_be_v3
    verbose = .false.
    aux_file = 'none'
    write_be_dat_r8 = .true.
+   pert1_read_opt = 1
 
    ! initialize internal options
    write_pert0 = .false.
@@ -1696,6 +1700,7 @@ subroutine compute_bv_sl
 
    integer, allocatable:: bin_pts2d(:)               ! Number of points in bin (2D fields).
    real, allocatable   :: field(:,:,:)               ! Input field.
+   real, allocatable   :: fieldv(:,:,:)              ! projected field
    real, allocatable   :: field2d(:,:)               ! Input field.
    real, allocatable   :: bv(:,:,:)                  ! Vertical BE for this time.
    real, allocatable   :: work(:,:)                  ! EOF work array.
@@ -1740,6 +1745,8 @@ subroutine compute_bv_sl
       iend_member   = nens
    end if
 
+   if ( pert1_read_opt == 1 ) then
+
    allocate(xdata(1:nvar,istart_member:iend_member,1:ncase), stat=ierr)
    call error_handler(ierr, 'allocating xdata in compute_bv_sl')
 
@@ -1770,6 +1777,8 @@ subroutine compute_bv_sl
       end do
    end do
 
+   end if ! pert1_read_opt=1, store all pert1 data in memory
+
    if ( do_eof_transform ) then
 
       if ( myproc == root ) write(stdout,'(4a)')'====== Computing vertical error eigenvalues, eigenvectors ======'
@@ -1783,6 +1792,10 @@ subroutine compute_bv_sl
       allocate( e_val(1:nk) )
       allocate( evec(1:nj,1:nk,1:nk) )
       allocate( eval(1:nj,1:nk) )
+
+      if ( pert1_read_opt == 2 ) then
+         allocate( fieldv(1:ni,1:nj,1:nk) )
+      end if
 
       var_loop: do iv = 1, nvar
 
@@ -1805,7 +1818,18 @@ subroutine compute_bv_sl
                !write(stdout,'(5a,i4)')'    Processing data for date ', filedates(ie,ic), ', variable ', trim(varnames(iv)), &
                !                  ', member ', ie
 
-               field(:,:,:) = xdata(iv,ie,ic)%value(:,:,:)
+               if ( pert1_read_opt == 1 ) then
+
+                  field(:,:,:) = xdata(iv,ie,ic)%value(:,:,:)
+
+               else if ( pert1_read_opt == 2 ) then
+
+                  write(ce,'(i3.3)') ie
+                  input_file = 'pert1.'//filedates(ie,ic)//'.e'//trim(ce)
+
+                  call get_pert1_data(trim(input_file), trim(varnames(iv)), ni, nj, nk, field)
+
+               end if
 
                ! Remove area mean
                do k = 1, nkk
@@ -1915,6 +1939,7 @@ subroutine compute_bv_sl
                   !                  ', member ', ie
                   ! Project fields onto vertical modes
                   ! Perform vv(i,j,m) = L^{-1/2} E^T vp(i,j,k) transform
+                if ( pert1_read_opt == 1 ) then
                   do m = 1, nk
                      do j = 1, nj
                         do i = 1, ni
@@ -1924,11 +1949,33 @@ subroutine compute_bv_sl
                      end do
                   end do
                   xdata(iv,ie,ic)%value(:,:,:) = field(:,:,:)
+                else if ( pert1_read_opt == 2 ) then
+                  write(ce,'(i3.3)') ie
+                  input_file = 'pert1.'//filedates(ie,ic)//'.e'//trim(ce)
+                  call get_pert1_data(trim(input_file), trim(varnames(iv)), ni, nj, nk, field)
+                  do m = 1, nk
+                     do j = 1, nj
+                        do i = 1, ni
+                           ETVp = sum(evec(j,1:nk,m) * field(i,j,1:nk))
+                           fieldv(i,j,m) = ETVp / eval(j,m)
+                        end do
+                     end do
+                  end do
+                  output_file = 'pertv_'//trim(varnames(iv))//'.'//filedates(ie,ic)//'.e'//trim(ce)
+                  !write(stdout,'(a,i3,a,a)') ' Proc', myproc, ' writing to ', trim(output_file)
+                  open (ounit, file=output_file, form='unformatted')
+                  write(ounit) 1, ni, nj, nk
+                  write(ounit) var_dim(iv)
+                  write(ounit) filedates(ie,ic), varnames(iv)
+                  write(ounit) fieldv(:,:,:)
+                  close(ounit)
+                end if ! pert1_read_opt
                end do ! End loop over members.
             end do
          end if
       end do var_loop
 
+      if ( pert1_read_opt == 1 ) then
 #ifdef DM_PARALLEL
       ijk = ni*nj*nk
       do iv = 1, nvar
@@ -1947,7 +1994,14 @@ subroutine compute_bv_sl
          end do
       end do
 #endif
+      end if ! pert1_read_opt=1
 
+      if ( pert1_read_opt == 2 ) then
+         deallocate( fieldv )
+#ifdef DM_PARALLEL
+         call mpi_barrier(mpi_comm_world,ierr)
+#endif
+      end if
       deallocate( eval )
       deallocate( evec )
       deallocate( e_val )
@@ -1959,8 +2013,6 @@ subroutine compute_bv_sl
       deallocate( bv )
 
    end if ! do_eof_transform
-
-   deallocate(field)
 
    if ( do_slen_calc ) then
       if ( myproc == root ) write(stdout,'(4a)')' ====== Computing horizontal length scales ======'
@@ -2001,7 +2053,20 @@ subroutine compute_bv_sl
                cov(0:nn,k) = 0.0
                do ic = 1, ncase
                   do ie = istart_member, iend_member
-                    field2d(:,:) = xdata(iv,ie,ic)%value(:,:,k)
+
+                     if ( pert1_read_opt == 1 ) then
+                        field2d(:,:) = xdata(iv,ie,ic)%value(:,:,k)
+                     else if ( pert1_read_opt == 2 ) then
+                        write(ce,'(i3.3)') ie
+                        if ( do_eof_transform .and. (var_dim(iv) == 3) ) then
+                           input_file = 'pertv_'//trim(varnames(iv))//'.'//filedates(ie,ic)//'.e'//trim(ce)
+                        else
+                           input_file = 'pert1.'//filedates(ie,ic)//'.e'//trim(ce)
+                        end if
+                        call get_pert1_data(trim(input_file), trim(varnames(iv)), ni, nj, nk, field)
+                        field2d(:,:) = field(:,:,k)
+                     end if
+
                      icount(k) = icount(k) + 1
                      ! Calculate spatial correlation
                      call get_covariance( ni, nj, nn, stride, icount(k), nr, &
@@ -2046,7 +2111,20 @@ subroutine compute_bv_sl
                hlt(:) = 0.0
                do ic = 1, ncase
                   do ie = istart_member, iend_member
-                    field2d(:,:) = xdata(iv,ie,ic)%value(:,:,k)
+
+                     if ( pert1_read_opt == 1 ) then
+                        field2d(:,:) = xdata(iv,ie,ic)%value(:,:,k)
+                     else if ( pert1_read_opt == 2 ) then
+                        write(ce,'(i3.3)') ie
+                        if ( do_eof_transform .and. (var_dim(iv) == 3) ) then
+                           input_file = 'pertv_'//trim(varnames(iv))//'.'//filedates(ie,ic)//'.e'//trim(ce)
+                        else
+                           input_file = 'pert1.'//filedates(ie,ic)//'.e'//trim(ce)
+                        end if
+                        call get_pert1_data(trim(input_file), trim(varnames(iv)), ni, nj, nk, field)
+                        field2d(:,:) = field(:,:,k)
+                     end if
+
                     call horz_lenscale(ni,nj,field2d,ds,mapfac_x,mapfac_y,hl,bin2d,num_bins2d)
                     icount(k) = icount(k) + 1
                     hlt(:) = hlt(:) + hl(:)
@@ -2077,6 +2155,9 @@ subroutine compute_bv_sl
       deallocate(sl_g)
    end if ! do_slen_calc
 
+   deallocate(field)
+
+   if ( pert1_read_opt == 1 ) then
    do ic = 1, ncase
       do ie = istart_member, iend_member
          do iv = 1, nvar
@@ -2085,6 +2166,7 @@ subroutine compute_bv_sl
       end do
    end do
    if ( allocated(xdata)) deallocate(xdata)
+   end if ! pert1_read_opt=1
 
 end subroutine compute_bv_sl
 
@@ -2615,6 +2697,60 @@ subroutine error_handler(ierr, err_message)
    end if
 
 end subroutine error_handler
+
+subroutine get_pert1_data(pert_file, vname, nx, ny, nz, vdata)
+
+   implicit none
+
+   character(len=*), intent(in)    :: pert_file
+   character(len=*), intent(in)    :: vname
+   integer,          intent(in)    :: nx, ny, nz
+   real,             intent(inout) :: vdata(nx,ny,nz)
+
+   integer :: nvar_read, nx_read, ny_read, nz_read
+   integer :: iv, iunit, ndim
+   logical :: isfile
+   real, allocatable :: field(:,:,:)
+   character(len=DateStrLen) :: DateStr_tmp
+   character(len=VarNameLen) :: var_tmp
+
+   !pert_file = 'pert1.'//filedates(ie,ic)//'.e'//trim(ce)
+   inquire(file=trim(pert_file), exist=isfile)
+   if ( .not. isfile ) then
+      call error_handler(-1, trim(pert_file)//' not found for getting perturbation')
+   end if
+   !write(stdout,'(a,i3,a,a)') ' Proc', myproc, ' Reading from ', trim(pert_file)
+   open (iunit, file=trim(pert_file), form='unformatted', status='old')
+   read(iunit) nvar_read, nx_read, ny_read, nz_read
+   if ( nx/=nx_read .or. ny/=ny_read .or. nz/=nz_read ) then
+      call error_handler(-1, 'dimensions mismatch in get_pert1_data')
+   end if
+   allocate(field(nx,ny,nz))
+   field(:,:,:) = 0.0
+   read_loop: do iv = 1, nvar_read
+      read(iunit) ndim
+      read(iunit) DateStr_tmp, var_tmp
+      if ( ndim == 2 ) then
+         read(iunit) field(:,:,1)
+      else if ( ndim == 3 ) then
+         read(iunit) field(:,:,:)
+      end if
+      if ( trim(vname) == trim(var_tmp) ) then
+         exit read_loop
+      else
+         if ( iv < nvar_read ) then
+            cycle read_loop
+         else
+            close(iunit)
+            call error_handler(-1, 'error reading pert1 for variable '//trim(vname))
+         end if
+      end if
+   end do read_loop
+   vdata(:,:,:) = field(:,:,:)
+   close(iunit)
+   deallocate(field)
+
+end subroutine get_pert1_data
 
 end program gen_be_v3
 

--- a/var/gen_be_v3/util/combine_be_cv7_ccv2.f90
+++ b/var/gen_be_v3/util/combine_be_cv7_ccv2.f90
@@ -1,0 +1,216 @@
+program be_readwrite
+
+! gfortran -o combine_be_cv7_ccv2.exe -fconvert=big-endian combine_be_cv7_ccv2.f90
+
+! input:  be_[U|V|T|RH|PSFC|QCLOUD|QRAIN|QICE|QSNOW|QGRAUP|W].dat
+! output: be.dat (in real(8) and big_endian) for cloud_cv_options=2
+
+   implicit none
+
+   integer               :: ni, nj, nk           ! dimensions read in
+   integer               :: bin_type             ! type of bin to average over
+   integer               :: num_bins             ! number of 3D bins
+   integer               :: num_bins2d           ! number of 2D bins
+   integer, allocatable  :: bin(:,:,:)           ! bin assigned to each 3D point
+   integer, allocatable  :: bin2d(:,:)           ! bin assigned to each 2D point
+
+!for be_[U|V|T|RH|PSFC].dat in real(4) when gen_be_v3 is run with write_be_dat_r8=.false.
+   !real,    allocatable  :: e_vec(:,:)           ! domain-averaged eigenvectors
+   !real,    allocatable  :: e_val(:)             ! domain-averaged eigenvalues
+   !real,    allocatable  :: e_vec_loc(:,:,:)     ! latitudinally varying eigenvectors
+   !real,    allocatable  :: e_val_loc(:,:)       ! latitudinally varying eigenvalues
+   !real,    allocatable  :: scale_length(:)      ! scale length for regional application
+!for be_[U|V|T|RH|PSFC].dat in real(8) when gen_be_v3 is run with write_be_dat_r8=.true. (default)
+   real*8,  allocatable  :: e_vec(:,:)           ! domain-averaged eigenvectors
+   real*8,  allocatable  :: e_val(:)             ! domain-averaged eigenvalues
+   real*8,  allocatable  :: e_vec_loc(:,:,:)     ! latitudinally varying eigenvectors
+   real*8,  allocatable  :: e_val_loc(:,:)       ! latitudinally varying eigenvalues
+   real*8,  allocatable  :: scale_length(:)      ! scale length for regional application
+
+   real*8,  allocatable  :: e_vec_r8(:,:)        ! domain-averaged eigenvectors
+   real*8,  allocatable  :: e_val_r8(:)          ! domain-averaged eigenvalues
+   real*8,  allocatable  :: e_vec_loc_r8(:,:,:)  ! latitudinally varying eigenvectors
+   real*8,  allocatable  :: e_val_loc_r8(:,:)    ! latitudinally varying eigenvalues
+   real*8,  allocatable  :: scale_length_r8(:)   ! scale length for regional application
+
+   character(len=256)    :: infile               ! input filename
+   character(len=256)    :: outfile              ! output filename
+   logical               :: isfile
+   integer               :: iunit, ounit
+
+   integer, parameter :: nvar = 11
+   character(len=10)  :: varnames(nvar) = (/ "U         ", &
+                                             "V         ", &
+                                             "T         ", &
+                                             "RH        ", &
+                                             "QCLOUD    ", &
+                                             "QRAIN     ", &
+                                             "QICE      ", &
+                                             "QSNOW     ", &
+                                             "QGRAUP    ", &
+                                             "W         ", &
+                                             "PSFC      " /)
+   character(len=10)  :: varout(nvar)   = (/ "u         ", &
+                                             "v         ", &
+                                             "t         ", &
+                                             "rh        ", &
+                                             "qcloud    ", &
+                                             "qrain     ", &
+                                             "qice      ", &
+                                             "qsnow     ", &
+                                             "qgraup    ", &
+                                             "w         ", &
+                                             "ps        " /)
+   character(len=10)  :: this_var
+   integer            :: var_dim
+   integer            :: i
+   integer            :: nk_2d = 1
+
+   real*8  :: lat_min, lat_max, binwidth_lat
+   real*8  :: hgt_min, hgt_max, binwidth_hgt
+
+   lat_min = 0.0
+   lat_max = 0.0
+   binwidth_lat = 0.0
+   hgt_min = 0.0
+   hgt_max = 0.0
+   binwidth_hgt = 0.0
+
+   iunit = 81
+   ounit = 82
+
+   outfile = 'be.dat'
+   open (ounit, file=trim(outfile), form='unformatted', status='replace')
+
+   do i = 1, nvar
+
+      infile = 'be_'//trim(varnames(i))//'.dat'
+      inquire(file=trim(infile), exist=isfile)
+      if ( .not. isfile ) then
+         write(*,*) 'STOP: ', trim(infile), ' does not exist.'
+         stop
+      end if
+      open (iunit, file=trim(infile), form='unformatted', status='old')
+      write(*,*) 'Reading from ', trim(infile)
+
+      read(iunit) ni, nj, nk
+
+      if ( i == 1 ) then
+         allocate( bin(1:ni,1:nj,1:nk) )
+         allocate( bin2d(1:ni,1:nj) )
+      end if
+
+      read(iunit) bin_type
+      read(iunit) num_bins, num_bins2d
+      read(iunit) bin
+      read(iunit) bin2d
+
+      if ( i == 1 ) then
+         write(ounit) ni, nj, nk
+         write(ounit) bin_type
+         write(ounit) lat_min, lat_max, binwidth_lat
+         write(ounit) hgt_min, hgt_max, binwidth_hgt
+         write(ounit) num_bins, num_bins2d
+         write(ounit) bin
+         write(ounit) bin2d
+      end if
+
+      if ( i == 1 ) then
+         allocate( e_vec(1:nk,1:nk) )
+         allocate( e_val(1:nk) )
+         allocate( e_vec_loc(1:nk,1:nk,1:num_bins2d) )
+         allocate( e_val_loc(1:nk,1:num_bins2d) )
+         allocate( e_vec_r8(1:nk,1:nk) )
+         allocate( e_val_r8(1:nk) )
+         allocate( e_vec_loc_r8(1:nk,1:nk,1:num_bins2d) )
+         allocate( e_val_loc_r8(1:nk,1:num_bins2d) )
+         allocate( scale_length(1:nk) )
+         allocate( scale_length_r8(1:nk) )
+      end if
+
+      read(iunit) this_var
+      write(ounit) varout(i)
+
+      read(iunit) var_dim
+      if ( var_dim == 3 ) then
+         read(iunit) e_vec
+         read(iunit) e_val
+         read(iunit) e_vec_loc
+         read(iunit) e_val_loc
+         e_vec_r8 = e_vec
+         e_val_r8 = e_val
+         e_vec_loc_r8 = e_vec_loc
+         e_val_loc_r8 = e_val_loc
+         write(ounit) nk, num_bins2d
+         write(ounit) e_vec_r8
+         write(ounit) e_val_r8
+         write(ounit) e_vec_loc_r8
+         write(ounit) e_val_loc_r8
+      else if ( var_dim == 2 ) then
+         read(iunit) e_vec(1:1,1:1)
+         read(iunit) e_val(1:1)
+         read(iunit) e_vec_loc(1:1,1:1,:)
+         read(iunit) e_val_loc(1:1,:)
+         e_vec_r8 = e_vec
+         e_val_r8 = e_val
+         e_vec_loc_r8 = e_vec_loc
+         e_val_loc_r8 = e_val_loc
+         write(ounit) nk_2d, num_bins2d
+         write(ounit) e_vec_r8(1:1,1:1)
+         write(ounit) e_val_r8(1:1)
+         write(ounit) e_vec_loc_r8(1:1,1:1,:)
+         write(ounit) e_val_loc_r8(1:1,:)
+      end if
+      close(iunit)
+   end do
+
+   ! read files again to gather lengthscales
+   do i = 1, nvar
+      infile = 'be_'//trim(varnames(i))//'.dat'
+      open (iunit, file=trim(infile), form='unformatted', status='old')
+      !write(*,*) 'Reading from ', trim(infile)
+      read(iunit) ni, nj, nk
+      read(iunit) bin_type
+      read(iunit) num_bins, num_bins2d
+      read(iunit) bin
+      read(iunit) bin2d
+
+      read(iunit) this_var
+      write(ounit) varout(i)
+
+      read(iunit) var_dim
+      if ( var_dim == 3 ) then
+         read(iunit) e_vec
+         read(iunit) e_val
+         read(iunit) e_vec_loc
+         read(iunit) e_val_loc
+         read(iunit) scale_length
+         scale_length_r8 = scale_length
+         write(ounit) scale_length_r8
+      else if ( var_dim == 2 ) then
+         read(iunit) e_vec(1:1,1:1)
+         read(iunit) e_val(1:1)
+         read(iunit) e_vec_loc(1:1,1:1,:)
+         read(iunit) e_val_loc(1:1,:)
+         read(iunit) scale_length(1:1)
+         scale_length_r8 = scale_length
+         write(ounit) scale_length_r8(1:1)
+      end if
+      close(iunit)
+   end do
+   close(ounit)
+
+   deallocate( e_vec )
+   deallocate( e_val )
+   deallocate( e_vec_loc )
+   deallocate( e_val_loc )
+   deallocate( e_vec_r8 )
+   deallocate( e_val_r8 )
+   deallocate( e_vec_loc_r8 )
+   deallocate( e_val_loc_r8 )
+
+   deallocate (scale_length)
+   deallocate (scale_length_r8)
+   write(*,*) 'Done writing be.dat'
+
+end program be_readwrite


### PR DESCRIPTION
TYPE: enhancement (to the not-yet-released code)

KEYWORDS: WRFDA, gen_be_v3, memory, be.dat for cloud_cv_options=2

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
1. For memory issue:
For applications that are for large number of cases and large domain sizes,
the gen_be_v3 program needs to run on a large-memory node.
To deal with the memory issue, add a namelist option pert1_read_opt
to choose how the program accesses pert1 data (output of do_pert_calc=true) internally.
pert1_read_opt=1: (default, original behavior) read and store all cases in memory at once.
pert1_read_opt=2: read from pert1 file when need it.
                  This option writes out additional vertical-mode-projected fields when do_eof_transform=.true.
Users can set pert1_read_opt=2 if memory insufficiency occurs.
With pert1_read_opt=2, the program runs slower than pert1_read_opt=1 but the memory usage is reduced

2. For reformatting individual be_[varname].dat into be.dat that WRFDA reads:
PR #912 already includes var/gen_be_v3/util/combine_be_cv7.f90 that handles basic variables.
This PR adds another var/gen_be_v3/util/combine_be_cv7_ccv2.f90 that reformat GEN_BE_V3 output
into the same format as GENBE_2.0 for cloud_cv_options=2 applications.

LIST OF MODIFIED FILES:
M       var/gen_be_v3/README.gen_be_v3
M       var/gen_be_v3/gen_be_v3.F90
A       var/gen_be_v3/util/combine_be_cv7_ccv2.f90

TESTS CONDUCTED:
The results are identical with pert1_read_opt=1 and pert1_read_opt=2.