### PR TITLE
FSBM: don't communicate global PARAMETER values to other MPI processes

### DIFF
--- a/phys/module_mp_fast_sbm.F
+++ b/phys/module_mp_fast_sbm.F
@@ -6071,19 +6071,6 @@ enddo
    	DM_BCAST_MACRO_R16 ( FBF5 )
    	DM_BCAST_MACRO_R16 ( FAB5 )
    	DM_BCAST_MACRO_R16 ( FBB5 )
- ! ### (KS) - Broadcating Temperature intervals
-   	CALL wrf_dm_bcast_integer ( temps_water , size ( temps_water ) )
-   	CALL wrf_dm_bcast_integer ( temps_fd , size ( temps_fd ) )
-   	CALL wrf_dm_bcast_integer ( temps_crystals , size ( temps_crystals ) )
-   	CALL wrf_dm_bcast_integer ( temps_snow , size ( temps_snow ) )
-   	CALL wrf_dm_bcast_integer ( temps_graupel , size ( temps_graupel ) )
-   	CALL wrf_dm_bcast_integer ( temps_hail , size ( temps_hail ) )
- ! ### (KS) - Broadcating Liquid fraction intervals
-   	DM_BCAST_MACRO_R4 ( fws_fd )
-   	DM_BCAST_MACRO_R4 ( fws_crystals )
-   	DM_BCAST_MACRO_R4 ( fws_snow )
-   	DM_BCAST_MACRO_R4 ( fws_graupel )
-   	DM_BCAST_MACRO_R4 ( fws_hail )
  ! ### (KS) - Broadcating Usetables array
  	  CALL wrf_dm_bcast_integer ( usetables , size ( usetables ) * IWORDSIZE )
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: bcast, parameter, fsbm

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
With GNU compilers 5, 8, and 9: FSBM runs OK serially. FSBM fails with
during intialization with MPI. It is traced to bcast of some variables that are
defined in module_mp_SBM_polar_radar.F.

INTEGER PARAMETER variables:
   * temps_water, temps_fd, temps_crystals, temps_snow, temps_graupel, temps_hail

REAL PARAMETER variables:
   * fws_fd, fws_crystals, fws_snow, fws_graupel, fws_hail

These variables are above the CONTAINS statement in 
module_mp_SBM_polar_radar.F and are PARAMETER values.

Solution:
We are not supposed to communicate PARAMETER values. These are already global
and cannot be written to. Just remove these unnecessary and illegal bcast statements.

LIST OF MODIFIED FILES:
m   module_mp_fast_sbm.F

TESTS CONDUCTED:
1. jenkins all pass
2. Without mods: seg fault 
3. With mods: code runs to completion. Test domain is:
![Screen Shot 2020-04-06 at 10 52 27 AM](https://user-images.githubusercontent.com/12666234/78584017-d5263d00-77f4-11ea-89b3-54cdf8357090.png)
