### PR TITLE
Make dx constant, though 2d dx array exists

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -5291,7 +5291,7 @@ subroutine interp_vec_cu(locvec,locwant,periodic,loc1,loc2,wght1,wght2)
      do j = jts, min(jde-1,jte)
         do i = its, min(ide-1,ite)
            area2d(i,j) = dx * dy
-           dx2d  (i,j) = sqrt ( area2d(i,j) )
+           dx2d  (i,j) = dx
         end do
      end do
 #endif

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -5280,6 +5280,7 @@ subroutine interp_vec_cu(locvec,locwant,periodic,loc1,loc2,wght1,wght2)
      real, dimension(ims:ime,jms:jme), intent(out) :: dx2d, area2d
 
      integer :: i, j
+
 #if 0
      do j = jts, min(jde-1,jte)
         do i = its, min(ide-1,ite)

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -5280,13 +5280,21 @@ subroutine interp_vec_cu(locvec,locwant,periodic,loc1,loc2,wght1,wght2)
      real, dimension(ims:ime,jms:jme), intent(out) :: dx2d, area2d
 
      integer :: i, j
-
+#if 0
      do j = jts, min(jde-1,jte)
         do i = its, min(ide-1,ite)
            area2d(i,j) = dx/msftx(i,j) * dy/msfty(i,j)
            dx2d  (i,j) = sqrt ( area2d(i,j) )
         end do
      end do
+#else
+     do j = jts, min(jde-1,jte)
+        do i = its, min(ide-1,ite)
+           area2d(i,j) = dx * dy
+           dx2d  (i,j) = sqrt ( area2d(i,j) )
+        end do
+     end do
+#endif
 
   end subroutine compute_2d_dx_area
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: dx

SOURCE: internal

DESCRIPTION OF CHANGES:
Instead of piecemeal modifications, we are going to get all of the 2d dx
physics schemes converted, and provide a mechanism to revert back to the
orginal behavior.

Temporarily, the existing mapfactor-dependent 2d dx is disabled. The 2d dx is constant.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
modified:   phys/module_physics_init.F

TESTS CONDUCTED:
1. Jenkins is OK.

2. Without mods, 2d dx has pattern similar to that of latitude or map factor.
<img width="1149" alt="Screen Shot 2020-04-01 at 9 48 05 PM" src="https://user-images.githubusercontent.com/12666234/78208786-7febd380-7462-11ea-970e-62adde0e40fc.png">

3. With mods, 2d dx is a constant.
![Screen Shot 2020-04-01 at 9 35 51 PM](https://user-images.githubusercontent.com/12666234/78208552-e3c1cc80-7461-11ea-9986-bc97ebbf0504.png)