### PR TITLE
ARW SAS is CU=95, not CU=4 (scaleaware for NMM)

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -390,7 +390,6 @@
 !-----------------------------------------------------------------------
 ! Assign the dimensions for the urban options to the values defined in 
 ! each of those respective modules.
-
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -340,6 +340,7 @@
 ! Check that SMS-3DTKE scheme (km_opt=5) Must work with diff_opt=2
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % km_opt(i) .EQ. 5 .AND. &
               model_config_rec % diff_opt(i) .NE. 2  ) THEN
             wrf_err_message = '--- ERROR: SMS-3DTKE scheme can only work with diff_opt=2 '
@@ -354,6 +355,7 @@
 ! Check that SMS-3DTKE scheme (km_opt=5) Must work with bl_pbl_physics=0
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % km_opt(i) .EQ. 5 .AND. &
               model_config_rec % bl_pbl_physics(i) .NE. 0  ) THEN
             wrf_err_message = '--- ERROR: SMS-3DTKE scheme can only work with bl_pbl_physics=0 '
@@ -371,6 +373,7 @@
 ! Must work with no surface layer scheme.
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % km_opt(i) .EQ. 5 .AND. &
               (model_config_rec % sf_sfclay_physics(i) .NE. nosfcscheme     .AND. &
                model_config_rec % sf_sfclay_physics(i) .NE. sfclayscheme    .AND. &
@@ -387,6 +390,7 @@
 !-----------------------------------------------------------------------
 ! Assign the dimensions for the urban options to the values defined in 
 ! each of those respective modules.
+
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
@@ -429,6 +433,7 @@
 ! Check that channel irrigation is run with Noah
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % sf_surface_physics(i) .NE. LSMSCHEME .AND.  &
              model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL ) THEN
               wrf_err_message = '--- ERROR: irrigation Opt 1 works only with Noah-LSM'
@@ -456,7 +461,6 @@
 !-----------------------------------------------------------------------
 ! If Deng Shallow Convection is on, icloud cannot be 3
 !-----------------------------------------------------------------------
-
       oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
@@ -469,14 +473,31 @@
       IF ( oops .GT. 0 ) THEN
          wrf_err_message = '--- ERROR: Options shcu_physics = 5 and icloud = 3 should not be used together'
          CALL wrf_message ( wrf_err_message )
-         wrf_err_message = '--- Choose either one in namelist.input and rerun the model'
+         wrf_err_message = '--- ERROR: Choose either one in namelist.input and rerun the model'
          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
          count_fatal_error = count_fatal_error + 1
       END IF
 
-#endif
+!-----------------------------------------------------------------------
+! For ARW users, a request for CU=4 (SAS) should be switched to option
+! CU = 95. The option CU = 4 is a scaleaware scheme used by NMM.
+!-----------------------------------------------------------------------
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec%cu_physics(i) .EQ. scalesasscheme ) THEN
+              oops = oops + 1
+         END IF
+      ENDDO
 
-#if (EM_CORE == 1)
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: Option cu_physics = 4 should not be used for ARW; cu_physics = 95 is suggested'
+         CALL wrf_message ( wrf_err_message )
+         wrf_err_message = '--- ERROR: Choose a different cu_physics option in the namelist.input file'
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+      END IF
+
 !-----------------------------------------------------------------------
 ! There is a binary file for Goddard radiation. It is single precision.
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: SAS, NMM, check_a_mundo

SOURCE: internal

DESCRIPTION OF CHANGES:
Previously, ARW users shared the SAS scheme with NMM. The new scale aware SAS
scheme for NMM has been slotted into the location of the older SAS scheme. For
ARW users wanting to run the SAS CU scheme, the correct option is 95.

Instead of just assigning a new option number within the code, the WRF model
stops and tells the user they are using the wrong option.

Also, I added a few missing "is this domain active" IF tests to the surrounding blocks.

LIST OF MODIFIED FILES:
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. Jenkins test all PASS

RELEASE NOTE: The typical ARW CU SAS scheme, previously cu_physics=4, has been changed to cu_physics=95.