### PR TITLE
Allow DA and FSBM to peacefully coexist in same repo

### DIFF
--- a/arch/postamble
+++ b/arch/postamble
@@ -28,7 +28,7 @@ ARCHFLAGS       =    $(COREDEFS) -DIWORDSIZE=$(IWORDSIZE) -DDWORDSIZE=$(DWORDSIZ
                       -DLIMIT_ARGS \
                       -DBUILD_RRTMG_FAST=0 \
                       -DBUILD_RRTMK=0 \
-                      -DBUILD_SBM_FAST=0 \
+                      -DBUILD_SBM_FAST=1 \
                       -DSHOW_ALL_VARS_USED=0 \
                       -DCONFIG_BUF_LEN=$(CONFIG_BUF_LEN) \
                       -DMAX_DOMAINS_F=$(MAX_DOMAINS) \

--- a/configure
+++ b/configure
@@ -537,6 +537,16 @@ elif command -v time > /dev/null 2>&1; then
   echo "Will use 'time' to report timing information"
 fi
 
+# Is this some type of WRF DA build? If so, it is real*8.
+# Let's go ahead and set a flag internally.
+if test -n "$wrf_core" ; then
+   if [ "$wrf_core" = "DA_CORE" -o \
+        "$wrf_core" = "4D_DA_CORE" -o \
+        "$wrf_core" = "WRF_PLUS_CORE" ] ; then
+      rword="-r8"
+   fi
+fi
+
 # Found perl, so proceed with configuration
 if test -n "$PERL" ; then
    srch=`grep -i "^#ARCH.*$os" arch/configure.defaults | grep -i "$mach"`


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: DA FSBM real*8

SOURCE: internal

DESCRIPTION OF CHANGES:
The Fast Spectral Bin Microphysics (FSBM) code only works with default real
size = 4 bytes due to a mixture of declarations using real, real(kind=8),
and double precision. To solve this problem, the FSBM code is ifdef'ed out
for any real(kind=8) build. This is handled via the configure step.

Problem:
The DA code is built with real(kind=8) by default without resorting to any special
setup in the configure file. The choice was to either disable FSBM, or not
build DA. Temporarily before the v4.2 release, we have disabled the FSBM code.

Solution:
This PR identifies the DA builds, and sets internal flags to let the build
know to ifdef out the FSBM code. If no DA code is requested AND if this is
not a real(kind=8) build, then the FSBM code is part of the built executable.

LIST OF MODIFIED FILES:
M       arch/postamble
M       configure

TESTS CONDUCTED:
1. Jenkins tests real(kind=4) and real(kind=8) builds - PASS
2. WRFPlus, 3DVAR, 4DVAR compiled successfully with this branch.