### PR TITLE
Recover two profiles for W and pressure and  add start date to TS output

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3060,7 +3060,7 @@ package   icedepth_one   seaice_thickness_opt==1     -             state:icedept
 
 #Time series options for text output
 package   notseries             process_time_series==0                 -             -
-package   tseries               process_time_series==1                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile
+package   tseries               process_time_series==1                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile,ts_p_profile,ts_w_profile
 package   tseries_add_solar     process_time_series==2                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile,ts_cldfrac2d,ts_wvp,ts_lwp,ts_iwp,ts_swp,ts_lwp_tot,ts_iwp_tot,ts_swp_tot,ts_re_qc,ts_re_qi,ts_re_qs,ts_re_qc_tot,ts_re_qi_tot,ts_re_qs_tot,ts_tau_qc,ts_tau_qi,ts_tau_qs,ts_tau_qc_tot,ts_tau_qi_tot,ts_tau_qs_tot,ts_cbaseht,ts_ctopht,ts_cbaseht_tot,ts_ctopht_tot,ts_clrnidx
 
 # WRF-HAILCAST

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -43,6 +43,15 @@ SUBROUTINE calc_ts_locations( grid )
    CHARACTER (LEN=2), DIMENSION(TS_FIELDS) :: &
       ts_file_endings = (/ 'UU', 'VV', 'PH', 'TH', 'QV' ,'WW', 'PR'/) 
 #endif
+   INTEGER   ierr
+   CHARACTER (len=19) simulation_start_date
+   INTEGER simulation_start_year   , &
+           simulation_start_month  , &
+           simulation_start_day    , &
+           simulation_start_hour   , &
+           simulation_start_minute , &
+           simulation_start_second
+
    TYPE (PROJ_INFO) :: ts_proj
    TYPE (grid_config_rec_type) :: config_flags
 
@@ -154,10 +163,25 @@ SUBROUTINE calc_ts_locations( grid )
    
       END IF
    
+      ! Determine simulation start time
+      ierr = 0
+      CALL nl_get_simulation_start_year   ( 1 , simulation_start_year   )
+      CALL nl_get_simulation_start_month  ( 1 , simulation_start_month  )
+      CALL nl_get_simulation_start_day    ( 1 , simulation_start_day    )
+      CALL nl_get_simulation_start_hour   ( 1 , simulation_start_hour   )
+      CALL nl_get_simulation_start_minute ( 1 , simulation_start_minute )
+      CALL nl_get_simulation_start_second ( 1 , simulation_start_second )
+      WRITE ( simulation_start_date , FMT = '(I4.4,"-",I2.2,"-",I2.2,"_",I2.2,":",I2.2,":",I2.2)' ) &
+              simulation_start_year,simulation_start_month,simulation_start_day,simulation_start_hour, &
+              simulation_start_minute,simulation_start_second
+!     WRITE(message,*)'wrf_timeseries: SIMULATION_START_DATE = ',simulation_start_date(1:19)
+!     CALL wrf_debug ( 0, TRIM( message ) )
+      
       ! Determine time series locations for domain
       IF (.NOT. grid%have_calculated_tslocs) THEN
          grid%have_calculated_tslocs = .TRUE.
-         WRITE(message, '(A43,I3)') 'Computing time series locations for domain ', grid%id
+         WRITE(message, '(A43,I3,A15,A19)') 'Computing time series locations for domain ', grid%id, &
+                                            ' starting from ',simulation_start_date
          CALL wrf_message(message)
    
          ntsloc_temp = 0
@@ -230,22 +254,22 @@ SUBROUTINE calc_ts_locations( grid )
 #if (EM_CORE == 1)
                IF ( .NOT. grid%tslist_ij ) THEN 
                   WRITE(UNIT=iunit, &
-                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7,A2,A19)') &
                         grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
                         ' '//grid%nametsloc(grid%id_tsloc(k)), &
                         ' (', grid%lattsloc(grid%id_tsloc(k)), ',', grid%lontsloc(grid%id_tsloc(k)), ') (', &
                         grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
                         ts_xlat, ',', ts_xlong, ') ', &
-                        ts_hgt,' meters'
+                        ts_hgt,' meters','  ',simulation_start_date(1:19)
                ELSE
                   WRITE(UNIT=iunit, &
-                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                        FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7,A2,A19)') &
                         grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
                         ' '//grid%nametsloc(grid%id_tsloc(k)), &
                         ' (', ts_xlat, ',', ts_xlong, ') (', &
                         grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
                         ts_xlat, ',', ts_xlong, ') ', &
-                        ts_hgt,' meters'
+                        ts_hgt,' meters','  ',simulation_start_date(1:19)
                END IF
 #else
                WRITE(UNIT=iunit, &
@@ -271,22 +295,22 @@ SUBROUTINE calc_ts_locations( grid )
 #if (EM_CORE == 1)
                   IF ( .NOT. grid%tslist_ij ) THEN 
                      WRITE(UNIT=iunit, &
-                           FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                           FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7,A2,A19)') &
                            grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
                            ' '//grid%nametsloc(grid%id_tsloc(k)), &
                            ' (', grid%lattsloc(grid%id_tsloc(k)), ',', grid%lontsloc(grid%id_tsloc(k)), ') (', &
                            grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
                            ts_xlat, ',', ts_xlong, ') ', &
-                           ts_hgt,' meters'
+                           ts_hgt,' meters','  ',simulation_start_date
                   ELSE
                      WRITE(UNIT=iunit, &
-                           FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7)') &
+                           FMT='(A26,I2,I3,A6,A2,F7.3,A1,F8.3,A3,I4,A1,I4,A3,F7.3,A1,F8.3,A2,F6.1,A7,A2,A19)') &
                            grid%desctsloc(grid%id_tsloc(k))//' ', grid%id, grid%id_tsloc(k), &
                            ' '//grid%nametsloc(grid%id_tsloc(k)), &
                            ' (', ts_xlat, ',', ts_xlong, ') (', &
                            grid%itsloc(k), ',', grid%jtsloc(k), ') (', &
                            ts_xlat, ',', ts_xlong, ') ', &
-                           ts_hgt,' meters'
+                           ts_hgt,' meters,','  ',simulation_start_date
                  END IF
 #else
                   WRITE(UNIT=iunit, &
@@ -435,7 +459,8 @@ SUBROUTINE calc_ts( grid )
             grid%ts_u_profile(n,i,k)   = earth_u_profile(k)
             grid%ts_v_profile(n,i,k)   = earth_v_profile(k)
             grid%ts_w_profile(n,i,k)   = (grid%w_2(ix,k,iy)+grid%w_2(ix,k+1,iy))/2.0 ! w on cell center
-            grid%ts_gph_profile(n,i,k) = (grid%phb(ix,k,iy)+grid%ph_2(ix,k,iy))/9.81 
+            grid%ts_gph_profile(n,i,k) = 0.5*((grid%phb(ix,k,iy)+grid%ph_2(ix,k,iy)) &
+                                             +(grid%phb(ix,k+1,iy)+grid%ph_2(ix,k+1,iy)))/9.81 
             IF (grid%use_theta_m == 1) THEN
                grid%ts_th_profile(n,i,k)  = (grid%t_2(ix,k,iy) + T0)/(1.+R_v/R_d*grid%moist(ix,k,iy,P_QV))
             ELSE


### PR DESCRIPTION
TYPE: bug fix, small enhancement

KEYWORDS: time series profiles of WW, P, simulation start date

SOURCE: reported by Pedro Jimenez of RAL, fixed internally

DESCRIPTION OF CHANGES: 
1. The time series profile output has two other fields, W and P, that were not written out. This PR fixes 
those ommitted fields. 
2. The geopotential height in the time series profiles was on full levels (only the first kte-1 levels). 
This PR moves the calculation to half levels (the same as is already done for the existing vertical 
velocity WW). 
3. A simulation start date is added to the time series output in the form of yyyy-mm-dd_hh:mm:ss. The date remains as simulation start time in a time series file after restart.

LIST OF MODIFIED FILES: list of changed files:
M       Registry/Registry.EM_COMMON
M       share/wrf_timeseries.F

TESTS CONDUCTED: 
1. Tested on 1 and 2 domain runs. The output is as expected. The output now includes two more 
profile files: pt_a_d01.WW, and pt_a.d01.PR (due to the bug fix in this PR). The new profiles join
the original profiles for UU, VV, TH, QV, PH. 
2. The title of these used to be:
```
Bogus point A              1  1 pt_a  ( 35.718, -95.272) (  39,  29) ( 35.617, -95.227)  192.1 meters
```
Now, the title is:
```
Bogus point A              1  1 pt_a  ( 35.718, -95.272) (  39,  29) ( 35.617, -95.227)  192.1 meters  2016-05-12_00:00:00
```
3. Jenkins test passed.
![ts-j](https://user-images.githubusercontent.com/12705680/76669380-f5920d00-6550-11ea-8125-e45b26deb890.png)

RELEASE NOTE: 
Added vertical motion (suffix = WW) and pressure (suffix = PR) to time series profile output. The
simulation start date is now in the title or alll time series output. The geopotential height in the time series output is now at half levels (similar to as is done for the vertical velocity WW).