### PR TITLE
If (FARMS+Goddard MP) then -> must use RRTMG radiation

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -576,6 +576,27 @@
          END IF
       ENDDO
 
+!-----------------------------------------------------------------------
+! The combination of using the FARMS option (swint_opt==2) along with the
+! Goddard MP scheme requires that the RRTMG radiation be used.
+!-----------------------------------------------------------------------
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( ( model_config_rec%swint_opt .EQ. SWINTOPT2 ) .AND. &
+              ( model_config_rec%mp_physics(i) .EQ. nuwrf4icescheme ) ) THEN
+            IF ( ( model_config_rec%ra_sw_physics(i) .NE. rrtmg_lwscheme ) .OR. &
+                 ( model_config_rec%ra_lw_physics(i) .NE. rrtmg_swscheme ) ) THEN
+              oops = oops + 1
+            END IF
+         END IF
+      ENDDO
+
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: Option FARMS + Goddard MP requires RRTMG radiation'
+         CALL wrf_message ( wrf_err_message )
+         count_fatal_error = count_fatal_error + 1
+      END IF
 #endif
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, Goddard, RRTMG

SOURCE: internal

DESCRIPTION OF CHANGES:
A new fatal check is added to check_a_mundo.
```
IF ( FARMS and Goddard MP) THEN
   IF ( using any radiation scheme except for RRTMG ) THEN
      FAIL
```

LIST OF MODIFIED FILES:
modified:   module_check_a_mundo.F

TESTS CONDUCTED:
1. jenkins is all PASS
2. Code proceeds as expected with OK nml options. Basically, no harm done.
```
 &physics
 physics_suite = 'CONUS'
 swint_opt     = 2
 mp_physics    = 7
 ra_lw_physics = 4
 ra_sw_physics = 4
```
3. Code correctly stops with trapped bad combination
```
 &physics
 physics_suite = 'CONUS'
 swint_opt     = 2
 mp_physics    = 7
 ra_lw_physics = 1
 ra_sw_physics = 1
```
With this output:
```
--- ERROR: Option FARMS + Goddard MP requires RRTMG radiation
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2340
NOTE:       1 namelist settings are wrong. Please check and reset these options
```
4. Code proceeds as expected with non-trapped schemes. Basically, still no harm done.
```
 &physics
 physics_suite = 'CONUS'
 swint_opt     = 1
 mp_physics    = 7
 ra_lw_physics = 4
 ra_sw_physics = 4
```