### PR TITLE
Allow .f90 files in kpp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 configure.wrf*
 *.backup
 *.f90
+!chem/KPP/kpp/kpp-2.1/**/*.f90

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,11 @@ configure.wrf*
 
 ##############################################################################
 # These files are EXCLUDED from not being tracked, so they are still         #
-# tracked                                                                    #
-# The "!" character is the NOT                                               #
-# The "**" syntax is "this directory and recursively all below"              #
+# tracked (double negative logic hurts my head)                              #
+#                                                                            #
+# The leading "!" character is the NOT operator                              #
+#                                                                            #
+# The "**" syntax means "this directory level and recursively all            #
+# directories below this level"                                              #
 ##############################################################################
 !chem/KPP/kpp/kpp-2.1/**/*.f90

--- a/.gitignore
+++ b/.gitignore
@@ -17,15 +17,3 @@
 configure.wrf*
 *.backup
 *.f90
-
-
-##############################################################################
-# These files are EXCLUDED from not being tracked, so they are still         #
-# tracked (double negative logic hurts my head)                              #
-#                                                                            #
-# The leading "!" character is the NOT operator                              #
-#                                                                            #
-# The "**" syntax means "this directory level and recursively all            #
-# directories below this level"                                              #
-##############################################################################
-!chem/KPP/kpp/kpp-2.1/**/*.f90

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+##############################################################################
 # This is the top-level .gitignore file for the WRF model                    #
 #                                                                            #
 # Filenames and wildcards added below will not be tracked by git in any      #
@@ -16,4 +17,12 @@
 configure.wrf*
 *.backup
 *.f90
+
+
+##############################################################################
+# These files are EXCLUDED from not being tracked, so they are still         #
+# tracked                                                                    #
+# The "!" character is the NOT                                               #
+# The "**" syntax is "this directory and recursively all below"              #
+##############################################################################
 !chem/KPP/kpp/kpp-2.1/**/*.f90

--- a/chem/KPP/kpp/kpp-2.1/.gitignore
+++ b/chem/KPP/kpp/kpp-2.1/.gitignore
@@ -1,0 +1,9 @@
+##############################################################################
+# These files are EXCLUDED from not being tracked, so they are still tracked #
+#                                                                            #
+# The leading "!" character is the NOT operator                              #
+#                                                                            #
+# The "**" syntax means "this directory level and recursively all            #
+# directories below this level"                                              #
+##############################################################################
+!**/*.f90


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: .gitignore, kpp, f90

DESCRIPTION OF CHANGES:
Problem:
The *.f90 files are part of .gitignore. This is not entirely correct. There are instances where the
*.f90 files should be tracked by git.

Solution:
Exclude the *.f90 files under the kpp directory from this overly broad identification of files. There
are other directories where this fix could also be applied (such as for DA).

ISSUE:
Fixes #1105 

LIST OF MODIFIED FILES:
M  .gitignore

TESTS CONDUCTED:
Compile and run WRF-Chem successfully
