### PR TITLE
FSBM: use existing package flag for T/F compute diagnostics

### DIFF
--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -3812,6 +3812,7 @@ BENCH_START(micro_driver_tim)
       &        ,tempc=grid%tempc                                         &
       &        ,ccn_conc=grid%ccn_conc                                   & ! RAS
       &        ,sbmradar=sbmradar,num_sbmradar=num_sbmradar              & ! for SBM
+      &        ,sbm_diagnostics=config_flags%sbm_diagnostics             & ! for SBM
       &        ,aerocu=aerocu                                            &
       &        ,aercu_fct=config_flags%aercu_fct                         &
       &        ,aercu_opt=config_flags%aercu_opt                         &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -139,6 +139,7 @@ SUBROUTINE microphysics_driver(                                          &
                       ,aercu_opt                                         &
 # if( EM_CORE==1 )
                       ,sbmradar,num_sbmradar                             &
+                      ,sbm_diagnostics                                   &
                       ,aerocu,aercu_fct,no_src_types_cu                  &
                       ,PBL,EFCG,EFIG,EFSG,WACT,CCN1_GS,CCN2_GS           &
                       ,CCN3_GS,CCN4_GS,CCN5_GS,CCN6_GS,CCN7_GS           &
@@ -410,6 +411,7 @@ SUBROUTINE microphysics_driver(                                          &
    INTEGER,      INTENT(IN   )    ::       ims,ime, jms,jme, kms,kme,num_scalar
 #if (EM_CORE == 1)
    INTEGER,      INTENT(IN   )    ::     num_sbmradar
+   INTEGER,      INTENT(IN   )    ::     sbm_diagnostics
 #endif
    INTEGER, OPTIONAL, INTENT(IN   )    ::       ips,ipe, jps,jpe, kps,kpe
    INTEGER,      INTENT(IN   )    ::                         kts,kte
@@ -1133,6 +1135,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  ,QNG=qng_curr                                      &
                  ,QNA=qnn_curr                                      &
                  ,sbmradar=sbmradar,num_sbmradar=num_sbmradar       &
+                 ,sbm_diagnostics=sbm_diagnostics                   &
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
                  ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte &

--- a/phys/module_mp_fast_sbm.F
+++ b/phys/module_mp_fast_sbm.F
@@ -3991,11 +3991,12 @@ enddo
       &                      xland,domain_id,ivgtyp,xlat,xlong,          &
       &                      QV,QC,QR,QI,QS,QG,QV_OLD,                   &
       &                      QNC,QNR,QNI,QNS,QNG,QNA,                    &
-      &                      ids,ide, jds,jde, kds,kde,		        	     &
-      &                      ims,ime, jms,jme, kms,kme,		        	     &
+      &                      ids,ide, jds,jde, kds,kde,                  &
+      &                      ims,ime, jms,jme, kms,kme,                  &
       &                      its,ite, jts,jte, kts,kte,                  &
-      &                      diagflag,      	                           &
+      &                      diagflag,                                   &
       &                      sbmradar,num_sbmradar,                      &
+      &                      sbm_diagnostics,                            &
       &                      RAINNC,RAINNCV,SNOWNC,SNOWNCV,GRAUPELNC,GRAUPELNCV,SR)
  !-----------------------------------------------------------------------
        IMPLICIT NONE
@@ -4005,7 +4006,8 @@ enddo
  	INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE                     &
  	&                     ,IMS,IME,JMS,JME,KMS,KME                    &
  	&                     ,ITS,ITE,JTS,JTE,KTS,KTE                    &
- 	&                     ,ITIMESTEP,N_CHEM,NUM_SBMRADAR,domain_id
+ 	&                     ,ITIMESTEP,N_CHEM,NUM_SBMRADAR,domain_id    &
+ 	&                     ,sbm_diagnostics
 
  	REAL, INTENT(IN) 	    :: DT,DX,DY
  	REAL,  DIMENSION( ims:ime , kms:kme , jms:jme ), &
@@ -5128,7 +5130,7 @@ enddo
 ! ... Polarimetric Forward Radar Operator
 ! ..........................................
   if ( PRESENT (diagflag) ) then
-    if( diagflag .and. IPolar_HUCM ) then
+    if( diagflag .and. IPolar_HUCM .and. (sbm_diagnostics==1) ) then
 
       dx_dbl = dx
       dy_dbl = dy


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FSBM, IPolar_HUCM, sbm_diagnostics, seg fault

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The IPolar_HUCM variable is a LOGICAL PARAMETER that is always TRUE. It is a
module local variable. When we get down to the IF test in FSBM to determine if
we are doing diagnostics, we therefore are always proceeding with diagnostic
calculations. If the sbm_diagnostics flag is zero, then the sbmradar array is
only "unit" allocated. We get a segfault when filling the array sbmradar.

Solution:
The sbm_diagnostics namelist variable is used in the registry.polrad to package
the sbmradar array. Use that same variable to determine if we compute the
diagnostics.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
modified:   dyn_em/solve_em.F
modified:   phys/module_microphysics_driver.F
modified:   phys/module_mp_fast_sbm.F

TESTS CONDUCTED:
 - [x] Jenkins is all PASS
 - [x] Without mod, code either seg faults or hits infinite loop (depending on compiler):
```
WRF TILE   1 IS      1 IE     74 JS      1 JE     61
WRF NUMBER OF TILES =   1
 FAST SBM: ICE PROCESES ACTIVE
Timing for main: time 2000-01-24_12:03:00 on domain   1:   43.67795 elapsed seconds
Timing for main: time 2000-01-24_12:06:00 on domain   1:   38.95089 elapsed seconds
Timing for Writing wrfout_d01_2000-01-24_12:06:00 for domain        1:    0.84913 elapsed seconds
Timing for main: time 2000-01-24_12:09:00 on domain   1:   26.13694 elapsed seconds
 Flerchinger USEd in NEW version. Iterations=          10
```
 - [x] With mod, code runs to completion
```
WRF TILE   1 IS      1 IE     74 JS      1 JE     61
WRF NUMBER OF TILES =   1
 FAST SBM: ICE PROCESES ACTIVE
Timing for main: time 2000-01-24_12:03:00 on domain   1:   45.59690 elapsed seconds
Timing for main: time 2000-01-24_12:06:00 on domain   1:   29.35197 elapsed seconds
Timing for Writing wrfout_d01_2000-01-24_12:06:00 for domain        1:    1.40992 elapsed seconds
Timing for main: time 2000-01-24_12:09:00 on domain   1:   31.92416 elapsed seconds
Timing for main: time 2000-01-24_12:12:00 on domain   1:   31.06189 elapsed seconds
Timing for Writing wrfout_d01_2000-01-24_12:12:00 for domain        1:    1.44116 elapsed seconds
Timing for main: time 2000-01-24_12:15:00 on domain   1:   32.63334 elapsed seconds
Timing for main: time 2000-01-24_12:18:00 on domain   1:   31.89320 elapsed seconds
Timing for Writing wrfout_d01_2000-01-24_12:18:00 for domain        1:    1.23190 elapsed seconds
Timing for main: time 2000-01-24_12:21:00 on domain   1:   33.30915 elapsed seconds
Timing for main: time 2000-01-24_12:24:00 on domain   1:   49.25972 elapsed seconds
Timing for Writing wrfout_d01_2000-01-24_12:24:00 for domain        1:    1.98051 elapsed seconds
Timing for main: time 2000-01-24_12:27:00 on domain   1:   35.74490 elapsed seconds
Timing for main: time 2000-01-24_12:30:00 on domain   1:   34.33335 elapsed seconds
Timing for Writing wrfout_d01_2000-01-24_12:30:00 for domain        1:    1.56202 elapsed seconds
d01 2000-01-24_12:30:00 wrf: SUCCESS COMPLETE WRF
```
 - [x] In addition to this small test, a full day run and a restart test with FSBM also exhibit the same
behavior. Without the mods the longer 3-km CONUS test and the restart test both failed to complete.
With the new mods, both the high-res run and the restart case completed (and the restart case is
bit-for-bit identical).