### PR TITLE
Fix feedback for odd nest ratios > 3:1

### DIFF
--- a/share/interp_fcn.F
+++ b/share/interp_fcn.F
@@ -1465,11 +1465,11 @@ END MODULE module_interp_info
 
         IF      ( ( .NOT. xstag ) .AND. ( .NOT. ystag ) ) THEN
            DO cj = MAX(jpos+spec_zone,cjts),MIN(jpos+(njde-njds)/nrj-jstag-spec_zone,cjte)
-              nj = (cj-jpos)*nrj + jstag + 1
+              nj = (cj-jpos)*nrj + nrj/2 + 1
               DO ck = ckts, ckte
                  nk = ck
                  DO ci = MAX(ipos+spec_zone,cits),MIN(ipos+(nide-nids)/nri-istag-spec_zone,cite)
-                    ni = (ci-ipos)*nri + istag + 1
+                    ni = (ci-ipos)*nri + nri/2 + 1
                     cfld( ci, ck, cj ) = 0.
                     DO ijpoints = 1 , nri * nrj
                        ipoints = MOD((ijpoints-1),nri) + 1 - nri/2 - 1
@@ -1487,17 +1487,43 @@ END MODULE module_interp_info
 !                                           nfld( ni-1, nk , nj+1) + &
 !                                           nfld( ni  , nk , nj+1) + &
 !                                           nfld( ni+1, nk , nj+1) )
+!                   cfld( ci, ck, cj ) =  1./25. * &
+!                                         ( nfld( ni-2, nk , nj-2) + &
+!                                           nfld( ni-2, nk , nj-1) + &
+!                                           nfld( ni-2, nk , nj-0) + &
+!                                           nfld( ni-2, nk , nj+1) + &
+!                                           nfld( ni-2, nk , nj+2) + &
+!                                           nfld( ni-1, nk , nj-2) + &
+!                                           nfld( ni-1, nk , nj-1) + &
+!                                           nfld( ni-1, nk , nj-0) + &
+!                                           nfld( ni-1, nk , nj+1) + &
+!                                           nfld( ni-1, nk , nj+2) + &
+!                                           nfld( ni-0, nk , nj-2) + &
+!                                           nfld( ni-0, nk , nj-1) + &
+!                                           nfld( ni-0, nk , nj-0) + &
+!                                           nfld( ni-0, nk , nj+1) + &
+!                                           nfld( ni-0, nk , nj+2) + &
+!                                           nfld( ni+1, nk , nj-2) + &
+!                                           nfld( ni+1, nk , nj-1) + &
+!                                           nfld( ni+1, nk , nj-0) + &
+!                                           nfld( ni+1, nk , nj+1) + &
+!                                           nfld( ni+1, nk , nj+2) + &
+!                                           nfld( ni+2, nk , nj-2) + &
+!                                           nfld( ni+2, nk , nj-1) + &
+!                                           nfld( ni+2, nk , nj-0) + &
+!                                           nfld( ni+2, nk , nj+1) + &
+!                                           nfld( ni+2, nk , nj+2) )
                  ENDDO
               ENDDO
            ENDDO
 
         ELSE IF ( (       xstag ) .AND. ( .NOT. ystag ) ) THEN
            DO cj = MAX(jpos+spec_zone,cjts),MIN(jpos+(njde-njds)/nrj-jstag-spec_zone,cjte)
-              nj = (cj-jpos)*nrj + jstag + 1
+              nj = (cj-jpos)*nrj + nrj/2 + 1
               DO ck = ckts, ckte
                  nk = ck
                  DO ci = MAX(ipos+spec_zone,cits),MIN(ipos+(nide-nids)/nri-istag-spec_zone,cite)
-                    ni = (ci-ipos)*nri + istag + 1
+                    ni = (ci-ipos)*nri + 1
                     cfld( ci, ck, cj ) = 0.
                     DO ijpoints = (nri+1)/2 , (nri+1)/2 + nri*(nri-1) , nri
                        ipoints = MOD((ijpoints-1),nri) + 1 - nri/2 - 1
@@ -1515,11 +1541,11 @@ END MODULE module_interp_info
 
         ELSE IF ( ( .NOT. xstag ) .AND. (       ystag ) ) THEN
            DO cj = MAX(jpos+spec_zone,cjts),MIN(jpos+(njde-njds)/nrj-jstag-spec_zone,cjte)
-              nj = (cj-jpos)*nrj + jstag + 1
+              nj = (cj-jpos)*nrj + 1
               DO ck = ckts, ckte
                  nk = ck
                  DO ci = MAX(ipos+spec_zone,cits),MIN(ipos+(nide-nids)/nri-istag-spec_zone,cite)
-                    ni = (ci-ipos)*nri + istag + 1
+                    ni = (ci-ipos)*nri + nri/2 + 1
                     cfld( ci, ck, cj ) = 0.
                     DO ijpoints = ( nrj*nrj +1 )/2 - nrj/2 , ( nrj*nrj +1 )/2 - nrj/2 + nrj-1
                        ipoints = MOD((ijpoints-1),nri) + 1 - nri/2 - 1

--- a/share/interp_fcn.F
+++ b/share/interp_fcn.F
@@ -1577,7 +1577,7 @@ END MODULE module_interp_info
    
         !  Shown below is the area of the CG that is in the area of the FG.   The
         !  first grid point of the depicted CG is the starting location of the nest
-        !  in the parent domain (ipos,jpos - i_parent_start and j_parent_start from
+        !  in the parent domain (ipos,jpos = i_parent_start and j_parent_start from
         !  the namelist).  
    
         !  For each of the CG points, the feedback loop is over each of the FG points
@@ -1616,7 +1616,7 @@ END MODULE module_interp_info
 !              |-------------||-------------|                          |-------------||-------------|
 ! jpoints = 1  |  t      t   ||  t      t   |                          |  t      t   ||  t      t   |
 !              |             ||             |                          |             ||             |
-!    jpos      |      T      ||      T      |          ...             |      T      ||      T      |
+!    jpos -->  |      T      ||      T      |          ...             |      T      ||      T      |
 !              |             ||             |          ...             |             ||             |
 ! jpoints = 0, |  t      t   ||  t      t   |          ...             |  t      t   ||  t      t   |
 !  nj=1        |-------------||-------------|                          |-------------||-------------|


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: nest feedback

SOURCE: Reported by Kevin Manning (NCAR), fixed internally

DESCRIPTION OF CHANGES:
Problem:
All nonmasked, odd-ratio (with ratios greater than 3:1) feedback was incorrect. The fine
grid feedback was incorrectly shifted down and to the left.

Solution:
A fixed constant value of 1 was correct for a 3:1 ratio since the term was
supposed to be ratio/2. For a 5:1 ratio the value needed to be 2. Replacing
the fixed value with the correct term fixes the problem. This solution works
for all odd ratios.

LIST OF MODIFIED FILES:
modified:   share/interp_fcn.F

TESTS CONDUCTED:
The test involves generating a known block of values on the fine grid that
should all feedback to their respective parent grid cells. By choosing the
fine grid cells so that only full parent cells are selected, and by filling
in the fine grid with a constant value (in our case: 1.0), then the coarse
grid should visually reflect the fine grid after feedback by appearing as a
square with sharp edges, rather than a smeared image.

1. Example of original code with wrong indexing. This is wrong:
<img width="1149" alt="Screen Shot 2020-02-21 at 10 56 19 AM" src="https://user-images.githubusercontent.com/12666234/75071194-1d420800-54b2-11ea-9186-0fd42317f501.png">

2. Example of corrected code with hard-coded assignment of 25 fine-grid points. This
is correct:
<img width="1150" alt="Screen Shot 2020-02-21 at 11 50 58 AM" src="https://user-images.githubusercontent.com/12666234/75071231-2f23ab00-54b2-11ea-91a1-b6860d523c15.png">

3. Example with fixed but now standard code. This is correct:
<img width="1150" alt="Screen Shot 2020-02-21 at 2 03 16 PM" src="https://user-images.githubusercontent.com/12666234/75071614-f33d1580-54b2-11ea-8c00-59c78cd6b617.png">

4. Even ratios of 2:1 and 4:1 are correct

RELEASE NOTE: ALL of the odd nest ratios (excluding 3:1) had an incorrect feedback. The indexing was off by (ratio/2 -1). For example, a 5:1 ratio would be off by a single fine grid point. Even ratio feedback was not impacted.