### PR TITLE
Better RELEASE NOTES guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -13,7 +13,7 @@ SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev c
 
 DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
 
-ISSUE: For use when this PR closes an issue. For exzmple, if this PR closes issue number 123
+ISSUE: For use when this PR closes an issue. For example, if this PR closes issue number 123
 Fixes #123
 
 LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -14,12 +14,10 @@ SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev c
 DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
 
 ISSUE: For use when this PR closes an issue. For issue number 123
-```
 Fixes #123
-```
 
 LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
 
 TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
 
-RELEASE NOTE: Optional, as appropriate. Delete if not used. Included only once for new features requiring several merge cycles. Changes to default behavior are also note worthy.
+RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -13,7 +13,7 @@ SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev c
 
 DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
 
-ISSUE: For use when this PR closes an issue. For issue number 123
+ISSUE: For use when this PR closes an issue. For exzmple, if this PR closes issue number 123
 Fixes #123
 
 LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

--- a/tools/commit_form.txt
+++ b/tools/commit_form.txt
@@ -17,7 +17,7 @@ LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status maste
 
 TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
 
-RELEASE NOTE: Optional, as appropriate. Delete if not used. Included only once for new features requiring several merge cycles. Changes to default behavior are also note worthy.
+RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
 
 ------------------------------------------------------------------
 


### PR DESCRIPTION
TYPE: text only

KEYWORDS: RELEASE NOTES

SOURCE: internal

DESCRIPTION OF CHANGES: 
Prompt contributor for citation in the RELEASE NOTES section of the PR commit message.

LIST OF MODIFIED FILES:
modified:   tools/commit_form.txt
modified:   .github/PULL_REQUEST_TEMPLATE

TESTS CONDUCTED: 
None required for text-only mod.