### PR TITLE
New default setting for RRTMG FAST and RRTMG KIAPS: no compile

### DIFF
--- a/arch/postamble
+++ b/arch/postamble
@@ -26,8 +26,8 @@ ARCHFLAGS       =    $(COREDEFS) -DIWORDSIZE=$(IWORDSIZE) -DDWORDSIZE=$(DWORDSIZ
                       -DINTIO \
                       -DKEEP_INT_AROUND \
                       -DLIMIT_ARGS \
-                      -DBUILD_RRTMG_FAST=1 \
-                      -DBUILD_RRTMK=1 \
+                      -DBUILD_RRTMG_FAST=0 \
+                      -DBUILD_RRTMK=0 \
                       -DSHOW_ALL_VARS_USED=0 \
                       -DCONFIG_BUF_LEN=$(CONFIG_BUF_LEN) \
                       -DMAX_DOMAINS_F=$(MAX_DOMAINS) \


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: RRTMG, FAST, KIAPS, postamble, cpp

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The WRF code with the GNU compilers (from 6.3.* inclusive to anything before 9.1.0) will
sometimes fail to compile. The error is listed as an "internal compiler error". The two RRTMG 
schemes (FAST and KIAPS) are the standard causes for GNU failing to compile the WRF 
code successfully.

Solution:
The following two mods were previously made to the WRF source code:
1. commit 17b5ac4062, PR #517 "KLUGE: RRTMG FAST + GNU > 6.3.0 is an internal compiler error"
2. commit a83c7cb27d, PR #1084 "KLUGE - Option to avoid building RRTMK due to GNU problem"

This new PR just resests the default settings from "always build these schemes" to "never
build these schemes".

LIST OF MODIFIED FILES:
modified:   arch/postamble

TESTS CONDUCTED:
1. The logic to disable the RRTMG FAST scheme has been in place for more than 18 months.
2. Actually disabling the build of RRTMG FAST has been tested hundreds of times with
the combination of the automated Jenkins regression test and the NCAR-only classroom
tests.
3. The KIAPS infrastructure has been tested with both the automated Jenkins test and
the NCAR classroom regression tests.

RELEASE NOTE: The default setting for the WRF model is to NOT compile either of the two derivative RRTMG schemes: FAST or KIAPS. These codes break the GNU compiler (v6.3.0 through v8.*). To re-enable the schemes, modify the `configure.wrf` file after running the `./configure` command. Replace the "zero" values with "ones" in the lines `-DBUILD_RRTMG_FAST=0` or `-DBUILD_RRTMK=0`. This is a compile-time modification.