### PR TITLE
Fix edit conflict in phys/module_surface_driver.F

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3182,13 +3182,8 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
-<<<<<<< HEAD
-     END IF
-  END IF
-=======
       ENDIF
   ENDIF
->>>>>>> origin/master
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &
               &            SEAICE_THICKNESS_DEFAULT, SEAICE_SNOWDEPTH_OPT,             &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: remove conflict marker "<<<<<" and ">>>>"

SOURCE: Jan Mandel

DESCRIPTION OF CHANGES: 
In the surface driver, we have:
```
<<<<<<< HEAD
     END IF
  END IF
=======
      ENDIF
  ENDIF
>>>>>>> origin/master
```

LIST OF MODIFIED FILES: 
M       phys/module_surface_driver.F

TESTS CONDUCTED:  
1. Jenkins auto testing  is PASS