### PR TITLE
Bug fix for retrieval radar reflectivity DA

### DIFF
--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -463,12 +463,13 @@ END IF
                         if (model_tc(k,n).le.0.0) then
                            czs = (1.0-czr)*zds/(zds+zg) ! dry snow
                            czg = (1.0-czr)*zg/(zds+zg)
+                           iv % radar(n) % rsno(k) = exp ( log(czs*rze/zds)/1.75 )/model_rho(k,n)
                         else
                            czs = (1.0-czr)*zws/(zws+zg) ! wet snow
                            czg = (1.0-czr)*zg/(zws+zg)
+                           iv % radar(n) % rsno(k) = exp ( log(czs*rze/zws)/1.75 )/model_rho(k,n)
                         end if
                         iv % radar(n) % rrno(k) = exp ( log(czr*rze/zrr)/1.75 )/model_rho(k,n)
-                        iv % radar(n) % rsno(k) = exp ( log(czs*rze/zds)/1.75 )/model_rho(k,n)
                         iv % radar(n) % rgro(k) = exp ( log(czg*rze/zg )/1.75 )/model_rho(k,n)
                         iv % radar(n) % rrn(k) % qc = 0
                         iv % radar(n) % rsn(k) % qc = 0


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: reflectivity, snow retrieval

SOURCE: Tao Sun (NUIST)

DESCRIPTION OF CHANGES: 
A bug in the snow profile retrieval in radar DA has been fixed. When the temperature is above 0℃, zds (dry snow) should be replaced by zws (wet snow). This bug resulted in the overestimation of snow.

LIST OF MODIFIED FILES:
M       var/da/da_radar/da_get_innov_vector_radar.inc

TESTS CONDUCTED: WRFDA regression tests running.

RELEASE NOTE: A fix for retrieving a snow profile with radar DA. In the snow profile retrieval with radar DA, when the temperature is above 0℃, dry snow should be replaced by wet snow. This bug resulted in the overestimation of snow.
