### PR TITLE
FARMS can use climatological effective radius

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2999,7 +2999,7 @@ package   fasdas         grid_sfdda==2              -              state:u10_ndg
 package   aeropt1        aer_opt==1                 -              state:aerodm
 package   aeropt2        aer_opt==2                 -              state:aod5503d
 
-package   swintopt2      swint_opt==2               -              state:swdown2,swddni2,swddif2,swddir2,swdownc2,swddnic2
+package   swintopt2      swint_opt==2               -              state:swdown2,swddni2,swddif2,swddir2,swdownc2,swddnic2,re_cloud,re_ice,re_snow
 
 package   aercuopt       aercu_used==1              -              state:aeromcu,CU_UAF,EFCS,EFIS,EFSS,qr_cu,qs_cu,nc_cu,ni_cu,nr_cu,ns_cu,ccn_cu,aerovar;aerocu:cu_sulfate,cu_seasalt,cu_dust1,cu_dust2,cu_dust3,cu_dust4,cu_phoocar,cu_phiocar,cu_phobcar,cu_phibcar
 

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -902,6 +902,7 @@ CONTAINS
 #endif
          (config_flags%ra_lw_physics .eq. goddardlwscheme ) ) .and. &
        ( (config_flags%ra_sw_physics .eq. RRTMG_SWSCHEME ) .or. &
+         (config_flags%swint_opt .eq. 2 ) .or. &
 #if( BUILD_RRTMG_FAST == 1)
          (config_flags%ra_sw_physics .eq. RRTMG_SWSCHEME_FAST ) .or. &
 #endif

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -893,6 +893,7 @@ CONTAINS
    has_reqs = 0
    IF ( config_flags%use_mp_re .EQ. 1 ) THEN
    if (( (config_flags%ra_lw_physics .eq. RRTMG_LWSCHEME ) .or. &
+         (config_flags%swint_opt .eq. 2 ) .or. &
 #if( BUILD_RRTMG_FAST == 1)
          (config_flags%ra_lw_physics .eq. RRTMG_LWSCHEME_FAST ) .or. &
 #endif
@@ -942,10 +943,7 @@ CONTAINS
 ! for cloud, ice, and snow.
 
    IF ( config_flags%swint_opt .eq. 2 ) THEN
-      IF ( ( has_reqc .EQ. 1 ) .AND. &
-           ( has_reqi .EQ. 1 ) .AND. &
-           ( has_reqs .EQ. 1 ) .AND. &
-           ( f_qc            ) .AND. &
+      IF ( ( f_qc            ) .AND. &
            ( f_qi            ) .AND. &
            ( f_qs            ) ) THEN
          !  everything is A-OK for FARMS

--- a/phys/module_ra_farms.F
+++ b/phys/module_ra_farms.F
@@ -27,26 +27,29 @@
     real, parameter :: DE_CLOUD_MIN = 5.0, DE_CLOUD_MAX = 120.0
     real, parameter :: TAU_MIN = 0.0001, TAU_MAX = 300.0
     real, parameter :: AOD550_VAL = 0.12, ANGEXP_VAL = 1.3, AERSSA_VAL = 0.85, AERASY_VAL = 0.9
+    real, parameter :: RE_CLOUD_CLIM = 5.0 * 1.E-6, RE_ICE_CLIM = 10.0 * 1.E-6, RE_SNOW_CLIM = 10.0 * 1.E-6
 
   contains
 
     subroutine Farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte,  &
            p8w, rho, dz8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
            coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-           julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+           julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2, &
+           has_reqc, has_reqi, has_reqs)
 
       implicit None
 
       integer, intent(in) :: ims, ime, jms, jme, its, ite, jts, jte, kms, kme, &
           kts, kte
 
-      integer, intent(in) :: aer_opt
+      integer, intent(in) :: aer_opt, has_reqc, has_reqi, has_reqs
       real,    intent(in) :: julian
 
       real, dimension(ims:ime, jms:jme), intent(in) :: albedo, coszen_loc
 
       real, dimension(ims:ime, kms:kme, jms:jme ), intent(in) :: qv, qi, qs, qc, &
-          p8w, rho, dz8w, re_cloud, re_ice, re_snow 
+          p8w, rho, dz8w
+      real, dimension(ims:ime, kms:kme, jms:jme ), intent(inout) :: re_cloud, re_ice, re_snow 
 
       real, dimension(ims:ime, jms:jme), intent(inout) :: aerssa2d, aerasy2d, aod5502d, angexp2d
       real, dimension(ims:ime,jms:jme), intent(inout) :: swddir2, swdown2, &
@@ -70,6 +73,10 @@
              swdownc2(i, j) = 0.0
              swddnic2(i, j) = 0.0
            else
+             if (has_reqc == 0) re_cloud(i, :, j) = RE_CLOUD_CLIM
+             if (has_reqi == 0) re_ice(i, :, j) = RE_ICE_CLIM
+             if (has_reqs == 0) re_snow(i, :, j) = RE_SNOW_CLIM
+
              rhodz(:) = rho(i, :, j) * dz8w(i, :, j) / (1. + qv(i, :, j))
                ! PMW
              pmw = integrate_1var (rhodz, qv(i, :, j), kms, kme, kts, kte)

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2798,7 +2798,8 @@ CONTAINS
          call farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte, &
               p8w, rho, dz8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
               coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-              julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+              julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2, &
+              has_reqc, has_reqi, has_reqs)
        enddo
        !$OMP END PARALLEL DO
     end if


### PR DESCRIPTION
TYPE:  Enhancement

KEYWORDS: FARMS, climatological hydrometeor radius

SOURCE: Ju Hye Kim (NCAR/RAL), Jimy Dudhia (NCAR/MMM) and Pedro Jimenez (NCAR/RAL)

DESCRIPTION OF CHANGES: FARMS required the microphysics parameterization to provide the effective radius of the hydrometeors. If a given micrphysics parameterization does not provide the effective radius FARMS could not be used. To avoid this limitation we have enhanced FARMS to use climatological effective radius if the microphysics parameterization does not provide them. 

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       phys/module_physics_init.F
M       phys/module_ra_farms.F
M       phys/module_radiation_driver.F

TESTS CONDUCTED: We have tested that FARMS works when one uses the microphysics option 2. This microphysics does not provide effective radius so FARMS is using the climatological effective radius. Jenkins test is all PASS.

RELEASE NOTE: FARMS radiation parameterization uses climatological effective radius of the hydrometeors if the radius is not provided by the microphysics parameterization.