### PR TITLE
Fixed typo "Makfile_org" to "Makefile_org" in clean_kpp

### DIFF
--- a/chem/KPP/clean_kpp
+++ b/chem/KPP/clean_kpp
@@ -9,7 +9,7 @@ echo "# DO NOT EDIT! Placeholder for automatically generated file"  >&   configu
 # remove the traces of KPP
 if (-e ../Makefile_org ) then
 cp  -f ../Makefile_org  ../Makefile
-rm -f ../Makfile_org
+rm -f ../Makefile_org
 endif
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: chem, KPP

SOURCE: Michael Newman (Woodard & Curran)

DESCRIPTION OF CHANGES: 
Fixed typo "Makfile_org" to "Makefile_org" in chem/KPP/clean_kpp. Expected behavior: After 
copying "Makefile_org" to "Makefile", the script is expecting to delete "Makefile_org" to clean up.

LIST OF MODIFIED FILES:
M chem/KPP/clean_kpp

TESTS CONDUCTED: 
1. Ran clean_kpp to confirm expected behavior. 
2. Searched code base to confirm no additional references to the typo "Makfile_org".
3. Jenkins tests all PASS.

RELEASE NOTE: Fixed typo "Makfile_org" to "Makefile_org" in chem/KPP/clean_kpp.