### PR TITLE
Add more checks for Deng shallow scheme

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -822,7 +822,8 @@ Namelist variables for controlling the adaptive time step option:
                                      = 5, Deng cumulus scheme (including both shallow and deep convections) from PSU and WRF-Solar.
                                           However the deep part isn't very active. Not recommended to use alone for deep convection 
                                           case. Could work well for grid sizes 3-9 km.
-                                          This scheme only works with MYJ or MYNN PBL schemes 
+                                          This scheme only works with MYJ PBL scheme, and should not be combined with icloud=3
+                                          This scheme can also work with MYNN PBL scheme, but one should turn off EDMF (bl_mynn_edmf=0)
 
  ishallow                            = 0, !  = 1 turns on shallow convection, used with Grell 3D ensemble schemes (cu_physics = 3 or 5)
  clos_choice                         = 0, !  closure choice (place holder only)

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -445,13 +445,34 @@
          IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
               (model_config_rec % bl_pbl_physics(i) /= myjpblscheme .AND. &
                model_config_rec % bl_pbl_physics(i) /= mynnpblscheme2 ) ) THEN
-            wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN PBL '
+            wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN (with bl_mynn_edmf off) PBL '
             CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
             count_fatal_error = count_fatal_error + 1
          END IF
       ENDDO
+
+!-----------------------------------------------------------------------
+! If Deng Shallow Convection is on, icloud cannot be 3
+!-----------------------------------------------------------------------
+
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec%shcu_physics(i) .EQ. 5 .AND.       &
+              ( model_config_rec%icloud .EQ. 3 ) ) THEN
+              oops = oops + 1
+         END IF
+      ENDDO
+
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: Options shcu_physics = 5 and icloud = 3 should not be used together '
+         CALL wrf_message ( wrf_err_message )
+         wrf_err_message = '--- Choose either one in namelist.input and rerun the model '
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+      END IF
 
 #endif
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -467,9 +467,9 @@
       ENDDO
 
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- ERROR: Options shcu_physics = 5 and icloud = 3 should not be used together '
+         wrf_err_message = '--- ERROR: Options shcu_physics = 5 and icloud = 3 should not be used together'
          CALL wrf_message ( wrf_err_message )
-         wrf_err_message = '--- Choose either one in namelist.input and rerun the model '
+         wrf_err_message = '--- Choose either one in namelist.input and rerun the model'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
       END IF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -460,7 +460,7 @@
       oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( model_config_rec%shcu_physics(i) .EQ. 5 .AND.       &
+         IF ( ( model_config_rec%shcu_physics(i) .EQ. dengshcuscheme ) .AND. &
               ( model_config_rec%icloud .EQ. 3 ) ) THEN
               oops = oops + 1
          END IF


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Deng shallow scheme, MYNN PBL, Thompson cloud fraction scheme

SOURCE: internal

DESCRIPTION OF CHANGES: 
Add a fatal stop if Deng shallow scheme (shcu_physics=5) and icloud=3 are used together. Modify the PBL check for use with Deng shallow scheme: Deng scheme may be used with MYNN, but EDMF and icloud_bl have to be off. But making these options off will change the behaviour of the MYNN PBL option. Hence this should not be recommended.

LIST OF MODIFIED FILES: 
M       run/README.namelist
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Tested by turning on and off different physics options to produce the correct message. For example, if one has both shcu_physics = 5 and icloud = 3 on, one should see the following message:

--- ERROR: Options shcu_physics = 5 and icloud = 3 should not be used together
  --- Choose either one in namelist.input and rerun the model

If one has shcu_physics = 5 and bl_pbl_physics .NE. 2 and 5, one gets

--- ERROR: Deng shallow convection can only work with MYJ or MYNN (with bl_mynn_edmf off) PBL
  --- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.

2. Jenkins test pending

RELEASE NOTE: 
A check is added if Deng shallow scheme (shcu_physics=5) and Thompson cloud fraction icloud=3 are used together. Since Deng shallow scheme provides subgrid cloud, it should not be used with Thompson cloud fraction. The PBL check for use with Deng shallow scheme is modified: Deng scheme may be used with MYNN, but EDMF and icloud_bl have to be off. But making these options off will change the behavior of the MYNN PBL option. Hence this is not recommended.
