### PR TITLE
Remove icloud dependency for qc_tot and qi_tot calc when Solar diagnostics package is activated

### DIFF
--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2819,8 +2819,7 @@ CONTAINS
       jts = j_start(ij)
       jte = j_end(ij)
  ! Save resolved + unresolved hydrometeor mass mixing ratios for Solar diag
- ! Only done for icloud = 3
-      IF ( solar_opt_local == 1 .and. icloud == 3 ) THEN
+      IF ( solar_opt_local == 1 ) THEN
         IF ( PRESENT(qc_tot) .AND. PRESENT(qi_tot) ) THEN
           IF ( F_QC ) THEN
              DO j=jts,jte


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRF-Solar, diagnostics

SOURCE: Timothy Juliano (NCAR/RAL)

DESCRIPTION OF CHANGES: 
Remove unintentional icloud dependency for qc_tot and qi_tot variable calculations in radiation 
driver when Solar diagnostics package is activated because we want to also calculate these two 
variables when other methods that account for subgrid hydrometeors are activated.

LIST OF MODIFIED FILES:
M phys/module_radiation_driver.F

TESTS CONDUCTED:
1. Bit-for-bit results before and after modification.
2. Jenkins test OK.