### PR TITLE
Filling aerssa2d/aerasy2d if sw = 5 and prescribed values from namelist

### DIFF
--- a/phys/module_ra_aerosol.F
+++ b/phys/module_ra_aerosol.F
@@ -256,6 +256,12 @@ subroutine calc_aerosol_goddard_sw(ht,dz8w,p,t3d,qv3d,aer_type,                 
              end do
           end do
 
+          do j = jts, jte
+             do i = its, ite
+                aerssa2d(i, j) = aer_ssa_val
+             end do
+          end do
+
        case(2)
           if (.not.(present(aerssa2d))) then
              write(wrf_err_message,*) &
@@ -327,6 +333,12 @@ subroutine calc_aerosol_goddard_sw(ht,dz8w,p,t3d,qv3d,aer_type,                 
                       asyaer(i,k,j,nb)=aer_asy_val
                    end do
                 end do
+             end do
+          end do
+
+          do j = jts, jte
+             do i = its, ite
+                aerasy2d(i, j) = aer_asy_val
              end do
           end do
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: aer_opt = 2, Goddard SW, single scattering albedo, asymmetry factor, prescribed aerosol optical properties from namelist.input

SOURCE: Pedro A. Jimenez and Ju Hye Kim (NCAR/RAL), and J. Dudhia (NCAR/MMM) 

DESCRIPTION OF CHANGES: Fill in aerssa2d and aerasy2d arrays if aer_opt = 2 and sw = 5 (Goddard shortwave parameterization) with the values imposed in the namelist via aer_ssa_opt = 1 and/or aer_asy_opt = 1 options. The variables aerssa2d and aerasy2d are always present for ARW so there is no concern with memory packaging. The filling of the variables is properly handled by RRTMG but not by the Goddard SW parameterization. Similarly to the RRTMG implementation, no special treatment for HWRF (e.g. ifdef) is necessary to fill in the variables. If the variables are not filled in, FARMS will not use the values specified in the namelist. Instead, FARMS will use zero values for the single scattering albedo (SSA) and the asymmetry factor (g) leading to an incorrect irradiance parameterization. 

LIST OF MODIFIED FILES: 
M       phys/module_ra_aerosol.F

TESTS CONDUCTED: 
1. Before the fix, aerssa2d and aerasy2d were zero. 
2. After the fix these arrays have the values specified in the namelist.
3. Jenkins test is all PASS

RELEASE NOTE: Bug fix for aer_opt =2 and Goddard SW radiation to fill in the 2D arrays with the aerosol optical properties (SSA and g) from namelist.input. The bug affects the FARMS output which will not properly account for either SSA or g (both values will be zero).
