### PR TITLE
Fixes so WRFPLUS builds with develop branch

### DIFF
--- a/arch/postamble
+++ b/arch/postamble
@@ -28,7 +28,7 @@ ARCHFLAGS       =    $(COREDEFS) -DIWORDSIZE=$(IWORDSIZE) -DDWORDSIZE=$(DWORDSIZ
                       -DLIMIT_ARGS \
                       -DBUILD_RRTMG_FAST=0 \
                       -DBUILD_RRTMK=0 \
-                      -DBUILD_SBM_FAST=1 \
+                      -DBUILD_SBM_FAST=0 \
                       -DSHOW_ALL_VARS_USED=0 \
                       -DCONFIG_BUF_LEN=$(CONFIG_BUF_LEN) \
                       -DMAX_DOMAINS_F=$(MAX_DOMAINS) \

--- a/main/depend.common
+++ b/main/depend.common
@@ -574,6 +574,7 @@ module_physics_init.o : \
 		module_mp_etanew.o		\
 		module_mp_fer_hires.o 		\
 		module_mp_HWRF.o		\
+		module_mp_fast_sbm.o		\
 		module_fdda_psufddagd.o		\
 		module_fdda_spnudging.o         \
 		module_fddaobs_rtfdda.o		\
@@ -618,6 +619,8 @@ module_microphysics_driver.o: \
                 module_mp_nssl_2mom.o         \
 		module_mp_wdm5.o module_mp_wdm6.o \
 		module_mp_cammgmp_driver.o \
+		module_irrigation.o \
+		module_mp_fast_sbm.o \
 		../frame/module_driver_constants.o \
 		../frame/module_state_description.o \
 		../frame/module_wrf_error.o \
@@ -747,6 +750,7 @@ module_surface_driver.o: \
 		module_sf_scmflux.o		\
 		module_sf_scmskintemp.o		\
 		module_sf_ocean_driver.o	\
+		module_irrigation.o             \
 		../frame/module_state_description.o \
 		../frame/module_configure.o \
 		../frame/module_cpl.o \

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2251,12 +2251,13 @@
       ENDDO
 #endif
 
+#if (EM_CORE == 1)
+# if( BUILD_SBM_FAST != 1)
 !-----------------------------------------------------------------------
 !  If the FAST SBM scheme is requested and it is not compiled, let the
 !  user know.
 !-----------------------------------------------------------------------
 
-#if( BUILD_SBM_FAST != 1)
       IF ( model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND ) THEN
          wrf_err_message = '--- ERROR: FAST SBM scheme must be built with a default compile-time flag'
          CALL wrf_message ( wrf_err_message )
@@ -2264,6 +2265,7 @@
          CALL wrf_message ( wrf_err_message )
          count_fatal_error = count_fatal_error + 1
       END IF
+# endif
 #endif
 
 !-----------------------------------------------------------------------

--- a/wrftladj/solve_em_ad.F
+++ b/wrftladj/solve_em_ad.F
@@ -3806,6 +3806,18 @@ BENCH_START(micro_driver_tim)
       &        ,KTS=k_start, KTE=min(k_end,kde-1)                         &
       &        ,NUM_TILES=grid%num_tiles                                  &
       &        ,NAER=grid%naer                                            &
+!===================== IRRIGATION =========================
+      &        ,IRRIGATION=grid%irrigation                                &
+      &        ,SF_SURF_IRR_SCHEME=config_flags%sf_surf_irr_scheme        &
+      &        ,IRR_DAILY_AMOUNT=config_flags%irr_daily_amount            &
+      &        ,IRR_START_HOUR=config_flags%irr_start_hour                &
+      &        ,IRR_NUM_HOURS=config_flags%irr_num_hours                  &
+      &        ,JULIAN_IN=grid%julian                                     &
+      &        ,IRR_START_JULIANDAY=config_flags%irr_start_julianday      &
+      &        ,IRR_END_JULIANDAY=config_flags%irr_end_julianday          &
+      &        ,IRR_FREQ=config_flags%irr_freq,IRR_PH=config_flags%irr_ph &
+      &        ,IRR_RAND_FIELD=grid%irr_rand_field                        &
+      &        ,GMT=grid%gmt,XTIME=grid%xtime                             &
 !======================
       ! Variables required for CAMMGMP Scheme
       &        ,DLF=grid%dlf,DLF2=grid%dlf2,T_PHY=grid%t_phy,P_HYD=grid%p_hyd  &
@@ -3907,6 +3919,7 @@ BENCH_START(micro_driver_tim)
       &        ,height=grid%height                                         &
       &        ,tempc=grid%tempc                                         &
       &        ,ccn_conc=grid%ccn_conc                                   & ! RAS
+      &        ,sbmradar=sbmradar,num_sbmradar=num_sbmradar              & ! for SBM
       &        ,aerocu=aerocu                                            &
       &        ,aercu_fct=config_flags%aercu_fct                         &
       &        ,aercu_opt=config_flags%aercu_opt                         &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFPLUS

SOURCE: internal

DESCRIPTION OF CHANGES:

Problem:
With the develop branch, WRFPLUS did not build.

Solution:
1. There were missing dependencies for two new physics schemes:
irrigation and FSBM. Those were added to physics drivers and
physics init.
2. The argument list for the microphysics driver was also modified by
those same two new physics schemes. The (not used for WRFPLUS) sections
for both irrigation and FSBM were added.
3. Since the DA code builds with 8-byte reals as the default, the FSBM code is
removed from the default compilation (as this code is known to fail to build when
8-byte reals are used). A simple test in the `configure` script is likely to be enough 
for a fix. For example, something similar to the existing test for 8-byte reals:
```
sed -e 's/-DBUILD_SBM_FAST=1/-DBUILD_SBM_FAST=0/' configure.wrf > configure.wrf.edit 
/bin/mv configure.wrf.edit configure.wrf
```

LIST OF MODIFIED FILES:
modified:   arch/postamble
modified:   main/depend.common
modified:   share/module_check_a_mundo.F
modified:   wrftladj/solve_em_ad.F

TESTS CONDUCTED:
1. Without these mods, WRFPLUS does not compile. With mods = yay, success.
2. Jenkins verifies all PASS.