### PR TITLE
MP=28: avoid unintended constant aerosol distribution

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2191,7 +2191,7 @@ integer::oops1,oops2
  
          IF ( config_flags%gca_input_opt .EQ. 1 ) THEN
          IF ( ( config_flags%num_gca_levels .GT. 0 ) .AND. &
-              ( ABS(grid %p_gca_jan(its,config_flags%num_gca_levels/2,jts)) .GT. 1 ) ) THEN
+              ( ABS(grid %p_gca(its,config_flags%num_gca_levels/2,jts)) .GT. 1 ) ) THEN
 
             !  Insert source code here to vertically interpolate an extra set of 3d arrays
             !  that could be on a different vertical structure than the input atmospheric

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2547,14 +2547,17 @@ integer::oops1,oops2
                                ims , ime , jms , jme , kms , kme , &
                                its , ite , jts , jte , kts , kte )
 
-         ELSE IF ( ( config_flags%wif_input_opt .EQ. 1 ) .AND. &
-                   ( config_flags%mp_physics .EQ. THOMPSONAERO ) .AND. &
+         ELSE IF ( ( config_flags%mp_physics .EQ. THOMPSONAERO ) .AND. &
+                   ( ( config_flags%wif_input_opt .EQ. USE_WIF_INPUT ) .OR. &
+                     ( config_flags%use_aero_icbc                    ) ) .AND. &
                    ( ( flag_qnwfa .NE. 1 ) .OR.  &
                      ( flag_qnifa .NE. 1 ) ) ) THEN
-            WRITE (a_message,*) 'COMMENT: QNWFA or QNIFA flags not set in metgrid input, cannot have wif_input_opt=1'
-            CALL wrf_debug ( 0 , a_message)
-            WRITE (a_message,*) 'COMMENT: QNWFA and QNIFA will be initialized to zero values'
-            CALL wrf_debug ( 0 , a_message)
+            WRITE (a_message,*) '--- ERROR: QNWFA or QNIFA fields are not in the metgrid input'
+            CALL wrf_message ( a_message)
+            WRITE (a_message,*) '--- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html'
+            CALL wrf_message ( a_message)
+            WRITE (a_message,*) '--- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data'
+            CALL wrf_message ( a_message)
 
          END IF
 

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2189,8 +2189,8 @@ integer::oops1,oops2
          !  met variables? If so, we can skip all of this interpolation, as the pressure field
          !  is allocated, but all zeros.
  
+         IF ( config_flags%gca_input_opt .EQ. 1 ) THEN
          IF ( ( config_flags%num_gca_levels .GT. 0 ) .AND. &
-              ( config_flags%gca_input_opt .EQ. 1 ) .AND. &
               ( ABS(grid %p_gca_jan(its,config_flags%num_gca_levels/2,jts)) .GT. 1 ) ) THEN
 
             !  Insert source code here to vertically interpolate an extra set of 3d arrays
@@ -2370,6 +2370,7 @@ integer::oops1,oops2
                                   ims , ime , jms , jme , kms , kme , &
                                   its , ite , jts , jte , kts , kte )
             END IF
+            END IF
          END IF
 #endif
 
@@ -2377,8 +2378,8 @@ integer::oops1,oops2
          !  met variables? If so, we can skip all of this interpolation, as the pressure field
          !  is allocated, but all zeros.
  
+         IF ( config_flags%wif_input_opt .EQ. 1 ) THEN
          IF ( ( config_flags%num_wif_levels .GT. 0 ) .AND. &
-              ( config_flags%wif_input_opt .EQ. 1 ) .AND. &
               ( ABS(grid %p_wif_jan(its,config_flags%num_wif_levels/2,jts)) .GT. 1 ) ) THEN
 
             ! OPTIONAL DATA #2: Thompson Water-Friendly Ice-Friendly Aerosols
@@ -2576,6 +2577,7 @@ integer::oops1,oops2
                WRITE (a_message,*) '--- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data'
                CALL wrf_error_fatal ( a_message)
 
+            END IF
             END IF
          END IF
 

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2184,381 +2184,399 @@ integer::oops1,oops2
 !    START OF OPTIONAL 3D DATA, USUALLY AEROSOLS
 !=========================================================================================
 
-         !  Insert source code here to vertically interpolate an extra set of 3d arrays
-         !  that could be on a different vertical structure than the input atmospheric
-         !  data.  Mostly, this is expected to be for monthly data (such as background
-         !  aerosol information).
-
 #if ( WRF_CHEM == 1 )
-         ! OPTIONAL DATA #1: GCA - Go Cart Aerosols: OH, H2O2, NO3
-         !       Pressure name: p_gca
-         !       Number of vertical levels: num_gca_levels
-         !       Variable names (assumed to end with _jan, _feb, _mar, ..., _nov, _dec): oh, h2o2, no3
-         !       Option to interpolate data: gca_input_opt = 1
-         !       Not stored in scalar arrays.
+         !  Do we have the old data that came in on the same vertical levels as the other
+         !  met variables? If so, we can skip all of this interpolation, as the pressure field
+         !  is allocated, but all zeros.
+ 
+         IF ( ( config_flags%num_gca_levels .GT. 0 ) .AND. &
+              ( config_flags%gca_input_opt .EQ. 1 ) .AND. &
+              ( ABS(grid %p_gca_jan(its,config_flags%num_gca_levels/2,jts)) .GT. 1 ) ) THEN
 
-         IF ( config_flags%gca_input_opt .EQ. 1 ) THEN
+            !  Insert source code here to vertically interpolate an extra set of 3d arrays
+            !  that could be on a different vertical structure than the input atmospheric
+            !  data.  Mostly, this is expected to be for monthly data (such as background
+            !  aerosol information).
 
-            CALL wrf_debug ( 0 , 'Using monthly GOcart Aerosol input: OH, H2O2, NO3 from metgrid input file' )
+            ! OPTIONAL DATA #1: GCA - Go Cart Aerosols: OH, H2O2, NO3
+            !       Pressure name: p_gca
+            !       Number of vertical levels: num_gca_levels
+            !       Variable names (assumed to end with _jan, _feb, _mar, ..., _nov, _dec): oh, h2o2, no3
+            !       Option to interpolate data: gca_input_opt = 1
+            !       Not stored in scalar arrays.
 
-            !  There are three fields - they are 3d, so no easy way to loop over them.
-            !  OH - Hydroxyl
-            !  H2O2 - Hydrogen Peroxide
-            !  NO3 - Nitrate
+            IF ( config_flags%gca_input_opt .EQ. 1 ) THEN
 
-            DO k = 1, config_flags%num_gca_levels
-               WRITE(a_message,*) '  transferring each K-level ', k, ' to   OH, sample Jan data, ', grid %  oh_gca_jan(its,k,jts)
-               CALL wrf_debug ( 1 , a_message)
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid%qntemp(i, 1, j) = grid %  oh_gca_jan(i,k,j)
-                     grid%qntemp(i, 2, j) = grid %  oh_gca_feb(i,k,j)
-                     grid%qntemp(i, 3, j) = grid %  oh_gca_mar(i,k,j)
-                     grid%qntemp(i, 4, j) = grid %  oh_gca_apr(i,k,j)
-                     grid%qntemp(i, 5, j) = grid %  oh_gca_may(i,k,j)
-                     grid%qntemp(i, 6, j) = grid %  oh_gca_jun(i,k,j)
-                     grid%qntemp(i, 7, j) = grid %  oh_gca_jul(i,k,j)
-                     grid%qntemp(i, 8, j) = grid %  oh_gca_aug(i,k,j)
-                     grid%qntemp(i, 9, j) = grid %  oh_gca_sep(i,k,j)
-                     grid%qntemp(i,10, j) = grid %  oh_gca_oct(i,k,j)
-                     grid%qntemp(i,11, j) = grid %  oh_gca_nov(i,k,j)
-                     grid%qntemp(i,12, j) = grid %  oh_gca_dec(i,k,j)
+               CALL wrf_debug ( 0 , 'Using monthly GOcart Aerosol input: OH, H2O2, NO3 from metgrid input file' )
+
+               !  There are three fields - they are 3d, so no easy way to loop over them.
+               !  OH - Hydroxyl
+               !  H2O2 - Hydrogen Peroxide
+               !  NO3 - Nitrate
+
+               DO k = 1, config_flags%num_gca_levels
+                  WRITE(a_message,*) '  transferring each K-level ', k, ' to   OH, sample Jan data, ', grid %  oh_gca_jan(its,k,jts)
+                  CALL wrf_debug ( 1 , a_message)
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid%qntemp(i, 1, j) = grid %  oh_gca_jan(i,k,j)
+                        grid%qntemp(i, 2, j) = grid %  oh_gca_feb(i,k,j)
+                        grid%qntemp(i, 3, j) = grid %  oh_gca_mar(i,k,j)
+                        grid%qntemp(i, 4, j) = grid %  oh_gca_apr(i,k,j)
+                        grid%qntemp(i, 5, j) = grid %  oh_gca_may(i,k,j)
+                        grid%qntemp(i, 6, j) = grid %  oh_gca_jun(i,k,j)
+                        grid%qntemp(i, 7, j) = grid %  oh_gca_jul(i,k,j)
+                        grid%qntemp(i, 8, j) = grid %  oh_gca_aug(i,k,j)
+                        grid%qntemp(i, 9, j) = grid %  oh_gca_sep(i,k,j)
+                        grid%qntemp(i,10, j) = grid %  oh_gca_oct(i,k,j)
+                        grid%qntemp(i,11, j) = grid %  oh_gca_nov(i,k,j)
+                        grid%qntemp(i,12, j) = grid %  oh_gca_dec(i,k,j)
+                     END DO
+                  END DO
+                  IF ( k .EQ. 1 ) THEN
+                     WRITE(a_message,*) ' GOcart Aerosols   OH (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
+                                                ids , ide , jds , jde , kds , kde , &
+                                                ims , ime , jms , jme , kms , kme , &
+                                                its , ite , jts , jte , kts , kte )
+                  IF ( k .eq. 1 ) THEN
+                     write(a_message,*) ' GOcart Aerosols   OH (now) ', grid%qntemp2(its,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid %  oh_gca_now(i,k,j) = grid%qntemp2(i,j)
+                     END DO
                   END DO
                END DO
-               IF ( k .EQ. 1 ) THEN
-                  WRITE(a_message,*) ' GOcart Aerosols   OH (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
+
+               CALL vert_interp ( grid %  oh_gca_now , grid%p_gca , grid%backg_oh   , grid%pb , &
+                                  grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
+                                  grid%pmaxwnn , grid%ptropnn , &
+                                  0 , 0 , &
+                                  config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
+                                  config_flags%maxw_above_this_level , &
+                                  config_flags%num_gca_levels , 'Q' , &
+                                  interp_type , linear_interp , extrap_type , &
+                                  .false. , use_levels_below_ground , use_surface , &
+                                  zap_close_levels , force_sfc_in_vinterp , grid%id , &
+                                  ids , ide , jds , jde , kds , kde , &
+                                  ims , ime , jms , jme , kms , kme , &
+                                  its , ite , jts , jte , kts , kte )
+
+               DO k = 1, config_flags%num_gca_levels
+                  WRITE(a_message,*) '  transferring each K-level ', k, ' to H2O2, sample Jan data, ', grid %h2o2_gca_jan(its,k,jts)
                   CALL wrf_debug ( 1 , a_message)
-               END IF
-               CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
-                                             ids , ide , jds , jde , kds , kde , &
-                                             ims , ime , jms , jme , kms , kme , &
-                                             its , ite , jts , jte , kts , kte )
-               IF ( k .eq. 1 ) THEN
-                  write(a_message,*) ' GOcart Aerosols   OH (now) ', grid%qntemp2(its,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid %  oh_gca_now(i,k,j) = grid%qntemp2(i,j)
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid%qntemp(i, 1, j) = grid %h2o2_gca_jan(i,k,j)
+                        grid%qntemp(i, 2, j) = grid %h2o2_gca_feb(i,k,j)
+                        grid%qntemp(i, 3, j) = grid %h2o2_gca_mar(i,k,j)
+                        grid%qntemp(i, 4, j) = grid %h2o2_gca_apr(i,k,j)
+                        grid%qntemp(i, 5, j) = grid %h2o2_gca_may(i,k,j)
+                        grid%qntemp(i, 6, j) = grid %h2o2_gca_jun(i,k,j)
+                        grid%qntemp(i, 7, j) = grid %h2o2_gca_jul(i,k,j)
+                        grid%qntemp(i, 8, j) = grid %h2o2_gca_aug(i,k,j)
+                        grid%qntemp(i, 9, j) = grid %h2o2_gca_sep(i,k,j)
+                        grid%qntemp(i,10, j) = grid %h2o2_gca_oct(i,k,j)
+                        grid%qntemp(i,11, j) = grid %h2o2_gca_nov(i,k,j)
+                        grid%qntemp(i,12, j) = grid %h2o2_gca_dec(i,k,j)
+                     END DO
+                  END DO
+                  IF ( k .EQ. 1 ) THEN
+                     WRITE(a_message,*) ' GOcart Aerosols H2O2 (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
+                                                ids , ide , jds , jde , kds , kde , &
+                                                ims , ime , jms , jme , kms , kme , &
+                                                its , ite , jts , jte , kts , kte )
+                  IF ( k .eq. 1 ) THEN
+                     write(a_message,*) ' GOcart Aerosols H2O2 (now) ', grid%qntemp2(its,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid %h2o2_gca_now(i,k,j) = grid%qntemp2(i,j)
+                     END DO
                   END DO
                END DO
-            END DO
 
-            CALL vert_interp ( grid %  oh_gca_now , grid%p_gca , grid%backg_oh   , grid%pb , &
-                               grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
-                               grid%pmaxwnn , grid%ptropnn , &
-                               0 , 0 , &
-                               config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
-                               config_flags%maxw_above_this_level , &
-                               config_flags%num_gca_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
-                               .false. , use_levels_below_ground , use_surface , &
-                               zap_close_levels , force_sfc_in_vinterp , grid%id , &
-                               ids , ide , jds , jde , kds , kde , &
-                               ims , ime , jms , jme , kms , kme , &
-                               its , ite , jts , jte , kts , kte )
+               CALL vert_interp ( grid %h2o2_gca_now , grid%p_gca , grid%backg_h2o2 , grid%pb , &
+                                  grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
+                                  grid%pmaxwnn , grid%ptropnn , &
+                                  0 , 0 , &
+                                  config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
+                                  config_flags%maxw_above_this_level , &
+                                  config_flags%num_gca_levels , 'Q' , &
+                                  interp_type , linear_interp , extrap_type , &
+                                  .false. , use_levels_below_ground , use_surface , &
+                                  zap_close_levels , force_sfc_in_vinterp , grid%id , &
+                                  ids , ide , jds , jde , kds , kde , &
+                                  ims , ime , jms , jme , kms , kme , &
+                                  its , ite , jts , jte , kts , kte )
 
-            DO k = 1, config_flags%num_gca_levels
-               WRITE(a_message,*) '  transferring each K-level ', k, ' to H2O2, sample Jan data, ', grid %h2o2_gca_jan(its,k,jts)
-               CALL wrf_debug ( 1 , a_message)
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid%qntemp(i, 1, j) = grid %h2o2_gca_jan(i,k,j)
-                     grid%qntemp(i, 2, j) = grid %h2o2_gca_feb(i,k,j)
-                     grid%qntemp(i, 3, j) = grid %h2o2_gca_mar(i,k,j)
-                     grid%qntemp(i, 4, j) = grid %h2o2_gca_apr(i,k,j)
-                     grid%qntemp(i, 5, j) = grid %h2o2_gca_may(i,k,j)
-                     grid%qntemp(i, 6, j) = grid %h2o2_gca_jun(i,k,j)
-                     grid%qntemp(i, 7, j) = grid %h2o2_gca_jul(i,k,j)
-                     grid%qntemp(i, 8, j) = grid %h2o2_gca_aug(i,k,j)
-                     grid%qntemp(i, 9, j) = grid %h2o2_gca_sep(i,k,j)
-                     grid%qntemp(i,10, j) = grid %h2o2_gca_oct(i,k,j)
-                     grid%qntemp(i,11, j) = grid %h2o2_gca_nov(i,k,j)
-                     grid%qntemp(i,12, j) = grid %h2o2_gca_dec(i,k,j)
+               DO k = 1, config_flags%num_gca_levels
+                  WRITE(a_message,*) '  transferring each K-level ', k, ' to  NO3, sample Jan data, ', grid % no3_gca_jan(its,k,jts)
+                  CALL wrf_debug ( 1 , a_message)
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid%qntemp(i, 1, j) = grid % no3_gca_jan(i,k,j)
+                        grid%qntemp(i, 2, j) = grid % no3_gca_feb(i,k,j)
+                        grid%qntemp(i, 3, j) = grid % no3_gca_mar(i,k,j)
+                        grid%qntemp(i, 4, j) = grid % no3_gca_apr(i,k,j)
+                        grid%qntemp(i, 5, j) = grid % no3_gca_may(i,k,j)
+                        grid%qntemp(i, 6, j) = grid % no3_gca_jun(i,k,j)
+                        grid%qntemp(i, 7, j) = grid % no3_gca_jul(i,k,j)
+                        grid%qntemp(i, 8, j) = grid % no3_gca_aug(i,k,j)
+                        grid%qntemp(i, 9, j) = grid % no3_gca_sep(i,k,j)
+                        grid%qntemp(i,10, j) = grid % no3_gca_oct(i,k,j)
+                        grid%qntemp(i,11, j) = grid % no3_gca_nov(i,k,j)
+                        grid%qntemp(i,12, j) = grid % no3_gca_dec(i,k,j)
+                     END DO
+                  END DO
+                  IF ( k .EQ. 1 ) THEN
+                     WRITE(a_message,*) ' GOcart Aerosols  NO3 (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
+                                                ids , ide , jds , jde , kds , kde , &
+                                                ims , ime , jms , jme , kms , kme , &
+                                                its , ite , jts , jte , kts , kte )
+                  IF ( k .eq. 1 ) THEN
+                     write(a_message,*) ' GOcart Aerosols  NO3 (now) ', grid%qntemp2(its,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid % no3_gca_now(i,k,j) = grid%qntemp2(i,j)
+                     END DO
                   END DO
                END DO
-               IF ( k .EQ. 1 ) THEN
-                  WRITE(a_message,*) ' GOcart Aerosols H2O2 (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
-                                             ids , ide , jds , jde , kds , kde , &
-                                             ims , ime , jms , jme , kms , kme , &
-                                             its , ite , jts , jte , kts , kte )
-               IF ( k .eq. 1 ) THEN
-                  write(a_message,*) ' GOcart Aerosols H2O2 (now) ', grid%qntemp2(its,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid %h2o2_gca_now(i,k,j) = grid%qntemp2(i,j)
-                  END DO
-               END DO
-            END DO
 
-            CALL vert_interp ( grid %h2o2_gca_now , grid%p_gca , grid%backg_h2o2 , grid%pb , &
-                               grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
-                               grid%pmaxwnn , grid%ptropnn , &
-                               0 , 0 , &
-                               config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
-                               config_flags%maxw_above_this_level , &
-                               config_flags%num_gca_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
-                               .false. , use_levels_below_ground , use_surface , &
-                               zap_close_levels , force_sfc_in_vinterp , grid%id , &
-                               ids , ide , jds , jde , kds , kde , &
-                               ims , ime , jms , jme , kms , kme , &
-                               its , ite , jts , jte , kts , kte )
-
-            DO k = 1, config_flags%num_gca_levels
-               WRITE(a_message,*) '  transferring each K-level ', k, ' to  NO3, sample Jan data, ', grid % no3_gca_jan(its,k,jts)
-               CALL wrf_debug ( 1 , a_message)
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid%qntemp(i, 1, j) = grid % no3_gca_jan(i,k,j)
-                     grid%qntemp(i, 2, j) = grid % no3_gca_feb(i,k,j)
-                     grid%qntemp(i, 3, j) = grid % no3_gca_mar(i,k,j)
-                     grid%qntemp(i, 4, j) = grid % no3_gca_apr(i,k,j)
-                     grid%qntemp(i, 5, j) = grid % no3_gca_may(i,k,j)
-                     grid%qntemp(i, 6, j) = grid % no3_gca_jun(i,k,j)
-                     grid%qntemp(i, 7, j) = grid % no3_gca_jul(i,k,j)
-                     grid%qntemp(i, 8, j) = grid % no3_gca_aug(i,k,j)
-                     grid%qntemp(i, 9, j) = grid % no3_gca_sep(i,k,j)
-                     grid%qntemp(i,10, j) = grid % no3_gca_oct(i,k,j)
-                     grid%qntemp(i,11, j) = grid % no3_gca_nov(i,k,j)
-                     grid%qntemp(i,12, j) = grid % no3_gca_dec(i,k,j)
-                  END DO
-               END DO
-               IF ( k .EQ. 1 ) THEN
-                  WRITE(a_message,*) ' GOcart Aerosols  NO3 (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
-                                             ids , ide , jds , jde , kds , kde , &
-                                             ims , ime , jms , jme , kms , kme , &
-                                             its , ite , jts , jte , kts , kte )
-               IF ( k .eq. 1 ) THEN
-                  write(a_message,*) ' GOcart Aerosols  NO3 (now) ', grid%qntemp2(its,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid % no3_gca_now(i,k,j) = grid%qntemp2(i,j)
-                  END DO
-               END DO
-            END DO
-
-            CALL vert_interp ( grid % no3_gca_now , grid%p_gca , grid%backg_no3 , grid%pb , &
-                               grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
-                               grid%pmaxwnn , grid%ptropnn , &
-                               0 , 0 , &
-                               config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
-                               config_flags%maxw_above_this_level , &
-                               config_flags%num_gca_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
-                               .false. , use_levels_below_ground , use_surface , &
-                               zap_close_levels , force_sfc_in_vinterp , grid%id , &
-                               ids , ide , jds , jde , kds , kde , &
-                               ims , ime , jms , jme , kms , kme , &
-                               its , ite , jts , jte , kts , kte )
+               CALL vert_interp ( grid % no3_gca_now , grid%p_gca , grid%backg_no3 , grid%pb , &
+                                  grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
+                                  grid%pmaxwnn , grid%ptropnn , &
+                                  0 , 0 , &
+                                  config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
+                                  config_flags%maxw_above_this_level , &
+                                  config_flags%num_gca_levels , 'Q' , &
+                                  interp_type , linear_interp , extrap_type , &
+                                  .false. , use_levels_below_ground , use_surface , &
+                                  zap_close_levels , force_sfc_in_vinterp , grid%id , &
+                                  ids , ide , jds , jde , kds , kde , &
+                                  ims , ime , jms , jme , kms , kme , &
+                                  its , ite , jts , jte , kts , kte )
+            END IF
          END IF
 #endif
 
-         ! OPTIONAL DATA #2: Thompson Water-Friendly Ice-Friendly Aerosols
-         !       Pressure name (assumed to end with _jan, _feb, _mar, ..., _nov, _dec): p_wif
-         !       Number of vertical levels: num_wif_levels
-         !       Variable names (assumed to end with _jan, _feb, _mar, ..., _nov, _dec): w_wif, i_wif
-         !       Option to interpolate data: wif_input_opt = 1
-         !       Stored in scalar arrays, tested and assumed to be upside down.
+         !  Do we have the old data that came in on the same vertical levels as the other
+         !  met variables? If so, we can skip all of this interpolation, as the pressure field
+         !  is allocated, but all zeros.
+ 
+         IF ( ( config_flags%num_wif_levels .GT. 0 ) .AND. &
+              ( config_flags%wif_input_opt .EQ. 1 ) .AND. &
+              ( ABS(grid %p_wif_jan(its,config_flags%num_wif_levels/2,jts)) .GT. 1 ) ) THEN
 
-         IF ( ( config_flags%wif_input_opt .EQ. 1 ) .AND. &
-              ( config_flags%mp_physics .EQ. THOMPSONAERO ) .AND. &
-              ( flag_qnwfa .EQ. 1 ) .AND.  &
-              ( flag_qnifa .EQ. 1 ) ) THEN
+            ! OPTIONAL DATA #2: Thompson Water-Friendly Ice-Friendly Aerosols
+            !       Pressure name (assumed to end with _jan, _feb, _mar, ..., _nov, _dec): p_wif
+            !       Number of vertical levels: num_wif_levels
+            !       Variable names (assumed to end with _jan, _feb, _mar, ..., _nov, _dec): w_wif, i_wif
+            !       Option to interpolate data: wif_input_opt = 1
+            !       Stored in scalar arrays, tested and assumed to be upside down.
 
-            CALL wrf_debug ( 0 , 'Using monthly Water-Friendly and Ice-Friendly aerosols from metgrid input file' )
+            IF ( ( config_flags%wif_input_opt .EQ. 1 ) .AND. &
+                 ( config_flags%mp_physics .EQ. THOMPSONAERO ) .AND. &
+                 ( flag_qnwfa .EQ. 1 ) .AND.  &
+                 ( flag_qnifa .EQ. 1 ) ) THEN
 
-            !  There are two data fields plus pressure - they are 3d, so no easy way to loop over them.
-            !  QNWFA - Number concentration water-friendly aerosols
-            !  QNIFA - Number concentration ice-friendly aerosols
+               CALL wrf_debug ( 0 , 'Using monthly Water-Friendly and Ice-Friendly aerosols from metgrid input file' )
 
-            !  First, get the pressure temporally interpolated to the correct date/time since
-            !  this is a hybrid coordinate (not isobaric), and the pressure changes by month.
-            !  NOTE: The input pressure is not vertically interpolated, but the other two input   
-            !  fields (QNWFA, QNIFA) are interpolated to the WRF eta coordinate.
+               !  There are two data fields plus pressure - they are 3d, so no easy way to loop over them.
+               !  QNWFA - Number concentration water-friendly aerosols
+               !  QNIFA - Number concentration ice-friendly aerosols
 
-            IF ( grid%p_wif_jan(its,config_flags%num_wif_levels/2-1,jts) - &
-                 grid%p_wif_jan(its,config_flags%num_wif_levels/2+1,jts) .LT. 0 ) THEN
-               wif_upside_down = .TRUE.
+               !  First, get the pressure temporally interpolated to the correct date/time since
+               !  this is a hybrid coordinate (not isobaric), and the pressure changes by month.
+               !  NOTE: The input pressure is not vertically interpolated, but the other two input   
+               !  fields (QNWFA, QNIFA) are interpolated to the WRF eta coordinate.
+
+               IF ( grid%p_wif_jan(its,config_flags%num_wif_levels/2-1,jts) - &
+                    grid%p_wif_jan(its,config_flags%num_wif_levels/2+1,jts) .LT. 0 ) THEN
+                  wif_upside_down = .TRUE.
+               END IF
+
+               DO k = 1, config_flags%num_wif_levels
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid%qntemp(i, 1, j) = grid %p_wif_jan(i,k,j)
+                        grid%qntemp(i, 2, j) = grid %p_wif_feb(i,k,j)
+                        grid%qntemp(i, 3, j) = grid %p_wif_mar(i,k,j)
+                        grid%qntemp(i, 4, j) = grid %p_wif_apr(i,k,j)
+                        grid%qntemp(i, 5, j) = grid %p_wif_may(i,k,j)
+                        grid%qntemp(i, 6, j) = grid %p_wif_jun(i,k,j)
+                        grid%qntemp(i, 7, j) = grid %p_wif_jul(i,k,j)
+                        grid%qntemp(i, 8, j) = grid %p_wif_aug(i,k,j)
+                        grid%qntemp(i, 9, j) = grid %p_wif_sep(i,k,j)
+                        grid%qntemp(i,10, j) = grid %p_wif_oct(i,k,j)
+                        grid%qntemp(i,11, j) = grid %p_wif_nov(i,k,j)
+                        grid%qntemp(i,12, j) = grid %p_wif_dec(i,k,j)
+                     END DO
+                  END DO
+                  CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
+                                                ids , ide , jds , jde , kds , kde , &
+                                                ims , ime , jms , jme , kms , kme , &
+                                                its , ite , jts , jte , kts , kte )
+                  IF      (       wif_upside_down ) THEN
+                     DO j = jts, MIN(jte,jde-1)
+                        DO i = its, MIN(ite,ide-1)
+                           grid %p_wif_now(i,config_flags%num_wif_levels+1-k,j) = grid%qntemp2(i,j)
+                        END DO
+                     END DO
+                  ELSE IF ( .NOT. wif_upside_down ) THEN
+                     DO j = jts, MIN(jte,jde-1)
+                        DO i = its, MIN(ite,ide-1)
+                           grid %p_wif_now(i,                              k,j) = grid%qntemp2(i,j)
+                        END DO
+                     END DO
+                  END IF
+               END DO
+
+               DO k = 1, config_flags%num_wif_levels
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid%qntemp(i, 1, j) = grid %w_wif_jan(i,k,j)
+                        grid%qntemp(i, 2, j) = grid %w_wif_feb(i,k,j)
+                        grid%qntemp(i, 3, j) = grid %w_wif_mar(i,k,j)
+                        grid%qntemp(i, 4, j) = grid %w_wif_apr(i,k,j)
+                        grid%qntemp(i, 5, j) = grid %w_wif_may(i,k,j)
+                        grid%qntemp(i, 6, j) = grid %w_wif_jun(i,k,j)
+                        grid%qntemp(i, 7, j) = grid %w_wif_jul(i,k,j)
+                        grid%qntemp(i, 8, j) = grid %w_wif_aug(i,k,j)
+                        grid%qntemp(i, 9, j) = grid %w_wif_sep(i,k,j)
+                        grid%qntemp(i,10, j) = grid %w_wif_oct(i,k,j)
+                        grid%qntemp(i,11, j) = grid %w_wif_nov(i,k,j)
+                        grid%qntemp(i,12, j) = grid %w_wif_dec(i,k,j)
+                     END DO
+                  END DO
+                  CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
+                                                ids , ide , jds , jde , kds , kde , &
+                                                ims , ime , jms , jme , kms , kme , &
+                                                its , ite , jts , jte , kts , kte )
+                  IF      (       wif_upside_down ) THEN
+                     DO j = jts, MIN(jte,jde-1)
+                        DO i = its, MIN(ite,ide-1)
+                           grid %w_wif_now(i,config_flags%num_wif_levels+1-k,j) = grid%qntemp2(i,j)
+                        END DO
+                     END DO
+                  ELSE IF ( .NOT. wif_upside_down ) THEN
+                     DO j = jts, MIN(jte,jde-1)
+                        DO i = its, MIN(ite,ide-1)
+                           grid %w_wif_now(i,                              k,j) = grid%qntemp2(i,j)
+                        END DO
+                     END DO
+                  END IF
+               END DO
+
+               !..Capture the monthly climatology value for the lowest level because we use later to compute surface flux value.
+
+               DO j = jts, MIN(jte,jde-1)
+                  DO i = its, MIN(ite,ide-1)
+                     grid%QNWFA_now(i,1,j) = grid%w_wif_now(i,1,j)
+                  END DO
+               END DO
+
+               CALL vert_interp ( grid %w_wif_now , grid%p_wif_now , scalar(:,:,:,P_qnwfa) , grid%pb , &
+                                  grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
+                                  grid%pmaxwnn , grid%ptropnn , &
+                                  0 , 0 , &
+                                  config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
+                                  config_flags%maxw_above_this_level , &
+                                  config_flags%num_wif_levels , 'Q' , &
+                                  interp_type , linear_interp , extrap_type , &
+                                  .false. , use_levels_below_ground , use_surface , &
+                                  zap_close_levels , force_sfc_in_vinterp , grid%id , &
+                                  ids , ide , jds , jde , kds , kde , &
+                                  ims , ime , jms , jme , kms , kme , &
+                                  its , ite , jts , jte , kts , kte )
+
+
+               DO k = 1, config_flags%num_wif_levels
+                  WRITE(a_message,*) '  transferring each K-level ', k, ' to QNIFA, sample Jan data, ', grid %i_wif_jan(its,k,jts)
+                  CALL wrf_debug ( 1 , a_message)
+                  DO j = jts, MIN(jte,jde-1)
+                     DO i = its, MIN(ite,ide-1)
+                        grid%qntemp(i, 1, j) = grid %i_wif_jan(i,k,j)
+                        grid%qntemp(i, 2, j) = grid %i_wif_feb(i,k,j)
+                        grid%qntemp(i, 3, j) = grid %i_wif_mar(i,k,j)
+                        grid%qntemp(i, 4, j) = grid %i_wif_apr(i,k,j)
+                        grid%qntemp(i, 5, j) = grid %i_wif_may(i,k,j)
+                        grid%qntemp(i, 6, j) = grid %i_wif_jun(i,k,j)
+                        grid%qntemp(i, 7, j) = grid %i_wif_jul(i,k,j)
+                        grid%qntemp(i, 8, j) = grid %i_wif_aug(i,k,j)
+                        grid%qntemp(i, 9, j) = grid %i_wif_sep(i,k,j)
+                        grid%qntemp(i,10, j) = grid %i_wif_oct(i,k,j)
+                        grid%qntemp(i,11, j) = grid %i_wif_nov(i,k,j)
+                        grid%qntemp(i,12, j) = grid %i_wif_dec(i,k,j)
+                     END DO
+                  END DO
+                  IF ( k .EQ. 1 ) THEN
+                     WRITE(a_message,*) ' QNIFA (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
+                                                ids , ide , jds , jde , kds , kde , &
+                                                ims , ime , jms , jme , kms , kme , &
+                                                its , ite , jts , jte , kts , kte )
+                  IF ( k .eq. 1 ) THEN
+                     write(a_message,*) ' QNIFA (now) ', grid%qntemp2(its,jts)
+                     CALL wrf_debug ( 1 , a_message)
+                  END IF
+                  IF      (       wif_upside_down ) THEN
+                     DO j = jts, MIN(jte,jde-1)
+                        DO i = its, MIN(ite,ide-1)
+                           grid %i_wif_now(i,config_flags%num_wif_levels+1-k,j) = grid%qntemp2(i,j)
+                        END DO
+                     END DO
+                  ELSE IF ( .NOT. wif_upside_down ) THEN
+                     DO j = jts, MIN(jte,jde-1)
+                        DO i = its, MIN(ite,ide-1)
+                           grid %i_wif_now(i,                              k,j) = grid%qntemp2(i,j)
+                        END DO
+                     END DO
+                  END IF
+               END DO
+
+               CALL vert_interp ( grid %i_wif_now , grid%p_wif_now , scalar(:,:,:,P_qnifa) , grid%pb , &
+                                  grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
+                                  grid%pmaxwnn , grid%ptropnn , &
+                                  0 , 0 , &
+                                  config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
+                                  config_flags%maxw_above_this_level , &
+                                  config_flags%num_wif_levels , 'Q' , &
+                                  interp_type , linear_interp , extrap_type , &
+                                  .false. , use_levels_below_ground , use_surface , &
+                                  zap_close_levels , force_sfc_in_vinterp , grid%id , &
+                                  ids , ide , jds , jde , kds , kde , &
+                                  ims , ime , jms , jme , kms , kme , &
+                                  its , ite , jts , jte , kts , kte )
+
+            ELSE IF ( ( config_flags%mp_physics .EQ. THOMPSONAERO  ) .AND. &
+                      ( ( config_flags%wif_input_opt .EQ. USE_WIF_INPUT ) .OR.  &
+                        ( config_flags%use_aero_icbc                    ) ) .AND. &
+                      ( ( flag_qnwfa .NE. 1 ) .OR.  &
+                        ( flag_qnifa .NE. 1 ) ) ) THEN
+               WRITE (a_message,*) "--- ERROR: QNWFA or QNIFA fields are not in the metgrid input, they can't be interpolated"
+               CALL wrf_message ( a_message)
+               WRITE (a_message,*) '--- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html'
+               CALL wrf_message ( a_message)
+               WRITE (a_message,*) '--- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data'
+               CALL wrf_error_fatal ( a_message)
+
             END IF
-
-            DO k = 1, config_flags%num_wif_levels
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid%qntemp(i, 1, j) = grid %p_wif_jan(i,k,j)
-                     grid%qntemp(i, 2, j) = grid %p_wif_feb(i,k,j)
-                     grid%qntemp(i, 3, j) = grid %p_wif_mar(i,k,j)
-                     grid%qntemp(i, 4, j) = grid %p_wif_apr(i,k,j)
-                     grid%qntemp(i, 5, j) = grid %p_wif_may(i,k,j)
-                     grid%qntemp(i, 6, j) = grid %p_wif_jun(i,k,j)
-                     grid%qntemp(i, 7, j) = grid %p_wif_jul(i,k,j)
-                     grid%qntemp(i, 8, j) = grid %p_wif_aug(i,k,j)
-                     grid%qntemp(i, 9, j) = grid %p_wif_sep(i,k,j)
-                     grid%qntemp(i,10, j) = grid %p_wif_oct(i,k,j)
-                     grid%qntemp(i,11, j) = grid %p_wif_nov(i,k,j)
-                     grid%qntemp(i,12, j) = grid %p_wif_dec(i,k,j)
-                  END DO
-               END DO
-               CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
-                                             ids , ide , jds , jde , kds , kde , &
-                                             ims , ime , jms , jme , kms , kme , &
-                                             its , ite , jts , jte , kts , kte )
-               IF      (       wif_upside_down ) THEN
-                  DO j = jts, MIN(jte,jde-1)
-                     DO i = its, MIN(ite,ide-1)
-                        grid %p_wif_now(i,config_flags%num_wif_levels+1-k,j) = grid%qntemp2(i,j)
-                     END DO
-                  END DO
-               ELSE IF ( .NOT. wif_upside_down ) THEN
-                  DO j = jts, MIN(jte,jde-1)
-                     DO i = its, MIN(ite,ide-1)
-                        grid %p_wif_now(i,                              k,j) = grid%qntemp2(i,j)
-                     END DO
-                  END DO
-               END IF
-            END DO
-
-            DO k = 1, config_flags%num_wif_levels
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid%qntemp(i, 1, j) = grid %w_wif_jan(i,k,j)
-                     grid%qntemp(i, 2, j) = grid %w_wif_feb(i,k,j)
-                     grid%qntemp(i, 3, j) = grid %w_wif_mar(i,k,j)
-                     grid%qntemp(i, 4, j) = grid %w_wif_apr(i,k,j)
-                     grid%qntemp(i, 5, j) = grid %w_wif_may(i,k,j)
-                     grid%qntemp(i, 6, j) = grid %w_wif_jun(i,k,j)
-                     grid%qntemp(i, 7, j) = grid %w_wif_jul(i,k,j)
-                     grid%qntemp(i, 8, j) = grid %w_wif_aug(i,k,j)
-                     grid%qntemp(i, 9, j) = grid %w_wif_sep(i,k,j)
-                     grid%qntemp(i,10, j) = grid %w_wif_oct(i,k,j)
-                     grid%qntemp(i,11, j) = grid %w_wif_nov(i,k,j)
-                     grid%qntemp(i,12, j) = grid %w_wif_dec(i,k,j)
-                  END DO
-               END DO
-               CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
-                                             ids , ide , jds , jde , kds , kde , &
-                                             ims , ime , jms , jme , kms , kme , &
-                                             its , ite , jts , jte , kts , kte )
-               IF      (       wif_upside_down ) THEN
-                  DO j = jts, MIN(jte,jde-1)
-                     DO i = its, MIN(ite,ide-1)
-                        grid %w_wif_now(i,config_flags%num_wif_levels+1-k,j) = grid%qntemp2(i,j)
-                     END DO
-                  END DO
-               ELSE IF ( .NOT. wif_upside_down ) THEN
-                  DO j = jts, MIN(jte,jde-1)
-                     DO i = its, MIN(ite,ide-1)
-                        grid %w_wif_now(i,                              k,j) = grid%qntemp2(i,j)
-                     END DO
-                  END DO
-               END IF
-            END DO
-
-            !..Capture the monthly climatology value for the lowest level because we use later to compute surface flux value.
-
-            DO j = jts, MIN(jte,jde-1)
-               DO i = its, MIN(ite,ide-1)
-                  grid%QNWFA_now(i,1,j) = grid%w_wif_now(i,1,j)
-               END DO
-            END DO
-
-            CALL vert_interp ( grid %w_wif_now , grid%p_wif_now , scalar(:,:,:,P_qnwfa) , grid%pb , &
-                               grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
-                               grid%pmaxwnn , grid%ptropnn , &
-                               0 , 0 , &
-                               config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
-                               config_flags%maxw_above_this_level , &
-                               config_flags%num_wif_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
-                               .false. , use_levels_below_ground , use_surface , &
-                               zap_close_levels , force_sfc_in_vinterp , grid%id , &
-                               ids , ide , jds , jde , kds , kde , &
-                               ims , ime , jms , jme , kms , kme , &
-                               its , ite , jts , jte , kts , kte )
-
-
-            DO k = 1, config_flags%num_wif_levels
-               WRITE(a_message,*) '  transferring each K-level ', k, ' to QNIFA, sample Jan data, ', grid %i_wif_jan(its,k,jts)
-               CALL wrf_debug ( 1 , a_message)
-               DO j = jts, MIN(jte,jde-1)
-                  DO i = its, MIN(ite,ide-1)
-                     grid%qntemp(i, 1, j) = grid %i_wif_jan(i,k,j)
-                     grid%qntemp(i, 2, j) = grid %i_wif_feb(i,k,j)
-                     grid%qntemp(i, 3, j) = grid %i_wif_mar(i,k,j)
-                     grid%qntemp(i, 4, j) = grid %i_wif_apr(i,k,j)
-                     grid%qntemp(i, 5, j) = grid %i_wif_may(i,k,j)
-                     grid%qntemp(i, 6, j) = grid %i_wif_jun(i,k,j)
-                     grid%qntemp(i, 7, j) = grid %i_wif_jul(i,k,j)
-                     grid%qntemp(i, 8, j) = grid %i_wif_aug(i,k,j)
-                     grid%qntemp(i, 9, j) = grid %i_wif_sep(i,k,j)
-                     grid%qntemp(i,10, j) = grid %i_wif_oct(i,k,j)
-                     grid%qntemp(i,11, j) = grid %i_wif_nov(i,k,j)
-                     grid%qntemp(i,12, j) = grid %i_wif_dec(i,k,j)
-                  END DO
-               END DO
-               IF ( k .EQ. 1 ) THEN
-                  WRITE(a_message,*) ' QNIFA (jan and feb) ', grid%qntemp(its,1,jts),grid%qntemp(its,2,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               CALL monthly_interp_to_date ( grid%qntemp , current_date , grid%qntemp2 , &
-                                             ids , ide , jds , jde , kds , kde , &
-                                             ims , ime , jms , jme , kms , kme , &
-                                             its , ite , jts , jte , kts , kte )
-               IF ( k .eq. 1 ) THEN
-                  write(a_message,*) ' QNIFA (now) ', grid%qntemp2(its,jts)
-                  CALL wrf_debug ( 1 , a_message)
-               END IF
-               IF      (       wif_upside_down ) THEN
-                  DO j = jts, MIN(jte,jde-1)
-                     DO i = its, MIN(ite,ide-1)
-                        grid %i_wif_now(i,config_flags%num_wif_levels+1-k,j) = grid%qntemp2(i,j)
-                     END DO
-                  END DO
-               ELSE IF ( .NOT. wif_upside_down ) THEN
-                  DO j = jts, MIN(jte,jde-1)
-                     DO i = its, MIN(ite,ide-1)
-                        grid %i_wif_now(i,                              k,j) = grid%qntemp2(i,j)
-                     END DO
-                  END DO
-               END IF
-            END DO
-
-            CALL vert_interp ( grid %i_wif_now , grid%p_wif_now , scalar(:,:,:,P_qnifa) , grid%pb , &
-                               grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop , &
-                               grid%pmaxwnn , grid%ptropnn , &
-                               0 , 0 , &
-                               config_flags%maxw_horiz_pres_diff , config_flags%trop_horiz_pres_diff , &
-                               config_flags%maxw_above_this_level , &
-                               config_flags%num_wif_levels , 'Q' , &
-                               interp_type , linear_interp , extrap_type , &
-                               .false. , use_levels_below_ground , use_surface , &
-                               zap_close_levels , force_sfc_in_vinterp , grid%id , &
-                               ids , ide , jds , jde , kds , kde , &
-                               ims , ime , jms , jme , kms , kme , &
-                               its , ite , jts , jte , kts , kte )
-
-         ELSE IF ( ( config_flags%mp_physics .EQ. THOMPSONAERO  ) .AND. &
-                   ( ( config_flags%wif_input_opt .EQ. USE_WIF_INPUT ) .OR.  &
-                     ( config_flags%use_aero_icbc                    ) ) .AND. &
-                   ( ( flag_qnwfa .NE. 1 ) .OR.  &
-                     ( flag_qnifa .NE. 1 ) ) ) THEN
-            WRITE (a_message,*) "--- ERROR: QNWFA or QNIFA fields are not in the metgrid input, they can't be interpolated"
-            CALL wrf_message ( a_message)
-            WRITE (a_message,*) '--- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html'
-            CALL wrf_message ( a_message)
-            WRITE (a_message,*) '--- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data'
-            CALL wrf_error_fatal ( a_message)
-
          END IF
 
 !=========================================================================================

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2557,7 +2557,7 @@ integer::oops1,oops2
             WRITE (a_message,*) '--- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html'
             CALL wrf_message ( a_message)
             WRITE (a_message,*) '--- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data'
-            CALL wrf_message ( a_message)
+            CALL wrf_error_fatal ( a_message)
 
          END IF
 

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2547,12 +2547,12 @@ integer::oops1,oops2
                                ims , ime , jms , jme , kms , kme , &
                                its , ite , jts , jte , kts , kte )
 
-         ELSE IF ( ( config_flags%mp_physics .EQ. THOMPSONAERO ) .AND. &
-                   ( ( config_flags%wif_input_opt .EQ. USE_WIF_INPUT ) .OR. &
+         ELSE IF ( ( config_flags%mp_physics .EQ. THOMPSONAERO  ) .AND. &
+                   ( ( config_flags%wif_input_opt .EQ. USE_WIF_INPUT ) .OR.  &
                      ( config_flags%use_aero_icbc                    ) ) .AND. &
                    ( ( flag_qnwfa .NE. 1 ) .OR.  &
                      ( flag_qnifa .NE. 1 ) ) ) THEN
-            WRITE (a_message,*) '--- ERROR: QNWFA or QNIFA fields are not in the metgrid input'
+            WRITE (a_message,*) "--- ERROR: QNWFA or QNIFA fields are not in the metgrid input, they can't be interpolated"
             CALL wrf_message ( a_message)
             WRITE (a_message,*) '--- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html'
             CALL wrf_message ( a_message)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: aerosol, Thompson, long meeting

SOURCE: Pedro Jimenez (RAL/NCAR), internal

DESCRIPTION OF CHANGES:
Problem 1:
Users with mp_physics=28 that do not have climatology aerosols from metgrid
have not been aggressively informed that their simulations are not using
climatology. These users have been given a horizontally uniform distribution,
and likely those users did not know it. Previously the user was given only a couple 
lines of print buried in a long print-out in the real program, and probably very few 
users saw that message.

Solution 1:
1. Turn the previous comment-style messaging into a fatal call.
2. Augment the IF test to include `use_aero_icbc` as a reason to fail. If there is no aerosol data,
activating `use_aero_icbc` is not a valid request.

Problem 2:
Until there is a complete removal of the older method of processing aerosols inside of the real
program, the existing logic to use the water and ice friendly monthly data overwrites the previously
interpolated data with zeros. Included in the fields of zeros are is the pressure array. This causes a 
floating error (divide by zero) or a seg-fault (incorrect indexing).

Solution 2:
Before undergoing the new aerosol processing, make sure that the input pressure data is valid. To do
that, make sure that the user requested the new processing option. Since there is both a template for
chemistry and a section for water / ice friendly aerosols, two IF tests are introduced to safely surround
the vertical interpolation.

LIST OF MODIFIED FILES: 
modified:   dyn_em/module_initialize_real.F

TESTS CONDUCTED:
1. Jenkins status is all PASS.
2. Testing with the namelist to verify this mod traps bad settings, but permits correct functioning:
 - [x] Successfully completes run with
```
 &physics
 mp_physics    = 28
```
 - [x] No WIF input data in metgrid, correctly fails with
```
 &physics
 mp_physics    = 28
 use_aero_icbc = T
```
```
 --- ERROR: QNWFA or QNIFA fields are not in the metgrid input
 --- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2392
 --- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data
```
 - [x] No WIF input data in metgrid, correctly fails with
```
 &domains
 wif_input_opt = 1

 &physics
 mp_physics    = 28
```
```
 --- ERROR: QNWFA or QNIFA fields are not in the metgrid input
 --- ERROR: See https://www2.mmm.ucar.edu/wrf/users/wrfv3.9/mp28_updated.html
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2392
 --- ERROR: Neither wif_input_opt=1 nor use_aero_icbc=T are allowed without aerosol data
```
 - [x] With WIF data in metgrid, successfully completes simulation with
```
 &domains
 wif_input_opt = 1

 &physics
 mp_physics    = 28
 use_aero_icbc = T
```