### PR TITLE
Implicit Explicit Vertical Advection (IEVA) scheme

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2621,7 +2621,7 @@ rconfig   integer scm_force_flux          namelist,scm  1       0           rh  
 rconfig   integer dyn_opt                 namelist,dynamics	1             2 
 rconfig   integer rk_ord                  namelist,dynamics	1             3       irh   "rk_order"               ""      ""
 rconfig   integer w_damping               namelist,dynamics	1             0       irh    "w_damping"             ""      ""
-rconfig   real    w_crit_cfl              namelist,dynamics 1             1.0     irh    "w_crit_cfl"           "maximum W-CFL where w-damping is now applied"      ""
+rconfig   real    w_crit_cfl              namelist,dynamics 1             1.2     irh    "w_crit_cfl"           "maximum W-CFL where w-damping is now applied"      ""
 rconfig   integer zadvect_implicit        namelist,dynamics 1             0       irh    "zadvect_implicit"     ""turns on adaptive implicit advection in vertical""
 # diff_opt 1=old diffusion, 2=new
 rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh    "diff_opt"              ""      ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2621,6 +2621,8 @@ rconfig   integer scm_force_flux          namelist,scm  1       0           rh  
 rconfig   integer dyn_opt                 namelist,dynamics	1             2 
 rconfig   integer rk_ord                  namelist,dynamics	1             3       irh   "rk_order"               ""      ""
 rconfig   integer w_damping               namelist,dynamics	1             0       irh    "w_damping"             ""      ""
+rconfig   real    w_crit_cfl              namelist,dynamics 1             1.0     irh    "w_crit_cfl"           "maximum W-CFL where w-damping is now applied"      ""
+rconfig   integer zadvect_implicit        namelist,dynamics 1             0       irh    "zadvect_implicit"     ""turns on adaptive implicit advection in vertical""
 # diff_opt 1=old diffusion, 2=new
 rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh    "diff_opt"              ""      ""
 # diff_opt_dfi is needed for backwards integration in dfi

--- a/dyn_em/Makefile
+++ b/dyn_em/Makefile
@@ -7,26 +7,27 @@ RM      =       rm -f
 
 MODULES =                 		\
         module_advect_em.o   		\
-	module_diffusion_em.o  		\
-	module_small_step_em.o 		\
+        module_ieva_em.o            \
+	  module_diffusion_em.o  		\
+	  module_small_step_em.o 		\
         module_big_step_utilities_em.o  \
         module_em.o         		\
         module_solvedebug_em.o    	\
         module_bc_em.o                  \
         module_init_utilities.o         \
         module_wps_io_arw.o             \
-	module_damping_em.o		\
-	module_polarfft.o		\
+	  module_damping_em.o		\
+	  module_polarfft.o		\
         module_force_scm.o              \
         module_first_rk_step_part1.o    \
         module_first_rk_step_part2.o    \
         module_avgflx_em.o              \
-	module_sfs_nba.o		\
+	  module_sfs_nba.o		\
         module_convtrans_prep.o         \
-	module_sfs_driver.o		\
-	module_stoch.o			\
-	module_after_all_rk_steps.o	\
-	$(CASE_MODULE)
+	  module_sfs_driver.o		\
+	  module_stoch.o			\
+	  module_after_all_rk_steps.o	\
+	  $(CASE_MODULE)
 
 # possible CASE_MODULE settings
 #	module_initialize_b_wave.o      \

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -10346,7 +10346,7 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
    DO i=i_start, i_end
 
 ! ----------------------------------------------------------------------------------------------
-! LJW
+! IEVA
 ! We need to correct for the partial divergence created by the IEVA scheme.
 ! If there is no implicit vertical advection, this term == 1.0.  
 ! Else, it rescales the qmax & qmin value to reflect the partial divergence present in both the

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -6106,8 +6106,8 @@ SUBROUTINE advect_scalar_pd   ( field, field_old, tendency,    &
 
    REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
                                                                       field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
+                                                                      ru,        &
+                                                                      rv,        &
                                                                       rom
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut, mub, mu_old
@@ -8553,17 +8553,17 @@ END SUBROUTINE advect_scalar_weno
 !---------------------------------------------------------------------------------
 
 SUBROUTINE advect_scalar_wenopd ( field, field_old, tendency,    &
-                                ru, rv, rom,                   &
-                                c1, c2,                        &
-                                mut, mub, mu_old,              &
-                                time_step, config_flags,       &
-                                msfux, msfuy, msfvx, msfvy,    &
-                                msftx, msfty,                  &
-                                fzm, fzp,                      &
-                                rdx, rdy, rdzw, dt,            &
-                                ids, ide, jds, jde, kds, kde,  &
-                                ims, ime, jms, jme, kms, kme,  &
-                                its, ite, jts, jte, kts, kte  )
+                                  ru, rv, rom,                   &
+                                  c1, c2,                        &
+                                  mut, mub, mu_old,              &
+                                  time_step, config_flags,       &
+                                  msfux, msfuy, msfvx, msfvy,    &
+                                  msftx, msfty,                  &
+                                  fzm, fzp,                      &
+                                  rdx, rdy, rdzw, dt,            &
+                                  ids, ide, jds, jde, kds, kde,  &
+                                  ims, ime, jms, jme, kms, kme,  &
+                                  its, ite, jts, jte, kts, kte  )
 
 !  this is a first cut at a positive definite advection option
 !  for scalars in WRF.  This version is memory intensive ->
@@ -8595,8 +8595,8 @@ SUBROUTINE advect_scalar_wenopd ( field, field_old, tendency,    &
 
    REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
                                                                       field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
+                                                                      ru,        &
+                                                                      rv,        &
                                                                       rom
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut, mub, mu_old
@@ -9476,7 +9476,7 @@ END SUBROUTINE advect_scalar_wenopd
 
 SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                                   h_tendency, z_tendency,        &
-                                  ru, rv, rom,                   &
+                                  ru, rv, rom, romI,             &
                                   c1, c2,                        &
                                   mut, mub, mu_old,              &
                                   config_flags,                  &
@@ -9512,8 +9512,9 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
 
    REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
                                                                       field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
+                                                                      ru,        &
+                                                                      rv,        &
+                                                                      romI,      &
                                                                       rom
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut, mub, mu_old
@@ -9544,7 +9545,7 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
    INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
    INTEGER :: jmin, jmax, jp, jm, imin, imax
 
-   REAL    :: mrdx, mrdy, ub, vb, uw, vw, mu
+   REAL    :: mrdx, mrdy, ub, vb, uw, vw, mu, ieva_corr
    REAL , DIMENSION(its:ite, kts:kte) :: vflux
 
 
@@ -10344,6 +10345,18 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
    DO k=kts, ktf
    DO i=i_start, i_end
 
+! ----------------------------------------------------------------------------------------------
+! LJW
+! We need to correct for the partial divergence created by the IEVA scheme.
+! If there is no implicit vertical advection, this term == 1.0.  
+! Else, it rescales the qmax & qmin value to reflect the partial divergence present in both the
+! low-order and high-order fluxes because the VV field is partioned.
+! ----------------------------------------------------------------------------------------------
+
+     ieva_corr = (c1(k)*mut(i,j)+c2(k))+dt*msfty(i,j)*rdzw(k)*(romI(i,k+1,j)-romI(i,k,j))
+
+! ----------------------------------------------------------------------------------------------
+
      ph_upwind = ((c1(k)*mub(i,j)+c2(k))+(c1(k)*mu_old(i,j)))*field_old(i,k,j)        &
                    - dt*( msftx(i,j)*msfty(i,j)*(               &
                           rdx*(fqxl(i+1,k,j)-fqxl(i,k,j)) +     &
@@ -10358,7 +10371,8 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                +msfty(i,j)*rdzw(k)*(  max(0.,fqz (i,k+1,j))      &
                                      -min(0.,fqz (i,k  ,j)) )   )
 
-     ph_hi = (c1(k)*mut(i,j)+c2(k))*qmax(i,k,j) - ph_upwind
+     ph_hi = ieva_corr*qmax(i,k,j) - ph_upwind
+
      IF( flux_in .gt. ph_hi ) scale_in(i,k,j) = max(0.,ph_hi/(flux_in+eps))
 
 
@@ -10369,8 +10383,9 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                                       -min(0.,fqy (i,k,j  )) ) )  &
                 +msfty(i,j)*rdzw(k)*(  min(0.,fqz (i,k+1,j))      &
                                       -max(0.,fqz (i,k  ,j)) )   )
+ 
+     ph_low = ph_upwind - ieva_corr*qmin(i,k,j)
 
-     ph_low = ph_upwind - (c1(k)*mut(i,j)+c2(k))*qmin(i,k,j)
      IF( flux_out .gt. ph_low ) scale_out(i,k,j) = max(0.,ph_low/(flux_out+eps))
 
    ENDDO

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2531,12 +2531,14 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    integer :: total
    REAL :: msfuxt , msfxffl
    
-   REAL    :: w_damp_on
-   REAL    :: w_crit_cfl = 2.0
-   REAL    :: w_flag_cfl = 1.2
-   LOGICAL :: print_flag = .true.
+   REAL    :: w_damp_on     = 1.0
+   REAL    :: w_crit_cfl    = 2.0
+   REAL    :: w_flag_cfl    = 1.2
+   LOGICAL :: wflags_differ = .false.
+   LOGICAL :: print_flag    = .true.
    SAVE    :: print_flag
-   INTEGER :: some1, some2
+   INTEGER :: some1         = 0     ! Now have two catagories of CFL information, hence some1 & some2
+   INTEGER :: some2         = 0
 
 !<DESCRIPTION>
 !
@@ -2586,19 +2588,21 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    itf=MIN(ite,ide-1)
    jtf=MIN(jte,jde-1)
 
-   some1 = 0    ! Now have two catagories of CFL information, hence (2) some(s)!
-   some2 = 0
-   max_vert_cfl = 0.
+   max_vert_cfl  = 0.
    max_horiz_cfl = 0.
    total = 0
 
    w_crit_cfl = config_flags%w_crit_cfl
 
+   IF( abs(w_crit_cfl - w_flag_cfl) > 0.1 ) THEN
+     wflags_differ = .true.
+   ELSE
+     wflags_differ = .false.
+   ENDIF
+
    IF( print_flag ) THEN
      write(wrf_err_message,*) '----------------------------------------'
      CALL wrf_debug( 0, wrf_err_message )
-     WRITE(temp,*) 'W-FLAGGING BEGINS AT W-COURANT NUMBER = ',w_flag_cfl
-     CALL wrf_debug ( 0 , TRIM(temp) )
      WRITE(temp,*) 'W-DAMPING  BEGINS AT W-COURANT NUMBER = ',w_crit_cfl
      CALL wrf_debug ( 0 , TRIM(temp) )
      write(wrf_err_message,*) '----------------------------------------'
@@ -2610,115 +2614,87 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
      msfxffl = 1.0/COS(config_flags%fft_filter_lat*degrad)
    END IF
 
-! There is a lot of redundant code due to wanting information whether w_damping is turned on or not.
-! I decided that instead of multiple blocks of nearly identical code - I would simple have a constant of
-! (0.0,1.0) if damping was on or off to turn things on and off and then execute the same code.
-! Since w_damping is almost always on for NWP application, the cost would be the same.
+! Routine has been reorganized to hopefully reduce redundant code while maintaining efficiency
 
-   IF ( config_flags%w_damping == 1 ) THEN
-
-     w_damp_on = 1.0
-
-   ELSE
- 
-     w_damp_on = 0.0
-
-   ENDIF
-
-!#ifdef OPTIMIZE_CFL_TEST
+#ifdef OPTIMIZE_CFL_TEST
 ! 20121025, L. Meadows vector optimization does not include special case for Cassini
-!    IF(config_flags%polar ) then
-!      CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
-!    END IF
-!endif
+
+   IF(config_flags%polar ) then
+     CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
+   END IF
+
+#endif
 
    DO j = jts,jtf
      DO k = 2,kde-1
        DO i = its,itf
 
-!#if 1
-!# ifdef OPTIMIZE_CFL_TEST
+         vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
+
+# ifdef OPTIMIZE_CFL_TEST
 ! L. Meadows, Intel, MIC optimization, 20121025
-!       msfuxt = msfux(i,j)
-!       vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-!       IF ( vert_cfl > max_vert_cfl ) THEN
-!          max_vert_cfl = vert_cfl
-!       ENDIF
-!# else
-!       IF(config_flags%polar ) then
-!          msfuxt = MIN(msfux(i,j), msfxffl)
-!       ELSE
-!          msfuxt = msfux(i,j)
-!       END IF
-!       vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-!
-!       IF ( vert_cfl > max_vert_cfl ) THEN
-!          max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
-!          maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-!       ENDIF
-!# endif
+
+         msfuxt = msfux(i,j)
+
+         IF ( vert_cfl > max_vert_cfl ) THEN
+            max_vert_cfl = vert_cfl
+         ENDIF
+# else
+         IF(config_flags%polar ) THEN
+            msfuxt = MIN(msfux(i,j), msfxffl)
+         ELSE
+            msfuxt = msfux(i,j)
+         ENDIF
+
+         IF ( vert_cfl > max_vert_cfl ) THEN
+            max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
+            maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
+         ENDIF
+# endif
         
-!       horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt),                          &
-!            abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
-!       if (horiz_cfl > max_horiz_cfl) then
-!          max_horiz_cfl = horiz_cfl
-!       endif
-!       
-!       if(vert_cfl .gt. w_beta)then
-!#else
-! restructure to get rid of divide
-!
-! This had been used for efficiency, but with the addition of returning the cfl values,
-!   the old version (above) was reinstated.  (T. Hutchinson, 3/5/2007)
-!
-!       cf_n = abs(ww(i,k,j)*rdnw(k)*dt)
-!       cf_d = abs((c1f(k)*mut(i,j)+c2f(k)))
-!       if(cf_n .gt. cf_d*w_beta )then
-!#endif
-!#ifndef OPTIMIZE_CFL_TEST
+         horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt     * dt),    &
+                          abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+
+         IF (horiz_cfl > max_horiz_cfl) THEN
+            max_horiz_cfl = horiz_cfl
+         ENDIF
+
+! Dump out more information without affecting performance
+        
+#ifndef OPTIMIZE_CFL_TEST
 ! This internal write is costly on newer Xeon processors because it breaks
 ! vectorization.  (J. Michalakes for L. Meadows at Intel, 12/13/2012)
-!          WRITE(temp,*)i,j,k,' vert_cfl,w,d(eta)=',vert_cfl,w(i,k,j),-1./rdnw(k)
-!          CALL wrf_debug ( 100 , TRIM(temp) )
-!#endif
-!          if ( vert_cfl > 2. ) some = some + 1
-!          rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_beta)*(c1f(k)*mut(i,j)+c2f(k))
-!       endif
 
+         IF (vert_cfl .gt. w_crit_cfl) THEN
 
-        IF(config_flags%polar ) THEN
-          msfuxt = MIN(msfux(i,j), msfxffl)
-        ELSE
-          msfuxt = msfux(i,j)
-        END IF
+           some1 = some1 + 1
 
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
+           WRITE(temp,FMT="(3(1x,i5,1x),'W-CRIT_CFL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") &
+                                         i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+           CALL wrf_debug ( 100 , TRIM(temp) )
 
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
-           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-        ENDIF
+         ENDIF
 
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt), abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+         IF ((vert_cfl .gt. w_flag_cfl) .and. wflags_differ) THEN
 
-        IF (horiz_cfl > max_horiz_cfl) THEN
-           max_horiz_cfl = horiz_cfl
-        ENDIF
+           some2 = some2 + 1
 
-        IF (vert_cfl > w_flag_cfl .and. vert_cfl < w_crit_cfl) THEN
-          WRITE(temp,FMT="(3(1x,i5,1x),'W_FLAG: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
-          CALL wrf_debug ( 100 , TRIM(temp) )
-          some2 = some2 + 1
-        ELSEIF(vert_cfl >= w_crit_cfl) THEN
-          WRITE(temp,FMT="(3(1x,i5,1x),'W-CRITICAL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
-          CALL wrf_debug ( 100 , TRIM(temp) )
-          some1 = some1 + 1
-          rw_tend(i,k,j) = rw_tend(i,k,j)-w_damp_on*sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_crit_cfl)*(c1f(k)*mut(i,j)+c2f(k))
-        ENDIF
+           WRITE(temp,FMT="(3(1x,i5,1x),'W-FLAG_CFL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") &
+                                         i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+           CALL wrf_debug ( 100 , TRIM(temp) )
 
-       ENDDO
-     ENDDO
-   ENDDO
+         ENDIF
+#endif
+
+         IF ((vert_cfl .gt. w_crit_cfl) .and. (config_flags%w_damping == 1) ) THEN
+
+           rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_crit_cfl)*(c1f(k)*mut(i,j)+c2f(k))
+
+         ENDIF
+
+       ENDDO   ! end i-loop
+     ENDDO   ! end k-loop
+   ENDDO   ! end j-loop
 
    IF ( some1 .GT. 0 ) THEN
      CALL get_current_time_string( time_str )
@@ -2727,14 +2703,14 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
             ' points exceeded W_CRITICAL_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
      CALL wrf_debug ( 0 , TRIM(temp) )
      WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'W-CFL: ',f7.2,2x,'dETA: ',f7.2))") &
-           maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
+                            maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
      CALL wrf_debug ( 0 , TRIM(temp) )
      WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'U-CFL: ',f7.2,2x,'V: ',f7.2,2x,'V-CFL: ',f7.2))") &
            maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
      CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF
 
-   IF ( some2 .GT. 0 .and. ((w_crit_cfl - w_flag_cfl) > 0.1) ) THEN   ! if the two flags are the same, some1 is only dumped
+   IF ( some2 .GT. 0 ) THEN   
      CALL get_current_time_string( time_str )
      CALL get_current_grid_name( grid_str )
      WRITE(temp,*) some2,                                            &

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2531,14 +2531,12 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    integer :: total
    REAL :: msfuxt , msfxffl
    
-! LJW BEGIN
    REAL    :: w_damp_on
    REAL    :: w_crit_cfl = 2.0
    REAL    :: w_flag_cfl = 1.2
    LOGICAL :: print_flag = .true.
    SAVE    :: print_flag
    INTEGER :: some1, some2
-! LJW END
 
 !<DESCRIPTION>
 !
@@ -2594,8 +2592,6 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    max_horiz_cfl = 0.
    total = 0
 
-! LJW BEGIN
-
    w_crit_cfl = config_flags%w_crit_cfl
 
    IF( print_flag ) THEN
@@ -2610,13 +2606,9 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
      print_flag = .false.
    ENDIF
 
-! LJW END
-
    IF(config_flags%polar ) then
      msfxffl = 1.0/COS(config_flags%fft_filter_lat*degrad)
    END IF
-
-! LJW BEGIN
 
 ! There is a lot of redundant code due to wanting information whether w_damping is turned on or not.
 ! I decided that instead of multiple blocks of nearly identical code - I would simple have a constant of
@@ -2643,9 +2635,6 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    DO j = jts,jtf
      DO k = 2,kde-1
        DO i = its,itf
-
-! LJW BEGIN COMMENT OUT
-! I doubt whether this old code is needed with newer compilers - so I commented it all out
 
 !#if 1
 !# ifdef OPTIMIZE_CFL_TEST
@@ -2696,9 +2685,6 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
 !          rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_beta)*(c1f(k)*mut(i,j)+c2f(k))
 !       endif
 
-! LJW END COMMENT OUT   
-
-! LJW BEGIN
 
         IF(config_flags%polar ) THEN
           msfuxt = MIN(msfux(i,j), msfxffl)

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2482,13 +2482,13 @@ END SUBROUTINE pg_buoy_w
 !-------------------------------------------------------------------------------
 
 SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
-                      u, v, ww, w, mut, c1f, c2f, rdnw, &
-                      rdx, rdy, msfux, msfuy,           &
-                      msfvx, msfvy, dt,                 &
-                      config_flags,                     &
-                      ids, ide, jds, jde, kds, kde,     &
-                      ims, ime, jms, jme, kms, kme,     &
-                      its, ite, jts, jte, kts, kte     )
+                   u, v, ww, w, mut, c1f, c2f, rdnw,    &
+                   rdx, rdy, msfux, msfuy,              &
+                   msfvx, msfvy, dt,                    &
+                   config_flags,                        &
+                   ids, ide, jds, jde, kds, kde,        &
+                   ims, ime, jms, jme, kms, kme,        &
+                   its, ite, jts, jte, kts, kte     )
 
    USE module_llxy
    IMPLICIT NONE
@@ -2523,7 +2523,6 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    REAL                :: vert_cfl, cf_n, cf_d, maxdub, maxdeta
 
    INTEGER :: itf, jtf, i, j, k, maxi, maxj, maxk
-   INTEGER :: some
    CHARACTER*512 :: temp
 
    CHARACTER (LEN=256) :: time_str
@@ -2532,9 +2531,18 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    integer :: total
    REAL :: msfuxt , msfxffl
    
+! LJW BEGIN
+   REAL    :: w_damp_on
+   REAL    :: w_crit_cfl = 2.0
+   REAL    :: w_flag_cfl = 1.2
+   LOGICAL :: print_flag = .true.
+   SAVE    :: print_flag
+   INTEGER :: some1, some2
+! LJW END
+
 !<DESCRIPTION>
 !
-!  w_damp computes a damping term for the vertical velocity when the
+!  W_damp computes a damping term for the vertical velocity when the
 !  vertical Courant number is too large.  This was found to be preferable to
 !  decreasing the timestep or increasing the diffusion in real-data applications
 !  that produced potentially-unstable large vertical velocities because of
@@ -2545,154 +2553,210 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
 !  horizontal motion.  These values are returned via the max_vert_cfl and
 !  max_horiz_cfl variables.  (Added by T. Hutchinson, WSI, 3/5/2007)
 !
+!-----
+!
+!  W_damp modified to be more flexible with IEVA capability. Two things changed.
+!  First, the value of the W-CFL where damping is turned on can now be set in the namelist
+!  using "w_crit_cfl".  Second, the code has been modified to report two levels of
+!  W-CFL information.  Previously, both damping and W-CFL information was
+!  printed at a W-CFL == 1.2.  This new capability does not need IEVA on to run.
+!
+!  We keep the old level reporting (for consistency), but use "w_flag_cfl" to flag 
+!  and print information from those points.  "w_flag_cfl" is set here in w_damp.  
+!  A second level of print occurs, which is useful for when we run
+!  IEVA, because many points can run with W-CFL > 1.2.  We now print this
+!  second level separately, as these points might make the model blow up.
+!  and where we now want Rayleigh damping turned on.  The default value "w_crit_cfl" 
+!  which replaced "w_beta" in the old code, is set in the namelist/Registery
+!  turn on w_damp at 1.2 consistent with the WRFV3/4 (before this) code.
+!
+!  Summary
+!  -------
+!  W_damp will write out CFL information when the vertical courant number is > w_flag_cfl,
+!  and W_damp will also turn on Rayleigh damping if vertical courant number > w_crit_cfl.
+!
+!  Typical settings for non-IEVA use:  w_crit_cfl = 1.2
+!  Typical settings for     IEVA use:  w_crit_cfl = 2.0
+!
+!  I also commented out a lot of code put in 8-13 years ago for timing assuming that
+!  this is no longer needed....there is some pretty hacky stuff.  HTH.
+!
+!      (Added by L. Wicker, NSSL, 5/4/2020)
+!
 !</DESCRIPTION>
 
    itf=MIN(ite,ide-1)
    jtf=MIN(jte,jde-1)
 
-   some = 0
+   some1 = 0    ! Now have two catagories of CFL information, hence (2) some(s)!
+   some2 = 0
    max_vert_cfl = 0.
    max_horiz_cfl = 0.
    total = 0
+
+! LJW BEGIN
+
+   w_crit_cfl = config_flags%w_crit_cfl
+
+   IF( print_flag ) THEN
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 0, wrf_err_message )
+     WRITE(temp,*) 'W-FLAGGING BEGINS AT W-COURANT NUMBER = ',w_flag_cfl
+     CALL wrf_debug ( 0 , TRIM(temp) )
+     WRITE(temp,*) 'W-DAMPING  BEGINS AT W-COURANT NUMBER = ',w_crit_cfl
+     CALL wrf_debug ( 0 , TRIM(temp) )
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 0, wrf_err_message )
+     print_flag = .false.
+   ENDIF
+
+! LJW END
 
    IF(config_flags%polar ) then
      msfxffl = 1.0/COS(config_flags%fft_filter_lat*degrad)
    END IF
 
+! LJW BEGIN
+
+! There is a lot of redundant code due to wanting information whether w_damping is turned on or not.
+! I decided that instead of multiple blocks of nearly identical code - I would simple have a constant of
+! (0.0,1.0) if damping was on or off to turn things on and off and then execute the same code.
+! Since w_damping is almost always on for NWP application, the cost would be the same.
+
    IF ( config_flags%w_damping == 1 ) THEN
-#ifdef OPTIMIZE_CFL_TEST
+
+     w_damp_on = 1.0
+
+   ELSE
+ 
+     w_damp_on = 0.0
+
+   ENDIF
+
+!#ifdef OPTIMIZE_CFL_TEST
 ! 20121025, L. Meadows vector optimization does not include special case for Cassini
-     IF(config_flags%polar ) then
-       CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
-     END IF
-#endif
+!    IF(config_flags%polar ) then
+!      CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
+!    END IF
+!endif
 
-     DO j = jts,jtf
+   DO j = jts,jtf
+     DO k = 2,kde-1
+       DO i = its,itf
 
-     DO k = 2, kde-1
-     DO i = its,itf
-#if 1
-# ifdef OPTIMIZE_CFL_TEST
+! LJW BEGIN COMMENT OUT
+! I doubt whether this old code is needed with newer compilers - so I commented it all out
+
+!#if 1
+!# ifdef OPTIMIZE_CFL_TEST
 ! L. Meadows, Intel, MIC optimization, 20121025
-        msfuxt = msfux(i,j)
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl
-        ENDIF
-# else
-        IF(config_flags%polar ) then
-           msfuxt = MIN(msfux(i,j), msfxffl)
-        ELSE
-           msfuxt = msfux(i,j)
-        END IF
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
-           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-        ENDIF
-# endif
+!       msfuxt = msfux(i,j)
+!       vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
+!       IF ( vert_cfl > max_vert_cfl ) THEN
+!          max_vert_cfl = vert_cfl
+!       ENDIF
+!# else
+!       IF(config_flags%polar ) then
+!          msfuxt = MIN(msfux(i,j), msfxffl)
+!       ELSE
+!          msfuxt = msfux(i,j)
+!       END IF
+!       vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
+!
+!       IF ( vert_cfl > max_vert_cfl ) THEN
+!          max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
+!          maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
+!       ENDIF
+!# endif
         
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt),                          &
-             abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
-        if (horiz_cfl > max_horiz_cfl) then
-           max_horiz_cfl = horiz_cfl
-        endif
-        
-        if(vert_cfl .gt. w_beta)then
-#else
+!       horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt),                          &
+!            abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+!       if (horiz_cfl > max_horiz_cfl) then
+!          max_horiz_cfl = horiz_cfl
+!       endif
+!       
+!       if(vert_cfl .gt. w_beta)then
+!#else
 ! restructure to get rid of divide
 !
 ! This had been used for efficiency, but with the addition of returning the cfl values,
 !   the old version (above) was reinstated.  (T. Hutchinson, 3/5/2007)
 !
-        cf_n = abs(ww(i,k,j)*rdnw(k)*dt)
-        cf_d = abs((c1f(k)*mut(i,j)+c2f(k)))
-        if(cf_n .gt. cf_d*w_beta )then
-#endif
-#ifndef OPTIMIZE_CFL_TEST
+!       cf_n = abs(ww(i,k,j)*rdnw(k)*dt)
+!       cf_d = abs((c1f(k)*mut(i,j)+c2f(k)))
+!       if(cf_n .gt. cf_d*w_beta )then
+!#endif
+!#ifndef OPTIMIZE_CFL_TEST
 ! This internal write is costly on newer Xeon processors because it breaks
 ! vectorization.  (J. Michalakes for L. Meadows at Intel, 12/13/2012)
-           WRITE(temp,*)i,j,k,' vert_cfl,w,d(eta)=',vert_cfl,w(i,k,j),-1./rdnw(k)
-           CALL wrf_debug ( 100 , TRIM(temp) )
-#endif
-           if ( vert_cfl > 2. ) some = some + 1
-           rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_beta)*(c1f(k)*mut(i,j)+c2f(k))
-        endif
-     END DO
-     ENDDO
-     ENDDO
-   ELSE
-! just print
-     DO j = jts,jtf
+!          WRITE(temp,*)i,j,k,' vert_cfl,w,d(eta)=',vert_cfl,w(i,k,j),-1./rdnw(k)
+!          CALL wrf_debug ( 100 , TRIM(temp) )
+!#endif
+!          if ( vert_cfl > 2. ) some = some + 1
+!          rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_beta)*(c1f(k)*mut(i,j)+c2f(k))
+!       endif
 
-     DO k = 2, kde-1
-     DO i = its,itf
+! LJW END COMMENT OUT   
 
-#if 1
-# ifdef OPTIMIZE_CFL_TEST
-        msfuxt = msfux(i,j)
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl
-        ENDIF
-# else
-! L. Meadows MIC optimization, 20121025
-        IF(config_flags%polar ) then
-           msfuxt = MIN(msfux(i,j), msfxffl)
+! LJW BEGIN
+
+        IF(config_flags%polar ) THEN
+          msfuxt = MIN(msfux(i,j), msfxffl)
         ELSE
-           msfuxt = msfux(i,j)
+          msfuxt = msfux(i,j)
         END IF
+
         vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-        
+
         IF ( vert_cfl > max_vert_cfl ) THEN
            max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
            maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
         ENDIF
-# endif
-        
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt),                          &
-             abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
 
-        if (horiz_cfl > max_horiz_cfl) then
+        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt), abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+
+        IF (horiz_cfl > max_horiz_cfl) THEN
            max_horiz_cfl = horiz_cfl
-        endif
-        
-        if(vert_cfl .gt. w_beta)then
-#else
-! restructure to get rid of divide
-!
-! This had been used for efficiency, but with the addition of returning the cfl values,
-!   the old version (above) was reinstated.  (T. Hutchinson, 3/5/2007)
-!
-        cf_n = abs(ww(i,k,j)*rdnw(k)*dt)
-        cf_d = abs((c1f(k)*mut(i,j)+c2f(k)))
-        if(cf_n .gt. cf_d*w_beta )then
-#endif
-#ifndef OPTIMIZE_CFL_TEST
-           WRITE(temp,*)i,j,k,' vert_cfl,w,d(eta)=',vert_cfl,w(i,k,j),-1./rdnw(k)
-           CALL wrf_debug ( 100 , TRIM(temp) )
-#endif
-           if ( vert_cfl > 2. ) some = some + 1
-        endif
-     END DO
+        ENDIF
+
+        IF (vert_cfl > w_flag_cfl .and. vert_cfl < w_crit_cfl) THEN
+          WRITE(temp,FMT="(3(1x,i5,1x),'W_FLAG: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+          CALL wrf_debug ( 100 , TRIM(temp) )
+          some2 = some2 + 1
+        ELSEIF(vert_cfl >= w_crit_cfl) THEN
+          WRITE(temp,FMT="(3(1x,i5,1x),'W-CRITICAL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+          CALL wrf_debug ( 100 , TRIM(temp) )
+          some1 = some1 + 1
+          rw_tend(i,k,j) = rw_tend(i,k,j)-w_damp_on*sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_crit_cfl)*(c1f(k)*mut(i,j)+c2f(k))
+        ENDIF
+
+       ENDDO
      ENDDO
-     ENDDO
-   ENDIF
-   IF ( some .GT. 0 ) THEN
+   ENDDO
+
+   IF ( some1 .GT. 0 ) THEN
      CALL get_current_time_string( time_str )
      CALL get_current_grid_name( grid_str )
-     WRITE(temp,*)some,                                            &
-            ' points exceeded cfl=2 in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+     WRITE(temp,*) some1,                                            &
+            ' points exceeded W_CRITICAL_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
      CALL wrf_debug ( 0 , TRIM(temp) )
-#ifndef OPTIMIZE_CFL_TEST
-     WRITE(temp,*)'MAX AT i,j,k: ',maxi,maxj,maxk,' vert_cfl,w,d(eta)=',max_vert_cfl, &
-                             maxdub,maxdeta
+     WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'W-CFL: ',f7.2,2x,'dETA: ',f7.2))") &
+           maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
      CALL wrf_debug ( 0 , TRIM(temp) )
-#endif
+     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'U-CFL: ',f7.2,2x,'V: ',f7.2,2x,'V-CFL: ',f7.2))") &
+           maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
+     CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF
 
-END SUBROUTINE w_damp
+   IF ( some2 .GT. 0 .and. ((w_crit_cfl - w_flag_cfl) > 0.1) ) THEN   ! if the two flags are the same, some1 is only dumped
+     CALL get_current_time_string( time_str )
+     CALL get_current_grid_name( grid_str )
+     WRITE(temp,*) some2,                                            &
+            ' points exceeded W_FLAG_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+     CALL wrf_debug ( 0 , TRIM(temp) )
+   ENDIF
+
+END SUBROUTINE W_DAMP
 
 !-------------------------------------------------------------------------------
 

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -301,7 +301,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                                                     mub,     &
                                                                     muu,     &
                                                                     muv,     &
-                                                                    ht             ! added LJW IEVA
+                                                                    ht             
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fnm,     &
                                                                   fnp,     &
@@ -341,7 +341,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    INTEGER :: rk_order
    REAL    :: dt_step
 
- ! LJW IEVA declarations
+! IEVA declarations
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
    REAL , DIMENSION( ims:ime , jms:jme )         :: mut_old, mut_new                                                              
    LOGICAL                                       :: ieva
@@ -431,7 +431,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    rk_order = config_flags%rk_ord
    dt_step  = dt / (rk_order - rk_step + 1)   ! needed for calculations using sub-rk step
 
-! LJW IEVA
+! IEVA
    
    ieva = CHK_IEVA( config_flags, rk_step ) 
 
@@ -1074,7 +1074,7 @@ END SUBROUTINE rk_addtend_dry
 SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                             tenddec,                         &
                             rk_step, dt_step,                &
-                            ru, rv, ww, u,  v,  w,           &  ! LJW IEVA
+                            ru, rv, ww, u,  v,  w,           &  
                             mut, mub, mu_old,                &
                             c1h, c2h, alt,                   &
                             scalar_old, scalar,              &
@@ -1172,7 +1172,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
    REAL    :: khdq, kvdq, tendency
 
- ! LJW IEVA variables
+! IEVA variables
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
    LOGICAL                                      :: ieva
 
@@ -1189,7 +1189,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    rk_order = config_flags%rk_ord
    dt       = dt_step * (rk_order - rk_step + 1)    ! need large time step
 
-! LJW IEVA
+! IEVA
                          
    ieva = CHK_IEVA( config_flags, rk_step )
 
@@ -1203,7 +1203,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                  ims, ime, jms, jme, kms, kme,     &
                  its, ite, jts, jte, kts, kte )             
                  
-! END LJW IEVA
+! IEVA
 
    CALL nl_get_time_step ( 1, time_step )
 

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -16,7 +16,7 @@ MODULE module_em
         sixth_order_diffusion, rk_rayleigh_damp, theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
   
   USE module_ieva_em, only: advect_u_implicit, advect_v_implicit, advect_w_implicit, advect_s_implicit, advect_ph_implicit, &
-                            chk_ieva, ww_split, w_damp2, calc_mut_new
+                            chk_ieva, ww_split, calc_mut_new
   
   USE module_state_description, only: param_first_scalar, p_qr, p_qv, p_qc, p_qg, p_qi, p_qs, tiedtkescheme,ntiedtkescheme, heldsuarez, &
         positivedef, gdscheme, g3scheme, gfscheme, kfetascheme, mskfscheme, monotonic, wenopd_scalar, weno_scalar, weno_mom

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -11,12 +11,14 @@ MODULE module_em
    
    USE module_big_step_utilities_em, only: grid_config_rec_type, calculate_full, couple_momentum, calc_mu_uv, calc_ww_cp, &
         calc_cq, calc_alt, calc_php, set_tend, rhs_ph, &
-    horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
-        horizontal_diffusion_3dmp, vertical_diffusion_u, &
- vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, sixth_order_diffusion, rk_rayleigh_damp, &
-        theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
-
-   USE module_state_description, only: param_first_scalar, p_qr, p_qv, p_qc, p_qg, p_qi, p_qs, tiedtkescheme,ntiedtkescheme, heldsuarez, &
+        horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
+        horizontal_diffusion_3dmp, vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, &
+        sixth_order_diffusion, rk_rayleigh_damp, theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
+  
+  USE module_ieva_em, only: advect_u_implicit, advect_v_implicit, advect_w_implicit, advect_s_implicit, advect_ph_implicit, &
+                            chk_ieva, ww_split, w_damp2, calc_mut_new
+  
+  USE module_state_description, only: param_first_scalar, p_qr, p_qv, p_qc, p_qg, p_qi, p_qs, tiedtkescheme,ntiedtkescheme, heldsuarez, &
         positivedef, gdscheme, g3scheme, gfscheme, kfetascheme, mskfscheme, monotonic, wenopd_scalar, weno_scalar, weno_mom
 
    USE module_damping_em, only: held_suarez_damp
@@ -195,8 +197,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                          u, v, w, t, ph,                                  &
                          u_old, v_old, w_old, t_old, ph_old,              &
                          h_diabatic, phb,t_init,                          &
-                         mu, mut, muu, muv, mub, c1h, c2h, c1f, c2f,      &
-                         al, alt, p, pb, php, cqu, cqv, cqw,              &
+                         mu_old, mu, mut, muu, muv, mub,                  &
+                         c1h, c2h, c1f, c2f,                              &
+                         al, ht, alt, p, pb, php, cqu, cqv, cqw,          &
                          u_base, v_base, t_base, qv_base, z_base,         &
                          msfux, msfuy, msfvx, msfvx_inv,                  &
                          msfvy, msftx, msfty,                             &
@@ -292,11 +295,13 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                                                     e,       &
                                                                     sina,    &
                                                                     cosa,    &
+                                                                    mu_old,  &
                                                                     mu,      &
                                                                     mut,     &
                                                                     mub,     &
                                                                     muu,     &
-                                                                    muv
+                                                                    muv,     &
+                                                                    ht             ! added LJW IEVA
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fnm,     &
                                                                   fnp,     &
@@ -314,7 +319,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
    REAL ,                                      INTENT(IN   ) :: rdx,     &
                                                                 rdy,     &
-                                                                dt,      &
+                                                                dt,      &    ! this is the large time step
                                                                 u_frame, &
                                                                 v_frame, &
                                                                 khdif,   &
@@ -333,7 +338,14 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    REAL    :: kdift, khdq, kvdq, cfn, cfn1, cf1, cf2, cf3
    INTEGER :: i,j,k
    INTEGER :: time_step
+   INTEGER :: rk_order
+   REAL    :: dt_step
 
+ ! LJW IEVA declarations
+   REAL , DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
+   REAL , DIMENSION( ims:ime , jms:jme )         :: mut_old, mut_new                                                              
+   LOGICAL                                       :: ieva
+   
 !<DESCRIPTION>
 !
 !  rk_tendency computes the large-timestep tendency terms in the
@@ -414,109 +426,182 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                     ims, ime, jms, jme, 1, 1, &
                     its, ite, jts, jte, 1, 1 )
 
-   !  advection tendencies
    CALL nl_get_time_step ( 1, time_step )
 
+   rk_order = config_flags%rk_ord
+   dt_step  = dt / (rk_order - rk_step + 1)   ! needed for calculations using sub-rk step
 
-    IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
+! LJW IEVA
+   
+   ieva = CHK_IEVA( config_flags, rk_step ) 
 
-     CALL advect_weno_u ( u, u , ru_tend, ru, rv, ww, &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
+! Need an estimate of the mut at the n time level...
 
-     ELSE
+   CALL calculate_full( mut_old, mub, mu_old,     &
+                        ids, ide, jds, jde, 1, 2, &
+                        ims, ime, jms, jme, 1, 1, &
+                        its, ite, jts, jte, 1, 1 )
+                        
+! Estimate new temporary column mass
+                        
+   CALL calc_mut_new ( u, v, c1h, c2h,                      &
+                       mut_old, muu, muv, mut_new,          &
+                       dt, rdx, rdy, msftx, msfty,          &
+                       msfux, msfuy, msfvx, msfvx_inv,      &
+                       msfvy, rdnw,                         &
+                       ids, ide, jds, jde, kds, kde,        &
+                       ims, ime, jms, jme, kms, kme,        &
+                       its, ite, jts, jte, kts, kte    )
+                         
+! Code for splitting vertical velocity into ex/im parts
+
+   CALL WW_SPLIT(wwE, wwI, ph, phb,                &
+                 u, v, ww, w, mut, rdnw, msfty,    &
+                 c1f, c2f,                         &
+                 rdx, rdy, msfux, msfuy,           &
+                 msfvx, msfvy, dt,                 &
+                 config_flags, rk_step,            &
+                 ids, ide, jds, jde, kds, kde,     &
+                 ims, ime, jms, jme, kms, kme,     &
+                 its, ite, jts, jte, kts, kte )              
+
+! Okay do normal advection now....using the wwE array
+
+   IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+
+     CALL advect_weno_u ( u, u , ru_tend, ru, rv, wwE,  &
+                          c1h, c2h,                     &
+                          mut, time_step, config_flags, &
+                          msfux, msfuy, msfvx, msfvy,   &
+                          msftx, msfty,                 &
+                          fnm, fnp, rdx, rdy, rdnw,     &
+                          ids, ide, jds, jde, kds, kde, &
+                          ims, ime, jms, jme, kms, kme, &
+                          its, ite, jts, jte, kts, kte )
+
+   ELSE
      
-     CALL advect_u ( u, u , ru_tend, ru, rv, ww, &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
-      ENDIF
+     CALL advect_u ( u, u , ru_tend, ru, rv, wwE,  &
+                     c1h, c2h,                     &
+                     mut, time_step, config_flags, &
+                     msfux, msfuy, msfvx, msfvy,   &
+                     msftx, msfty,                 &
+                     fnm, fnp, rdx, rdy, rdnw,     &
+                     ids, ide, jds, jde, kds, kde, &
+                     ims, ime, jms, jme, kms, kme, &
+                     its, ite, jts, jte, kts, kte )
+   ENDIF
 
-     IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
+   IF( ieva ) THEN
 
-     CALL advect_weno_v ( v, v , rv_tend, ru, rv, ww,  &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
+     CALL advect_u_implicit ( u, u_old, ru_tend, ru, rv, wwI,  &
+                              c1h, c2h,                        &
+                              mut_old, mut, mut_new,           &
+                              config_flags,                    &
+                              msfux, msfuy, msfvx, msfvy,      &
+                              msftx, msfty,                    &
+                              fnm, fnp,                        &
+                              dt_step,                         &
+                              rdx, rdy, rdnw,                  &
+                              ids, ide, jds, jde, kds, kde,    &
+                              ims, ime, jms, jme, kms, kme,    &
+                              its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+
+      CALL advect_weno_v ( v, v , rv_tend, ru, rv, wwE,  &
+                           c1h, c2h,                     &
+                           mut, time_step, config_flags, &
+                           msfux, msfuy, msfvx, msfvy,   &
+                           msftx, msfty,                 &
+                           fnm, fnp, rdx, rdy, rdnw,     &
+                           ids, ide, jds, jde, kds, kde, &
+                           ims, ime, jms, jme, kms, kme, &
+                           its, ite, jts, jte, kts, kte )
+
+   ELSE
+     
+    CALL advect_v ( v, v , rv_tend, ru, rv, wwE,  &
+                    c1h, c2h,                     &
+                    mut, time_step, config_flags, &
+                    msfux, msfuy, msfvx, msfvy,   &
+                    msftx, msfty,                 &
+                    fnm, fnp, rdx, rdy, rdnw,     &
+                    ids, ide, jds, jde, kds, kde, &
+                    ims, ime, jms, jme, kms, kme, &
+                    its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF( ieva ) THEN
+     
+     CALL advect_v_implicit ( v, v_old, rv_tend, ru, rv, wwI,  &
+                              c1h, c2h,                        &
+                              mut_old, mut, mut_new,           &
+                              config_flags,                    &
+                              msfux, msfuy, msfvx, msfvy,      &
+                              msftx, msfty,                    &
+                              fnm, fnp,                        &
+                              dt_step,                         &
+                              rdx, rdy, rdnw,                  &
+                              ids, ide, jds, jde, kds, kde,    &
+                              ims, ime, jms, jme, kms, kme,    &
+                              its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF (non_hydrostatic) THEN
+   
+    IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+     
+      CALL advect_weno_w ( w, w, rw_tend, ru, rv, wwE,    &
+                            c1h, c2h,                     &
+                            mut, time_step, config_flags, &
+                            msfux, msfuy, msfvx, msfvy,   &
+                            msftx, msfty,                 &
+                            fnm, fnp, rdx, rdy, rdn,      &
+                            ids, ide, jds, jde, kds, kde, &
+                            ims, ime, jms, jme, kms, kme, &
+                            its, ite, jts, jte, kts, kte )
 
     ELSE
      
-     CALL advect_v ( v, v , rv_tend, ru, rv, ww,  &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
+      CALL advect_w ( w, w, rw_tend, ru, rv, wwE,   &
+                      c1h, c2h,                     &
+                      mut, time_step, config_flags, &
+                      msfux, msfuy, msfvx, msfvy,   &
+                      msftx, msfty,                 &
+                      fnm, fnp, rdx, rdy, rdn,      &
+                      ids, ide, jds, jde, kds, kde, &
+                      ims, ime, jms, jme, kms, kme, &
+                      its, ite, jts, jte, kts, kte )
     ENDIF
-
-
-   IF (non_hydrostatic) THEN
-     IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
-     CALL advect_weno_w ( w, w, rw_tend, ru, rv, ww,    &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdn,      &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
-
-     ELSE
-     
-     CALL advect_w ( w, w, rw_tend, ru, rv, ww,    &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdn,      &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
-     ENDIF
-   ENDIF
+    
+   ENDIF  ! Non-Hydrostatic
+   
 !  theta flux divergence
 
 ! 11/2016 ERM: Use WENO for theta flux on 3rd RK step if using WENO_SCALAR or WENOPD_SCALAR
 ! to be consistent with other scalar fluxes
-      IF(  ( config_flags%scalar_adv_opt == WENO_SCALAR  &
-                 .or. config_flags%scalar_adv_opt == WENOPD_SCALAR    &
-                 .or. config_flags%moist_adv_opt == WENO_SCALAR       &
-                 .or. config_flags%moist_adv_opt == WENOPD_SCALAR     &
-                       )  .and. (rk_step == 3) ) THEN
+   IF(  ( config_flags%scalar_adv_opt == WENO_SCALAR      &
+     .or. config_flags%scalar_adv_opt == WENOPD_SCALAR    &
+     .or. config_flags%moist_adv_opt == WENO_SCALAR       &
+     .or. config_flags%moist_adv_opt == WENOPD_SCALAR )    &
+     .and. (rk_step == rk_order) ) THEN
+     
 ! also use weno for monotonic scalar option so that the h_ and z_tendency arrays are not needed
 
-        CALL advect_scalar_weno ( t, t, t_tend, ru, rv, ww,     &
-                                 c1h, c2h, mut, time_step,      &
-                                 config_flags,                  &
-                                 msfux, msfuy, msfvx, msfvy,    &
-                                 msftx, msfty, fnm, fnp,        &
-                                 rdx, rdy, rdnw,                &
-                                 ids, ide, jds, jde, kds, kde,  &
-                                 ims, ime, jms, jme, kms, kme,  &
-                                 its, ite, jts, jte, kts, kte  )
-     ELSE
+     CALL advect_scalar_weno ( t, t, t_tend, ru, rv, wwE,    &
+                              c1h, c2h, mut, time_step,      &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty, fnm, fnp,        &
+                              rdx, rdy, rdnw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+   ELSE
 
-     CALL advect_scalar ( t, t, t_tend, ru, rv, ww,     &
+     CALL advect_scalar ( t, t, t_tend, ru, rv, wwE,    &
                           c1h, c2h,                     &
                           mut, time_step, config_flags, &
                           msfux, msfuy, msfvx, msfvy,   &
@@ -526,23 +611,40 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           ims, ime, jms, jme, kms, kme, &
                           its, ite, jts, jte, kts, kte )
 
-     ENDIF
-     
-     IF ( config_flags%cu_physics == GDSCHEME  .OR.     &
-          config_flags%cu_physics == GFSCHEME  .OR.     &
-          config_flags%cu_physics == G3SCHEME  .OR.     &
-          config_flags%cu_physics == NTIEDTKESCHEME )  THEN     ! NTiedtke
+   ENDIF
+   
+   IF( ieva ) THEN
+      
+     CALL advect_s_implicit ( t, t_old, t_tend, ru, rv, wwI,  &
+                              c1h, c2h,                       &
+                              mut_old, mut, mut_new,          &
+                              config_flags,                   &
+                              msfux, msfuy, msfvx, msfvy,     &
+                              msftx, msfty,                   &
+                              fnm, fnp,                       &
+                              dt_step,                        &
+                              rdx, rdy, rdnw,                 &
+                              ids, ide, jds, jde, kds, kde,   &
+                              ims, ime, jms, jme, kms, kme,   &
+                              its, ite, jts, jte, kts, kte )
 
-     ! theta advection only:
+   ENDIF
+   
+   IF ( config_flags%cu_physics == GDSCHEME  .OR.     &
+        config_flags%cu_physics == GFSCHEME  .OR.     &
+        config_flags%cu_physics == G3SCHEME  .OR.     &
+        config_flags%cu_physics == NTIEDTKESCHEME )  THEN     ! NTiedtke
 
-         CALL set_tend( RTHFTEN, t_tend, msfty,          &
-                        ids, ide, jds, jde, kds, kde,    &
-                        ims, ime, jms, jme, kms, kme,    &
-                        its, ite, jts, jte, kts, kte     )
+  ! theta advection only:
 
-     END IF
+      CALL set_tend( RTHFTEN, t_tend, msfty,          &
+                     ids, ide, jds, jde, kds, kde,    &
+                     ims, ime, jms, jme, kms, kme,    &
+                     its, ite, jts, jte, kts, kte     )
 
-     CALL rhs_ph( ph_tend, u, v, ww, ph, ph, phb, w, &
+   ENDIF  ! cu_physics scheme
+
+     CALL rhs_ph( ph_tend, u, v, wwE, ph, ph, phb, w, &
                   mut, muu, muv,                     &
                   c1f, c2f,                          &
                   fnm, fnp,                          &
@@ -556,6 +658,41 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                   ims, ime, jms, jme, kms, kme,      &
                   its, ite, jts, jte, kts, kte      )
 
+    IF( ieva ) THEN
+      
+        CALL advect_ph_implicit ( ph, ph_old, ph_tend, phb,       &
+                                  ru, rv, wwE, wwI, w,            & 
+                                  c1f, c2f,                       &
+                                  mut, config_flags,              &
+                                  msfux, msfuy, msfvx, msfvy,     &
+                                  msftx, msfty,                   &
+                                  fnm, fnp,                       &
+                                  dt_step,                        &
+                                  rdx, rdy, rdnw,                 &
+                                  ids, ide, jds, jde, kds, kde,   &
+                                  ims, ime, jms, jme, kms, kme,   &
+                                  its, ite, jts, jte, kts, kte )
+
+     IF (non_hydrostatic) THEN
+      
+       CALL advect_w_implicit ( w, w_old, rw_tend,              &
+                                ru_tend, rv_tend, ht, wwI,      &
+                                ph, ph_old, ph_tend,            &
+                                c1f, c2f, cf1, cf2, cf3,        &
+                                mut_old, mut, mut_new,          &
+                                config_flags,                   &
+                                msfux, msfuy, msfvx, msfvy,     &
+                                msftx, msfty,                   &
+                                fnm, fnp,                       &
+                                dt_step,                        &
+                                rdx, rdy, rdn,                  &
+                                ids, ide, jds, jde, kds, kde,   &
+                                ims, ime, jms, jme, kms, kme,   &
+                                its, ite, jts, jte, kts, kte )
+     ENDIF
+     
+   ENDIF  ! IEVA
+      
      CALL horizontal_pressure_gradient( ru_tend,rv_tend,                 &
                                          ph,alt,p,pb,al,php,cqu,cqv,     &
                                          muu,muv,mu,c1h,c2h,fnm,fnp,rdnw,&
@@ -577,14 +714,14 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           its, ite, jts, jte, kts, kte   )
      ENDIF
 
-     CALL w_damp   ( rw_tend, max_vert_cfl,             &
-                      max_horiz_cfl,                    &
-                      u, v, ww, w, mut, c1f, c2f, rdnw, &
-                      rdx, rdy, msfux, msfuy, msfvx,    &
-                      msfvy, dt, config_flags,          &
-                      ids, ide, jds, jde, kds, kde,     &
-                      ims, ime, jms, jme, kms, kme,     &
-                      its, ite, jts, jte, kts, kte     )
+     CALL w_damp   ( rw_tend, max_vert_cfl,            &
+                     max_horiz_cfl,                    &
+                     u, v, ww, w, mut, c1f, c2f, rdnw, &
+                     rdx, rdy, msfux, msfuy, msfvx,    &
+                     msfvy, dt, config_flags,          &
+                     ids, ide, jds, jde, kds, kde,     &
+                     ims, ime, jms, jme, kms, kme,     &
+                     its, ite, jts, jte, kts, kte     )
 
      IF(config_flags%pert_coriolis) THEN
 
@@ -935,9 +1072,10 @@ END SUBROUTINE rk_addtend_dry
 !-------------------------------------------------------------------------------
 
 SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
-                            tenddec,                        &
-                            rk_step, dt,                     &
-                            ru, rv, ww, mut, mub, mu_old,    &
+                            tenddec,                         &
+                            rk_step, dt_step,                &
+                            ru, rv, ww, u,  v,  w,           &  ! LJW IEVA
+                            mut, mub, mu_old,                &
                             c1h, c2h, alt,                   &
                             scalar_old, scalar,              &
                             scalar_tends, advect_tend,       &
@@ -985,6 +1123,9 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,  &
                                                                       rv,  &
                                                                       ww,  &
+                                                                      u,   &
+                                                                      v,   &
+                                                                      w,   &
                                                                       xkmhd,  &
                                                                       alt,    &
                                                                       phb,    &
@@ -1017,7 +1158,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    INTEGER, INTENT( IN ) :: diff_6th_opt
    REAL,    INTENT( IN ) :: diff_6th_factor
 
-   REAL ,                                        INTENT(IN   ) :: dt
+   REAL,    INTENT(IN   ) :: dt_step    ! This is the local dt for each RK sub-step
 
    INTEGER, INTENT(IN   ) :: adv_opt          
    LOGICAL, INTENT(IN   ) :: mix2_off, mix6_off
@@ -1026,8 +1167,14 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
   
    INTEGER :: im, i,j,k
    INTEGER :: time_step
+   INTEGER :: rk_order
+   REAL    :: dt         ! This is the large time step computed below
 
    REAL    :: khdq, kvdq, tendency
+
+ ! LJW IEVA variables
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
+   LOGICAL                                      :: ieva
 
 !<DESCRIPTION>
 !
@@ -1036,9 +1183,29 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 !
 !</DESCRIPTION>
 
-
    khdq = khdif/prandtl
    kvdq = kvdif/prandtl
+
+   rk_order = config_flags%rk_ord
+   dt       = dt_step * (rk_order - rk_step + 1)    ! need large time step
+
+! LJW IEVA
+                         
+   ieva = CHK_IEVA( config_flags, rk_step )
+
+   CALL WW_SPLIT(wwE, wwI, ph, phb,                &
+                 u, v, ww, w, mut, rdnw, msfty,    &
+                 c1h, c2h,                         &
+                 rdx, rdy, msfux, msfuy,           &
+                 msfvx, msfvy, dt,                 &
+                 config_flags, rk_step,            & 
+                 ids, ide, jds, jde, kds, kde,     &
+                 ims, ime, jms, jme, kms, kme,     &
+                 its, ite, jts, jte, kts, kte )             
+                 
+! END LJW IEVA
+
+   CALL nl_get_time_step ( 1, time_step )
 
    scalar_loop : DO im = scs, sce
 
@@ -1057,48 +1224,47 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                       ims, ime, jms, jme, kms, kme, &
                       its, ite, jts, jte, kts, kte )
 
-     CALL nl_get_time_step ( 1, time_step )
 
-      IF( (rk_step == 3) .and. (adv_opt == POSITIVEDEF) ) THEN
+    IF( (rk_step == rk_order) .and. (adv_opt == POSITIVEDEF) ) THEN
 
         CALL advect_scalar_pd       ( scalar(ims,kms,jms,im),             &
                                       scalar_old(ims,kms,jms,im),         &
                                       advect_tend(ims,kms,jms),           &
                                       h_tendency(ims,kms,jms),            &
                                       z_tendency(ims,kms,jms),            &
-                                      ru, rv, ww, c1h, c2h,               &
+                                      ru, rv, wwE, c1h, c2h,              &
                                       mut, mub, mu_old,                   &
                                       time_step, config_flags, tenddec,   &
                                       msfux, msfuy, msfvx, msfvy,         &
                                       msftx, msfty, fnm, fnp,             &
-                                      rdx, rdy, rdnw,dt,                  &
+                                      rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt here
                                       ids, ide, jds, jde, kds, kde,       &
                                       ims, ime, jms, jme, kms, kme,       &
                                       its, ite, jts, jte, kts, kte     )
 
-      ELSE IF( (rk_step == 3) .and. (adv_opt == MONOTONIC) ) THEN
+      ELSE IF( (rk_step == rk_order) .and. (adv_opt == MONOTONIC) ) THEN
 
         CALL advect_scalar_mono       ( scalar(ims,kms,jms,im),             &
                                         scalar_old(ims,kms,jms,im),         &
                                         advect_tend(ims,kms,jms),           &
                                         h_tendency(ims,kms,jms),            &
                                         z_tendency(ims,kms,jms),            &
-                                        ru, rv, ww, c1h, c2h,               &
+                                        ru, rv, wwE, wwI, c1h, c2h,         &
                                         mut, mub, mu_old,                   &
                                         config_flags, tenddec,              &
                                         msfux, msfuy, msfvx, msfvy,         &
                                         msftx, msfty, fnm, fnp,             &
-                                        rdx, rdy, rdnw,dt,                  &
+                                        rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt here
                                         ids, ide, jds, jde, kds, kde,       &
                                         ims, ime, jms, jme, kms, kme,       &
                                         its, ite, jts, jte, kts, kte     )
 
-      ELSE IF( (rk_step == 3) .and. (adv_opt == WENO_SCALAR) ) THEN
+      ELSE IF( (rk_step == rk_order) .and. (adv_opt == WENO_SCALAR) ) THEN
 
         CALL advect_scalar_weno ( scalar(ims,kms,jms,im),        &
                                  scalar(ims,kms,jms,im),        &
                                  advect_tend(ims,kms,jms),      &
-                                 ru, rv, ww, c1h, c2h,          &
+                                 ru, rv, wwE, c1h, c2h,          &
                                  mut, time_step,                &
                                  config_flags,                  &
                                  msfux, msfuy, msfvx, msfvy,    &
@@ -1108,17 +1274,17 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                  ims, ime, jms, jme, kms, kme,  &
                                  its, ite, jts, jte, kts, kte  )
 
-      ELSEIF( (rk_step == 3) .and. (adv_opt == WENOPD_SCALAR) ) THEN
+      ELSEIF( (rk_step == rk_order) .and. (adv_opt == WENOPD_SCALAR) ) THEN
 
         CALL advect_scalar_wenopd   ( scalar(ims,kms,jms,im),             &
                                       scalar_old(ims,kms,jms,im),         &
                                       advect_tend(ims,kms,jms),           &
-                                      ru, rv, ww, c1h, c2h,               &
+                                      ru, rv, wwE, c1h, c2h,              &
                                       mut, mub, mu_old,                   &
                                       time_step, config_flags,            &
                                       msfux, msfuy, msfvx, msfvy,         &
                                       msftx, msfty, fnm, fnp,             &
-                                      rdx, rdy, rdnw,dt,                  &
+                                      rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt
                                       ids, ide, jds, jde, kds, kde,       &
                                       ims, ime, jms, jme, kms, kme,       &
                                       its, ite, jts, jte, kts, kte     )
@@ -1128,7 +1294,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
         CALL advect_scalar     ( scalar(ims,kms,jms,im),        &
                                  scalar(ims,kms,jms,im),        &
                                  advect_tend(ims,kms,jms),      &
-                                 ru, rv, ww, c1h, c2h,          &
+                                 ru, rv, wwE, c1h, c2h,         &
                                  mut, time_step,                &
                                  config_flags,                  &
                                  msfux, msfuy, msfvx, msfvy,    &
@@ -1140,6 +1306,26 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
       END IF
 
+      IF( ieva ) THEN
+     
+       CALL advect_s_implicit ( scalar(ims,kms,jms,im),         &
+                                scalar_old(ims,kms,jms,im),     &
+                                advect_tend(ims,kms,jms),       &
+                                ru, rv, wwI,                    &
+                                c1h, c2h,                       &
+                                mut, mut, mut,                  &
+                                config_flags,                   &
+                                msfux, msfuy, msfvx, msfvy,     &
+                                msftx, msfty,                   &
+                                fnm, fnp,                       &
+                                dt_step,                        &
+                                rdx, rdy, rdnw,                 &
+                                ids, ide, jds, jde, kds, kde,   &
+                                ims, ime, jms, jme, kms, kme,   &
+                                its, ite, jts, jte, kts, kte )
+                               
+     ENDIF
+    
      IF((config_flags%cu_physics == GDSCHEME .OR. config_flags%cu_physics == G3SCHEME .OR. &
          config_flags%cu_physics == GFSCHEME .OR.    &
          config_flags%cu_physics == KFETASCHEME .OR. config_flags%cu_physics == MSKFSCHEME .OR. &
@@ -1195,10 +1381,12 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
     ENDIF diff_opt1
 
-    IF ( (diff_6th_opt .NE. 0 ) .and. (.not. mix6_off) )              &
+    IF ( (diff_6th_opt .NE. 0) .and. (.not. mix6_off) ) THEN
+
       CALL sixth_order_diffusion( 'm', scalar(ims,kms,jms,im),        &
                                        scalar_tends(ims,kms,jms,im),  &
-                                       mut, dt, config_flags, c1h,c2h,&
+                                       mut, dt_step,                  &
+                                       config_flags, c1h, c2h,        &
                                        diff_6th_opt, diff_6th_factor, &
                                        phb, ph,                       &
                                        rdx, rdy,                      &
@@ -1208,6 +1396,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                        ids, ide, jds, jde, kds, kde,  &
                                        ims, ime, jms, jme, kms, kme,  &
                                        its, ite, jts, jte, kts, kte )
+    ENDIF
 
   ENDIF rk_step_1
 

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -1,0 +1,1488 @@
+MODULE module_ieva_em
+
+  USE module_bc
+  USE module_model_constants
+  USE module_wrf_error
+  
+  REAL(KIND=8), PARAMETER :: eps        = 1.0d-08
+  REAL,         PARAMETER :: alpha_max  = 1.1
+  REAL,         PARAMETER :: alpha_min  = 0.9
+
+CONTAINS
+
+LOGICAL FUNCTION CHK_IEVA( config_flags, rk_step )
+
+   IMPLICIT NONE
+
+   TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
+   INTEGER,                    INTENT(IN) :: rk_step
+
+   INTEGER :: zadvect_implicit
+   INTEGER :: rk_order
+
+   rk_order         = config_flags%rk_ord
+   zadvect_implicit = config_flags%zadvect_implicit
+
+   CHK_IEVA = .FALSE.
+
+   IF( zadvect_implicit .eq. 3 ) THEN   ! DO IEVA on all sub-steps of RK integrator
+       CHK_IEVA = .TRUE.
+   ENDIF
+
+   IF( zadvect_implicit .eq. 2 .and. rk_step .ge. rk_order-1 ) THEN ! DO IEVA on last two sub-steps of RK integrator
+       CHK_IEVA = .TRUE.
+   ENDIF
+
+   IF( zadvect_implicit .eq. 1 .and. rk_step .eq. rk_order ) THEN  ! DO IEVA on last sub-step of RK integrator
+       CHK_IEVA = .TRUE.
+   ENDIF
+
+RETURN
+END FUNCTION CHK_IEVA
+
+!-------------------------------------------------------------------------------
+! Is a modified w_damp routine to deal with IEVA capability
+! We may want to change when things are print out versus
+! when they too large (e.g., w-cfl > 2, let me know, w-cfl > 3, turn on w_damp)
+
+SUBROUTINE w_damp2( rw_tend, max_vert_cfl, max_horiz_cfl, &
+                    u, v, ww, w, mut, c1, c2, rdnw,       &
+                    rdx, rdy, msfux, msfuy,               &
+                    msfvx, msfvy, dt,                     &
+                    config_flags,                         &
+                    ids, ide, jds, jde, kds, kde,         &
+                    ims, ime, jms, jme, kms, kme,         &
+                    its, ite, jts, jte, kts, kte     )
+
+   USE module_llxy
+   IMPLICIT NONE
+
+   ! Input data
+
+   TYPE(grid_config_rec_type   ) ,   INTENT(IN   ) :: config_flags
+
+   INTEGER ,          INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                       ims, ime, jms, jme, kms, kme, &
+                                       its, ite, jts, jte, kts, kte
+
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, w
+
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(INOUT) ::  rw_tend
+
+   REAL, INTENT(OUT) ::  max_vert_cfl
+   REAL, INTENT(OUT) ::  max_horiz_cfl
+   REAL              ::  horiz_cfl
+
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   ) :: mut
+
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: rdnw
+
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: c1, c2
+
+   REAL, INTENT(IN)    :: dt
+   REAL, INTENT(IN)    :: rdx, rdy
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux, msfuy
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfvx, msfvy
+
+   REAL                :: vert_cfl, cf_n, cf_d, maxdub, maxdeta
+
+   INTEGER :: itf, jtf, i, j, k, maxi, maxj, maxk
+   INTEGER :: some1, some2
+   CHARACTER*512 :: temp
+
+   CHARACTER (LEN=256) :: time_str
+   CHARACTER (LEN=256) :: grid_str
+
+   integer :: total
+   REAL :: msfuxt , msfxffl
+   
+! LJW
+   REAL    :: w_crit_cfl = 1.00
+   REAL    :: w_flag_cfl = 1.50
+   REAL    :: w_alpha2
+   LOGICAL :: print_flag = .true.
+   SAVE    :: print_flag
+! LJW
+   
+!<DESCRIPTION>
+!
+!  w_damp computes a damping term for the vertical velocity when the
+!  vertical Courant number is too large.  This was found to be preferable to 
+!  decreasing the timestep or increasing the diffusion in real-data applications
+!  that produced potentially-unstable large vertical velocities because of
+!  unphysically large heating rates coming from the cumulus parameterization 
+!  schemes run at moderately high resolutions (dx ~ O(10) km).
+!
+!  Additionally, w_damp returns the maximum cfl values due to vertical motion and
+!  horizontal motion.  These values are returned via the max_vert_cfl and 
+!  max_horiz_cfl variables.  (Added by T. Hutchinson, WSI, 3/5/2007)
+!
+!</DESCRIPTION>
+
+   itf=MIN(ite,ide-1)
+   jtf=MIN(jte,jde-1)
+
+   some1 = 0
+   some2 = 0
+   max_vert_cfl = 0.
+   max_horiz_cfl = 0.
+   total = 0
+
+! BEGIN LJW
+
+   w_crit_cfl = config_flags%w_crit_cfl
+   IF( print_flag ) THEN
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 0, wrf_err_message )
+     WRITE(temp,*) 'W_DAMP2 BEGINS AT W-COURANT NUMBER = ',w_crit_cfl
+     CALL wrf_debug ( 0 , TRIM(temp) )
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 0, wrf_err_message )
+     print_flag = .false.
+   ENDIF
+
+! END LJW
+
+   IF ( config_flags%w_damping == 1 ) THEN
+
+     DO j = jts,jtf
+      DO k = 2, kde-1
+       DO i = its,itf
+       
+        IF(config_flags%polar ) THEN
+           msfuxt = MIN(msfux(i,j), msfxffl)
+        ELSE
+           msfuxt = msfux(i,j)
+        END IF
+        
+        vert_cfl = abs(ww(i,k,j)/(c1(k)*mut(i,j)+c2(k))*rdnw(k)*dt)
+
+        IF ( vert_cfl > max_vert_cfl ) THEN
+           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k 
+           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
+        ENDIF
+        
+        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt), abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+        
+        IF (horiz_cfl > max_horiz_cfl) THEN
+           max_horiz_cfl = horiz_cfl
+        ENDIF
+
+        IF (vert_cfl > w_flag_cfl .and. vert_cfl <= w_crit_cfl) THEN
+          WRITE(temp,FMT="(3(1x,i5,1x),'W_FLAG: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+          CALL wrf_debug ( 100 , TRIM(temp) )
+          some2 = some2 + 1
+          rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_crit_cfl)*(c1(k)*mut(i,j)+c2(k))
+        ELSEIF(vert_cfl > w_crit_cfl) THEN
+          WRITE(temp,FMT="(3(1x,i5,1x),'W-CRITICAL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+          CALL wrf_debug ( 100 , TRIM(temp) )
+          some1 = some1 + 1
+        ENDIF
+                       
+       ENDDO
+      ENDDO
+     ENDDO
+     
+   ELSE
+
+     DO j = jts,jtf
+      DO k = 2, kde-1
+       DO i = its,itf
+
+        IF(config_flags%polar ) then
+           msfuxt = MIN(msfux(i,j), msfxffl)
+        ELSE
+           msfuxt = msfux(i,j)
+        END IF
+        
+        vert_cfl = abs(ww(i,k,j)/(c1(k)*mut(i,j)+c2(k))*rdnw(k)*dt)
+        
+        IF ( vert_cfl > max_vert_cfl ) THEN
+           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k 
+           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
+        ENDIF
+        
+        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt), abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+        
+        IF (horiz_cfl > max_horiz_cfl) THEN
+           max_horiz_cfl = horiz_cfl
+        ENDIF
+        
+        IF (vert_cfl > w_flag_cfl .and. vert_cfl <= w_crit_cfl) THEN
+          WRITE(temp,FMT="(3(1x,i5,1x),'W_FLAG: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+          CALL wrf_debug ( 100 , TRIM(temp) )
+          some2 = some2 + 1
+        ELSEIF(vert_cfl > w_crit_cfl) THEN
+          WRITE(temp,FMT="(3(1x,i5,1x),'W-CRITICAL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
+          CALL wrf_debug ( 100 , TRIM(temp) )
+          some1 = some1 + 1
+        ENDIF
+
+       ENDDO
+      ENDDO
+     ENDDO
+     
+   ENDIF
+   
+   IF ( some1 .GT. 0 ) THEN
+     CALL get_current_time_string( time_str )
+     CALL get_current_grid_name( grid_str )
+     WRITE(temp,*) some1,                                            &
+            ' points exceeded W_CRITICAL_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+     CALL wrf_debug ( 0 , TRIM(temp) )
+     WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'W-CFL: ',f7.2,2x,'dETA: ',f7.2))") & 
+           maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
+     CALL wrf_debug ( 0 , TRIM(temp) )
+     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'U-CFL: ',f7.2,2x,'V: ',f7.2,2x,'V-CFL: ',f7.2))") & 
+           maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
+     CALL wrf_debug ( 0 , TRIM(temp) )
+   ENDIF
+   
+   IF ( some2 .GT. 0 ) THEN
+     CALL get_current_time_string( time_str )
+     CALL get_current_grid_name( grid_str )
+     WRITE(temp,*) some2,                                            &
+            ' points exceeded W_FLAG_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+     CALL wrf_debug ( 0 , TRIM(temp) )
+   ENDIF
+
+END SUBROUTINE w_damp2
+
+!-------------------------------------------------------------------------------
+! LJW - code for splitting vertical velocity for ex/im based on Shchepetkin (2015)
+
+SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
+                    u, v, ww, w, mut, rdnw, msfty,    &
+                    c1, c2,                           &
+                    rdx, rdy, msfux, msfuy,           &
+                    msfvx, msfvy, dt,                 &
+                    config_flags, rk_step,            &
+                    ids, ide, jds, jde, kds, kde,     &
+                    ims, ime, jms, jme, kms, kme,     &
+                    its, ite, jts, jte, kts, kte )
+                     
+   TYPE( grid_config_rec_type ) ,   INTENT(IN   ) :: config_flags
+
+   INTEGER ,          INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                       ims, ime, jms, jme, kms, kme, &
+                                       its, ite, jts, jte, kts, kte, &
+                                       rk_step
+
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, w, ph, phb
+
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(INOUT) ::  wwE, wwI
+
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   ) :: mut
+
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: rdnw 
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: c1, c2
+
+   REAL, INTENT(IN)    :: dt
+   REAL, INTENT(IN)    :: rdx, rdy
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux, msfuy
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfvx, msfvy, msfty
+
+! Local variables
+
+   REAL(KIND=4)    :: cr, cx, cy, c0, c2d, cw_max2, cw_min, cw, cff, rdz
+   INTEGER         :: i, j, k, ii, jj, i_start, i_end, j_start, j_end
+   LOGICAL         :: print_flag = .true.
+   SAVE            :: print_flag
+   
+! Implicit advection parameters based on Shchepetkin (2015)
+! Moved these to the top of the module.
+
+!  REAL, PARAMETER :: alpha_max  = 1.1
+!  REAL, PARAMETER :: alpha_min  = 0.9
+   REAL, PARAMETER :: cmnx_ratio = alpha_min/alpha_max
+   REAL, PARAMETER :: cutoff     = 2.0 - cmnx_ratio
+   REAL, PARAMETER :: r4cmx      = 1.0/(4.0 - 4.0*cmnx_ratio )
+   REAL, PARAMETER :: Ceps       = 0.9
+
+   LOGICAL         :: ieva
+
+!! Debug declarations
+
+   REAL,    PARAMETER :: binfrac = 0.1
+   INTEGER, PARAMETER :: binsize = 11
+   INTEGER            :: count(binsize)
+   real(KIND=4)       :: binavg(binsize), crs(binsize)
+
+! Check to see if IEVA is on for this RK3 substep
+
+   ieva = CHK_IEVA(config_flags, rk_step)
+
+! =========================================================================
+! LJW DEBUG
+!     
+     IF( print_flag ) THEN
+       write(wrf_err_message,*) '----------------------------------------'
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  ZADVECT_IMPLICT = ', config_flags%zadvect_implicit
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  IEVA = ', ieva
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  dt = ', dt
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  alpha_max/min = ', alpha_max, alpha_min
+       CALL wrf_debug( 0, wrf_err_message )
+       print_flag = .false.     
+      ENDIF
+!    
+! LJW
+! =========================================================================
+   
+   i_start = its-1
+   i_end   = MIN(ite,ide-1) + 1
+   j_start = jts - 1
+   j_end   = MIN(jte,jde-1) + 1
+   
+   wwE(:,:,:) = 0.0
+   wwI(:,:,:) = 0.0
+
+   IF( ieva ) THEN   ! Implicit adaptive advection
+   
+!=========================================================================
+! LJW DEBUG CODE BLOCK
+!        
+!    binavg(:) = 0.0
+!    crs(:)    = 0.0
+!    count(:)  = 0
+!
+!=========================================================================
+                                                        
+     DO j = j_start, j_end
+       DO k = 2, kde-1
+       
+         IF( k == 2 ) THEN               ! Dont do implicit at lower boundary
+           wwE(i_start:i_end,1,j) = 0.0
+           wwI(i_start:i_end,1,j) = 0.0
+         ENDIF
+         
+         IF( k == kde-1 ) THEN           ! Dont do implicit at upper boundary
+           wwE(i_start:i_end,kde,j) = ww(i_start:i_end,kde,j)
+           wwI(i_start:i_end,kde,j) = 0.0
+         ENDIF
+       
+         DO i = i_start,i_end
+         
+!=========================================================================
+! LJW 
+!      
+! Translating Shchepetkin (2015), all the volumes and surface areas cancel out (not obvious unless you read
+! the definitions of U, V, and W right after equation 3.7 (they are u*dy*dz, v*dx*dz, w*dx*dy)...
+! You can write the algorithm using the adjusted maximum vertical courant number (alpha_max - eps*hor_div)
+! versus the actual vertical courant number.  This code is based on the appendix C of Shchepetkin (2015).
+! The CX and CY measure the maximum possible divergence for a zone, e.g., the Lipschlitz number.  If this number ~O(1), 
+! then you want to reduce the maximum allowed vertical courant number for the explicit advection.  Ceps is a fudge
+! factor - so when the 2D Lipschlitz number is larger than O(1), the scheme switches to fully implicit.
+!
+!=========================================================================
+           wfrac = 1.0
+            
+           IF( ww(i,k,j) < 0.0 ) THEN    !! Omega has opposite sign of W
+             cx = msfty(i,j)*rdx*(max(u(i+1,k,j), 0.0) - min(u(i,k,j), 0.0)) 
+             cy = msfty(i,j)*rdy*(max(v(i,k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
+           ELSE
+             cx = msfty(i,j)*rdx*(max(u(i+1,k-1,j), 0.0) - min(u(i,k-1,j), 0.0)) 
+             cy = msfty(i,j)*rdy*(max(v(i,k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
+           ENDIF
+
+           cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
+           cr     = ww(i,k,j) * dt * rdnw(k) / (c1(k)*mut(i,j)+c2(k))      ! vertical courant number
+         
+           IF( cw_max > 0.0 ) THEN
+      
+             cw_max2 = cw_max**2
+             cw_min  = cw_max*cmnx_ratio
+             cw      = abs(cr)
+      
+             if ( cw < cw_min ) then
+               cff = cw_max2
+             elseif ( cw < cutoff*cw_min ) then
+               cff = cw_max2 + r4cmx*(cw-cw_min)**2
+             else
+               cff = cw_max*cw
+             endif
+        
+             wfrac = cw_max2 / cff
+             wfrac = amax1(amin1(wfrac, 1.0), 0.0)
+
+             wwE(i,k,j) = ww(i,k,j) * wfrac
+             wwI(i,k,j) = ww(i,k,j) * (1.0 - wfrac)
+
+!=========================================================================
+! LJW DEBUG CODE BLOCK: compute distribution of wfrac 
+!             
+!            DO mm = 1, binsize
+!              IF( (mm-1)*binfrac / wfrac <= 1.0 .and. &
+!                      mm*binfrac / wfrac  > 1.0 ) THEN   
+!                count(mm)  = count(mm) + 1
+!                binavg(mm) = binavg(mm) + wfrac
+!                crs(mm)    = crs(mm) + cw
+!              ENDIF
+!            ENDDO
+!
+! LJW
+!=========================================================================
+                
+           ELSE
+
+!=========================================================================
+! LJW DEBUG CODE BLOCK:  write out information when fully implicit
+!        
+!            write(wrf_err_message,*) ' MAX VERTICAL CFL ~ 0: i,j,k, cw_max, dt*(cx+cy) ',i,j,k,cw_max,Ceps*dt*(cx+cy)
+!            CALL wrf_debug(0, wrf_err_message )
+!
+!=========================================================================
+             
+             wwE(i,k,j) = 0.0
+             wwI(i,k,j) = ww(i,k,j)
+       
+           ENDIF
+
+         ENDDO
+       ENDDO
+     ENDDO
+     
+   ELSE  ! NOT doing IEVA, pure explicit advection
+
+     DO j = j_start, j_end
+       DO k = kds, kde
+         DO i = i_start,i_end
+           wwE(i,k,j) = ww(i,k,j)
+           wwI(i,k,j) = 0.0
+         ENDDO
+       ENDDO
+     ENDDO
+   
+   ENDIF
+
+!=========================================================================
+! LJW DEBUG - print distribution of wfrac 
+! 
+!  write(wrf_err_message,*) '----------------------------------------'
+!  CALL wrf_debug( 0, wrf_err_message )
+!  DO mm = 1,11 
+!    write(wrf_err_message,FMT='(a, 2(2x,f4.2),2x,i9,2(2x,f6.4))' ) &
+!     'WW_SPLIT: BIN #, count', (mm-1)*binfrac, mm*binfrac, count(mm), binavg(mm)/(count(mm)+1), crs(mm)/(count(mm)+1)
+!    CALL wrf_debug( 0, wrf_err_message )
+!  ENDDO
+!  write(wrf_err_message,*) '----------------------------------------'
+!  CALL wrf_debug( 0, wrf_err_message )
+!
+! LJW
+!=========================================================================
+
+ RETURN
+ END SUBROUTINE WW_SPLIT
+ 
+ 
+ SUBROUTINE TRIDIAG2D(a, b, c, r, bb, is, ie, istart, iend, ks, ke, kstart, kend)
+!--------------------------------------------------------------------------------------------------
+!     Solves for a vector u of length n the tridiagonal linear set      ! from numerical recipes
+!     m u = r, where a, b and c are the three main diagonals of matrix  !
+!     m(n,n), the other terms are 0. r is the right side vector.        !
+!
+!     a(1) and c(n) are not used in the calculation
+!--------------------------------------------------------------------------------------------------
+     
+    integer,                              intent(in)    :: is, ie, ks, ke, istart, iend, kstart, kend
+    real(kind=8), dimension(is:ie,ks:ke), intent(in)    :: a, b, c, r
+    real(kind=8), dimension(is:ie,ks:ke), intent(inout) :: bb
+    
+    !
+    ! Local Variables
+    ! 
+      
+    real(kind=8), dimension(ks:ke) :: gam
+    real(kind=8), dimension(is:ie) :: bet
+    integer                        :: i, k
+
+! Copy into temp storage...
+    
+    DO i = istart, iend   
+     
+      bet(i) = b(i,kstart)  
+           
+    ENDDO
+
+! I did this in this manner so I wont break vectorization
+  
+!   IF ( ANY( bet < 1.0e-15 ) ) THEN      
+!     write(wrf_err_message,*) '----------------------------------------'
+!     CALL wrf_debug( 0, wrf_err_message )
+!     write(wrf_err_message,*) "TriDiag2D Error!!! Min value of diagonal is ", minval(bet)
+!     CALL wrf_debug( 0, wrf_err_message )
+!     write(wrf_err_message,*) '----------------------------------------'
+!     CALL wrf_debug( 0, wrf_err_message )
+!     STOP
+!   ENDIF
+
+    DO i = istart, iend
+        
+       bb(i,kstart) = r(i,kstart)/bet(i)
+    
+       DO k = kstart+1, kend
+       
+         gam(k) = c(i,k-1) / bet(i)
+         bet(i) = b(i,k) - a(i,k) * gam(k)
+      
+         bb(i,k) = ( r(i,k) - a(i,k) * bb(i,k-1) ) / bet(i)
+      
+       ENDDO
+ 
+       DO k = kend-1, kstart, -1
+       
+         bb(i,k) = bb(i,k) - gam(k+1) * bb(i,k+1)
+         
+       ENDDO
+       
+     ENDDO
+ 
+ END SUBROUTINE TRIDIAG2D
+!--------------------------------------------------------------------------------------------------
+ SUBROUTINE TRIDIAG(a, b, c, r, bb, ks, ke, kstart, kend)
+!--------------------------------------------------------------------------------------------------
+!     Solves for a vector u of length n the tridiagonal linear set      ! from numerical recipes
+!     m u = r, where a, b and c are the three main diagonals of matrix  !
+!     m(n,n), the other terms are 0. r is the right side vector.        !
+!
+!     a(1) and c(n) are not used in the calculation
+!--------------------------------------------------------------------------------------------------
+    IMPLICIT NONE
+    
+    integer,                        intent(in)  :: ks, ke, kstart, kend
+    real(kind=4), dimension(ks:ke), intent(in ) :: a, b, c, r
+    real(kind=4), dimension(ks:ke), intent(out) :: bb
+    
+    !
+    ! Local Variables
+    ! 
+      
+    real(kind=4), dimension(size(b,1)) :: gam
+    real(kind=4)                       :: bet
+    integer                            :: k
+    
+    bet = b(kstart)
+     
+    bb(kstart) = r(kstart)/bet
+ 
+    DO k = kstart+1, kend
+       
+      gam(k) = c(k-1) / bet
+      bet    = b(k) - a(k) * gam(k)
+      
+      bb(k) = ( r(k) - a(k) * bb(k-1) ) / bet
+   
+    ENDDO
+
+    DO k = kend-1, kstart, -1
+      bb(k) = bb(k) - gam(k+1) * bb(k+1)
+    ENDDO
+     
+END SUBROUTINE TRIDIAG
+!-------------------------------------------------------------------------------
+!
+
+SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
+                         mut_old, muu, muv, mut_new,         &
+                         dt, rdx, rdy, msftx, msfty,         &
+                         msfux, msfuy, msfvx, msfvx_inv,     &
+                         msfvy, rdnw,                        &
+                         ids, ide, jds, jde, kds, kde,       &
+                         ims, ime, jms, jme, kms, kme,       &
+                         its, ite, jts, jte, kts, kte    )
+
+   IMPLICIT NONE
+
+   ! Input data
+
+
+   INTEGER ,    INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                 ims, ime, jms, jme, kms, kme, &
+                                 its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: u, v
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut_old, muu, muv, &
+                                                            msftx, msfty, &
+                                                            msfux, msfuy, &
+                                                            msfvx, msfvy, &
+                                                            msfvx_inv
+   REAL , DIMENSION( kms:kme ) , INTENT(IN   ) :: rdnw
+   REAL , DIMENSION( kms:kme ) , INTENT(IN   ) :: c1h, c2h
+   
+   REAL , DIMENSION( ims:ime, jms:jme ) , INTENT(OUT  ) :: mut_new
+   REAL , INTENT(IN)  :: dt, rdx, rdy
+   
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   REAL , DIMENSION( its:ite ) :: dmdt
+   REAL , DIMENSION( its:ite, kts:kte ) :: divv
+   REAL :: bigerr
+
+!<DESCRIPTION>
+!
+!  LJW
+!
+!  The algorithm integrates the continuity equation through the column
+!  to find a new column mass needed for IEVA calculations
+!
+!  LJW
+!
+!</DESCRIPTION>
+
+
+    jtf=MIN(jte,jde-1)
+    ktf=MIN(kte,kde-1)  
+    itf=MIN(ite,ide-1)
+
+
+    DO j=jts,jtf
+
+      DO i=its,ite
+        dmdt(i) = 0.
+      ENDDO
+
+!       Comments on the modifications for map scale factors
+!       ADT eqn 47 / my (putting rho -> 'mu') is:
+!       (1/my) partial d mu/dt = -mx partial d/dx(mu u/my)
+!                                -mx partial d/dy(mu v/mx)
+!                                -partial d/dz(mu w/my)
+!
+!       Using nu instead of z the last term becomes:
+!                                -partial d/dnu((c1(k)*mu(dnu/dt))/my)
+!
+!       Integrating with respect to nu over ALL levels, with dnu/dt=0 at top
+!       and bottom, the last term becomes = 0
+!
+!       Integral|bot->top[(1/my) partial d mu/dt]dnu =
+!       Integral|bot->top[-mx partial d/dx(mu u/my)
+!                         -mx partial d/dy(mu v/mx)]dnu
+!
+!       muu='mu'[on u]/my, muv='mu'[on v]/mx
+!       (1/my) partial d mu/dt is independent of nu
+!         => LHS = Integral|bot->top[con]dnu = conservation*(-1) = -dmdt
+!
+!         => dmdt = mx*Integral|bot->top[partial d/dx(mu u/my) +
+!                                        partial d/dy(mu v/mx)]dnu
+!         => dmdt = sum_bot->top[divv]
+!       where
+!         divv=mx*[partial d/dx(mu u/my) + partial d/dy(mu v/mx)]*delta nu
+
+      DO k=kts,ktf
+       DO i=its,itf
+
+        divv(i,k) = (msftx(i,j) / rdnw(k)) *                                                                        &
+            (rdx*((c1h(k)*muu(i+1,j)+c2h(k))*u(i+1,k,j)/msfuy(i+1,j)-(c1h(k)*muu(i,j)+c2h(k))*u(i,k,j)/msfuy(i,j))  &
+            +rdy*((c1h(k)*muv(i,j+1)+c2h(k))*v(i,k,j+1)*msfvx_inv(i,j+1)-(c1h(k)*muv(i,j)+c2h(k))*v(i,k,j)*msfvx_inv(i,j)) )
+                                  
+        dmdt(i) = dmdt(i) + divv(i,k)
+
+       ENDDO
+      ENDDO
+
+!       Further map scale factor notes:
+!       Now integrate from bottom to top, level by level:
+!       mu dnu/dt/my [k+1] = mu dnu/dt/my [k] + [-(1/my) partial d mu/dt
+!                           -mx partial d/dx(mu u/my)
+!                           -mx partial d/dy(mu v/mx)]*dnu[k->k+1]
+!       ww [k+1] = ww [k] -(1/my) partial d mu/dt * dnu[k->k+1] - divv[k]
+!                = ww [k] -dmdt * dnw[k] - divv[k]
+
+      DO i=its,itf
+
+           mut_new(i,j) = mut_old(i,j) - dt*dmdt(i)
+
+! LJW - debug code.           
+!          bigerr = (mut_new(i,j) / mut_old(i,j))
+!     
+!          IF( abs(bigerr) > 2.0 .or. mut_old(i,j) < 0.0 ) THEN    
+!             write(wrf_err_message,*) '------------- CALC_MU_TMP ---------------------------'
+!             CALL wrf_debug( 0, wrf_err_message )
+!             write(wrf_err_message,*) 'MU_ERR: ', bigerr, mut_new(i,j), mut_old(i,j), dt, dt*dmdt(i)
+!             CALL wrf_debug( 0, wrf_err_message )
+!         ENDIF
+
+      ENDDO   ! END I
+    
+    ENDDO     ! END J
+
+
+END SUBROUTINE CALC_MUT_NEW
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_ph_implicit( ph, pho, tendency, phb,        &
+                               ru, rv, wwE, wwI, w,           &
+                               c1, c2,                        &
+                               mut, config_flags,             &
+                               msfux, msfuy, msfvx, msfvy,    &
+                               msftx, msfty,                  &
+                               fzm, fzp,                      &
+                               dt_rk,                         &
+                               rdx, rdy, rdzw,                &
+                               ids, ide, jds, jde, kds, kde,  &
+                               ims, ime, jms, jme, kms, kme,  &
+                               its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: ph,    &
+                                                                      pho,   &
+                                                                      phb,   &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      wwI,   &
+                                                                      wwE,   &
+                                                                      w
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   REAL    :: wiL, wiR, wiC, weL, weR, dz
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp(ims:ime)
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1, valid_ik
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+   ktf     = kde-1
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+
+! Vertical loop to do implicit advection.....
+! Different from the other schemes - the advection here is not in flux form...
+
+   DO j = j_start, j_end
+ 
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0
+     
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+
+! We are choosing to do the vertical advection here the same as in RHS_PH,
+! e.g., 2nd order box averaging instead of the usual upwinding...
+! Divide my mu(i,j) to make sure the diagnonal term is ~O(1)
+
+! Upwind
+         wiC     = 0.5*wwI(i,k,j)*(rdzw(k-1)+rdzw(k)) * msfty(i,j) / (c1(k)*mut(i,j)+c2(k))
+         at(i,k) = - dt_rk*max(wiC,0.0)
+         ct(i,k) =   dt_rk*min(wiC,0.0)
+         btmp(i) =   - at(i,k) - ct(i,k)
+
+! 2nd order centered for both implicit piece of advection
+!          wiL     = 0.5*(wwI(i,k-1,j)+wwI(i,k,j)) * rdzw(k-1) * msfty(i,j) / mut(i,j) 
+!          wiR     = 0.5*(wwI(i,k+1,j)+wwI(i,k,j)) * rdzw(k)   * msfty(i,j) / mut(i,j)         
+!          at(i,k) = - dt_rk*wiL*fzp(k)
+!          ct(i,k) =   dt_rk*wiR*fzm(k)
+!          btmp(i) =   - at(i,k) - ct(i,k)
+      
+! Diagonal term
+
+         bt(i,k) =   1.0 + btmp(i)
+
+! 2nd order centered for explict piece of advection  (TURNED OFF AND COMPUTED IN RHS_PH)
+!
+!          weL   = -dt_rk*fzp(k)*0.5*(wwE(i,k-1,j)+wwE(i,k,j)) * rdzw(k-1) * msfty(i,j) / mut(i,j)  
+!          weR   =  dt_rk*fzm(k)*0.5*(wwE(i,k+1,j)+wwE(i,k,j)) * rdzw(k)   * msfty(i,j) / mut(i,j)        
+       
+! Eq here is more complicated because the solution to the tridiagonal is in phi', not total
+! phi.  So we retain the vertical advection of phb on RHS.
+
+         rt(i,k) = tendency(i,k,j) * dt_rk * msfty(i,j) / (c1(k)*mut(i,j)+c2(k))        &
+!                  - weL*ph (i,k-1,j)     + (weL + weR)*ph (i,k,j) - weR*ph (i,k+1,j)     &
+!                  - weL*phb(i,k-1,j)     + (weL + weR)*phb(i,k,j) - weR*phb(i,k+1,j)     &            
+                 - at(i,k)*pho(i,k-1,j) -     btmp(i)*pho(i,k,j) - ct(i,k)*pho(i,k+1,j) &
+                 - at(i,k)*phb(i,k-1,j) -     btmp(i)*phb(i,k,j) - ct(i,k)*phb(i,k+1,j)  
+
+! BC's need because tendencies of phi, at kts and kte are not zero, so add them to RHS of Tridiagonal eqs
+! NOT USED!         
+!          IF( k == kts+1 ) THEN
+!             rt(i,k) = rt(i,k) - at(i,k)*(ph(i,k-1,j) - pho(i,k-1,j))       ! lower boundary condition 
+!          ENDIF
+!        
+!          IF( k == ktf ) THEN    ! upper boundary condition
+!           rt(i,k)   = rt(i,k) - ct(i,k) * (ph(i,k+1,j) - pho(i,k+1,j))
+!         ENDIF
+
+       ENDDO
+     ENDDO
+
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts+1, ktf) 
+
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+     
+         tendency(i,k,j) = sngl(bb(i,k)) * (c1(k)*mut(i,j)+c2(k)) / dt_rk / msfty(i,j)
+       
+       ENDDO
+     ENDDO
+   
+   ENDDO
+    
+END SUBROUTINE advect_ph_implicit
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
+                              ru, rv, rom,                   &
+                              c1, c2,                        &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
+
+   INTEGER ,                   INTENT(IN) :: ids, ide, jds, jde, kds, kde, &
+                                             ims, ime, jms, jme, kms, kme, &
+                                             its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN) :: s,     &
+                                                                   s_old, &
+                                                                   ru,    &
+                                                                   rv,    &
+                                                                   rom
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut     ==> current column mass from sub-step
+! mut_old ==> "n" time level column mass
+! mut_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+   
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   INTEGER :: jp1, jp0, jtmp
+
+   INTEGER :: horz_order, vert_order
+
+   REAL    :: mrdx, mrdy, ub, vb, uw, vw, dvm, dvp, wiL, wiR, dz
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb   
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik, skip
+   CHARACTER*512 :: temp
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+   ktf     = MIN(kte,kde-1)
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+   
+! Vertical loop to do implicit advection.....
+
+   DO j = j_start, j_end
+ 
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0
+     
+     DO k = kts, ktf
+       DO i = i_start, i_end
+
+         km1 = k - 1
+         kp1 = k + 1
+         IF( k .eq. ktf ) kp1 = ktf
+         IF( k .eq. kts ) km1 = kts
+
+         ! Redefine mass fluxes with new temporary column mass
+       
+         wiL   = rom(i,k,  j) * rdzw(k) / (c1(k)*mut_new(i,j)+c2(k))
+         wiR   = rom(i,k+1,j) * rdzw(k) / (c1(k)*mut_new(i,j)+c2(k))
+
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0)
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0))
+         bt(i,k) = 1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j)  &
+                   - (c1(k)*mut_old(i,j)+c2(k))*(at(i,k)*s_old(i,km1,j) + btmp(i)*s_old(i,k,j) + ct(i,k)*s_old(i,kp1,j))
+       ENDDO
+     ENDDO
+      
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts, ktf) 
+
+     DO k = kts, ktf
+       DO i = i_start, i_end
+
+         ! Rescale tendency with old column mass for consistency in update step.
+     
+         tendency(i,k,j) = sngl(bb(i,k)) / dt_rk
+       
+       ENDDO
+     ENDDO
+       
+   ENDDO  ! J-LOOP
+
+END SUBROUTINE advect_s_implicit
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
+                              ru, rv, rom,                   &
+                              c1, c2,                        &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: u,     &
+                                                                      u_old, &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      rom
+
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut    ==> current column mass from sub-step
+! mu_old ==> "n" time level column mass
+! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   INTEGER :: jp1, jp0, jtmp
+
+   INTEGER :: horz_order, vert_order
+
+   REAL    :: wiL, wiR, dz
+   
+   REAL , DIMENSION( ims:ime+1 , jms:jme ) :: muu, muu_old, muu_new
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+      
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+!-------------------- vertical advection
+!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
+!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
+!  Since 'my' (map scale factor in y-direction) isn't a function of z,
+!  this is what we need, so leave unchanged in advect_u
+
+   ktf     = MIN(kte,kde-1)
+
+   i_start = its
+   i_end   = ite
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+   
+! Compute column masses for u-staggering...
+
+   DO j = j_start, j_end
+    DO i = its,min(ite+1,ide)
+
+      muu(i,j)     = 0.5*(mut(i,j)    +mut(i-1,j))
+      muu_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i-1,j))
+      muu_new(i,j) = 0.5*(mut_new(i,j)+mut_new(i-1,j))
+      
+    ENDDO
+  ENDDO
+    
+! Vertical loop to do implicit advection.....
+
+   DO j = j_start, j_end
+   
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0    
+     
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+         km1 = k - 1
+         kp1 = k + 1
+         IF( k .eq. ktf ) kp1 = ktf
+         IF( k .eq. kts ) km1 = kts
+
+! SO IMPORTANT to * 1/DZ HERE CAUSE IT CHANGES Wi* SIGN TO BE CORRECT FOR UPWINDING!!!!
+         wiL   = 0.5*(rom(i-1,k,  j)+rom(i,k,  j)) * rdzw(k) * msfuy(i,j) / (c1(k)*muu_new(i,j)+c2(k)) 
+         wiR   = 0.5*(rom(i-1,k+1,j)+rom(i,k+1,j)) * rdzw(k) * msfuy(i,j) / (c1(k)*muu_new(i,j)+c2(k)) 
+       
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0) 
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0)) 
+         bt(i,k) = 1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j)*msfuy(i,j)  &
+                 - (c1(k)*muu_old(i,j)+c2(k))*(at(i,k)*u_old(i,km1,j) + btmp(i)*u_old(i,k,j) + ct(i,k)*u_old(i,kp1,j))
+       
+       ENDDO
+     ENDDO
+   
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts, ktf) 
+
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+         tendency(i,k,j) = sngl(bb(i,k)) / dt_rk / msfuy(i,j)
+                
+       ENDDO
+     ENDDO
+        
+   ENDDO ! J-LOOP
+    
+END SUBROUTINE advect_u_implicit
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
+                              ru, rv, rom,                   &
+                              c1, c2,                        &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: v,     &
+                                                                      v_old, &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      rom
+
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut    ==> current column mass from sub-step
+! mu_old ==> "n" time level column mass
+! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   INTEGER :: jp1, jp0, jtmp
+
+   INTEGER :: horz_order, vert_order
+
+   REAL    :: mrdx, mrdy, ub, vb, uw, vw, dvm, dvp, wiL, wiR, dz
+
+   REAL,   DIMENSION( ims:ime , jms:jme+1 ) :: muv, muv_old, muv_new
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik
+   
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+!-------------------- vertical advection
+!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
+!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
+!  Since 'my' (map scale factor in y-direction) isn't a function of z,
+!  this is what we need, so leave unchanged in advect_u
+
+
+   ktf     = MIN(kte,kde-1)
+   
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = jte
+   
+! Compute column masses for u-staggering...
+
+   DO j = jts,min(jte+1,jde)
+    DO i = i_start, i_end
+
+      muv(i,j)     = 0.5*(mut(i,j)    +mut(i,j-1))
+      muv_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i,j-1))
+      muv_new(i,j) = 0.5*(mut_new(i,j)+mut_new(i,j-1))
+      
+    ENDDO
+  ENDDO
+ 
+! Main Loop
+
+   DO j = j_start, j_end
+   
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0 
+     
+      
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+         km1 = k - 1
+         kp1 = k + 1
+         IF( k .eq. ktf ) kp1 = ktf
+         IF( k .eq. kts ) km1 = kts
+
+         wiL   = 0.5*(rom(i,k,  j-1)+rom(i,k,  j)) * rdzw(k) * msfvy(i,j) / (c1(k)*muv_new(i,j)+c2(k)) 
+         wiR   = 0.5*(rom(i,k+1,j-1)+rom(i,k+1,j)) * rdzw(k) * msfvy(i,j) / (c1(k)*muv_new(i,j)+c2(k))
+       
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0)
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0))
+         bt(i,k) = 1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j) * msfvx(i,j) &
+                 - (c1(k)*muv_old(i,j)+c2(k))*(at(i,k)*v_old(i,km1,j) + btmp(i)*v_old(i,k,j) + ct(i,k)*v_old(i,kp1,j))
+       
+       ENDDO
+     ENDDO
+      
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts, ktf) 
+
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+       tendency(i,k,j) = sngl(bb(i,k)) / dt_rk / msfvx(i,j)
+       
+       ENDDO     
+     ENDDO
+          
+   ENDDO
+    
+END SUBROUTINE advect_v_implicit
+
+!-------------------------------------------------------------------------------
+! 
+SUBROUTINE advect_w_implicit( w, w_old, tendency,            &
+                              utend, vtend, ht, rom,         &
+                              ph_new, ph_old, ph_tend,       &
+                              c1, c2,                        &
+                              cf1, cf2, cf3,                 &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &                              
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzu,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: w,     &
+                                                                      w_old, &
+                                                                      utend, &
+                                                                      vtend, &
+                                                                     ph_old, &
+                                                                     ph_new, &
+                                                                    ph_tend, &
+                                                                      rom
+
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut    ==> current column mass from sub-step
+! mu_old ==> "n" time level column mass
+! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+   
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty,  &
+                                                                    ht
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzu, &
+                                                                  c1,   &
+                                                                  c2
+                                                                  
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy,  &
+                                                                  cf1,  &
+                                                                  cf2,  &
+                                                                  cf3
+                                                                  
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   REAL    :: wiL, wiR, dz, dw
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik
+   
+   specified = .false.
+   IF(config_flags%specified .or. config_flags%nested) specified = .true.
+
+!-------------------- vertical advection
+!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
+!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
+!  Since 'my' (map scale factor in y-direction) isn't a function of z,
+!  this is what we need, so leave unchanged in advect_u
+
+   ktf     = MIN(kte,kde-1)
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+  
+! Main loop
+
+   DO j = j_start, j_end
+   
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0    
+           
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+
+! SO IMPORTANT to * 1/DZ HERE CAUSE IT CHANGES Wi* SIGN TO BE CORRECT FOR UPWINDING!!!!
+         wiL   = 0.5*(rom(i,k-1,j)+rom(i,k,j)) * rdzu(k) * msfty(i,j) / (c1(k)*mut_new(i,j)+c2(k)) 
+         wiR   = 0.5*(rom(i,k+1,j)+rom(i,k,j)) * rdzu(k) * msfty(i,j) / (c1(k)*mut_new(i,j)+c2(k))
+
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0) 
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0)) 
+         bt(i,k) =   1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j) * msfty(i,j)  &
+                 - (c1(k)*mut_old(i,j)+c2(k))*(at(i,k)*w_old(i,k-1,j) + btmp(i)*w_old(i,k,j) + ct(i,k)*w_old(i,k+1,j))
+       
+! BC at lower boundary needed because (W(i,kts,j)  .ne. 0) and value need for RHS of tridiagonal at kts+1
+! Since we already included w_old, just need to compute dw increment from UTEND, VTEND at kts 
+
+        IF( k == kts+1 ) THEN
+         dw =  msfty(i,j)*.5*rdy*(                                       &
+                           (ht(i,j+1)-ht(i,j  ))                         &
+          *(cf1*vtend(i,1,j+1)+cf2*vtend(i,2,j+1)+cf3*vtend(i,3,j+1))    &
+                          +(ht(i,j  )-ht(i,j-1))                         &
+          *(cf1*vtend(i,1,j  )+cf2*vtend(i,2,j  )+cf3*vtend(i,3,j  ))  ) &
+                 +msftx(i,j)*.5*rdx*(                                    &
+                           (ht(i+1,j)-ht(i,j  ))                         &
+          *(cf1*utend(i+1,1,j)+cf2*utend(i+1,2,j)+cf3*utend(i+1,3,j))    &
+                          +(ht(i,j  )-ht(i-1,j))                         &
+          *(cf1*utend(i  ,1,j)+cf2*utend(i  ,2,j)+cf3*utend(i  ,3,j))  )
+
+          rt(i,k) = rt(i,k) - (c1(k)*mut(i,j)+c2(k))*at(i,k)*dt_rk*dw       
+        ENDIF
+
+! W-increment at upper boundary is computed from phi
+       
+        IF( k == ktf ) THEN    ! upper boundary condition
+          dw = msfty(i,j)*(  (ph_new(i,k+1,j)-ph_old(i,k+1,j))/dt_rk     &
+                            - ph_tend(i,k+1,j)/(c1(k)*mut(i,j)+c2(k))/g) 
+
+          rt(i,k)   = rt(i,k) - (c1(k)*mut(i,j)+c2(k))*ct(i,k) * (dw - w_old(i,k+1,j))
+        ENDIF
+
+       ENDDO
+     ENDDO
+
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts+1, ktf) 
+
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+     
+         tendency(i,k,j) = sngl(bb(i,k)) / dt_rk / msfty(i,j)
+                         
+       ENDDO
+     ENDDO
+     
+   ENDDO
+    
+END SUBROUTINE advect_w_implicit
+
+END MODULE module_ieva_em
+
+!-----------------------------------

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -41,215 +41,7 @@ RETURN
 END FUNCTION CHK_IEVA
 
 !-------------------------------------------------------------------------------
-! Is a modified w_damp routine to deal with IEVA capability
-! We may want to change when things are print out versus
-! when they too large (e.g., w-cfl > 2, let me know, w-cfl > 3, turn on w_damp)
-
-SUBROUTINE w_damp2( rw_tend, max_vert_cfl, max_horiz_cfl, &
-                    u, v, ww, w, mut, c1, c2, rdnw,       &
-                    rdx, rdy, msfux, msfuy,               &
-                    msfvx, msfvy, dt,                     &
-                    config_flags,                         &
-                    ids, ide, jds, jde, kds, kde,         &
-                    ims, ime, jms, jme, kms, kme,         &
-                    its, ite, jts, jte, kts, kte     )
-
-   USE module_llxy
-   IMPLICIT NONE
-
-   ! Input data
-
-   TYPE(grid_config_rec_type   ) ,   INTENT(IN   ) :: config_flags
-
-   INTEGER ,          INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
-                                       ims, ime, jms, jme, kms, kme, &
-                                       its, ite, jts, jte, kts, kte
-
-   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, w
-
-   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(INOUT) ::  rw_tend
-
-   REAL, INTENT(OUT) ::  max_vert_cfl
-   REAL, INTENT(OUT) ::  max_horiz_cfl
-   REAL              ::  horiz_cfl
-
-   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   ) :: mut
-
-   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: rdnw
-
-   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: c1, c2
-
-   REAL, INTENT(IN)    :: dt
-   REAL, INTENT(IN)    :: rdx, rdy
-   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux, msfuy
-   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfvx, msfvy
-
-   REAL                :: vert_cfl, cf_n, cf_d, maxdub, maxdeta
-
-   INTEGER :: itf, jtf, i, j, k, maxi, maxj, maxk
-   INTEGER :: some1, some2
-   CHARACTER*512 :: temp
-
-   CHARACTER (LEN=256) :: time_str
-   CHARACTER (LEN=256) :: grid_str
-
-   integer :: total
-   REAL :: msfuxt , msfxffl
-   
-! LJW
-   REAL    :: w_crit_cfl = 1.00
-   REAL    :: w_flag_cfl = 1.50
-   REAL    :: w_alpha2
-   LOGICAL :: print_flag = .true.
-   SAVE    :: print_flag
-! LJW
-   
-!<DESCRIPTION>
-!
-!  w_damp computes a damping term for the vertical velocity when the
-!  vertical Courant number is too large.  This was found to be preferable to 
-!  decreasing the timestep or increasing the diffusion in real-data applications
-!  that produced potentially-unstable large vertical velocities because of
-!  unphysically large heating rates coming from the cumulus parameterization 
-!  schemes run at moderately high resolutions (dx ~ O(10) km).
-!
-!  Additionally, w_damp returns the maximum cfl values due to vertical motion and
-!  horizontal motion.  These values are returned via the max_vert_cfl and 
-!  max_horiz_cfl variables.  (Added by T. Hutchinson, WSI, 3/5/2007)
-!
-!</DESCRIPTION>
-
-   itf=MIN(ite,ide-1)
-   jtf=MIN(jte,jde-1)
-
-   some1 = 0
-   some2 = 0
-   max_vert_cfl = 0.
-   max_horiz_cfl = 0.
-   total = 0
-
-! BEGIN LJW
-
-   w_crit_cfl = config_flags%w_crit_cfl
-   IF( print_flag ) THEN
-     write(wrf_err_message,*) '----------------------------------------'
-     CALL wrf_debug( 0, wrf_err_message )
-     WRITE(temp,*) 'W_DAMP2 BEGINS AT W-COURANT NUMBER = ',w_crit_cfl
-     CALL wrf_debug ( 0 , TRIM(temp) )
-     write(wrf_err_message,*) '----------------------------------------'
-     CALL wrf_debug( 0, wrf_err_message )
-     print_flag = .false.
-   ENDIF
-
-! END LJW
-
-   IF ( config_flags%w_damping == 1 ) THEN
-
-     DO j = jts,jtf
-      DO k = 2, kde-1
-       DO i = its,itf
-       
-        IF(config_flags%polar ) THEN
-           msfuxt = MIN(msfux(i,j), msfxffl)
-        ELSE
-           msfuxt = msfux(i,j)
-        END IF
-        
-        vert_cfl = abs(ww(i,k,j)/(c1(k)*mut(i,j)+c2(k))*rdnw(k)*dt)
-
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k 
-           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-        ENDIF
-        
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt), abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
-        
-        IF (horiz_cfl > max_horiz_cfl) THEN
-           max_horiz_cfl = horiz_cfl
-        ENDIF
-
-        IF (vert_cfl > w_flag_cfl .and. vert_cfl <= w_crit_cfl) THEN
-          WRITE(temp,FMT="(3(1x,i5,1x),'W_FLAG: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
-          CALL wrf_debug ( 100 , TRIM(temp) )
-          some2 = some2 + 1
-          rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_crit_cfl)*(c1(k)*mut(i,j)+c2(k))
-        ELSEIF(vert_cfl > w_crit_cfl) THEN
-          WRITE(temp,FMT="(3(1x,i5,1x),'W-CRITICAL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
-          CALL wrf_debug ( 100 , TRIM(temp) )
-          some1 = some1 + 1
-        ENDIF
-                       
-       ENDDO
-      ENDDO
-     ENDDO
-     
-   ELSE
-
-     DO j = jts,jtf
-      DO k = 2, kde-1
-       DO i = its,itf
-
-        IF(config_flags%polar ) then
-           msfuxt = MIN(msfux(i,j), msfxffl)
-        ELSE
-           msfuxt = msfux(i,j)
-        END IF
-        
-        vert_cfl = abs(ww(i,k,j)/(c1(k)*mut(i,j)+c2(k))*rdnw(k)*dt)
-        
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k 
-           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-        ENDIF
-        
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt), abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
-        
-        IF (horiz_cfl > max_horiz_cfl) THEN
-           max_horiz_cfl = horiz_cfl
-        ENDIF
-        
-        IF (vert_cfl > w_flag_cfl .and. vert_cfl <= w_crit_cfl) THEN
-          WRITE(temp,FMT="(3(1x,i5,1x),'W_FLAG: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
-          CALL wrf_debug ( 100 , TRIM(temp) )
-          some2 = some2 + 1
-        ELSEIF(vert_cfl > w_crit_cfl) THEN
-          WRITE(temp,FMT="(3(1x,i5,1x),'W-CRITICAL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
-          CALL wrf_debug ( 100 , TRIM(temp) )
-          some1 = some1 + 1
-        ENDIF
-
-       ENDDO
-      ENDDO
-     ENDDO
-     
-   ENDIF
-   
-   IF ( some1 .GT. 0 ) THEN
-     CALL get_current_time_string( time_str )
-     CALL get_current_grid_name( grid_str )
-     WRITE(temp,*) some1,                                            &
-            ' points exceeded W_CRITICAL_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
-     CALL wrf_debug ( 0 , TRIM(temp) )
-     WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'W-CFL: ',f7.2,2x,'dETA: ',f7.2))") & 
-           maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
-     CALL wrf_debug ( 0 , TRIM(temp) )
-     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'U-CFL: ',f7.2,2x,'V: ',f7.2,2x,'V-CFL: ',f7.2))") & 
-           maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
-     CALL wrf_debug ( 0 , TRIM(temp) )
-   ENDIF
-   
-   IF ( some2 .GT. 0 ) THEN
-     CALL get_current_time_string( time_str )
-     CALL get_current_grid_name( grid_str )
-     WRITE(temp,*) some2,                                            &
-            ' points exceeded W_FLAG_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
-     CALL wrf_debug ( 0 , TRIM(temp) )
-   ENDIF
-
-END SUBROUTINE w_damp2
-
-!-------------------------------------------------------------------------------
-! LJW - code for splitting vertical velocity for ex/im based on Shchepetkin (2015)
+! IEVA code for splitting vertical velocity for ex/im based on Shchepetkin (2015)
 
 SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
                     u, v, ww, w, mut, rdnw, msfty,    &
@@ -301,7 +93,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 
    LOGICAL         :: ieva
 
-!! Debug declarations
+! Debug declarations
 
    REAL,    PARAMETER :: binfrac = 0.1
    INTEGER, PARAMETER :: binsize = 11
@@ -313,8 +105,8 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    ieva = CHK_IEVA(config_flags, rk_step)
 
 ! =========================================================================
-! LJW DEBUG
-!     
+! PRINT OUT IEVA INFO
+
      IF( print_flag ) THEN
        write(wrf_err_message,*) '----------------------------------------'
        CALL wrf_debug( 0, wrf_err_message )
@@ -328,8 +120,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
        CALL wrf_debug( 0, wrf_err_message )
        print_flag = .false.     
       ENDIF
-!    
-! LJW
+
 ! =========================================================================
    
    i_start = its-1
@@ -343,7 +134,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    IF( ieva ) THEN   ! Implicit adaptive advection
    
 !=========================================================================
-! LJW DEBUG CODE BLOCK
+! DEBUG CODE BLOCK
 !        
 !    binavg(:) = 0.0
 !    crs(:)    = 0.0
@@ -367,7 +158,6 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
          DO i = i_start,i_end
          
 !=========================================================================
-! LJW 
 !      
 ! Translating Shchepetkin (2015), all the volumes and surface areas cancel out (not obvious unless you read
 ! the definitions of U, V, and W right after equation 3.7 (they are u*dy*dz, v*dx*dz, w*dx*dy)...
@@ -412,7 +202,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
              wwI(i,k,j) = ww(i,k,j) * (1.0 - wfrac)
 
 !=========================================================================
-! LJW DEBUG CODE BLOCK: compute distribution of wfrac 
+! DEBUG CODE BLOCK: compute distribution of wfrac 
 !             
 !            DO mm = 1, binsize
 !              IF( (mm-1)*binfrac / wfrac <= 1.0 .and. &
@@ -423,13 +213,12 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !              ENDIF
 !            ENDDO
 !
-! LJW
 !=========================================================================
                 
            ELSE
 
 !=========================================================================
-! LJW DEBUG CODE BLOCK:  write out information when fully implicit
+! DEBUG CODE BLOCK:  write out information when fully implicit
 !        
 !            write(wrf_err_message,*) ' MAX VERTICAL CFL ~ 0: i,j,k, cw_max, dt*(cx+cy) ',i,j,k,cw_max,Ceps*dt*(cx+cy)
 !            CALL wrf_debug(0, wrf_err_message )
@@ -459,7 +248,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    ENDIF
 
 !=========================================================================
-! LJW DEBUG - print distribution of wfrac 
+! DEBUG - print distribution of wfrac 
 ! 
 !  write(wrf_err_message,*) '----------------------------------------'
 !  CALL wrf_debug( 0, wrf_err_message )
@@ -471,7 +260,6 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !  write(wrf_err_message,*) '----------------------------------------'
 !  CALL wrf_debug( 0, wrf_err_message )
 !
-! LJW
 !=========================================================================
 
  RETURN
@@ -624,12 +412,8 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
 
 !<DESCRIPTION>
 !
-!  LJW
-!
 !  The algorithm integrates the continuity equation through the column
 !  to find a new column mass needed for IEVA calculations
-!
-!  LJW
 !
 !</DESCRIPTION>
 
@@ -695,7 +479,7 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
 
            mut_new(i,j) = mut_old(i,j) - dt*dmdt(i)
 
-! LJW - debug code.           
+! DEBUG code.           
 !          bigerr = (mut_new(i,j) / mut_old(i,j))
 !     
 !          IF( abs(bigerr) > 2.0 .or. mut_old(i,j) < 0.0 ) THEN    

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -25,13 +25,13 @@ LOGICAL FUNCTION CHK_IEVA( config_flags, rk_step )
 
    CHK_IEVA = .FALSE.
 
-   IF( zadvect_implicit .eq. 3 ) THEN   ! DO IEVA on all sub-steps of RK integrator
-       CHK_IEVA = .TRUE.
-   ENDIF
+!  IF( zadvect_implicit .eq. 3 ) THEN   ! DO IEVA on all sub-steps of RK integrator
+!      CHK_IEVA = .TRUE.
+!  ENDIF
 
-   IF( zadvect_implicit .eq. 2 .and. rk_step .ge. rk_order-1 ) THEN ! DO IEVA on last two sub-steps of RK integrator
-       CHK_IEVA = .TRUE.
-   ENDIF
+!  IF( zadvect_implicit .eq. 2 .and. rk_step .ge. rk_order-1 ) THEN ! DO IEVA on last two sub-steps of RK integrator
+!      CHK_IEVA = .TRUE.
+!  ENDIF
 
    IF( zadvect_implicit .eq. 1 .and. rk_step .eq. rk_order ) THEN  ! DO IEVA on last sub-step of RK integrator
        CHK_IEVA = .TRUE.
@@ -114,6 +114,10 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
        CALL wrf_debug( 0, wrf_err_message )
        write(wrf_err_message,*) 'WW_SPLIT:  IEVA = ', ieva
        CALL wrf_debug( 0, wrf_err_message )
+       IF( config_flags%zadvect_implicit > 1 ) THEN
+         write(wrf_err_message,*) 'WW_SPLIT:  WARNING: IEVA IS ONLY RUNNING on LAST RK-substep'
+         CALL wrf_debug( 0, wrf_err_message )
+       ENDIF
        write(wrf_err_message,*) 'WW_SPLIT:  dt = ', dt
        CALL wrf_debug( 0, wrf_err_message )
        write(wrf_err_message,*) 'WW_SPLIT:  alpha_max/min = ', alpha_max, alpha_min
@@ -220,8 +224,8 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !=========================================================================
 ! DEBUG CODE BLOCK:  write out information when fully implicit
 !        
-!            write(wrf_err_message,*) ' MAX VERTICAL CFL ~ 0: i,j,k, cw_max, dt*(cx+cy) ',i,j,k,cw_max,Ceps*dt*(cx+cy)
-!            CALL wrf_debug(0, wrf_err_message )
+! write(wrf_err_message,*) ' MAX VERTICAL CFL ~ 0: i,j,k, cw_max, dt*(cx+cy) ',i,j,k,cw_max,Ceps*dt*(cx+cy)
+! CALL wrf_debug(0, wrf_err_message )
 !
 !=========================================================================
              

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -810,9 +810,9 @@ BENCH_START(rk_tend_tim)
                          ,grid%u_2, grid%v_2, grid%w_2, grid%t_2, grid%ph_2                                    &
                          ,grid%u_1, grid%v_1, grid%w_1, grid%t_1, grid%ph_1                                    &
                          ,grid%h_diabatic, grid%phb, grid%t_init                                               &
-                         ,grid%mu_2, grid%mut, grid%muu, grid%muv, grid%mub                                    &
+                         ,grid%mu_1, grid%mu_2, grid%mut, grid%muu, grid%muv, grid%mub                         & ! LJW
                          ,grid%c1h, grid%c2h, grid%c1f, grid%c2f                                               &
-                         ,grid%al, grid%alt, grid%p, grid%pb, grid%php, cqu, cqv, cqw                          &
+                         ,grid%al, grid%ht, grid%alt, grid%p, grid%pb, grid%php, cqu, cqv, cqw                & ! LJW
                          ,grid%u_base, grid%v_base, grid%t_base, grid%qv_base, grid%z_base                     &
                          ,grid%msfux,grid%msfuy, grid%msfvx, grid%msfvx_inv                                    &
                          ,grid%msfvy, grid%msftx,grid%msfty, grid%clat, grid%f, grid%e, grid%sina, grid%cosa   &
@@ -2138,6 +2138,7 @@ BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
+                           grid%u_2, grid%v_2,  grid%w_2,                    &  ! LJW IEVA
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,                               &
                            grid%alt,                                         &
@@ -2306,6 +2307,7 @@ BENCH_START(tke_adv_tim)
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
+                            grid%u_2, grid%v_2,  grid%w_2,                         &  ! LJW IEVA
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,                                    &
                             grid%alt,                                              &
@@ -2398,6 +2400,7 @@ BENCH_START(chem_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
+                              grid%u_2, grid%v_2,  grid%w_2,                     &  ! LJW IEVA
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,                                &
                               grid%alt,                                          &
@@ -2559,6 +2562,7 @@ BENCH_START(tracer_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
+                              grid%u_2, grid%v_2,  grid%w_2,                     &  ! LJW IEVA
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,                                &
                               grid%alt,                                          &
@@ -2700,6 +2704,7 @@ BENCH_END(tracer_adv_tim)
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
+                                 grid%u_2, grid%v_2,  grid%w_2,                   &  ! LJW IEVA
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,                              &
                                  grid%alt,                                        &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -810,9 +810,9 @@ BENCH_START(rk_tend_tim)
                          ,grid%u_2, grid%v_2, grid%w_2, grid%t_2, grid%ph_2                                    &
                          ,grid%u_1, grid%v_1, grid%w_1, grid%t_1, grid%ph_1                                    &
                          ,grid%h_diabatic, grid%phb, grid%t_init                                               &
-                         ,grid%mu_1, grid%mu_2, grid%mut, grid%muu, grid%muv, grid%mub                         & ! LJW
+                         ,grid%mu_1, grid%mu_2, grid%mut, grid%muu, grid%muv, grid%mub                         & 
                          ,grid%c1h, grid%c2h, grid%c1f, grid%c2f                                               &
-                         ,grid%al, grid%ht, grid%alt, grid%p, grid%pb, grid%php, cqu, cqv, cqw                & ! LJW
+                         ,grid%al, grid%ht, grid%alt, grid%p, grid%pb, grid%php, cqu, cqv, cqw                 & 
                          ,grid%u_base, grid%v_base, grid%t_base, grid%qv_base, grid%z_base                     &
                          ,grid%msfux,grid%msfuy, grid%msfvx, grid%msfvx_inv                                    &
                          ,grid%msfvy, grid%msftx,grid%msfty, grid%clat, grid%f, grid%e, grid%sina, grid%cosa   &
@@ -2138,7 +2138,7 @@ BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
-                           grid%u_2, grid%v_2,  grid%w_2,                    &  ! LJW IEVA
+                           grid%u_2, grid%v_2,  grid%w_2,                    &  
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,                               &
                            grid%alt,                                         &
@@ -2307,7 +2307,7 @@ BENCH_START(tke_adv_tim)
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
-                            grid%u_2, grid%v_2,  grid%w_2,                         &  ! LJW IEVA
+                            grid%u_2, grid%v_2,  grid%w_2,                         &  
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,                                    &
                             grid%alt,                                              &
@@ -2400,7 +2400,7 @@ BENCH_START(chem_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_2, grid%v_2,  grid%w_2,                     &  ! LJW IEVA
+                              grid%u_2, grid%v_2,  grid%w_2,                     &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,                                &
                               grid%alt,                                          &
@@ -2562,7 +2562,7 @@ BENCH_START(tracer_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_2, grid%v_2,  grid%w_2,                     &  ! LJW IEVA
+                              grid%u_2, grid%v_2,  grid%w_2,                     &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,                                &
                               grid%alt,                                          &
@@ -2704,7 +2704,7 @@ BENCH_END(tracer_adv_tim)
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
-                                 grid%u_2, grid%v_2,  grid%w_2,                   &  ! LJW IEVA
+                                 grid%u_2, grid%v_2,  grid%w_2,                   &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,                              &
                                  grid%alt,                                        &

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1475,6 +1475,8 @@ The following are for observation nudging:
  w_damping                           = 0,       ! vertical velocity damping flag (for operational use)
                                                   0 = without damping
                                                   1 = with    damping
+ w_crit_cfl                          = 1.2      ! (1.2 default, old behavior) value of vertical CFL where w_damp turns on vert velo damping
+                                                  set to ~2.0 when IEVA is turned on (see below)
  base_temp                           = 290.,    ! real-data, em ONLY, base sea-level temp (K)
  base_pres                           = 10^5     ! real-data, em ONLY, base sea-level pres (Pa), DO NOT CHANGE
  base_lapse                          = 50.,     ! real-data, em ONLY, lapse rate (K), DO NOT CHANGE
@@ -1506,6 +1508,9 @@ The following are for observation nudging:
  h_sca_adv_order (max_dom)           = 5,       ! horizontal scalar advection order
  v_sca_adv_order (max_dom)           = 3,       ! vertical scalar advection order
 
+ zadvect_implicit                    = 0,       ! (default = 0, No IEVA) Turns on implicit-explicit vertical advection enabling stable
+                                                ! integration even when vertical CFLs ~ 3 - 3.5. 
+                                                ! 1 = zadvect_implicit, turn on IEVA 
  momentum_adv_opt(max_dom)           = 1,       ! advection options for momentum variables: 
                                                   1=original, 3 = 5th-order WENO
                                                   advection options for scalar variables: 0=simple, 1=positive definite,

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -728,5 +728,28 @@ To overwrite the cu_physics option for a second nest, set
 /
 
 
+** Using Implicit-Explicit Vertical Advection (IEVA)
 
+The most typical settings (used in the Wicker and Skamarock (MWR, 2021)
+is below in the namelist, setting w_crit_cfl to turn on Rayleigh
+damping at a vertical courant number of 2.0, and turning on the implicit 
+vertical advection for the last RK time step only (zadvect_implicit = 1).  
+The use of IEVA only on the last RK iteration is similiar to how monotonic 
+or pos-definite advection works as those more expensive routines are only 
+called on the last RK iteration.  We could find almost no difference in the 
+solutions or stability using zadvect_implicit = 1 or zadvect_implicit = 3.
+
+w_crit_cfl =     1.2   --> (default value and value previously used in w_damp when Rayleigh damping on)
+w_crit_cfl = 2.0 ~ 2.5 --> (typical values when using IEVA)
+zadvect_implicit = 0   --> turns IEVA off
+zadvect_implicit = 1   --> turns IEVA on, only applied at last RK iteration 
+zadvect_implicit = 2   --> turns IEVA on, only applied at last two RK iterations
+zadvect_implicit = 3   --> turns IEVA on, applied on all RK iterations
+
+&dynamics
+
+  w_crit_cfl = 2.0,
+  zadvect_implicit = 1
+
+/
 


### PR DESCRIPTION
TYPE: New feature

KEYWORDS: implicit vertical advection, larger time step

SOURCE: Louis J. Wicker (NOAA National Severe Storm Laboratory)

DESCRIPTION OF CHANGES:  
The implicit-explicit vertical advection (IEVA) scheme (Wicker and Skamarock 2021 Mon. Wea. Rev.) originally created for the ROMS ocean model, has been implemented in the WRF model.  The IEVA method is targeted at WRF convection-permitting simulations, particularly for NWP, as a way to increase model efficiency and solution accuracy.  Often for CAM NWP applications, the vertical velocity in only 10-100 grid columns in a regional or CONUS domain will restrict the size of the large time step of the model.  Previous applications often used filters to control the magnitude of the vertical velocities with the convection.  The most common was the latent heat limiter (mp_tend_lim) and a Rayleigh damper.  The combination of these filters enabled the large time step to be ~20 seconds for applications like the HRRR.  However, these filters reduced maximum vertical velocities by as much as 40% based on test cases in environments with large instabilities (CAPE ~ 5000-6000 J/kg).  IEVA eliminates the need for these filters by splitting the vertical advection into two pieces based on the local vertical CFL.  For stable CFLs the vertical transport is done using the conventional Runge-Kutta algorithms in WRF.  For  CFLs > 1.1, the vertical transport is done in two parts.  The vertical velocity field is separated into a field that is stable for explicit transport, and a second field that requires implicit transport.  The explicit transport is done using the same WRF algorithms, and the implicit transport is done using an upstream implicit algorithm.  Using IEVA, the large time step in the WRF model can be increased somewhat for CAM applications, while retaining much of the vertical velocity magnitudes and associated vertical transport.  CAM NWP applications remain stable even for vertical CFL's ~ 3-3.5, and permit an increase in the stable large time step.  Wicker and Skamarock (2021) show that in HRRR-like forecast with strong convection, the large time step can be increase to 24 seconds and wallclock time is reduced by nearly 10%.  

LIST OF MODIFIED FILES: 

M       Registry/Registry.EM_COMMON
M       dyn_em/Makefile
M       dyn_em/module_advect_em.F
M       dyn_em/module_big_step_utilities_em.F
M       dyn_em/module_em.F
A       dyn_em/module_ieva_em.F
M       dyn_em/solve_em.F
M       run/README.namelist
M       test/em_real/examples.namelist

TESTS CONDUCTED: 
1. The IEVA branch of the code was tested on the same case as described in Wicker and Skamarock (2021).  Since IEVA is only needed for CAM applications, tests at non-CAM resolutions are not needed.  Additionally, the scheme has been running at NCEP in GSL's WRFv3.9 HRRR-DAS/HRRRv4 parallel since early 2020 with all vertical velocity filters turned off.  Dr. David Dowell from GSL has communicated that crashes based on vertical CFL-violations have been completely eliminated in the HRRR-DAS and HRRRv4 forecast systems at NCEP.
2. Regression testing with jenkins is all PASS

RELEASE NOTE: 
An implicit-explicit vertical advection (IEVA) scheme originally created for the ROMS ocean model, has been implemented in the WRF model. The IEVA method is targeted at WRF convection-permitting simulations, particularly for NWP, as a way to increase model efficiency and solution accuracy. Wicker, L. J., and W. C. Skamarock, 2021:  An Implicit-Explicit Vertical Transport Scheme for Convection Allowing Models.  Mon. Wea. Rev., Accepted with minor revisions 5/1/2020.
