### PR TITLE
Rename ESMF_FractionMod to WRF_ESMF_FractionMod

### DIFF
--- a/external/esmf_time_f90/ESMF_Fraction.F90
+++ b/external/esmf_time_f90/ESMF_Fraction.F90
@@ -4,7 +4,7 @@
 !==============================================================================
 !
 !     ESMF Fraction Module
-      module ESMF_FractionMod
+      module WRF_ESMF_FractionMod
 !
 !==============================================================================
 !
@@ -17,7 +17,7 @@
 !===============================================================================
 !BOPI
 !
-! !MODULE: ESMF_FractionMod
+! !MODULE: WRF_ESMF_FractionMod
 !
 ! !DESCRIPTION:
 ! Part of ESMF F90 API wrapper of C++ implemenation
@@ -68,4 +68,4 @@
 
 !------------------------------------------------------------------------------
 
-      end module ESMF_FractionMod
+      end module WRF_ESMF_FractionMod

--- a/external/esmf_time_f90/ESMF_Mod.F90
+++ b/external/esmf_time_f90/ESMF_Mod.F90
@@ -6,7 +6,7 @@ MODULE ESMF_Mod
    USE WRF_ESMF_BaseTimeMod
    USE WRF_ESMF_CalendarMod
    USE WRF_ESMF_ClockMod
-   USE esmf_fractionmod
+   USE WRF_ESMF_FractionMod
    USE WRF_ESMF_TimeIntervalMod
    USE WRF_ESMF_TimeMod
    USE WRF_ESMF_AlarmClockMod

--- a/external/esmf_time_f90/ESMF_TimeInterval.F90
+++ b/external/esmf_time_f90/ESMF_TimeInterval.F90
@@ -34,7 +34,7 @@
       use WRF_ESMF_BaseTimeMod
 
       ! associated derived types
-      use ESMF_FractionMod, only : ESMF_Fraction
+      use WRF_ESMF_FractionMod, only : ESMF_Fraction
       use WRF_ESMF_CalendarMod
 
       implicit none

--- a/external/esmf_time_f90/Meat.F90
+++ b/external/esmf_time_f90/Meat.F90
@@ -562,7 +562,7 @@ SUBROUTINE c_esmc_basetimeeq (time1, time2, outflag)
   USE WRF_ESMF_BaseTimeMod
   USE WRF_ESMF_CalendarMod
   USE WRF_ESMF_ClockMod
-  USE esmf_fractionmod
+  USE WRF_ESMF_FractionMod
   USE WRF_ESMF_TimeIntervalMod
   USE WRF_ESMF_TimeMod
 IMPLICIT NONE
@@ -579,7 +579,7 @@ SUBROUTINE c_esmc_basetimege(time1, time2, outflag)
   USE WRF_ESMF_BaseTimeMod
   USE WRF_ESMF_CalendarMod
   USE WRF_ESMF_ClockMod
-  USE esmf_fractionmod
+  USE WRF_ESMF_FractionMod
   USE WRF_ESMF_TimeIntervalMod
   USE WRF_ESMF_TimeMod
       logical, intent(OUT) :: outflag
@@ -595,7 +595,7 @@ SUBROUTINE c_esmc_basetimegt(time1, time2, outflag)
   USE WRF_ESMF_BaseTimeMod
   USE WRF_ESMF_CalendarMod
   USE WRF_ESMF_ClockMod
-  USE esmf_fractionmod
+  USE WRF_ESMF_FractionMod
   USE WRF_ESMF_TimeIntervalMod
   USE WRF_ESMF_TimeMod
 IMPLICIT NONE
@@ -612,7 +612,7 @@ SUBROUTINE c_esmc_basetimele(time1, time2, outflag)
   USE WRF_ESMF_BaseTimeMod
   USE WRF_ESMF_CalendarMod
   USE WRF_ESMF_ClockMod
-  USE esmf_fractionmod
+  USE WRF_ESMF_FractionMod
   USE WRF_ESMF_TimeIntervalMod
   USE WRF_ESMF_TimeMod
 IMPLICIT NONE
@@ -629,7 +629,7 @@ SUBROUTINE c_esmc_basetimelt(time1, time2, outflag)
   USE WRF_ESMF_BaseTimeMod
   USE WRF_ESMF_CalendarMod
   USE WRF_ESMF_ClockMod
-  USE esmf_fractionmod
+  USE WRF_ESMF_FractionMod
   USE WRF_ESMF_TimeIntervalMod
   USE WRF_ESMF_TimeMod
 IMPLICIT NONE
@@ -646,7 +646,7 @@ SUBROUTINE c_esmc_basetimene(time1, time2, outflag)
   USE WRF_ESMF_BaseTimeMod
   USE WRF_ESMF_CalendarMod
   USE WRF_ESMF_ClockMod
-  USE esmf_fractionmod
+  USE WRF_ESMF_FractionMod
   USE WRF_ESMF_TimeIntervalMod
   USE WRF_ESMF_TimeMod
 IMPLICIT NONE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ESMF, ESMF_FractionMod, WRF_ESMF_FractionMod

SOURCE: Milan Curcic (University of Miami)

DESCRIPTION OF CHANGES: 

Problem and solution documented [here](https://github.com/wrf-model/WRF/pull/1066#issuecomment-611272321).

> Currently, it is not possible to build and link WRF with a chosen ESMF library due to the name 
conflicts between WRF internal ESMF interfaces with the intended ESMF library. I faced this problem 
while I was trying to compile WRF with the ESMF library during LILAC project development for coupling 
WRF with CTSM. This is specifically important for users and groups who would like to couple WRF 
with other models using ESMF infrastructure. This issue can be resolved by either updating WRF to 
use the new ESMF time manager interface or renaming all of WRF's internal ESMF interfaces to avoid 
name collisions when linking with the intended ESMF library.

ISSUE: Fixes #1065.

LIST OF MODIFIED FILES: 
M       external/esmf_time_f90/ESMF_Fraction.F90
M       external/esmf_time_f90/ESMF_Mod.F90
M       external/esmf_time_f90/ESMF_TimeInterval.F90
M       external/esmf_time_f90/Meat.F90

TESTS CONDUCTED: Compiled in em_real mode. Tested using the program mentioned [here](https://github.com/wrf-model/WRF/pull/1066#issuecomment-611272321). Otherwise, I don't have the tooling set up for regression tests. Can you please run them for me?