### PR TITLE
Fix WRFPlus compilation issue

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -701,6 +701,7 @@ module_radiation_driver.o: \
                 module_ra_rrtmg_lwk.o \
                 module_ra_rrtmg_swk.o \
 		module_ra_cam.o \
+		module_ra_farms.o \
 		module_ra_gfdleta.o \
 		module_ra_HWRF.o \
 		module_ra_hs.o \

--- a/main/depend.common
+++ b/main/depend.common
@@ -701,7 +701,6 @@ module_radiation_driver.o: \
                 module_ra_rrtmg_lwk.o \
                 module_ra_rrtmg_swk.o \
 		module_ra_cam.o \
-		module_ra_farms.o \
 		module_ra_gfdleta.o \
 		module_ra_HWRF.o \
 		module_ra_hs.o \

--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -40,7 +40,7 @@ SUBROUTINE med_before_solve_io ( grid , config_flags )
    USE mediation_pertmod_io , ONLY : save_tl_pert, read_ad_forcing, save_xtraj, read_xtraj, read_xtraj_reverse
    USE module_bc_em, ONLY : rk_phys_bc_dry_2
    USE module_bc, ONLY : set_physical_bc3d
-   USE esmf_timemod, ONLY : ESMF_TimeInc
+   USE wrf_esmf_timemod, ONLY : ESMF_TimeInc
 
 #ifdef DM_PARALLEL
    USE module_dm, ONLY : ntasks_x, ntasks_y, &

--- a/wrftladj/module_diffusion_em_ad.F
+++ b/wrftladj/module_diffusion_em_ad.F
@@ -3808,7 +3808,7 @@ CONTAINS
                                   rdz, rdzw, dx, dy, dt, isotropic,          &
                                   mix_upper_bound, msftx, msfty,             &
                                   hpbl,dlk,xkmv_meso,                        &
-                                  defor11,defor22,defor12,zx,zy,xkmh_t,      &
+                                  defor11,defor22,defor12,zx,zy,             &
                                   ids, ide, jds, jde, kds, kde,              &
                                   ims, ime, jms, jme, kms, kme,              &
                                   its, ite, jts, jte, kts, kte             )
@@ -7538,19 +7538,18 @@ Tmpv001 =(rdz(i,k+1,j)+rdz(i,k,j))
 !   END DO
 
        CALL tke_shear(    tendency, config_flags,                  &
-                          tke_shear_tend,                          &
                           defor11, defor22, defor33,               &
                           defor12, defor13, defor23,               &
                           u, v, w, tke, ust, mu,                   &
                           c1, c2, fnm, fnp,                        &
                           cf1, cf2, cf3, msftx, msfty,             &
-                          xkmh_t, xkmh, xkmv,                      &
+                          xkmh, xkmv,                              &
                           rdx, rdy, zx, zy, rdz, rdzw, dnw, dn,    &
                           ids, ide, jds, jde, kds, kde,            &
                           ims, ime, jms, jme, kms, kme,            &
                           its, ite, jts, jte, kts, kte           )
        CALL tke_buoyancy( tendency, config_flags, mu,              &
-                          tke_buoy_tend,c1, c2,                    &
+                          c1, c2,                                  &
                           tke, xkhv, BN2, theta, dt,               &
                           hfx, qfx, qv,  rho,                      &
                           nlflux,                                  &
@@ -7561,7 +7560,7 @@ Tmpv001 =(rdz(i,k+1,j)+rdz(i,k,j))
                           tke, bn2, theta, p8w, t8w, z,            &
                           dx, dy,rdz, rdzw, isotropic,             &
                           msftx, msfty,                            &
-                          hpbl, dlk,  l_scale,                     &
+                          hpbl, dlk,  l_scale,                      &
                           ids, ide, jds, jde, kds, kde,            &
                           ims, ime, jms, jme, kms, kme,            &
                           its, ite, jts, jte, kts, kte           )
@@ -11073,7 +11072,7 @@ END SUBROUTINE A_COMPUTE_DIFF_METRICS
 !   END DO
 
    Keep_Lpb0_nba_mij = nba_mij  ! Added by Ning Pan, 2010-08-11
-   CALL horizontal_diffusion_u_2(ru_tendf,config_flags,u_h_tend,defor11,defor12,div,  &
+   CALL horizontal_diffusion_u_2(ru_tendf,config_flags,defor11,defor12,div,  &
    nba_mij,n_nba_mij,tke(ims,kms,jms),msfux,msfuy,xkmh,rdx,rdy,fnm,fnp,dnw,zx,zy,rdzw,rho,ids,  &
    ide,jds,jde,kds,kde,ims,ime,jms,jme,kms,kme,its,ite,jts,jte,kts,kte)
 
@@ -11097,7 +11096,7 @@ END SUBROUTINE A_COMPUTE_DIFF_METRICS
 !   END DO
 
    Keep_Lpb1_nba_mij = nba_mij  ! Added by Ning Pan, 2010-08-11
-   CALL horizontal_diffusion_v_2(rv_tendf,config_flags,v_h_tend,defor12,defor22,div,  &
+   CALL horizontal_diffusion_v_2(rv_tendf,config_flags,defor12,defor22,div,  &
    nba_mij,n_nba_mij,tke(ims,kms,jms),msfvx,msfvy,xkmh,rdx,rdy,fnm,fnp,dnw,zx,zy,rdzw,rho,ids,  &
    ide,jds,jde,kds,kde,ims,ime,jms,jme,kms,kme,its,ite,jts,jte,kts,kte)
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: wrfplus, TL/AD code

SOURCE: internal

DESCRIPTION OF CHANGES:
Two recent WRF model code changes break the wrfplus compilation:
1. ESMF name change 
This modification allowed the CTSM development to use standard ESMF without conflicting 
with WRF _old_ ESMF library namespace.
Commit 8af53855b837, PR #1066 "Enabling WRF build with ESMF library"
2. module_diffusion_em_ad.F, 3d scale aware TKE (one of these, take your pick)
Commit d059afe1e646, PR #972 "Add a scale-adaptive 3DTKE parameterization scheme as a subgrid mixing option
Commit 6d95883111f5, PR #1012 "SMS3dTKE: Remove broken packaging for km_opt=5"
Commit 94e5ed97b69, PR #1013 "Add missing "IF km_opt==5" tests for diag computations"
Commit dd0c2094fc16, PR #1026 "Fixing the problem that km_opt=5 breaks km_opt=2 and cleaning codes"

LIST OF MODIFIED FILES: 
M       share/mediation_integrate.F
M       wrftladj/module_diffusion_em_ad.F

TESTS CONDUCTED: wrfplus code compiles now.

