### PR TITLE
Preventing MSKF to be used with 3DTKE option

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1089,6 +1089,24 @@
 !-----------------------------------------------------------------------
 ! cu_physics = 11 (scale-aware KF)
 !-----------------------------------------------------------------------
+! scale-aware KF cannot work with 3DTKE (km_opt=5)
+!-----------------------------------------------------------------------
+
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( ( model_config_rec%km_opt(i) .EQ. SMS_3DTKE ) .AND. &
+              ( model_config_rec%cu_physics(i) .EQ. MSKFSCHEME ) ) THEN
+            oops = oops + 1
+         END IF
+      ENDDO      ! Loop over domains
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: cu_physics = 11 cannot work with 3DTKE scheme '
+         CALL wrf_message ( wrf_err_message )
+         wrf_err_message = '--- Choose another bl_pbl_physics OR use another cu_physics option '
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+      END IF
 
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1087,8 +1087,6 @@
 
 #if (EM_CORE == 1)
 !-----------------------------------------------------------------------
-! cu_physics = 11 (scale-aware KF)
-!-----------------------------------------------------------------------
 ! scale-aware KF cannot work with 3DTKE (km_opt=5)
 !-----------------------------------------------------------------------
 
@@ -1107,6 +1105,10 @@
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
       END IF
+      
+!-----------------------------------------------------------------------
+! cu_physics = 11 (scale-aware KF)     
+!-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
@@ -1117,6 +1119,7 @@
             model_config_rec%icloud = 1
          END IF
       ENDDO
+      
 !-----------------------------------------------------------------------
 ! aercu_opt = 1 (CESM-aerosal) only works with MSKF, special Morrison
 !-----------------------------------------------------------------------

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1107,7 +1107,8 @@
       END IF
       
 !-----------------------------------------------------------------------
-! cu_physics = 11 (scale-aware KF)     
+! IF cu_physics = 11 (scale-aware KF), THEN set other required flags. This 
+! is not an error, just a convenience for the user.
 !-----------------------------------------------------------------------
 
       DO i = 1, model_config_rec % max_dom


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: MSKF, 3DTKE

SOURCE: internal

DESCRIPTION OF CHANGES: 
This PR adds a check in module_check_a_mundo.F to stop the model when MSKF (cu_physics=11) and 3DTKE (bl_pbl_physics=0, diff_opt=2, km_opt=5) are used together.

LIST OF MODIFIED FILES: list of changed files 
M     share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Jenkins test PASS
2. Test that show model stops with the following message when the two options are selected:

--- ERROR: cu_physics = 11 cannot work with 3DTKE scheme
  --- Choose another bl_pbl_physics OR use another cu_physics option

RELEASE NOTE: Add in the release note part for 3DTKE--> MSKF (cu_physics=11) and 3DTKE (bl_pbl_physics=0, diff_opt=2, km_opt=5) cannot be used together.
