### PR TITLE
Add number of tasks to WRF history global attributes

### DIFF
--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -800,7 +800,7 @@ endif
       CALL wrf_put_dom_ti_integer   ( fid, 'DFI_OPT',          config_flags%dfi_opt      , 1 , ierr )
       CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_X',         ntasks_x                  , 1 , ierr )
       CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_Y',         ntasks_y                  , 1 , ierr )
-      CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS',           ntasks_x*ntasks_y         , 1 , ierr )
+      CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_TOTAL',     ntasks_x*ntasks_y         , 1 , ierr )
 
       ENDIF ! history_only
 

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -48,6 +48,7 @@
     INTEGER skebs_on, sppt_on, rand_perturb_on, nens,ISEED_SKEBS,ISEED_SPPT,ISEED_RAND_PERT
     INTEGER skebs_vertstruc, sppt_vertstruc, rand_pert_vertstruc
     INTEGER LMINFORC,LMAXFORC,KMINFORC,KMAXFORC,LMINFORCT,LMAXFORCT,KMINFORCT,KMAXFORCT
+    INTEGER NTASKS_X, NTASKS_Y
     REAL    gridpt_stddev_rand_pert,stddev_cutoff_rand_pert,timescale_rand_pert
     REAL    gridpt_stddev_sppt,stddev_cutoff_sppt,timescale_sppt
     REAL    tot_backscat_psi,tot_backscat_t,REXPONENT_PSI,REXPONENT_T,ZTAU_PSI,ZTAU_T
@@ -157,6 +158,8 @@
     call nl_get_aer_ssa_val        ( grid%id,  aer_ssa_val        )
     call nl_get_aer_asy_val        ( grid%id,  aer_asy_val        )
     call nl_get_sf_lake_physics    ( grid%id,  sf_lake_physics    )
+    call nl_get_nproc_x            ( 1,        ntasks_x           )
+    call nl_get_nproc_y            ( 1,        ntasks_y           )
 
 #if (EM_CORE == 1)
     dt = grid%dt
@@ -795,6 +798,9 @@ endif
       ENDIF
 
       CALL wrf_put_dom_ti_integer   ( fid, 'DFI_OPT',          config_flags%dfi_opt      , 1 , ierr )
+      CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_X',         ntasks_x                  , 1 , ierr )
+      CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_Y',         ntasks_y                  , 1 , ierr )
+      CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS',           ntasks_x*ntasks_y         , 1 , ierr )
 
       ENDIF ! history_only
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: ntasks, metadata, global attributes

SOURCE: internal

DESCRIPTION OF CHANGES:
In the global attributes for the WRF history stream, include the number of total
tasks, and the number of tasks in both the X and Y directions.

LIST OF MODIFIED FILES:
modified:   share/output_wrf.F

TESTS CONDUCTED:
1. Jenkins PASS
2. Example of new metadata in WRF history file:

```
> mpirun -np 1 wrf.exe
 starting wrf task            0  of            1

> ncdump wrfo* | grep NTASKS
		:NTASKS_X = 1 ;
		:NTASKS_Y = 1 ;
		:NTASKS = 1 ;
```

```
> mpirun -np 3 wrf.exe
 starting wrf task            1  of            3
 starting wrf task            2  of            3
 starting wrf task            0  of            3

> ncdump wrfo* | grep NTASKS
		:NTASKS_X = 1 ;
		:NTASKS_Y = 3 ;
		:NTASKS = 3 ;
```
