### PR TITLE
Bug fix to PR "KLUGE - Option to avoid building RRTMK due to GNU problem"

### DIFF
--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2170,7 +2170,7 @@ CONTAINS
        IF (F_QNWFA .AND. aer_opt.eq.3 .AND.                             &
                              (sw_physics.eq.RRTMG_SWSCHEME              &
 #if( BUILD_RRTMG_FAST == 1)
-                              .OR. sw_physics.eq.RRTMG_SWSCHEME_FAST .OR.    &
+                              .OR. sw_physics.eq.RRTMG_SWSCHEME_FAST    &
 #endif
 #if( BUILD_RRTMK == 1)
                               .OR. sw_physics.eq.RRTMK_SWSCHEME &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: .OR., cpp

SOURCE: Found by Jamie Bresch (NCAR), fixed internally

DESCRIPTION OF CHANGES:
An extra .OR. in an expression needs to be removed.

LIST OF MODIFIED FILES:
modified:   phys/module_radiation_driver.F

TESTS CONDUCTED:
1. Build on cheyenne with Intel OK:
```
cheyenne.ucar.edu:/glade/scratch/gill/WRF_oops_OR>./compile em_real > & ! foo ; tail -20 foo

build started:   Wed Feb 12 12:25:56 MST 2020
build completed: Wed Feb 12 12:39:46 MST 2020
 
--->                  Executables successfully built                  <---
 
-rwxr-xr-x 1 gill p66770001 265016704 Feb 12 12:39 main/ndown.exe
-rwxr-xr-x 1 gill p66770001 264300968 Feb 12 12:39 main/real.exe
-rwxr-xr-x 1 gill p66770001 262477808 Feb 12 12:39 main/tc.exe
-rwxr-xr-x 1 gill p66770001 290619280 Feb 12 12:38 main/wrf.exe
 
==========================================================================
 
cheyenne.ucar.edu:/glade/scratch/gill/WRF_oops_OR>ml

Currently Loaded Modules:
  1) nco/4.7.9   2) ncarenv/1.3   3) intel/18.0.5   4) ncarcompilers/0.5.0   5) netcdf/4.6.3   6) mpt/2.19
```