### PR TITLE
Efficiency fix for nwp_diag reflectivity calculation

### DIFF
--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -127,6 +127,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
    
    ! Flag for producing diagnostic fields (e.g., radar reflectivity)
    LOGICAL                        :: diag_flag
+   INTEGER                        :: ke_diag ! tells reflectivity calculation whether to do full depth or only k=1
    
 #if (WRF_CHEM == 1)
    ! Index cross-referencing array for tendency accumulation
@@ -294,10 +295,12 @@ SUBROUTINE solve_em ( grid , config_flags  &
 !
 ! Set diagnostic flag value history output time
 !-----------------------------------------------------------------------------
-!  if ( Is_alarm_tstep(grid_clock, grid_alarms(HISTORY_ALARM)) ) then
-      diag_flag = .false.
+
+   ke_diag = kms ! default to ke_diag=1 in case of nwp_diagnostics == 1
+   diag_flag = .false.
    if ( Is_alarm_tstep(grid%domain_clock, grid%alarms(HISTORY_ALARM)) ) then
       diag_flag = .true.
+      ke_diag = min(k_end,kde-1) ! set depth to full domain for reflectivity field
    endif
    IF (config_flags%nwp_diagnostics == 1) diag_flag = .true.
 
@@ -3784,6 +3787,7 @@ BENCH_START(micro_driver_tim)
       &        , has_reqc=grid%has_reqc, has_reqi=grid%has_reqi, has_reqs=grid%has_reqs & ! G. Thompson
       &        , qnwfa2d=grid%qnwfa2d, qnifa2d=grid%qnifa2d                             & ! G. Thompson
       &        , diagflag=diag_flag, do_radar_ref=config_flags%do_radar_ref &
+      &        , ke_diag=ke_diag                                           &
       &        ,u=grid%u_phy,v=grid%v_phy &
       &        ,scalar=scalar,num_scalar=num_scalar                             &
       &        ,TH_OLD=grid%th_old                                        &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -122,6 +122,7 @@ SUBROUTINE microphysics_driver(                                          &
 ! Added the RI_CURR array to the call
                       ,ri_curr                                           &
                       ,diagflag,   do_radar_ref                          &
+                      ,ke_diag                                           &
                       ,re_cloud, re_ice, re_snow                         & ! G. Thompson
                       ,has_reqc, has_reqi, has_reqs                      & ! G. Thompson
                       ,ccn_conc                                          & ! RAS
@@ -692,6 +693,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 
 
    LOGICAL, OPTIONAL, INTENT(IN) :: diagflag
+   INTEGER, OPTIONAL, INTENT(IN) :: ke_diag ! tells reflectivity calculation whether to do full depth or only k=1
    REAL, INTENT(IN) :: ccn_conc ! RAS
    INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref
    REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(INOUT) ::  & ! G. Thompson
@@ -1037,6 +1039,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 #endif
                      REFL_10CM=refl_10cm,                &
                      diagflag=diagflag,                  &
+                     ke_diag = ke_diag,                  &
                      do_radar_ref=do_radar_ref,          &
                      re_cloud=re_cloud,                  &
                      re_ice=re_ice,                      &
@@ -1095,6 +1098,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 #endif
                      REFL_10CM=refl_10cm,                &
                      diagflag=diagflag,                  &
+                     ke_diag = ke_diag,                  &
                      do_radar_ref=do_radar_ref,          &
                      re_cloud=re_cloud,                  & ! G. Thompson
                      re_ice=re_ice,                      & ! G. Thompson
@@ -1729,6 +1733,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      SR=SR,                              &
                      dbz      = refl_10cm,               &
                      diagflag = diagflag,                &
+                     ke_diag = ke_diag,                &
                   IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde, &
                   IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme, &
                   ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte  &
@@ -1778,6 +1783,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      SR=SR,                              &
                      dbz      = refl_10cm,               &
                      diagflag = diagflag,                &
+                     ke_diag = ke_diag,                &
                   IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde, &
                   IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme, &
                   ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte  &
@@ -1846,6 +1852,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 #endif
                      nssl_progn=nssl_progn,              &
                      diagflag = diagflag,                &
+                     ke_diag = ke_diag,                &
                      cu_used=cu_used,                    &
                      qrcuten=qrcuten,                    &  ! hm
                      qscuten=qscuten,                    &  ! hm
@@ -2003,6 +2010,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
 #endif
                      nssl_progn=nssl_progn,              &
                      diagflag = diagflag,                &
+                     ke_diag = ke_diag,                &
                      cu_used=cu_used,                    &
                      qrcuten=qrcuten,                    &  ! hm
                      qscuten=qscuten,                    &  ! hm

--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -1625,7 +1625,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
 !                              re_liquid, re_graupel, re_hail, re_icesnow,               &
 !                              vtcloud, vtrain, vtsnow, vtgraupel, vthail,               &
                               ipelectmp,                                                &
-                              diagflag,                                                 &
+                              diagflag,ke_diag,                                         &
                               nssl_progn,                                              & ! wrf-chem 
 ! 20130903 acd_mb_washout start
                               rainprod, evapprod,                                       & ! wrf-chem 
@@ -1694,7 +1694,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
       real, intent(in)::    dtp
       integer, intent(in):: itimestep !, ccntype
       logical, optional, intent(in) :: diagflag, f_cna, f_cn
-      integer, optional, intent(in) :: ipelectmp
+      integer, optional, intent(in) :: ipelectmp, ke_diag
 
   LOGICAL, INTENT(IN), OPTIONAL ::    nssl_progn   ! flags for wrf-chem 
   
@@ -1753,6 +1753,8 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
       double precision :: timevtcalc,timesetvt
       
       logical :: f_cnatmp
+      
+      integer :: kediagloc
 
 
 
@@ -2241,12 +2243,17 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
    ! calc dbz
       
       IF ( .true. ) THEN
+      IF ( present(ke_diag) ) THEN
+        kediagloc = ke_diag
+      ELSE
+        kediagloc = nz
+      ENDIF
       call radardd02(nx,ny,nz,nor,na,an,t0,         &
-     &    dbz2d,dn1,nz,cnoh,rho_qh,ipconc, 0)
+     &    dbz2d,dn1,nz,cnoh,rho_qh,ipconc,kediagloc, 0)
       ENDIF ! .false.
 
      
-       DO kz = kts,kte
+       DO kz = kts,ke_diag ! kte
         DO ix = its,ite
          dbz(ix,kz,jy) = dbz2d(ix,1,kz)
          IF ( present( vzf ) ) THEN
@@ -6266,7 +6273,7 @@ END SUBROUTINE nssl_2mom_driver
 
 ! ##############################################################################
       subroutine radardd02(nx,ny,nz,nor,na,an,temk,         &
-     &    dbz,db,nzdbz,cnoh0t,hwdn1t,ipconc, iunit)
+     &    dbz,db,nzdbz,cnoh0t,hwdn1t,ipconc,ke_diag, iunit)
 !
 ! 11.13.2005: Changed values of indices for reordering of lip
 !
@@ -6323,6 +6330,7 @@ END SUBROUTINE nssl_2mom_driver
       parameter( ng1 = 1 )
       
       real cnoh0t,hwdn1t
+      integer ke_diag
       integer ipconc
       real vr
 
@@ -6685,7 +6693,7 @@ END SUBROUTINE nssl_2mom_driver
 
       DO jy=1,1
 
-        DO kz = 1,nz
+        DO kz = 1,ke_diag ! nz
          
           DO ix=1,nx
             dbz(ix,jy,kz) = 0.0

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -982,7 +982,7 @@
 #if ( WRF_CHEM == 1 )
                               rainprod, evapprod, &
 #endif
-                              refl_10cm, diagflag, do_radar_ref,      &
+                              refl_10cm, diagflag, ke_diag, do_radar_ref,      &
                               re_cloud, re_ice, re_snow,              &
                               has_reqc, has_reqi, has_reqs,           &
                               ids,ide, jds,jde, kds,kde, &             ! domain dims
@@ -1038,8 +1038,10 @@
       INTEGER:: kmax_qc,kmax_qr,kmax_qi,kmax_qs,kmax_qg,kmax_ni,kmax_nr
       INTEGER:: i_start, j_start, i_end, j_end
       LOGICAL, OPTIONAL, INTENT(IN) :: diagflag
-      INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref
+      INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref, ke_diag
       CHARACTER*256:: mp_debug
+      
+      integer :: kediagloc
 
 !+---+
 
@@ -1285,8 +1287,15 @@
 
          IF ( PRESENT (diagflag) ) THEN
          if (diagflag .and. do_radar_ref == 1) then
+          
+          IF ( present(ke_diag) ) THEN
+            kediagloc = ke_diag
+          ELSE
+            kediagloc = kte
+          ENDIF
+          
           call calc_refl10cm (qv1d, qc1d, qr1d, nr1d, qs1d, qg1d,       &
-                      t1d, p1d, dBZ, kts, kte, i, j)
+                      t1d, p1d, dBZ, kts, kte, i, j, kediagloc)
           do k = kts, kte
              refl_10cm(i,k,j) = MAX(-35., dBZ(k))
           enddo
@@ -5132,12 +5141,12 @@
 !+---+-----------------------------------------------------------------+
 
       subroutine calc_refl10cm (qv1d, qc1d, qr1d, nr1d, qs1d, qg1d,     &
-                          t1d, p1d, dBZ, kts, kte, ii, jj)
+                          t1d, p1d, dBZ, kts, kte, ii, jj, ke_diag)
 
       IMPLICIT NONE
 
 !..Sub arguments
-      INTEGER, INTENT(IN):: kts, kte, ii, jj
+      INTEGER, INTENT(IN):: kts, kte, ii, jj, ke_diag
       REAL, DIMENSION(kts:kte), INTENT(IN)::                            &
                           qv1d, qc1d, qr1d, nr1d, qs1d, qg1d, t1d, p1d
       REAL, DIMENSION(kts:kte), INTENT(INOUT):: dBZ
@@ -5160,12 +5169,13 @@
       REAL:: a_, b_, loga_, tc0
       DOUBLE PRECISION:: fmelt_s, fmelt_g
 
-      INTEGER:: i, k, k_0, kbot, n
+      INTEGER:: i, k, k_0, kbot, n, ktop
       LOGICAL:: melti
       LOGICAL, DIMENSION(kts:kte):: L_qr, L_qs, L_qg
 
       DOUBLE PRECISION:: cback, x, eta, f_d
       REAL:: xslw1, ygra1, zans1
+      INTEGER :: k_0loop
 
 !+---+
 
@@ -5176,6 +5186,7 @@
 !+---+-----------------------------------------------------------------+
 !..Put column of data into local arrays.
 !+---+-----------------------------------------------------------------+
+
       do k = kts, kte
          temp(k) = t1d(k)
          qv(k) = MAX(1.E-10, qv1d(k))
@@ -5222,8 +5233,9 @@
          smoc(k) = 0.
          smoz(k) = 0.
       enddo
-      if (ANY(L_qs .eqv. .true.)) then
-      do k = kts, kte
+      if ( ( ke_diag > kts .and. ANY(L_qs .eqv. .true.) ) .or.  &
+            (ke_diag == kts .and. L_qs(kts) .eqv. .true. ) ) then
+      do k = kts, ke_diag ! kte
          if (.not. L_qs(k)) CYCLE
          tc0 = MIN(-0.1, temp(k)-273.15)
          smob(k) = rs(k)*oams
@@ -5307,13 +5319,16 @@
       enddo
  195  continue
 
+! Set loop limit for wet ice according to whether the full 3D field is needed or just k=1
+      k_0loop = Min(k_0, ke_diag+1)
+
 !+---+-----------------------------------------------------------------+
 !..Assume Rayleigh approximation at 10 cm wavelength. Rain (all temps)
 !.. and non-water-coated snow and graupel when below freezing are
 !.. simple. Integrations of m(D)*m(D)*N(D)*dD.
 !+---+-----------------------------------------------------------------+
 
-      do k = kts, kte
+      do k = kts, ke_diag ! kte
          ze_rain(k) = 1.e-22
          ze_snow(k) = 1.e-22
          ze_graupel(k) = 1.e-22
@@ -5334,7 +5349,7 @@
 !+---+-----------------------------------------------------------------+
 
       if (.not. iiwarm .and. melti .and. k_0.ge.2) then
-       do k = k_0-1, kts, -1
+       do k = k_0loop-1, kts, -1
 
 !..Reflectivity contributed by melting snow
           if (L_qs(k) .and. L_qs(k_0) ) then
@@ -5381,7 +5396,7 @@
        enddo
       endif
 
-      do k = kte, kts, -1
+      do k = ke_diag, kts, -1
          dBZ(k) = 10.*log10((ze_rain(k)+ze_snow(k)+ze_graupel(k))*1.d18)
       enddo
 


### PR DESCRIPTION
TYPE:  enhancement

KEYWORDS: nwp_diagnostics, diag_flag

SOURCE: Ted Mansell (NSSL)

DESCRIPTION OF CHANGES: 
Replaces "Efficiency fix for nwp_diag reflectivity calculation" #1060

Problem:
With commit 86f7675359234d239, PR #749 "make refl_10cm available if nwp_diagnostics is on", 
solve_em.F was changed so that `diag_flag` was always set to true when `nwp_diagnostics==1`. 
This caused the full 3D radar reflectivity to be calculated on each time step, whereas the diagnostic 
for the max dBZ only needs to compute lowest level (k=1). The full 3D nature of the new computation
makes the cost of this diagnostic between one and two orders of magnitude more expensive than 
necessary. 

Solution:
A variable `ke_diag` is added in solve_em to tell the reflectivity calculation whether to do the full depth 
(for history output) or only the lowest level (for `nwp_diagnostics==1`). This avoids unnecessary 3D
computation of dBZ for `nwp_diagnostics==1`, which is expensive for a number of schemes. The variable
`ke_diag` is passed to the microphysics driver and from there to individual microphysics schemes. 
The NSSL and Thompson schemes have been updated to use this new capability, and other MP
schemes could be done in a very similar manner.

LIST OF MODIFIED FILES: 
 dyn_em/solve_em.F
 phys/module_microphysics_driver.F
 phys/module_mp_nssl_2mom.F
 phys/module_mp_thompson.F

TESTS CONDUCTED: Ideal full-physics tests showed that the NWP field REFD_MAX is the same after implementation.

RELEASE NOTE: Improved efficiency of reflectivity calculation for nwp_diagnostics=1 by only computing it at the level where maximum reflectivity is diagnosed.