### PR TITLE
Fixing extra biomass burning mass aloft

### DIFF
--- a/chem/module_chem_plumerise_scalar.F
+++ b/chem/module_chem_plumerise_scalar.F
@@ -154,7 +154,7 @@ subroutine plumerise(m1,m2,m3,ia,iz,ja,jz,firesize,mean_fct   &
 	   call set_flam_vert(ztopmax,k1,k2,nkp,zzcon,W_VMD,VMD)
 	   
 	   !- espessura da camada vertical 
-	   dz_flam=zzcon(k2)-zzcon(k1-1)
+	   dz_flam=zzcon(k2+1)-zzcon(k1)   ! fixed version
 	   
 	   !- distribui a emissao flaming entre os niveis k1 e k2	 
 !          print *,'distribui, k1,k2,dz_flam',k1,k2,dz_flam

--- a/chem/module_chem_plumerise_scalar.F
+++ b/chem/module_chem_plumerise_scalar.F
@@ -153,7 +153,7 @@ subroutine plumerise(m1,m2,m3,ia,iz,ja,jz,firesize,mean_fct   &
 	   !- define o dominio vertical onde a emissao flaming ira ser colocada
 	   call set_flam_vert(ztopmax,k1,k2,nkp,zzcon,W_VMD,VMD)
 	   
-	   !- espessura da camada vertical (compute vertical layer thickness)
+	   !- espessura da camada vertical (compute the vertical layer thickness)
 	   dz_flam=zzcon(k2+1)-zzcon(k1)
 	   
 	   !- distribui a emissao flaming entre os niveis k1 e k2	 

--- a/chem/module_chem_plumerise_scalar.F
+++ b/chem/module_chem_plumerise_scalar.F
@@ -153,7 +153,7 @@ subroutine plumerise(m1,m2,m3,ia,iz,ja,jz,firesize,mean_fct   &
 	   !- define o dominio vertical onde a emissao flaming ira ser colocada
 	   call set_flam_vert(ztopmax,k1,k2,nkp,zzcon,W_VMD,VMD)
 	   
-	   !- espessura da camada vertical 
+	   !- espessura da camada vertical (compute vertical layer thickness)
 	   dz_flam=zzcon(k2+1)-zzcon(k1)
 	   
 	   !- distribui a emissao flaming entre os niveis k1 e k2	 

--- a/chem/module_chem_plumerise_scalar.F
+++ b/chem/module_chem_plumerise_scalar.F
@@ -154,7 +154,7 @@ subroutine plumerise(m1,m2,m3,ia,iz,ja,jz,firesize,mean_fct   &
 	   call set_flam_vert(ztopmax,k1,k2,nkp,zzcon,W_VMD,VMD)
 	   
 	   !- espessura da camada vertical 
-	   dz_flam=zzcon(k2+1)-zzcon(k1)   ! fixed version
+	   dz_flam=zzcon(k2+1)-zzcon(k1)
 	   
 	   !- distribui a emissao flaming entre os niveis k1 e k2	 
 !          print *,'distribui, k1,k2,dz_flam',k1,k2,dz_flam


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: biomass burning, plume rise

SOURCE: Ravan Ahmadov (NOAA/ESRL)

DESCRIPTION OF CHANGES: 
This bug results in adding extra biomass burning mass aloft, when the thickness of the 
vertical grid (dz) increases with altitude. The fix does not change the WRF-Chem model 
results significantly.

LIST OF MODIFIED FILES:
M chem/module_chem_plumerise_scalar.F

TESTS CONDUCTED: 
1. Jenkins test has passed.
