### PR TITLE
Only test for FSBM input files if the FSBM code is built

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -573,6 +573,7 @@
 !--------------------------------------------------------------------------------------------------
 ! Input tables must exist in running directory for fast bin microphysics scheme (mp_physics = 30)
 !--------------------------------------------------------------------------------------------------
+# if ( BUILD_SBM_FAST == 1 )
       IF (  model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND   ) THEN
          INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
          IF (.not.fsbm_table1_exists ) THEN
@@ -591,6 +592,9 @@
             count_fatal_error = count_fatal_error + 1
          END IF
       END IF
+#else
+      EXIT
+#endif
 !-----------------------------------------------------------------------
 ! There are restrictions on the AFWA diagnostics regarding the choice
 ! of microphysics scheme. These are hard coded in the AFWA diags driver,

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -574,27 +574,25 @@
 ! Input tables must exist in running directory for fast bin microphysics scheme (mp_physics = 30)
 !--------------------------------------------------------------------------------------------------
 # if ( BUILD_SBM_FAST == 1 )
-      IF (  model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND   ) THEN
-         INQUIRE(FILE='./SBM_input_33', EXIST=fsbm_table1_exists)
+      IF ( model_config_rec % mp_physics(1) .EQ. FAST_KHAIN_LYNN_SHPUND ) THEN
+         INQUIRE(FILE='./SBM_input_33/BLKD_SDC.dat', EXIST=fsbm_table1_exists)
          IF (.not.fsbm_table1_exists ) THEN
-            wrf_err_message = "--- ERROR: Input table SBM_input_33 doesn't exist !!!"
+            wrf_err_message = "--- ERROR: Input directory SBM_input_33 doesn't exist !!!"
             CALL wrf_message ( wrf_err_message )
-            wrf_err_message = '--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+            wrf_err_message = '--- ERROR: Download this directory of table files from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
              CALL wrf_message ( wrf_err_message )
             count_fatal_error = count_fatal_error + 1
          END IF
-         INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110', EXIST=fsbm_table2_exists)
+         INQUIRE(FILE='./scattering_tables_2layer_high_quad_1dT_1%fw_110/GRAUPEL_+00C_000fvw.sct', EXIST=fsbm_table2_exists)
          IF (.not.fsbm_table2_exists ) THEN
-            wrf_err_message = "--- ERROR: Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
+            wrf_err_message = "--- ERROR: Input directory scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!"
             CALL wrf_message ( TRIM( wrf_err_message ) )
-            wrf_err_message = '--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
+            wrf_err_message = '--- ERROR: Download this directory of input table files from http://www2.mmm.ucar.edu/wrf/src/wrf_files/'
             CALL wrf_message ( wrf_err_message )
             count_fatal_error = count_fatal_error + 1
          END IF
       END IF
-#else
-      EXIT
-#endif
+# endif
 !-----------------------------------------------------------------------
 ! There are restrictions on the AFWA diagnostics regarding the choice
 ! of microphysics scheme. These are hard coded in the AFWA diags driver,


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: FSBM microphysics, check_a_mundo

SOURCE:  internal

DESCRIPTION OF CHANGES: 
Only check the availability of FSBM input tables when the FSBM code is compiled with the 
cpp flag BUILD_SBM_FAST == 1

LIST OF MODIFIED FILES: 
M    share/module_check_a_mundo.F

TESTS CONDUCTED:  
1. Regression test OK
2.  TEST1: BUILD_SBM_FAST = 0, and input tables exit. Message is:
```
--- ERROR: FAST SBM scheme must be built with a default compile-time flag
--- ERROR: Run ./clean -a, ./configure, ./compile scripts again
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2215
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
3. TEST2: BUILD_SBM_FAST = 1 , files exist
```
The case runs fine
```
4.  TEST3: BUILD_SBM_FAST = 1, input table doesn't exist, Message is:
```
--- ERROR: Input table SBM_input_33 doesn't exist !!!
--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/
--- ERROR: Input table scattering_tables_2layer_high_quad_1dT_1%fw_110 doesn't exist !!!
--- ERROR: Download this table from http://www2.mmm.ucar.edu/wrf/src/wrf_files/
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2221
NOTE:       2 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
5. TEST4: BUILD_SBM_FAST = 0, input table doesn't exist. Message is:
```
--- ERROR: FAST SBM scheme must be built with a default compile-time flag
--- ERROR: Run ./clean -a, ./configure, ./compile scripts again
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2215
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```

6. The tables are identified correctly on an Ubuntu 18.04 system.
