### PR TITLE
Several FARMS radiation related bug fixes

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -950,7 +950,7 @@ CONTAINS
            ( f_qs            ) ) THEN
          !  everything is A-OK for FARMS
       ELSE
-         CALL wrf_error_fatal ('--- ERROR: FARMS requires a different MP scheme')
+         CALL wrf_error_fatal ('--- ERROR: FARMS (swint_opt==2) requires a different MP scheme')
       END IF
    END IF
 

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -938,7 +938,8 @@ CONTAINS
       has_reqs = 0
    end if
 
-! If using FARMS, we need both effective radii and the mass
+! If using FARMS (swint_opt==2), we need both effective radii and the mass
+! for cloud, ice, and snow.
 
    IF ( config_flags%swint_opt .eq. swintopt2 ) THEN
       IF ( ( has_reqc .EQ. 1 ) .AND. &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -938,7 +938,22 @@ CONTAINS
       has_reqs = 0
    end if
 
-   ENDIF
+! If using FARMS, we need both effective radii and the mass
+
+   IF ( config_flags%swint_opt .eq. swintopt2 ) THEN
+      IF ( ( has_reqc .EQ. 1 ) .AND. &
+           ( has_reqi .EQ. 1 ) .AND. &
+           ( has_reqs .EQ. 1 ) .AND. &
+           ( f_qc            ) .AND. &
+           ( f_qi            ) .AND. &
+           ( f_qs            ) ) THEN
+         !  everything is A-OK for FARMS
+      ELSE
+         CALL wrf_error_fatal ('--- ERROR: FARMS requires a different MP scheme')
+      END IF
+   END IF
+
+   ENDIF ! use_mp_re .EQ. 1
 
 !-- should be from the namelist
 

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -941,7 +941,7 @@ CONTAINS
 ! If using FARMS (swint_opt==2), we need both effective radii and the mass
 ! for cloud, ice, and snow.
 
-   IF ( config_flags%swint_opt .eq. swintopt2 ) THEN
+   IF ( config_flags%swint_opt .eq. 2 ) THEN
       IF ( ( has_reqc .EQ. 1 ) .AND. &
            ( has_reqi .EQ. 1 ) .AND. &
            ( has_reqs .EQ. 1 ) .AND. &

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1028,7 +1028,7 @@ CONTAINS
    IF ( PRESENT(solar_opt) ) THEN
       solar_opt_local = solar_opt
    END IF
-   Solar_step: IF (run_param .or. solar_opt_local == 1) THEN
+   Solar_step: IF (run_param .or. solar_opt_local == 1 .or. swint_opt == 2) THEN
 
      !---------------
      ! Calculate constant for short wave radiation
@@ -2808,7 +2808,7 @@ CONTAINS
  IF ( PRESENT(solar_opt) ) THEN
     solar_opt_local = solar_opt
  END IF
- IF (run_param .or. solar_opt_local == 1) THEN
+ IF (run_param .or. solar_opt_local == 1 .or. swint_opt == 2) THEN
     do ij = 1,num_tiles
       its = i_start(ij)
       ite = i_end(ij)

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -992,6 +992,24 @@ CONTAINS
       radtacttime = curr_secs + radt*60
    END IF
 
+   IF ( mp_physics .EQ. nuwrf4icescheme ) THEN
+      DO ij = 1 , num_tiles
+         its = i_start(ij)
+         ite = i_end(ij)
+         jts = j_start(ij)
+         jte = j_end(ij)
+         DO j=jts,jte
+         DO k=kts,kte
+         DO i=its,ite
+            re_cloud(i,k,j) = re_cloud_gsfc(i,k,j) * 1.E-6
+            re_ice(i,k,j) = re_ice_gsfc(i,k,j) * 1.E-6
+            re_snow(i,k,j) = re_snow_gsfc(i,k,j) * 1.E-6
+         ENDDO
+         ENDDO
+         ENDDO
+      ENDDO
+   END IF
+
    if(swint_opt.eq.1 .or. swint_opt == 2) then
       DO ij = 1 , num_tiles
          its = i_start(ij)
@@ -1882,17 +1900,6 @@ CONTAINS
         CASE (RRTMG_LWSCHEME)
 
              CALL wrf_debug (100, 'CALL rrtmg_lw')
-             IF ( mp_physics .EQ. nuwrf4icescheme ) THEN
-                DO j=jts,jte
-                DO k=kts,kte
-                DO i=its,ite
-                   re_cloud(i,k,j) = re_cloud_gsfc(i,k,j) * 1.E-6
-                   re_ice(i,k,j) = re_ice_gsfc(i,k,j) * 1.E-6
-                   re_snow(i,k,j) = re_snow_gsfc(i,k,j) * 1.E-6
-                ENDDO
-                ENDDO
-                ENDDO
-             END IF
 
              !Need to reset NLAYERS if vertical nesting is used.
              !This code follows that for case RRTMSCHEME within
@@ -2400,17 +2407,6 @@ CONTAINS
         CASE (RRTMG_SWSCHEME)
 
              CALL wrf_debug(100, 'CALL rrtmg_sw')
-             IF ( mp_physics .EQ. nuwrf4icescheme ) THEN
-                DO j=jts,jte
-                DO k=kts,kte
-                DO i=its,ite
-                   re_cloud(i,k,j) = re_cloud_gsfc(i,k,j) * 1.E-6
-                   re_ice(i,k,j) = re_ice_gsfc(i,k,j) * 1.E-6
-                   re_snow(i,k,j) = re_snow_gsfc(i,k,j) * 1.E-6
-                ENDDO
-                ENDDO
-                ENDDO
-             END IF
 
              CALL RRTMG_SWRAD(                                         &
                      RTHRATENSW=RTHRATENSW,                            &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -576,6 +576,24 @@
          END IF
       ENDDO
 
+!-----------------------------------------------------------------------
+! The FARMS radiation option (swint_opt==2) requires both effective radii
+! and mass for cloud, ice, and snow. A run-time option is available to 
+! disable the use of effective radii in the MP schemes. These two options 
+! may not be used together.
+!-----------------------------------------------------------------------
+      oops = 0
+      IF ( ( model_config_rec%swint_opt .EQ. 2 ) .AND. &
+           ( model_config_rec%use_mp_re .NE. 1 ) ) THEN
+         oops = oops + 1
+      END IF
+
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: FARMS (swint_opt=2) requires effective radii (use_mp_re=1)'
+         CALL wrf_message ( wrf_err_message )
+         count_fatal_error = count_fatal_error + 1
+      END IF
+
 #endif
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, radii, Goddard

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The FARMS radiation option (`swint_opt==2`) assumes both the availabilty of effective radii
and mass for three species: cloud, ice, and snow. This causes several issues.
1. The Goddard MP scheme had the effective radii in a separate variable, in different units.
2. The effective radii for snow could be valid with an unallocated mass for snow (for example, WSM3).
3. Two locations in radiation driver that need to have the FARMS option in the IF test
4. Even though use_mp_re=1 is a default, if someone turns it off, the FARMS option is not possible 
(but that was not trapped).

Solution:
1. In the radiation driver, if the MP scheme is Goddard, translate the radii to the correct
variable name and with the correct units.
2. If the FARMS radiation option (`swint_opt==2`) is used, in the physics initialization
routine require that effective radii and mass for cloud, ice, and snow be available.
3. Welp, just add those additional `.or. swint_opt ==2` in (per Jimy and Pedro).
4. Add an IF test in check_a_mundo that FARMS + use_mp_re=0 is a FATAL error.

LIST OF MODIFIED FILES:
modified:   phys/module_physics_init.F
modified:   phys/module_radiation_driver.F
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. jenkins is all PASS
2. With acceptable nml (FARMS + MP with sufficient radii and mass info)
```
 &physics
 physics_suite = 'CONUS'
 swint_opt     = 2
 mp_physics    = 7
```
The _temporary_ messages indicate positive results
```
 In physics init, we have the correct radii and masses
INPUT LandUse = "USGS"
 LANDUSE TYPE = "USGS" FOUND          33  CATEGORIES           2  SEASONS WATER CATEGORY =           16  SNOW CATEGORY =           24
INITIALIZE THREE Noah LSM RELATED TABLES
 LANDUSE TYPE = USGS FOUND          27  CATEGORIES
 INPUT SOIL TEXTURE CLASSIFICATION = STAS
 SOIL TEXTURE CLASSIFICATION = STAS FOUND          19  CATEGORIES
Timing for Writing wrfout_d01_2000-01-24_12:00:00 for domain        1:    0.40447 elapsed seconds
d01 2000-01-24_12:00:00  Input data is acceptable to use: wrfbdy_d01
Timing for processing lateral boundary for domain        1:    0.03351 elapsed seconds
 Tile Strategy is not specified. Assuming 1D-Y
WRF TILE   1 IS      1 IE     74 JS      1 JE     61
WRF NUMBER OF TILES =   1
 In radiation driver, converting Goddard MP radii to traditional
```
3. With insufficient mass fields in WSM3 (no snow) to run the FARMS scheme:
```
 &physics
 physics_suite = 'CONUS'
 swint_opt     = 2
 mp_physics    = 3
```
The error is trapped
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     911
--- ERROR: FARMS (swint_opt==2) requires a different MP scheme
```
4. If a user manages to turn off `use_mp_re==0` and asks for FARMS (an inconsistent combination)
```
 &physics
 physics_suite = 'CONUS'
 swint_opt     = 2
 use_mp_re     = 0
```
This error combination is successfully trapped
```
--- ERROR: FARMS (swint_opt=2) requires effective radii (use_mp_re=1)
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2339
NOTE:       1 namelist settings are wrong. Please check and reset these options
```