### PR TITLE
Fix for horizontal diffusion of w (diff_opt=2)

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2003,7 +2003,7 @@ SUBROUTINE smag2d_km( config_flags,xkmh,xkmv,xkhh,xkhv,                        &
 !        xkmh(i,k,j)=max(c_s*c_s*mlen_h*mlen_h*tmp, 1.0E-6*mlen_h*mlen_h )
          xkmh(i,k,j)=c_s*c_s*mlen_h*mlen_h*tmp
          xkmh(i,k,j)=min(xkmh(i,k,j), 10.*mlen_h )
-         xkmv(i,k,j)=0.
+         xkmv(i,k,j)=xkmh(i,k,j)               ! after v4.2 this is used for hor. diff. of w
          xkhh(i,k,j)=xkmh(i,k,j)/pr
          xkhv(i,k,j)=0.
          IF(config_flags%diff_opt .EQ. 2)THEN
@@ -2021,6 +2021,7 @@ SUBROUTINE smag2d_km( config_flags,xkmh,xkmv,xkhh,xkhv,                        &
              xkmh(i,k,j)=xkmh(i,k,j)/(alpha)
            endif
            xkhh(i,k,j)=xkmh(i,k,j)/pr
+           xkmv(i,k,j)=xkmh(i,k,j)               ! after v4.2 this is used for hor. diff. of w
          ENDIF
       ENDDO
       ENDDO

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2003,7 +2003,7 @@ SUBROUTINE smag2d_km( config_flags,xkmh,xkmv,xkhh,xkhv,                        &
 !        xkmh(i,k,j)=max(c_s*c_s*mlen_h*mlen_h*tmp, 1.0E-6*mlen_h*mlen_h )
          xkmh(i,k,j)=c_s*c_s*mlen_h*mlen_h*tmp
          xkmh(i,k,j)=min(xkmh(i,k,j), 10.*mlen_h )
-         xkmv(i,k,j)=xkmh(i,k,j)               ! after v4.2 this is used for hor. diff. of w
+         xkmv(i,k,j)=xkmh(i,k,j)               ! v4.2 and later, this is used for hor. diff. of w
          xkhh(i,k,j)=xkmh(i,k,j)/pr
          xkhv(i,k,j)=0.
          IF(config_flags%diff_opt .EQ. 2)THEN
@@ -2021,7 +2021,7 @@ SUBROUTINE smag2d_km( config_flags,xkmh,xkmv,xkhh,xkhv,                        &
              xkmh(i,k,j)=xkmh(i,k,j)/(alpha)
            endif
            xkhh(i,k,j)=xkmh(i,k,j)/pr
-           xkmv(i,k,j)=xkmh(i,k,j)               ! after v4.2 this is used for hor. diff. of w
+           xkmv(i,k,j)=xkmh(i,k,j)               ! v4.2 and later, this is used for hor. diff. of w
          ENDIF
       ENDDO
       ENDDO

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2287,7 +2287,7 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                     div,                                       &
                                     moist, chem, scalar,tracer,                &
                                     msfux, msfuy, msfvx, msfvy,                &
-                                    msftx, msfty, xkmh, xkhh,km_opt,           &
+                                    msftx, msfty, xkmh, xkmv, xkhh, km_opt,    &
                                     rdx, rdy, rdz, rdzw, fnm, fnp,             &
                                     cf1, cf2, cf3, zx, zy, dn, dnw, rho,       &
                                     ids, ide, jds, jde, kds, kde,              &
@@ -2358,6 +2358,7 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                                                  defor23, &
                                                                      div, &
                                                                     xkmh, &
+                                                                    xkmv, &
                                                                     xkhh, &
                                                                       zx, &
                                                                       zy, &
@@ -2412,7 +2413,7 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                    defor13, defor23, div,                  &
                                    nba_mij, n_nba_mij,                     &
                                    tke(ims,kms,jms),                       &
-                                   msftx, msfty, xkmh, rdx, rdy, fnm, fnp, &
+                                   msftx, msfty, xkmv, rdx, rdy, fnm, fnp, &
                                    dn, zx, zy, rdz, rho,                   &
                                    ids, ide, jds, jde, kds, kde,           &
                                    ims, ime, jms, jme, kms, kme,           &
@@ -2932,7 +2933,7 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
                                      nba_mij, n_nba_mij,                  &
                                      tke,                                 &
                                      msftx, msfty,                        &
-                                     xkmh, rdx, rdy, fnm, fnp,            &
+                                     xkmv, rdx, rdy, fnm, fnp,            &
                                      dn, zx, zy, rdz, rho,                &
                                      ids, ide, jds, jde, kds, kde,        &
                                      ims, ime, jms, jme, kms, kme,        &
@@ -2962,7 +2963,7 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
                                                                  defor23, &
                                                                      div, &
                                                                      tke, &
-                                                                    xkmh, &
+                                                                    xkmv, &
                                                                       zx, &
                                                                       zy, &
                                                                      rdz, &
@@ -3044,7 +3045,7 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
    je_ext=0
    CALL cal_titau_13_31( config_flags, titau1, defor13,   &
                          nba_mij(ims,kms,jms,P_m13),      &
-                         xkmh, fnm, fnp, rho,             &
+                         xkmv, fnm, fnp, rho,             &
                          is_ext, ie_ext, js_ext, je_ext,  &
                          ids, ide, jds, jde, kds, kde,    &
                          ims, ime, jms, jme, kms, kme,    &
@@ -3057,7 +3058,7 @@ SUBROUTINE horizontal_diffusion_w_2( tendency, config_flags,              &
    je_ext=1
    CALL cal_titau_23_32( config_flags, titau2, defor23,   &
                          nba_mij(ims,kms,jms,P_m23),      &
-                         xkmh, fnm, fnp, rho,             &
+                         xkmv, fnm, fnp, rho,             &
                          is_ext, ie_ext, js_ext, je_ext,  &
                          ids, ide, jds, jde, kds, kde,    &
                          ims, ime, jms, jme, kms, kme,    &

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -958,7 +958,7 @@ BENCH_START(hor_diff_tim)
                                       grid%div,                     &
                                       moist, chem, scalar,tracer,               &
                                       grid%msfux,grid%msfuy, grid%msfvx,grid%msfvy, grid%msftx,  &
-                                      grid%msfty, grid%xkmh, grid%xkhh, config_flags%km_opt,     &
+                                      grid%msfty, grid%xkmh, grid%xkmv, grid%xkhh, config_flags%km_opt,     &
                                       grid%rdx, grid%rdy, grid%rdz, grid%rdzw,                   &
                                       grid%fnm, grid%fnp, grid%cf1, grid%cf2, grid%cf3,          &
                                       grid%zx, grid%zy, grid%dn, grid%dnw, grid%rho,             &

--- a/phys/module_diag_functions.F
+++ b/phys/module_diag_functions.F
@@ -368,7 +368,6 @@ CONTAINS
   !~ Description:
   !~    This function calculates precipitable water by summing up the 
   !~    water vapor in a column from the first eta layer to model top
-  !~    converting rho to dry rho
   !~
   !!!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!!!
   FUNCTION Pwat  ( nz, qv, qc, dz8w, rho )
@@ -389,7 +388,7 @@ CONTAINS
      !  ---------------------------
      Pwat=0
      DO k = 1, nz
-       Pwat = Pwat + (qv(k) + qc(k)) * dz8w(k) * rho(k) / (1. + qv(k))
+       Pwat = Pwat + (qv(k) + qc(k)) * dz8w(k) * rho(k)
      ENDDO
              
   END FUNCTION Pwat

--- a/phys/module_diag_functions.F
+++ b/phys/module_diag_functions.F
@@ -368,6 +368,7 @@ CONTAINS
   !~ Description:
   !~    This function calculates precipitable water by summing up the 
   !~    water vapor in a column from the first eta layer to model top
+  !~    converting rho to dry rho
   !~
   !!!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!!!
   FUNCTION Pwat  ( nz, qv, qc, dz8w, rho )
@@ -388,7 +389,7 @@ CONTAINS
      !  ---------------------------
      Pwat=0
      DO k = 1, nz
-       Pwat = Pwat + (qv(k) + qc(k)) * dz8w(k) * rho(k)
+       Pwat = Pwat + (qv(k) + qc(k)) * dz8w(k) * rho(k) / (1. + qv(k))
      ENDDO
              
   END FUNCTION Pwat


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: horizontal diffusion of w, diff_opt=2

SOURCE: internal, and Katie Lundquist and Tina Chow (LLNL), and Jason Simon (Berkeley)

DESCRIPTION OF CHANGES: 
When calculating horizontal diffusion of w, Kv is needed instead of Kh in the tau13 and tau23 
stress terms for theoretical reasons.

LIST OF MODIFIED FILES: 
M       dyn_em/module_diffusion_em.F
M       dyn_em/module_first_rk_step_part2.F

TESTS CONDUCTED: 
Differences in W in quarter_ss case after 1 hr are small.
<img width="1694" alt="Screen Shot 2020-03-06 at 2 36 27 PM" src="https://user-images.githubusercontent.com/17932284/76128244-02e35080-5fc1-11ea-98a1-7c8cdbb42c29.png">

Jenkins: passed with known failures related to NoahMP STEPWTD fix after 4.1.4

RELEASE NOTE: Fix based on theory for horizontal diffusion of w in diff_opt=2 (Lundquist and Chow, LLNL).