### PR TITLE
Very minor change to Graupel Y-intercept parameter equation

### DIFF
--- a/phys/module_diag_nwp.F
+++ b/phys/module_diag_nwp.F
@@ -177,7 +177,7 @@ CONTAINS
                                          ,hail_maxk1,hail_max2d  &
                                                       ,refd_max
 
-   REAL, DIMENSION(ims:ime,kms:kme,jms:jme):: temp_qg, temp_ng, temp_qr, temp_nr
+   REAL, DIMENSION(ims:ime,kms:kme,jms:jme):: temp_qg, temp_ng
 
    INTEGER :: idump
 
@@ -195,7 +195,7 @@ CONTAINS
       REAL, DIMENSION(3):: cge, cgg
       DOUBLE PRECISION:: f_d, sum_ng, sum_t, lamg, ilamg, N0_g, lam_exp, N0exp
       DOUBLE PRECISION:: lamr, N0min
-      REAL:: mvd_r, xslw1, ygra1, zans1
+      REAL:: xslw1, ygra1, zans1
       INTEGER:: ng, n
 
     REAL                                       :: time_from_output
@@ -591,7 +591,7 @@ CONTAINS
      CASE (THOMPSON, THOMPSONAERO)
 
        scheme_has_graupel = .true.
-       xmu_g = 1.
+       xmu_g = 0.
        cge(1) = xbm_g + 1.
        cge(2) = xmu_g + 1.
        cge(3) = xbm_g + xmu_g + 1.
@@ -606,7 +606,7 @@ CONTAINS
        DO i=i_start(ij),i_end(ij)
         DO k=kme-1, kms, -1
          if (temp_qg(i,k,j) .LT. 1.E-6) CYCLE
-         zans1 = (2.5 + 2./7. * (ALOG10(temp_qg(i,k,j))+7.))
+         zans1 = (3.5 + 2./7. * (ALOG10(temp_qg(i,k,j))+7.))
          zans1 = MAX(2., MIN(zans1, 7.))
          N0exp = 10.**zans1
          lam_exp = (N0exp*xam_g*cgg(1)/temp_qg(i,k,j))**(1./cge(1))

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1839,7 +1839,7 @@
 
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = (2.5 + 2.5/7. * (ygra1+7.))
+         zans1 = (3.5 + 2./7. * (ygra1+7.))
          zans1 = MAX(2., MIN(zans1, 7.))
          N0_exp = 10.**(zans1)
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -2900,7 +2900,7 @@
 
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = (2.5 + 2.5/7. * (ygra1+7.))
+         zans1 = (3.5 + 2./7. * (ygra1+7.))
          zans1 = MAX(2., MIN(zans1, 7.))
          N0_exp = 10.**(zans1)
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -5282,7 +5282,7 @@
       if (ANY(L_qg .eqv. .true.)) then
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = (2.5 + 2.5/7. * (ygra1+7.))
+         zans1 = (3.5 + 2./7. * (ygra1+7.))
          zans1 = MAX(2., MIN(zans1, 7.))
          N0_exp = 10.**(zans1)
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: graupel, Y-intercept, microphysics

SOURCE: Greg Thompson (NCAR-RAL)

DESCRIPTION OF CHANGES: 
Made some final cross-checks against observed radar reflectivity in order to calibrate the 
one-moment graupel Y-intercept diagnosed with mass mixing ratio.  The prior version had too 
much high reflectivity in the upper end of the distribution.  The small changes to the equation 
(in 3 places in mp_thompson plus 1 corresponding place in the diagnostic for max hail size) reduces 
the high bias to match radar observations better.

LIST OF MODIFIED FILES: 
phys/module_mp_thompson.F
phys/module_diag_nwp.F

TESTS CONDUCTED: 
1. Well tested in a PECAN case study and calibrated against the KUDX and KFSD radar data - 
primarily with help from Kyoko Ikeda to ensure the changes are absolutely making a better match 
of model versus observations.
2. Jenkins test is all PASS

RELEASE NOTE: The change of diagnosed graupel Y-intercept parameter (N0) from 2 variables to the new form is rather significant (compared to pre-v4.2).  The older diagnosis used an inverse relationship for N0 as function of graupel mass mixing ratio (Qg) plus a functional dependence on supercooled liquid water (to approximate favorable wet growth).  A recent analysis of T-28 aircraft-observed data by Field et al. (2019) shows observations in direct contradiction; particularly that N0 is more *directly* (not inversely) proportional to Qg.  After 5 slight modifications to the constants in the formula, this change produces the best match to observed radar reflectivities, particularly with the upper tail of the distribution.
