### PR TITLE
Redo PR#997 based on suggestion from Mike Iacono

### DIFF
--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -2574,12 +2574,10 @@
             zgamma4= 1._rb - zgamma3
     
 ! Recompute original s.s.a. to test for conservative solution
-            denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
-	    ! Code added to avoid 'divide by zero' error in zwo computation
-            if (abs(denom).eq.0.0_rb) then
-               denom = 1.0E-30_rb
-            end if
-            zwo= zw / denom
+            zwo = 0._rb
+            denom = 1._rb
+            if (zg .ne. 1._rb) denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
+            if (zw .gt. 0._rb .and. denom .ne. 0._rb) zwo = zw / denom
 
             if (zwo >= zwcrit) then
 ! Conservative scattering

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -9479,11 +9479,10 @@ real gpu_device  :: zcd(tncol,ngptsw,nlayers+1)  , zcu(tncol,ngptsw,nlayers+1)
     
 ! Recompute original s.s.a. to test for conservative solution
 
-               denom = (1. - (1. - zw) * (zg / (1. - zg))**2)
-               if (abs(denom).eq.0.0) then
-                  denom = 1.0E-30
-               end if
-               zwo= zw / denom
+               zwo = 0._rb
+               denom = 1._rb
+               if (zg .ne. 1._rb) denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
+               if (zw .gt. 0._rb .and. denom .ne. 0._rb) zwo = zw / denom
     
                if (zwo >= zwcrit) then
 ! Conservative scattering

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -9479,10 +9479,10 @@ real gpu_device  :: zcd(tncol,ngptsw,nlayers+1)  , zcu(tncol,ngptsw,nlayers+1)
     
 ! Recompute original s.s.a. to test for conservative solution
 
-               zwo = 0._rb
-               denom = 1._rb
-               if (zg .ne. 1._rb) denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
-               if (zw .gt. 0._rb .and. denom .ne. 0._rb) zwo = zw / denom
+               zwo = 0.
+               denom = 1.
+               if (zg .ne. 1.) denom = (1. - (1. - zw) * (zg / (1. - zg))**2)
+               if (zw .gt. 0. .and. denom .ne. 0.) zwo = zw / denom
     
                if (zwo >= zwcrit) then
 ! Conservative scattering

--- a/phys/module_ra_rrtmg_swk.F
+++ b/phys/module_ra_rrtmg_swk.F
@@ -2089,11 +2089,10 @@
 !
 ! Recompute original s.s.a. to test for conservative solution
 !
-       denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
-       if (abs(denom).eq.0.0_rb) then
-           denom = 1.0E-30_rb
-       end if
-       zwo= zw / denom
+       zwo = 0._rb
+       denom = 1._rb
+       if (zg .ne. 1._rb) denom = (1._rb - (1._rb - zw) * (zg / (1._rb - zg))**2)
+       if (zw .gt. 0._rb .and. denom .ne. 0._rb) zwo = zw / denom
 !
        if (zwo >= zwcrit) then
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RRTMG-shortwave, PR#997

SOURCE: Mike Iacono, AER

DESCRIPTION OF CHANGES: 
Regarding the fix from PR#997, Mike Iacono, a RRTMG code developer, suggested a different fix, which will cover the cases where “zw” and “zg” (the single-scattering albedo and asymmetry parameter inputs to the “denom” equation) can cause problems with value of 1.0.

LIST OF MODIFIED FILES: list of changed files 
M       phys/module_ra_rrtmg_sw.F
M       phys/module_ra_rrtmg_swf.F
M       phys/module_ra_rrtmg_swk.F

TESTS CONDUCTED: 
1. Run a test case over East Asia (same case as in PR#997), and compared differences. In the first image below, it shows difference plots for 6 h forecast of temperature at model level 31 (left, about 330 mb) and 46 (right, about 95 mb). The run it compares to has the original fix. The second image shows the domain averaged temperature difference between the runs (the difference is about 0.0005 K). Compared to PR#997 (which corrected a bias of about 0.1 K at some levels), the averaged change is small, and more random.

![rrtmg_diff-l31-l46](https://user-images.githubusercontent.com/12705680/76116380-200b2580-5fa7-11ea-9573-16ff6e209adf.png)

![rrtmg_diff_prof_06h](https://user-images.githubusercontent.com/12705680/76116441-3ca75d80-5fa7-11ea-97f0-c4da97132660.png)

2. Reg test: passed Jenkins tests.

RELEASE NOTE: 
More later.
