### PR TITLE
bug fix: NoahMP STEPWTD==0, divide by zero

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-WRF Model Version 4.1.4
+WRF Model Version 4.1.5
 
 http://www2.mmm.ucar.edu/wrf/users/
 

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -437,8 +437,8 @@ BENCH_START(surf_driver_tim)
 
 !gmm halo of wtd and riverflow for leafhydro
 #ifdef DM_PARALLEL
-  IF ( ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) .and. ( config_flags%opt_run.eq.5 ) ) THEN
-       IF ( mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
+  IF ( ( config_flags%sf_surface_physics.EQ.NOAHMPSCHEME ) .and. ( config_flags%opt_run.EQ.5 ) ) THEN
+       IF ( mod(grid%itimestep,grid%STEPWTD).EQ.0 )  THEN
 #     include "HALO_EM_HYDRO_NOAHMP.inc"
        ENDIF
   ENDIF

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -437,8 +437,8 @@ BENCH_START(surf_driver_tim)
 
 !gmm halo of wtd and riverflow for leafhydro
 #ifdef DM_PARALLEL
-  IF ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) THEN
-       IF ( config_flags%opt_run.eq.5.and.mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
+  IF ( ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) .and. ( config_flags%opt_run.eq.5 ) ) THEN
+       IF ( mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
 #     include "HALO_EM_HYDRO_NOAHMP.inc"
        ENDIF
   ENDIF

--- a/inc/version_decl
+++ b/inc/version_decl
@@ -1,1 +1,1 @@
-   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.1.4'
+   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.1.5'

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3103,7 +3103,8 @@ CONTAINS
 	 
 	 ENDIF 
 
-  if(iopt_run.eq.5.and.mod(itimestep,STEPWTD).eq.0)then
+  IF ( iopt_run .EQ. 5 ) THEN
+      IF ( MOD(itimestep,STEPWTD) .EQ. 0 ) THEN ! STEPWTD always and only non-zero for iopt_run == 5
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -3118,7 +3119,8 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
-  endif
+      ENDIF
+  ENDIF
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &
               &            SEAICE_THICKNESS_DEFAULT, SEAICE_SNOWDEPTH_OPT,             &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NoahMP, opt_run option

SOURCE: internal 

DESCRIPTION OF CHANGES: 
Problem:
When running the NoahMP scheme with the ground water option (opt_run=5), the STEPWTD 
variable is initialized to a non-zero value. However when opt_run!=5, then the STEPWTD 
variable remains an uninitialized zero value. In the WRF source code, there are a couple of
places where mod(x,STEPWTD) occurs. This causes an immediate "divide by zero" error in
the first call to the surface driver.

Solution:
The IF test logic is re-arranged so that only when opt_run=5 (which means that STEPWTD
is non-zero) is there a second IF test (using mod(x,STEPWTD)) to compute whether 
additional processing takes place.

This modification was made separately to the develop branch after the branch release-v4.1.4 
was released. See https://github.com/wrf-model/WRF/pull/1101. The purpose of this modification 
is to allow users access to the latest v4.1.* branch that works with NoahMP.

As this will be a single issue release, the README and inc/version_decl are also modified 
in preparation for the release of WRF release-v4.1.5 with this PR.

LIST OF MODIFIED FILES: 
M     dyn_em/module_first_rk_step_part1.F
M     phys/module_surface_driver.F
M     README
M     inc/version_decl

TESTS CONDUCTED: 
1. Jenkins test PASS (positively tests NoahMP)
2. Regression test in NCAR-MMM classroom machine PASS.

RELEASE NOTES: Newer versions of the GNU compiler more tightly conform to the Fortran standard and do not immediately short circuit IF test processing once a statement is known to be FALSE. This newer and legal behavior recently caused troubles with NoahMP regarding the frequency to process ground water. This release fixes that trouble with modified logic, but the still existing problem could extend (depending on the compiler) back to version 3.6.
