### PR TITLE
Irrigation clean-up: syntax error, derived nml packaging, protect against div by 0

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2272,7 +2272,7 @@ rconfig   real    naer                    namelist,physics      max_domains    1
 rconfig   integer     sf_sfclay_physics   namelist,physics	max_domains    -1      rh       "sf_sfclay_physics"             ""      ""
 # IRRIGATION
 rconfig   integer     sf_surf_irr_scheme  namelist,physics      max_domains    0       rh       "sf_surf_irr_scheme"   "ARI: 0=no irr; 1=drip; 2=sprinkler; 3=channel" ""
-rconfig   integer     sf_surf_irr_alloc   derived               1              0       rh       "sf_surf_irr_alloc"    "allocations/: 0=no irr; 1=drip; 2=sprinkler; 3=channel" ""
+rconfig   integer     sf_surf_irr_alloc   derived               1              0       rh       "sf_surf_irr_alloc"    "sf_surf_irr_scheme, for packaging: 0=no irr; 1=drip; 2=sprinkler; 3=channel" ""
 rconfig   real        irr_daily_amount    namelist,physics      max_domains    0       rh       "irr_daily_amount"     "sf_surf_irr_scheme WATER AMOUNT [mm]" ""
 rconfig   integer     irr_start_hour      namelist,physics      max_domains    0       rh       "irr_start_hour"       "sf_surf_irr_scheme, local start hour" ""
 rconfig   integer     irr_num_hours       namelist,physics      max_domains    0       rh       "irr_num_hours"        "sf_surf_irr_scheme, Number of hours to irrigate"  ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2270,15 +2270,16 @@ rconfig   integer     ra_sw_physics       namelist,physics	max_domains    -1    
 rconfig   real    radt                    namelist,physics	max_domains    0       h    "RADT"          ""      ""
 rconfig   real    naer                    namelist,physics      max_domains    1e9     rh   "NAER"          ""      ""
 rconfig   integer     sf_sfclay_physics   namelist,physics	max_domains    -1      rh       "sf_sfclay_physics"             ""      ""
-rconfig   integer     sf_surf_irr_scheme  namelist,physics      max_domains    0       rh       "sf_surf_irr_scheme"            "ARI:: 0:no irr 1: drip 2:sprinkler 3:channel" ""
 # IRRIGATION
-rconfig   real        irr_daily_amount    namelist,physics      max_domains    0       rh        "sf_surf_irr_scheme WATER AMOUNT [mm]" ""  ""
-rconfig   integer     irr_start_hour      namelist,physics      max_domains    0       rh        "sf_surf_irr_scheme, local start"            "Local start hour" ""
-rconfig   integer     irr_num_hours       namelist,physics      max_domains    0       rh        "sf_surf_irr_scheme" "Number of hours to irrigate"  ""
-rconfig   integer     irr_start_julianday namelist,physics      max_domains    0       rh        "sf_surf_irr_scheme" "Julian day to start irrigation (included)"  ""
-rconfig   integer     irr_end_julianday   namelist,physics      max_domains    0       rh        "sf_surf_irr_scheme" "Julian day to end irrigation (not included)"  ""
-rconfig   integer     irr_freq            namelist,physics      max_domains    1       rh        "sf_surf_irr_scheme" "frequency of irrigation in days"  ""
-rconfig   integer     irr_ph              namelist,physics      max_domains    0       rh        "sf_surf_irr_scheme" "phase of irrigation, 0:in phase, 1: not in phase"  ""
+rconfig   integer     sf_surf_irr_scheme  namelist,physics      max_domains    0       rh       "sf_surf_irr_scheme"   "ARI: 0=no irr; 1=drip; 2=sprinkler; 3=channel" ""
+rconfig   integer     sf_surf_irr_alloc   derived               1              0       rh       "sf_surf_irr_alloc"    "allocations/: 0=no irr; 1=drip; 2=sprinkler; 3=channel" ""
+rconfig   real        irr_daily_amount    namelist,physics      max_domains    0       rh       "irr_daily_amount"     "sf_surf_irr_scheme WATER AMOUNT [mm]" ""
+rconfig   integer     irr_start_hour      namelist,physics      max_domains    0       rh       "irr_start_hour"       "sf_surf_irr_scheme, local start hour" ""
+rconfig   integer     irr_num_hours       namelist,physics      max_domains    0       rh       "irr_num_hours"        "sf_surf_irr_scheme, Number of hours to irrigate"  ""
+rconfig   integer     irr_start_julianday namelist,physics      max_domains    0       rh       "irr_start_julianday"  "sf_surf_irr_scheme, Julian day to start irrigation (included)"  ""
+rconfig   integer     irr_end_julianday   namelist,physics      max_domains    0       rh       "irr_end_julianday"    "sf_surf_irr_scheme, Julian day to end irrigation (not included)"  ""
+rconfig   integer     irr_freq            namelist,physics      max_domains    1       rh       "irr_freq"             "sf_surf_irr_scheme, frequency of irrigation in days"  ""
+rconfig   integer     irr_ph              namelist,physics      max_domains    0       rh       "irr_ph"               "sf_surf_irr_scheme, phase of irrigation, 0=in phase; 1=not in phase; 2=not in phase, random"  ""
 
 
 rconfig   integer     sf_surface_physics  namelist,physics	max_domains    -1      rh       "sf_surface_physics"            ""      ""
@@ -2912,11 +2913,11 @@ package   ssibscheme     sf_surface_physics==8       -             state:ssib_fm
 
 package   noahmpoptcrop2 opt_crop==2                 -             state:gecros_state
 
-package   noahmosaicscheme  sf_surface_mosaic==1         -        state:TSK_mosaic,QSFC_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic,CANWAT_mosaic,SNOW_mosaic,SNOWH_mosaic,SNOWC_mosaic,ALBEDO_mosaic,ALBBCK_mosaic,EMISS_mosaic,EMBCK_mosaic,ZNT_mosaic,Z0_mosaic,HFX_mosaic,QFX_mosaic,LH_mosaic,GRDFLX_mosaic,SNOTIME_mosaic,TR_URB2D_mosaic,TB_URB2D_mosaic,TG_URB2D_mosaic,TC_URB2D_mosaic,TS_URB2D_mosaic,TS_RUL2D_mosaic,QC_URB2D_mosaic,UC_URB2D_mosaic,TRL_URB3D_mosaic,TBL_URB3D_mosaic,TGL_URB3D_mosaic,SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,mosaic_cat_index,landusef2,smcrel,RS_mosaic,LAI_mosaic
+package   noahmosaicscheme  sf_surface_mosaic==1     -             state:TSK_mosaic,QSFC_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic,CANWAT_mosaic,SNOW_mosaic,SNOWH_mosaic,SNOWC_mosaic,ALBEDO_mosaic,ALBBCK_mosaic,EMISS_mosaic,EMBCK_mosaic,ZNT_mosaic,Z0_mosaic,HFX_mosaic,QFX_mosaic,LH_mosaic,GRDFLX_mosaic,SNOTIME_mosaic,TR_URB2D_mosaic,TB_URB2D_mosaic,TG_URB2D_mosaic,TC_URB2D_mosaic,TS_URB2D_mosaic,TS_RUL2D_mosaic,QC_URB2D_mosaic,UC_URB2D_mosaic,TRL_URB3D_mosaic,TBL_URB3D_mosaic,TGL_URB3D_mosaic,SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,mosaic_cat_index,landusef2,smcrel,RS_mosaic,LAI_mosaic
 # IRRIGATION
-package   channel        sf_surf_irr_scheme==1        -            state:irrigation,irr_rand_field
-package   drip           sf_surf_irr_scheme==2        -            state:irrigation,irr_rand_field
-package   sprinkler      sf_surf_irr_scheme==3        -            state:irrigation,irr_rand_field
+package   channel        sf_surf_irr_alloc==1        -             state:irrigation,irr_rand_field
+package   drip           sf_surf_irr_alloc==2        -             state:irrigation,irr_rand_field
+package   sprinkler      sf_surf_irr_alloc==3        -             state:irrigation,irr_rand_field
 
 
 package   ysuscheme      bl_pbl_physics==1           -             -

--- a/phys/module_irrigation.F
+++ b/phys/module_irrigation.F
@@ -145,17 +145,15 @@ SUBROUTINE sprinkler_irrigation(  julian_in                                     
    DO a=its, ite
      DO b=jts,jte
 
-      IF ((irr_num_hours.GT.0) .AND. &
-          (tloc.GE.irr_start_hour .AND. tloc.LT.end_hour) .AND. &
+      constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
+      IF ( (tloc.GE.irr_start_hour .AND. tloc.LT.end_hour) .AND. &
           (irrigation(a,b).GE.0.1) .AND. &
           (julian_in.GE.irr_start_julianday .AND. julian_in.LT.irr_end_julianday )) THEN
         CALL irr_calc_phase(irr_ph,phase,irr_rand_field_val(a,b),a,b,irrigation(a,b),irr_freq)
         IF(irr_ph.EQ.0) THEN
-              constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
               qr_curr(a,kms,b)=qr_curr(a,kms,b)+irrigation(a,b)*constants_irrigation*dt
         ELSE
               IF(timing.EQ.int(phase))  THEN
-                   constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
                    qr_curr(a,kms,b)=qr_curr(a,kms,b)+irrigation(a,b)*constants_irrigation*dt
               END IF
         END IF

--- a/phys/module_irrigation.F
+++ b/phys/module_irrigation.F
@@ -137,7 +137,6 @@ SUBROUTINE sprinkler_irrigation(  julian_in                                     
                                                         qr_curr
    REAL, INTENT(IN   ) :: dt
 !
-   constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
    xt24=mod(xtime,1440.)
    tloc=floor(gmt+xt24/60.)
    if(tloc.lt.0) tloc=tloc+24
@@ -146,12 +145,17 @@ SUBROUTINE sprinkler_irrigation(  julian_in                                     
    DO a=its, ite
      DO b=jts,jte
 
-      IF ((tloc.GE.irr_start_hour .AND. tloc.LT.end_hour) .AND. (irrigation(a,b).GE.0.1) .AND. (julian_in.GE.irr_start_julianday .AND. julian_in.LT.irr_end_julianday )) THEN
+      IF ((irr_num_hours.GT.0) .AND. &
+          (tloc.GE.irr_start_hour .AND. tloc.LT.end_hour) .AND. &
+          (irrigation(a,b).GE.0.1) .AND. &
+          (julian_in.GE.irr_start_julianday .AND. julian_in.LT.irr_end_julianday )) THEN
         CALL irr_calc_phase(irr_ph,phase,irr_rand_field_val(a,b),a,b,irrigation(a,b),irr_freq)
         IF(irr_ph.EQ.0) THEN
+              constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
               qr_curr(a,kms,b)=qr_curr(a,kms,b)+irrigation(a,b)*constants_irrigation*dt
         ELSE
               IF(timing.EQ.int(phase))  THEN
+                   constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
                    qr_curr(a,kms,b)=qr_curr(a,kms,b)+irrigation(a,b)*constants_irrigation*dt
               END IF
         END IF

--- a/phys/module_irrigation.F
+++ b/phys/module_irrigation.F
@@ -148,7 +148,7 @@ SUBROUTINE sprinkler_irrigation(  julian_in                                     
       constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
       IF ( (tloc.GE.irr_start_hour .AND. tloc.LT.end_hour) .AND. &
           (irrigation(a,b).GE.0.1) .AND. &
-          (julian_in.GE.irr_start_julianday .AND. julian_in.LT.irr_end_julianday )) THEN
+          (julian_in.GE.irr_start_julianday .AND. julian_in.LT.irr_end_julianday ) ) THEN
         CALL irr_calc_phase(irr_ph,phase,irr_rand_field_val(a,b),a,b,irrigation(a,b),irr_freq)
         IF(irr_ph.EQ.0) THEN
               qr_curr(a,kms,b)=qr_curr(a,kms,b)+irrigation(a,b)*constants_irrigation*dt

--- a/phys/module_irrigation.F
+++ b/phys/module_irrigation.F
@@ -136,7 +136,8 @@ SUBROUTINE sprinkler_irrigation(  julian_in                                     
          INTENT(INOUT) ::                                       &
                                                         qr_curr
    REAL, INTENT(IN   ) :: dt
-!
+   end_hour=irr_start_hour+irr_num_hours
+
    xt24=mod(xtime,1440.)
    tloc=floor(gmt+xt24/60.)
    if(tloc.lt.0) tloc=tloc+24

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -447,9 +447,9 @@
       oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( ( model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL   )   .OR. &
-              ( model_config_rec % sf_surf_irr_scheme(i) .EQ. SPRINKLER )   .OR. &
-              ( model_config_rec % sf_surf_irr_scheme(i) .EQ. DRIP      ) ) .AND. &
+         IF ( ( ( model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL   )   .OR. &
+                ( model_config_rec % sf_surf_irr_scheme(i) .EQ. SPRINKLER )   .OR. &
+                ( model_config_rec % sf_surf_irr_scheme(i) .EQ. DRIP      ) ) .AND. &
               ( model_config_rec % irr_num_hours(i) .LE. 0 ) ) THEN
             oops = oops + 1
          END IF
@@ -459,6 +459,24 @@
          wrf_err_message = '--- ERROR: irr_num_hours must be greater than zero to work with irrigation'
          CALL wrf_message ( wrf_err_message )
          count_fatal_error = count_fatal_error + 1
+      END IF
+
+!-----------------------------------------------------------------------
+! Fix derived setting for irrigation. Since users may only want the irrigation
+! to be active in the inner-most domain, we have a separate variable that is
+! used to define packaging for the irrigation fields.
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL   ) THEN
+            model_config_rec % sf_surf_irr_alloc = CHANNEL
+         END IF
+         IF ( model_config_rec % sf_surf_irr_scheme(i) .EQ. SPRINKLER ) THEN
+            model_config_rec % sf_surf_irr_alloc = SPRINKLER
+         END IF
+         IF ( model_config_rec % sf_surf_irr_scheme(i) .EQ. DRIP      ) THEN
+            model_config_rec % sf_surf_irr_alloc = DRIP    
+         END IF
       ENDDO
 
 !-----------------------------------------------------------------------

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -440,22 +440,26 @@
          count_fatal_error = count_fatal_error + 1
          END IF
       ENDDO
+
 !-----------------------------------------------------------------------
-! Check that number of hours for irrigation is more than zero
+! Check that number of hours for irrigation is greater than zero
 !-----------------------------------------------------------------------
+      oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL .OR. &
-              model_config_rec % sf_surf_irr_scheme(i) .EQ. SPRINKLER .OR. &
-              model_config_rec % sf_surf_irr_scheme(i) .EQ. DRIP .AND. model_config_rec % irr_num_hours(i) .EQ. 0 ) THEN
-              wrf_err_message = '--- ERROR: irr_num_hours must be greater than zero to work with irrigation'
-              CALL wrf_message ( wrf_err_message )
-         count_fatal_error = count_fatal_error + 1
+         IF ( ( model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL   )   .OR. &
+              ( model_config_rec % sf_surf_irr_scheme(i) .EQ. SPRINKLER )   .OR. &
+              ( model_config_rec % sf_surf_irr_scheme(i) .EQ. DRIP      ) ) .AND. &
+              ( model_config_rec % irr_num_hours(i) .LE. 0 ) ) THEN
+            oops = oops + 1
          END IF
       ENDDO
-
-
-
+      
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: irr_num_hours must be greater than zero to work with irrigation'
+         CALL wrf_message ( wrf_err_message )
+         count_fatal_error = count_fatal_error + 1
+      ENDDO
 
 !-----------------------------------------------------------------------
 ! Check that Deng Shallow Convection Must work with MYJ or MYNN PBL

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -442,7 +442,9 @@
       ENDDO
 
 !-----------------------------------------------------------------------
-! Check that number of hours of daily irrigation is greater than zero
+! Check that number of hours of daily irrigation is greater than zero.
+! This value is used in the denominator to compute the amount of 
+! irrigated water per timestep, which would give a divide by zero.
 !-----------------------------------------------------------------------
       oops = 0
       DO i = 1, model_config_rec % max_dom

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -444,7 +444,9 @@
 !-----------------------------------------------------------------------
 ! Check that number of hours of daily irrigation is greater than zero.
 ! This value is used in the denominator to compute the amount of 
-! irrigated water per timestep, which would give a divide by zero.
+! irrigated water per timestep, and the default value from the Registry
+! is zero. This is a reminder to the user that this value needs to be
+! manually set.
 !-----------------------------------------------------------------------
       oops = 0
       DO i = 1, model_config_rec % max_dom

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -440,6 +440,22 @@
          count_fatal_error = count_fatal_error + 1
          END IF
       ENDDO
+!-----------------------------------------------------------------------
+! Check that number of hours for irrigation is more than zero
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec % sf_surf_irr_scheme(i) .EQ. CHANNEL .OR. &
+              model_config_rec % sf_surf_irr_scheme(i) .EQ. SPRINKLER .OR. &
+              model_config_rec % sf_surf_irr_scheme(i) .EQ. DRIP .AND. model_config_rec % irr_num_hours(i) .EQ. 0 ) THEN
+              wrf_err_message = '--- ERROR: irr_num_hours must be greater than zero to work with irrigation'
+              CALL wrf_message ( wrf_err_message )
+         count_fatal_error = count_fatal_error + 1
+         END IF
+      ENDDO
+
+
+
 
 !-----------------------------------------------------------------------
 ! Check that Deng Shallow Convection Must work with MYJ or MYNN PBL

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -442,7 +442,7 @@
       ENDDO
 
 !-----------------------------------------------------------------------
-! Check that number of hours for irrigation is greater than zero
+! Check that number of hours of daily irrigation is greater than zero
 !-----------------------------------------------------------------------
       oops = 0
       DO i = 1, model_config_rec % max_dom


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: irrigation, drip, statement function

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem 1:
In module_irrigation.F, in subroutine sprinkler_irrigation is this line:
```
constants_irrigation=irr_freq*irr_daily_amount/(irr_num_hours*3600*rho(a,kms,b)*dz8w(a,kms,b)*100)
```
It is clear from the rest of the routine, that this is to be treated as a statement function.
1. The line is after all of the declarations and before the first executable statement.
2. The values of a, b, and kms (among others) are not yet defined.
3. The following line _tries_ to use it as a statement function.
```
qr_curr(a,kms,b)=qr_curr(a,kms,b)+irrigation(a,b)*constants_irrigation*dt
```
However, the GNU compiler is segfaulting on the definition of the statement function,
because the variables "a" and "b" (again, among others) are not yet assigned and are likely
garbage values. The GNU compiler is segfaulting because it does not recognize this line
as a proper statement function.

Statement functions were declared obsolescent in f95, but we have them in other routines.

Solution 1:
Abandon the statement function completely. The code is actually written to not need a statement
function.

Problem 2:
The user defined integer `irr_num_hours` can be zero, resulting in a divide by zero.

Solution 2:
In check_a_mundo, verify that the number of hours to irrigate is >= 0. This handles all three irrigation
options in a single location.

Problem 3:
The irrigation schemes are designed to mostly be activated on the inner-most domain. As with many
physics schemes, ON vs OFF causes troubles for nested domains when packaging of variables is
involved.

Solution 3:
A derived namelist option is utilized. If any domain has an irrigation option activated, then all domains 
have the packaged fields allocated.

LIST OF MODIFIED FILES:
modified:   module_irrigation.F
modified:   Registry/Registry.EM_COMMON
modified:   share/module_check_a_mundo.F 

TESTS CONDUCTED:
1. Jenkins is all PASS.
2. With no mod, with the sprinkler irrigation option activated:
```
 &physics
 sf_surf_irr_scheme                  = 3,     3,     3,
```
We get the WRF output as:
```
WRF NUMBER OF TILES =   1

Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

Backtrace for this error:
	at /wrf/WRF/phys/module_irrigation.f90:140
```
3. With the mods, the code runs to completion. 
4. With Registry mods for derived nml for irrigation allocation, following is also OK for 2 domains:
```
 &physics
 sf_surf_irr_scheme                  = 0,     3,     3,
```