### PR TITLE
Check for the existence of input tables for mp=30 FSBM

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -577,19 +577,17 @@
            INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
            IF (.not.fsbm_table1_exists ) THEN
            wrf_err_message = "Input table SBM_input_33 doesn't exist !!!"
-           CALL wrf_debug ( 1, wrf_err_message )
+           CALL wrf_debug ( 0, wrf_err_message )
            wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
-           CALL wrf_debug ( 1, wrf_err_message )
-           CALL wrf_debug ( 0, TRIM( "  " ) )
+           CALL wrf_debug ( 0, wrf_err_message )
            count_fatal_error = count_fatal_error + 1
            END IF
            INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110', EXIST=fsbm_table2_exists)
            IF (.not.fsbm_table1_exists ) THEN
            wrf_err_message = "Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
-           CALL wrf_debug ( 1, TRIM( wrf_err_message ) )
+           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
            wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
-           CALL wrf_debug ( 1, wrf_err_message )
-           CALL wrf_debug ( 0, TRIM( "  " ) )
+           CALL wrf_debug ( 0, wrf_err_message )
            count_fatal_error = count_fatal_error + 1
            END IF
       END IF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -574,22 +574,22 @@
 ! Input tables must exist in running directory for fast bin microphysics scheme (mp_physics = 30)
 !--------------------------------------------------------------------------------------------------
       IF (  model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND   ) THEN
-           INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
-           IF (.not.fsbm_table1_exists ) THEN
-           wrf_err_message = "Input table SBM_input_33 doesn't exist !!!"
-           CALL wrf_debug ( 0, wrf_err_message )
-           wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
-           CALL wrf_debug ( 0, wrf_err_message )
-           count_fatal_error = count_fatal_error + 1
-           END IF
-           INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110', EXIST=fsbm_table2_exists)
-           IF (.not.fsbm_table1_exists ) THEN
-           wrf_err_message = "Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
-           CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-           wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
-           CALL wrf_debug ( 0, wrf_err_message )
-           count_fatal_error = count_fatal_error + 1
-           END IF
+         INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
+            IF (.not.fsbm_table1_exists ) THEN
+               wrf_err_message = "Input table SBM_input_33 doesn't exist !!!"
+               CALL wrf_debug ( 0, wrf_err_message )
+               wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+               CALL wrf_debug ( 0, wrf_err_message )
+               count_fatal_error = count_fatal_error + 1
+             END IF
+         INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110', EXIST=fsbm_table2_exists)
+            IF (.not.fsbm_table1_exists ) THEN
+               wrf_err_message = "Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
+               CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+               wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+               CALL wrf_debug ( 0, wrf_err_message )
+               count_fatal_error = count_fatal_error + 1
+            END IF
       END IF
 !-----------------------------------------------------------------------
 ! There are restrictions on the AFWA diagnostics regarding the choice

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -58,6 +58,7 @@
       INTEGER :: count_opt
       LOGICAL :: lon_extent_is_global , lat_extent_is_global
       LOGICAL :: rinblw_already_done
+      LOGICAL :: fsbm_table1_exists, fsbm_table2_exists
       INTEGER :: count_fatal_error
       INTEGER :: len1, len2, len_loop
 
@@ -569,6 +570,29 @@
       END DO
 
 #if (EM_CORE == 1)
+!--------------------------------------------------------------------------------------------------
+! Input tables must exist in running directory for fast bin microphysics scheme (mp_physics = 30)
+!--------------------------------------------------------------------------------------------------
+      IF (  model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND   ) THEN
+           INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
+           IF (.not.fsbm_table1_exists ) THEN
+           wrf_err_message = "Input table SBM_input_33 doesn't exist !!!"
+           CALL wrf_debug ( 1, wrf_err_message )
+           wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+           CALL wrf_debug ( 1, wrf_err_message )
+           CALL wrf_debug ( 0, TRIM( "  " ) )
+           count_fatal_error = count_fatal_error + 1
+           END IF
+           INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110', EXIST=fsbm_table2_exists)
+           IF (.not.fsbm_table1_exists ) THEN
+           wrf_err_message = "Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
+           CALL wrf_debug ( 1, TRIM( wrf_err_message ) )
+           wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+           CALL wrf_debug ( 1, wrf_err_message )
+           CALL wrf_debug ( 0, TRIM( "  " ) )
+           count_fatal_error = count_fatal_error + 1
+           END IF
+      END IF
 !-----------------------------------------------------------------------
 ! There are restrictions on the AFWA diagnostics regarding the choice
 ! of microphysics scheme. These are hard coded in the AFWA diags driver,

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -575,21 +575,21 @@
 !--------------------------------------------------------------------------------------------------
       IF (  model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND   ) THEN
          INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
-            IF (.not.fsbm_table1_exists ) THEN
-               wrf_err_message = "Input table SBM_input_33 doesn't exist !!!"
-               CALL wrf_debug ( 0, wrf_err_message )
-               wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
-               CALL wrf_debug ( 0, wrf_err_message )
-               count_fatal_error = count_fatal_error + 1
-             END IF
+         IF (.not.fsbm_table1_exists ) THEN
+            wrf_err_message = "--- ERROR: Input table SBM_input_33 doesn't exist !!!"
+            CALL wrf_message ( wrf_err_message )
+            wrf_err_message = '--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+             CALL wrf_message ( wrf_err_message )
+            count_fatal_error = count_fatal_error + 1
+         END IF
          INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110', EXIST=fsbm_table2_exists)
-            IF (.not.fsbm_table1_exists ) THEN
-               wrf_err_message = "Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
-               CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-               wrf_err_message = 'Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
-               CALL wrf_debug ( 0, wrf_err_message )
-               count_fatal_error = count_fatal_error + 1
-            END IF
+         IF (.not.fsbm_table2_exists ) THEN
+            wrf_err_message = "--- ERROR: Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
+            CALL wrf_message ( TRIM( wrf_err_message ) )
+            wrf_err_message = '--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+            CALL wrf_message ( wrf_err_message )
+            count_fatal_error = count_fatal_error + 1
+         END IF
       END IF
 !-----------------------------------------------------------------------
 ! There are restrictions on the AFWA diagnostics regarding the choice


### PR DESCRIPTION
KEYWORDS: check_a_mundo, FAST_KHAIN_LYNN_SHPUND

SOURCE: internal

DESCRIPTION OF CHANGES: 
check the existence of input tables for running the fast bin microphysics scheme (mp=30)
(FAST_KHAIN_LYNN_SHPUND)

LIST OF MODIFIED FILES:
M        share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. regression test OK

2. With both SBM files linked in:
```
 FAST SBM: INITIALIZING WRF_HUJISBM
 FAST SBM: ****** WRF_HUJISBM *******
 FAST_SBM_INIT : succesfull reading Table-1                                      
  FAST_SBM_INIT : succesfull reading Table-1
 FAST_SBM_INIT : succesfull reading Table-2                                      
  FAST_SBM_INIT : succesfull reading Table-2
 FAST_SBM_INIT : succesfull reading Table-3                                      
  FAST_SBM_INIT : succesfull reading Table-3
  FAST_SBM_INIT : succesfull reading Table-4
  FAST_SBM_INIT : succesfull reading Table-5
  FAST_SBM_INIT : succesfull reading Table-6
  FAST_SBM_INIT : succesfull reading Table-7
  FAST_SBM_INIT : succesfull reading Table-8
  FAST_SBM_INIT : succesfull reading Table-9
 scattering input directory is source/scattering_tables_2layer_high_quad_1dT_1%fw_110/
 READING SCATTERING TABLES: RAIN
 READING SCATTERING TABLES: SNOW
 READING SCATTERING TABLES: GRAUPEL
 READING SCATTERING TABLES: HAIL
module_mp_WRFsbm : succesfull reading Table-10
  FAST_SBM_INIT : succesfull reading "courant_bott_KS"
 CONCCCNIN   401.74097285574766     
 CONCCCNIN   1799.7710944902556     
  module_mp_WRFsbm : succesfull reading "LogNormal_modes_Aerosol"
  FAST_SBM_INIT : succesfull reading BREAKINIT_KS"
 IKR_Spon_Break=          33
  FAST_SBM_INIT : succesfull reading "Spontanous_Init"
```

3. When the link exists, but the actual file is removed, the logic still works:
```
--- ERROR: Input table SBM_input_33 doesn't exist !!!
--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/
--- ERROR: Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!
--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2194
NOTE:       2 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```