### PR TITLE
Add Makefile dependency for FARMS scheme

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -701,6 +701,7 @@ module_radiation_driver.o: \
                 module_ra_rrtmg_lwk.o \
                 module_ra_rrtmg_swk.o \
 		module_ra_cam.o \
+		module_ra_farms.o \
 		module_ra_gfdleta.o \
 		module_ra_HWRF.o \
 		module_ra_hs.o \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Makefile, depend.common, FARMS

SOURCE: internal

DESCRIPTION OF CHANGES:

Problem:
The DA code did not build. The file module_ra_farms.mod was not available
for the build of module_radiation_driver.o.

Solution:
The depend.common file needed to include the FARMS dependency for the
radiation driver.

LIST OF MODIFIED FILES:
modified:   main/depend.common

TESTS CONDUCTED:
1. Does not harm (regression test is OK).
2. Fixes DA builds