### PR TITLE
Add vertical nesting checks: no hybrid vert coord, no feedback

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2197,7 +2197,6 @@
 !  scheme selection.  For "choose any vertical levels" for the nest,
 !  only option 1 (RRTM/Dudhia) or option 4 (RRTMG) are eligible.
 !-----------------------------------------------------------------------
-
       DO i = 2, model_config_rec % max_dom
         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
         IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
@@ -2216,6 +2215,46 @@
           END IF
         END IF
       END DO
+
+!-----------------------------------------------------------------------
+!  Consistency checks for vertical refinement:
+!  must using the terrain following vertical coordinate
+!-----------------------------------------------------------------------
+      oops = 0 
+      DO i = 2, model_config_rec % max_dom
+        IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+        IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
+          IF ( model_config_rec%hybrid_opt .NE. 0 ) THEN
+            oops = oops + 1
+          END IF
+        END IF
+      END DO
+
+      IF ( oops .GT. 0 ) THEN
+        wrf_err_message = '--- ERROR: vert_refine_method=2 only works with hybrid_opt = 0 '
+        CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+        count_fatal_error = count_fatal_error + 1
+      END IF
+
+!-----------------------------------------------------------------------
+!  Consistency checks for vertical refinement:
+!  feedback has to be turned off
+!-----------------------------------------------------------------------
+      oops = 0 
+      DO i = 2, model_config_rec % max_dom
+        IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+        IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
+          IF ( model_config_rec%feedback .NE. 0 ) THEN
+            oops = oops + 1
+          END IF
+        END IF
+      END DO
+
+      IF ( oops .GT. 0 ) THEN
+        wrf_err_message = '--- ERROR: vert_refine_method=2 only works with feedback = 0 '
+        CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+        count_fatal_error = count_fatal_error + 1
+      END IF
 
 !-----------------------------------------------------------------------
 ! This WRF version does not support trajectories on a global domain

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2218,7 +2218,7 @@
 
 !-----------------------------------------------------------------------
 !  Consistency checks for vertical refinement:
-!  must using the terrain following vertical coordinate
+!  must use the terrain following vertical coordinate
 !-----------------------------------------------------------------------
       oops = 0 
       DO i = 2, model_config_rec % max_dom


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: vertial nest, hybrid_opt, feedback

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
If a user requests a vertical refinement for a nest, there are a couple
of capabilities that need to be shut off. Either will cause the model
to eventually die, and they are really hard to otherwise find.

Solution:
If a users asks for a vertical refinement on the nest, make sure that the
terrain following coordinate is used (`hybrid_opt=0`), and that the
feedback option is turned off (`feedback=0`).

LIST OF MODIFIED FILES:
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. Jenkins is OK (hopefully)
2. Incorrectly turning on `hybrid_opt=2` or `feedback=1` is now safely trapped.
```
  Domain # 1: dx = 30000.000 m
  Domain # 2: dx = 10000.000 m
  --- ERROR: vert_refine_method=2 only works with hybrid_opt = 0
  --- ERROR: vert_refine_method=2 only works with feedback = 0
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2293
NOTE:       2 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```