### PR TITLE
Change default value of fractional_seaice from 0 to 1

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2431,7 +2431,7 @@ rconfig   integer slope_rad               namelist,physics      max_domains    0
 rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
 rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
 rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
-rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice option"
+rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice option: 0=OFF, 1=ON"
 rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
 rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
 rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2431,7 +2431,7 @@ rconfig   integer slope_rad               namelist,physics      max_domains    0
 rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
 rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
 rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
-rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice option: 0=OFF, 1=ON"
+rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice switch: 0=OFF, 1=ON"
 rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
 rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
 rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2431,7 +2431,7 @@ rconfig   integer slope_rad               namelist,physics      max_domains    0
 rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
 rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
 rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
-rconfig   integer fractional_seaice       namelist,physics      1              0       -     "fractional_seaice" "Fractional sea-ice option"
+rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice option"
 rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
 rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
 rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2431,7 +2431,7 @@ rconfig   integer slope_rad               namelist,physics      max_domains    0
 rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
 rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
 rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
-rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice switch: 0=OFF, 1=ON"
+rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice option: 0=OFF, 1=ON"
 rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
 rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
 rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"


### PR DESCRIPTION
## Breaks several regression tests
### em_real 60NE MPI (serial and openmp are OK)
### moving nest case 01 MPI
### openmp b4b broken with 07NE, 20, 20NE, 60, 71, 78, tropical

TYPE: enhancement

KEYWORDS: namelist fractional_seaice, default

SOURCE: Internal

DESCRIPTION OF CHANGES: 
Since GFS, the most commonly used input data source, has been providing fractional seaice 
data for a while, it seems reasonable to make the default option for fractional_seaice to be 1. 
This should also help our general users. Both ERA5 and ERA-Interim provide fractional seaice 
data, too.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
Reg test:

RELEASE NOTE: The default option for using fractional_seaice has been changed from 0 (off) to 1 (on) starting with release v4.2.