### PR TITLE
Check if STEPWTD==0 in NoahMP before mod(timestep,STEPWTD)

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2457,7 +2457,7 @@ rconfig   integer calc_clean_atm_diag     derived               1              0
 rconfig   integer dveg        namelist,noah_mp      1           4         h    "dveg"     "dynamic vegetation (1 -> off ; 2 -> on)"   ""
 rconfig   integer opt_crs     namelist,noah_mp      1           1         h    "opt_crs"  "canopy stomatal resistance (1-> Ball-Berry; 2->Jarvis)"   ""
 rconfig   integer opt_btr     namelist,noah_mp      1           1         h    "opt_btr"  "soil moisture factor for stomatal resistance (1-> Noah; 2-> CLM; 3-> SSiB)"   ""
-rconfig   integer opt_run     namelist,noah_mp      1           3         h    "opt_run"  "runoff and groundwater (1->SIMGM; 2->SIMTOP; 3->Schaake96; 4->BATS)"   ""
+rconfig   integer opt_run     namelist,noah_mp      1           3         h    "opt_run"  "runoff and groundwater (1->SIMGM; 2->SIMTOP; 3->Schaake96; 4->BATS; 5->Miguez-Macho & Fan)"   ""
 rconfig   integer opt_sfc     namelist,noah_mp      1           1         h    "opt_sfc"  "surface layer drag coeff (CH & CM) (1->M-O; 2->Chen97)"   ""
 rconfig   integer opt_frz     namelist,noah_mp      1           1         h    "opt_frz"  "supercooled liquid water (1-> NY06; 2->Koren99)"   ""
 rconfig   integer opt_inf     namelist,noah_mp      1           1         h    "opt_inf"  "frozen soil permeability (1-> NY06; 2->Koren99)"   ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1090,7 +1090,7 @@ state    real   rc_mf           ikj     misc        1         -      r        "R
 rconfig   integer dveg        namelist,noah_mp      1            4         h    "dveg"     "dynamic vegetation (1 -> off ; 2 -> on)"   ""
 rconfig   integer opt_crs     namelist,noah_mp      1            1         h    "opt_crs"  "canopy stomatal resistance (1-> Ball-Berry; 2->Jarvis)"   ""
 rconfig   integer opt_btr     namelist,noah_mp      1            1         h    "opt_btr"  "soil moisture factor for stomatal resistance (1-> Noah; 2-> CLM; 3-> SSiB)"   ""
-rconfig   integer opt_run     namelist,noah_mp      1            1         h    "opt_run"  "runoff and groundwater (1->SIMGM; 2->SIMTOP; 3->Schaake96; 4->BATS)"   ""
+rconfig   integer opt_run     namelist,noah_mp      1            1         h    "opt_run"  "runoff and groundwater (1->SIMGM; 2->SIMTOP; 3->Schaake96; 4->BATS; 5->Miguez-Macho & Fan)"   ""
 rconfig   integer opt_sfc     namelist,noah_mp      1            1         h    "opt_sfc"  "surface layer drag coeff (CH & CM) (1->M-O; 2->Chen97)"   ""
 rconfig   integer opt_frz     namelist,noah_mp      1            1         h    "opt_frz"  "supercooled liquid water (1-> NY06; 2->Koren99)"   ""
 rconfig   integer opt_inf     namelist,noah_mp      1            1         h    "opt_inf"  "frozen soil permeability (1-> NY06; 2->Koren99)"   ""

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -449,7 +449,7 @@ BENCH_START(surf_driver_tim)
 
 !gmm halo of wtd and riverflow for leafhydro
 #ifdef DM_PARALLEL
-  IF ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) THEN
+  IF ( ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) .and. ( grid%STEPWTD .ne. 0 ) )THEN
        IF ( config_flags%opt_run.eq.5.and.mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
 #     include "HALO_EM_HYDRO_NOAHMP.inc"
        ENDIF

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -449,8 +449,8 @@ BENCH_START(surf_driver_tim)
 
 !gmm halo of wtd and riverflow for leafhydro
 #ifdef DM_PARALLEL
-  IF ( ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) .and. ( grid%STEPWTD .ne. 0 ) )THEN
-       IF ( config_flags%opt_run.eq.5.and.mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
+  IF ( ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) .and. ( config_flags%opt_run.eq.5 ) ) THEN
+       IF ( mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
 #     include "HALO_EM_HYDRO_NOAHMP.inc"
        ENDIF
   ENDIF

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3101,6 +3101,7 @@ CONTAINS
 	 ENDIF 
 
   if(iopt_run.eq.5)then
+     if (mod(itimestep,STEPWTD).eq.0)then
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -3115,6 +3116,7 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
+     endif
   endif
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3100,8 +3100,8 @@ CONTAINS
 	 
 	 ENDIF 
 
-  if(iopt_run.eq.5)then
-     if (mod(itimestep,STEPWTD).eq.0)then ! STEPWTD always and only defined for iopt_run == 5
+  IF ( iopt_run .EQ. 5 ) THEN
+     IF ( MOD(itimestep,STEPWTD) .EQ. 0 ) THEN ! STEPWTD always and only non-zero for iopt_run == 5
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -3116,8 +3116,8 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
-     endif
-  endif
+     END IF
+  END IF
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &
               &            SEAICE_THICKNESS_DEFAULT, SEAICE_SNOWDEPTH_OPT,             &

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3100,8 +3100,7 @@ CONTAINS
 	 
 	 ENDIF 
 
-  if(STEPWTD.ne.0)then
-     if(iopt_run.eq.5.and.mod(itimestep,STEPWTD).eq.0)then
+  if(iopt_run.eq.5)then
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -3116,7 +3115,6 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
-     endif
   endif
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3100,7 +3100,8 @@ CONTAINS
 	 
 	 ENDIF 
 
-  if(iopt_run.eq.5.and.mod(itimestep,STEPWTD).eq.0)then
+  if(STEPWTD.ne.0)then
+     if(iopt_run.eq.5.and.mod(itimestep,STEPWTD).eq.0)then
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -3115,6 +3116,7 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
+     endif
   endif
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3101,7 +3101,7 @@ CONTAINS
 	 ENDIF 
 
   if(iopt_run.eq.5)then
-     if (mod(itimestep,STEPWTD).eq.0)then
+     if (mod(itimestep,STEPWTD).eq.0)then ! STEPWTD always and only defined for iopt_run == 5
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NoahMP, STEPWTD, mod

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
There were two places in the WRF code that tested for mod(itimestep,STEPWTD).
If STEPWTD==0, then this is an error.

Solution:
The correct test order is defined as
1. Is this opt_run == 5? If true, then the STEPWTD has been previously defined, and can be used.
2. Is this the correct time step?

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON
modified:   Registry/Registry.NMM
modified:   dyn_em/module_first_rk_step_part1.F
modified:   phys/module_surface_driver.F

TESTS CONDUCTED:
1. All tests with NoahMP fail immediately with STEPWTD==0 due to a divide by 0.
2. All tests pass with this fix in place.
3. Regression test underway.