### PR TITLE
If WRF model has sf_urban_physics==0, wrf_inputdxx metadata value is ignored

### DIFF
--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -804,7 +804,9 @@
 
 #if ( DA_CORE != 1 )
     ! Test here to check that config_flags%sf_urban_physics in namelist
-    ! is equal to what is in the global attributes of the wrfinput files
+    ! is equal to the value listed the global attributes of the wrfinput files.
+    ! We only perform this check if the WRF model has sf_urban_physics turned on,
+    ! as the WRF model can run with any IC if the differing option is de-activated.
 
     IF ( config_flags%sf_urban_physics /= 0 ) THEN
        IF ( switch .EQ. input_only  ) THEN

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -805,8 +805,9 @@
 #if ( DA_CORE != 1 )
     ! Test here to check that config_flags%sf_urban_physics in namelist
     ! is equal to the value listed the global attributes of the wrfinput files.
-    ! We only perform this check if the WRF model has sf_urban_physics turned on,
-    ! as the WRF model can run with any IC if the differing option is de-activated.
+    ! We only perform this check if the WRF model has sf_urban_physics turned on.
+    ! If the WRF model runs with nml sf_urban_physics==0, then any setting of the 
+    ! sf_urban_physics in the metadata is acceptable, so not test is required.
 
     IF ( config_flags%sf_urban_physics /= 0 ) THEN
        IF ( switch .EQ. input_only  ) THEN

--- a/share/input_wrf.F
+++ b/share/input_wrf.F
@@ -806,19 +806,21 @@
     ! Test here to check that config_flags%sf_urban_physics in namelist
     ! is equal to what is in the global attributes of the wrfinput files
 
-    IF ( switch .EQ. input_only  ) THEN
-       CALL wrf_get_dom_ti_integer ( fid, 'SF_URBAN_PHYSICS', itmp, 1, icnt, ierr )
-       IF ( ierr .EQ. 0 ) THEN
-          WRITE(wrf_err_message,*)'input_wrf: global attribute SF_URBAN_PHYSICS returns ', itmp
-          CALL wrf_debug ( 300 , wrf_err_message )
-          IF ( config_flags%sf_urban_physics /= itmp ) THEN
-             call wrf_message("----------------- ERROR -------------------")
-             WRITE(wrf_err_message,'("namelist    : sf_urban_physics   = ",I10)') config_flags%sf_urban_physics
-             call wrf_message(wrf_err_message)
-             WRITE(wrf_err_message,'("input files : SF_URBAN_PHYSICS   = ",I10, " (from wrfinput files).")') itmp
-             call wrf_message(wrf_err_message)
-             call wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute SF_URBAN_PHYSICS")
-             count_fatal_error = count_fatal_error + 1
+    IF ( config_flags%sf_urban_physics /= 0 ) THEN
+       IF ( switch .EQ. input_only  ) THEN
+          CALL wrf_get_dom_ti_integer ( fid, 'SF_URBAN_PHYSICS', itmp, 1, icnt, ierr )
+          IF ( ierr .EQ. 0 ) THEN
+             WRITE(wrf_err_message,*)'input_wrf: global attribute SF_URBAN_PHYSICS returns ', itmp
+             CALL wrf_debug ( 300 , wrf_err_message )
+             IF ( config_flags%sf_urban_physics /= itmp ) THEN
+                call wrf_message("----------------- ERROR -------------------")
+                WRITE(wrf_err_message,'("namelist    : sf_urban_physics   = ",I10)') config_flags%sf_urban_physics
+                call wrf_message(wrf_err_message)
+                WRITE(wrf_err_message,'("input files : SF_URBAN_PHYSICS   = ",I10, " (from wrfinput files).")') itmp
+                call wrf_message(wrf_err_message)
+                call wrf_debug ( 0, "---- ERROR: Mismatch between namelist and global attribute SF_URBAN_PHYSICS")
+                count_fatal_error = count_fatal_error + 1
+             END IF
           END IF
        END IF
     END IF

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -175,7 +175,7 @@
     call nl_get_feedback             ( 1      ,  feedback             )
     call nl_get_smooth_option        ( 1      ,  smooth_option        )
     call nl_get_swrad_scat           ( 1      ,  swrad_scat           )
-    call nl_get_sf_urban_physics     ( 1      ,  sf_urban_physics     )
+    call nl_get_sf_urban_physics     ( grid%id,  sf_urban_physics     )
     call nl_get_w_damping            ( 1      ,  w_damping            )
 
 #if (EM_CORE == 1)


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: sf_urban_physics

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
If a user runs the real program with an urban physics option activated, then the
WRF model needs that same option activated. However, if the WRF model just turns
off the urban option, then ANY setting of the real program's namelist value of
sf_urban_physics should be acceptable.

Solution:
Add an extra IF test to check on the WRF model's namelist setting for sf_urban_physics. If
this namelist option is non-zero, then there is a validation test to determine if the
namelist and the input file metadata are identical. The new rule is: if the namelist value for
`sf_urban_physics==0` when running the WRF model, then an inconsistent value of `sf_urban_physics`
in the metadata will always be ignored.

This is consistent with the treatment of several other flags that are set by the real
program, for example: gwd_opt and sf_ocean_physics. 

The output_wrf.F file is modified as the namelist option `sf_urban_physics` is max_dom, not 
just a single entry. 

LIST OF MODIFIED FILES:
modified:   share/input_wrf.F
modified:   share/output_wrf.F

TESTS CONDUCTED:
1. Jenkins is all PASS
2. 4x4 contingency table for sf_urban_physics consistency

Sample error statement:
```
----------------- ERROR -------------------
namelist    : sf_urban_physics   =          3
input files : SF_URBAN_PHYSICS   =          0 (from wrfinput files).
  ---- ERROR: Mismatch between namelist and global attribute SF_URBAN_PHYSICS
NOTE:       1 namelist vs input data inconsistencies found.
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    1296
NOTE:  Please check and reset these options
```

|                | NML=0 | NML=1 | NML=2 | NML=3 |
|----------------|:-----:|:-----:|:-----:|:-----:|
|**File Metadata=0**|   OK    |    STOP   |   STOP    |   STOP    |
|**File Metadata=1**|    OK   |   OK    |   STOP    |   STOP    |
|**File Metadata=2**|   OK    |   STOP    |   OK    |  STOP     |
|**File Metadata=3**|   OK    |  STOP     |   STOP    |    OK   |