### PR TITLE
Fix nudging of temperature obs at edge of tile

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3248,7 +3248,7 @@ halo      HALO_EM_F_1 dyn_em  24:muus,muvs
 #halo      em_shift_halo_x  dyn_em 48:imask_nostag,imask_xstag,imask_ystag,imask_xystag,u_2,v_2,t_2
 
 # For observational nudging
-halo      HALO_OBS_NUDGE dyn_em 24:ph_2,p,uratx,vratx,tratx,kpbl
+halo      HALO_OBS_NUDGE dyn_em 24:ph_2,p,uratx,vratx,tratx,kpbl,th_phy_m_t0
 
 # cyl: For 3DPWP
 halo      HALO_PWP dyn_em 8: OM_TMP,OM_S,OM_U,OM_V,OM_DEPTH,OM_TINI,OM_SINI


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: observation nudging, temperature, tile, halo

SOURCE: Brian Reen (Army Research Lab)

DESCRIPTION OF CHANGES: 
Added th_phy_m_t0 to the HALO statement for observation nudging in the Registry. 

Problem:
Previously, observation nudging using temperature observations on the boundary edge of a 
tile used an incorrect nudging term.  During the interpolation of model potential temperature 
to the observation location, model values outside of the current tile are needed when the 
observation is on the boundary edge of the tile.  However, the model potential temperature 
for these points just outside the current tile was not available in the variable used for this calculation (tb in phys/module_fddaobs_rtfdda.F).  During testing, a value of zero was instead 
seen in these off-tile gridpoints (TB holds dry potential temperature minus 300 K, thus a value 
of tb = zero means that the model potential temperature = 300 K).  

Solution:
Now, the observation nudging HALO statement in the Registry has had th_phy_m_t0 added to 
it so that the values of tb one grid point beyond the tile boundary edge are correct.  This 
allows the first-order linear interpolation of model potential temperature to produce the 
correct value for comparison against the observation.  

The variable th_phy_m_t0 is the added to the HALO statement because subroutine 
first_rk_step_part2 (dyn_em/module_first_rk_step_part2.F) passes grid%th_phy_m_t0 to 
subroutine fddaobs_driver (phys/module_fddaobs_driver.F) which in turn passes it to 
subroutine errob (phys/module_fddaobs_rtfdda.F) where it is tb.  

The variable passed by first_rk_step_part2 for eventual use as tb was originally grid%t_2 in 
v3.9.1.1 and earlier versions of WRF. This bug was introduced during the change from 
grid%t_2 to grid%th_phy_m_t0 in WRFV4.0 (the dry potential temperature to moist potential 
temperature modification).

ISSUE: 
```
Fixes #1115 
```

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON

TESTS CONDUCTED: 

1. Inserted in subroutine errob in phys/module_fddaobs_rtfdda.F prints of the values used 
to interpolate the model potential temperature (tb) to the observed value.  For a temperature 
observation on the edge of a tile, previously the values of tb outside of the tile were zero 
whereas now the values of tb outside of the tile are very similar to those inside the tile.
2. Jenkins all PASS