### PR TITLE
Bug fix for WRFPLUS with SBM

### DIFF
--- a/compile
+++ b/compile
@@ -73,7 +73,6 @@ foreach a ( $argv )
     set ZAP = ( main/wrfplus.exe )
     setenv WRF_EM_CORE   1
     setenv WRF_PLUS_CORE 1
-    echo not sure what to do, but this seems to be legit so far
   else if   ( "$a" ==  "wrf" ) then
     set arglist = ( $arglist $a )
     set ZAP = ( main/wrf.exe )

--- a/wrftladj/solve_em_ad.F
+++ b/wrftladj/solve_em_ad.F
@@ -3920,6 +3920,7 @@ BENCH_START(micro_driver_tim)
       &        ,tempc=grid%tempc                                         &
       &        ,ccn_conc=grid%ccn_conc                                   & ! RAS
       &        ,sbmradar=sbmradar,num_sbmradar=num_sbmradar              & ! for SBM
+      &        ,sbm_diagnostics=config_flags%sbm_diagnostics             & ! for SBM
       &        ,aerocu=aerocu                                            &
       &        ,aercu_fct=config_flags%aercu_fct                         &
       &        ,aercu_opt=config_flags%aercu_opt                         &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFPLUS, AD, SBM

SOURCE: internal

DESCRIPTION OF CHANGES:
A new argument was added to the nonlinear model for the microphysics
driver (an integer flag for the spectral bin microphysics diagnostics
`sbm_diagnostics`). This argument has been added to the call to the
microphysics driver in `solve_em_ad.F`.

While tracking down this compile-time bug, an old debugging comment for 
WRFPLUS in the `compile` script was found and removed.

LIST OF MODIFIED FILES:
modified:   compile
modified:   wrftladj/solve_em_ad.F

TESTS CONDUCTED:
1. Without mods, the WRFPLUS code does not compile. With mod, the WRFPLUS
code compiles.
2. Jenkins will continue to pass because this code was not activated.
3. WRFPLUS regtest: ???