### PR TITLE
Prevent 0 index in GOCART settling array

### DIFF
--- a/chem/module_gocart_settling.F
+++ b/chem/module_gocart_settling.F
@@ -350,12 +350,14 @@ SUBROUTINE gocart_settling_driver(dt,config_flags,t_phy,moist,      &
             vd_wk1 = dt_settl(k)*vd_cor(l)/delz(i,j,l2)                  ! fraction to leave level
 
             tc(i,j,l,k)   =  tc(i,j,l,k)*(1.- vd_wk1)+transfer_to_below_level          ! [ug/kg]
-            transfer_to_below_level = (temp_tc*vd_wk1)*((delz(i,j,l2)*airden(i,j,l))/(delz(i,j,l2+1)*airden(i,j,l-1))) ! [ug/kg]
-
+!++SW
              IF (l==1) THEN
                 graset(i,j,k)=graset(i,j,k)+vd_cor(l)*temp_tc/ndt_settl(k) ! [ug/kg][m/s]
                 grasetvel(i,j,k)=vd_cor(l)                                 ! [m/s]
+             ELSE
+                transfer_to_below_level = (temp_tc*vd_wk1)*((delz(i,j,l2)*airden(i,j,l))/(delz(i,j,l2+1)*airden(i,j,l-1))) ! [ug/kg]
              ENDIF
+!--SW
           ENDDO                 !l, height
         ENDDO                   !n, time
       ENDDO                     !k, bin

--- a/chem/module_gocart_settling.F
+++ b/chem/module_gocart_settling.F
@@ -345,19 +345,18 @@ SUBROUTINE gocart_settling_driver(dt,config_flags,t_phy,moist,      &
 
              vd_cor(l) = 2./9.*g0*rho_priv(k)*rwet_priv(k)**2/viscosity  ! Settling velocity, depends on temp
 
-            ! Update mixing ratio; order of delz: top->sfc
-            temp_tc=tc(i,j,l,k)                                          ! temp_tc - for temporal storage [ug/kg]            
-            vd_wk1 = dt_settl(k)*vd_cor(l)/delz(i,j,l2)                  ! fraction to leave level
+             ! Update mixing ratio; order of delz: top->sfc
+             temp_tc=tc(i,j,l,k)                                          ! temp_tc - for temporal storage [ug/kg]            
+             vd_wk1 = dt_settl(k)*vd_cor(l)/delz(i,j,l2)                  ! fraction to leave level
 
-            tc(i,j,l,k)   =  tc(i,j,l,k)*(1.- vd_wk1)+transfer_to_below_level          ! [ug/kg]
-!++SW
+             tc(i,j,l,k)   =  tc(i,j,l,k)*(1.- vd_wk1)+transfer_to_below_level          ! [ug/kg]
+            
              IF (l==1) THEN
                 graset(i,j,k)=graset(i,j,k)+vd_cor(l)*temp_tc/ndt_settl(k) ! [ug/kg][m/s]
                 grasetvel(i,j,k)=vd_cor(l)                                 ! [m/s]
              ELSE
                 transfer_to_below_level = (temp_tc*vd_wk1)*((delz(i,j,l2)*airden(i,j,l))/(delz(i,j,l2+1)*airden(i,j,l-1))) ! [ug/kg]
              ENDIF
-!--SW
           ENDDO                 !l, height
         ENDDO                   !n, time
       ENDDO                     !k, bin


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: GOCART, settling

SOURCE: Stacy Walters (internal)

DESCRIPTION OF CHANGES: 
Put calculation of aerosol settling (variable = transfer_to_below_level) in layers > 1 
into IF/ELSE block that calculates gravitational settling for layer = 1.

LIST OF MODIFIED FILES: 
M chem/module_gocart_settling.F

TEST CONDUCTED:
Jenkins shows all tests PASS

**Compiled with debug option -check bounds**
_BEFORE FIX_: 2 indexes are OOB for l==1, 3rd dim of delz (> MAX) and 3rd dim of airden (0)

rsl.out.0000
 l/=1, calculting transfer_to_below_level =   3.153560196907218E-014
 l/=1, calculting transfer_to_below_level =   1.014890436929303E-012
 l/=1, calculting transfer_to_below_level =   2.118741307102124E-011
 l==1, still calculating transfer_to_below_level =
  = (temp_tc*vd_wk1)*((delz(i,j,l2)*airden(i,j,l))/(delz(i,j,l2+1)*airden(i,j,l-1)))
 l==1, index of airden(i,j,l-1) =            1           1           0
  and index of delz(i,j,l2+1) =            1           1          31
 but size of 3rd dim of delz  =           30
rsl.error.0000
forrtl: severe (408): fort: (2): Subscript #3 of the array DELZ has value 31 which is greater than the upper bound of 30

_AFTER FIX_: 
l/=1, calculating transfer_to_below_level =   3.153560196907218E-014
 l/=1, calculating transfer_to_below_level =   1.014890436929303E-012
 l/=1, calculating transfer_to_below_level =   2.118741307102124E-011
 l==1, not calculating transfer_to_below_level


