### PR TITLE
FARMS accounts for the effective radius of unresolved hydrometeors

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1304,16 +1304,16 @@
 
          IF (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) THEN
           do k = kts, kte
-             re_qc1d(k) = 2.49E-6
-             re_qi1d(k) = 4.99E-6
-             re_qs1d(k) = 9.99E-6
+             re_qc1d(k) = 0.0
+             re_qi1d(k) = 0.0
+             re_qs1d(k) = 0.0
           enddo
           call calc_effectRad (t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d,  &
                       re_qc1d, re_qi1d, re_qs1d, kts, kte)
           do k = kts, kte
-             re_cloud(i,k,j) = MAX(2.49E-6, MIN(re_qc1d(k), 50.E-6))
-             re_ice(i,k,j)   = MAX(4.99E-6, MIN(re_qi1d(k), 125.E-6))
-             re_snow(i,k,j)  = MAX(9.99E-6, MIN(re_qs1d(k), 999.E-6))
+             if (re_qc1d(k) /= 0.0) re_cloud(i,k,j) = MAX(2.49E-6, MIN(re_qc1d(k), 50.E-6))
+             if (re_qi1d(k) /= 0.0) re_ice(i,k,j)   = MAX(4.99E-6, MIN(re_qi1d(k), 125.E-6))
+             if (re_qs1d(k) /= 0.0) re_snow(i,k,j)  = MAX(9.99E-6, MIN(re_qs1d(k), 999.E-6))
           enddo
          ENDIF
 
@@ -5065,7 +5065,7 @@
 
       if (has_qc) then
       do k = kts, kte
-         re_qc1d(k) = 2.49E-6
+         re_qc1d(k) = 0.0
          if (rc(k).le.R1 .or. nc(k).le.R2) CYCLE
          if (nc(k).lt.100) then
             inu_c = 15
@@ -5081,7 +5081,7 @@
 
       if (has_qi) then
       do k = kts, kte
-         re_qi1d(k) = 2.49E-6
+         re_qi1d(k) = 0.0
          if (ri(k).le.R1 .or. ni(k).le.R2) CYCLE
          lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
          re_qi1d(k) = MAX(2.51E-6, MIN(SNGL(0.5D0 * DBLE(3.+mu_i)/lami), 125.E-6))
@@ -5090,7 +5090,7 @@
 
       if (has_qs) then
       do k = kts, kte
-         re_qs1d(k) = 4.99E-6
+         re_qs1d(k) = 0.0
          if (rs(k).le.R1) CYCLE
          tc0 = MIN(-0.1, t1d(k)-273.15)
          smob = rs(k)*oams

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -237,9 +237,9 @@ CONTAINS
         if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
           do i=its,ite
             do k=kts,kte
-              re_qc(k) = 2.51E-6
-              re_qi(k) = 10.01E-6
-              re_qs(k) = 25.E-6
+              re_qc(k) = 0.0
+              re_qi(k) = 0.0
+              re_qs(k) = 0.0
 
               t1d(k)  = th(i,k,j)*pii(i,k,j)
               den1d(k)= den(i,k,j)
@@ -251,9 +251,9 @@ CONTAINS
                                 qmin, t0c, re_qc, re_qi, re_qs,         &
                                 kts, kte, i, j)
             do k=kts,kte
-              re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
-              re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
-              re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
+              if (re_qc(k) /= 0.0) re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
+              if (re_qi(k) /= 0.0) re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
+              if (re_qs(k) /= 0.0) re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
             enddo 
           enddo   
         endif     ! has_reqc, etc...
@@ -2644,6 +2644,7 @@ CONTAINS
 
       if (has_qc) then
         do k=kts,kte
+          re_qc(k) = 0.0
           if (rqc(k).le.R1) CYCLE
           lamdac   = (pidnc*nc0/rqc(k))**obmr 
           re_qc(k) =  max(2.51E-6,min(1.5*(1.0/lamdac),50.E-6))
@@ -2652,6 +2653,7 @@ CONTAINS
 
      if (has_qi) then
         do k=kts,kte
+          re_qi(k) = 0.0
           if (rqi(k).le.R1 .or. rni(k).le.R2) CYCLE
           diai = 11.9*sqrt(rqi(k)/ni(k))
           re_qi(k) = max(10.01E-6,min(0.75*0.163*diai,125.E-6))
@@ -2660,6 +2662,7 @@ CONTAINS
 
       if (has_qs) then
         do k=kts,kte
+          re_qs(k) = 0.0
           if (rqs(k).le.R1) CYCLE
           supcol = t0c-t(k)
           n0sfac = max(min(exp(alpha*supcol),n0smax/n0s),1.)

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -942,12 +942,14 @@ CONTAINS
 ! for cloud, ice, and snow.
 
    IF ( config_flags%swint_opt .eq. 2 ) THEN
-      IF ( ( has_reqc .EQ. 1 ) .AND. &
-           ( has_reqi .EQ. 1 ) .AND. &
-           ( has_reqs .EQ. 1 ) .AND. &
-           ( f_qc            ) .AND. &
-           ( f_qi            ) .AND. &
-           ( f_qs            ) ) THEN
+      IF (((( has_reqc .EQ. 1 .AND. has_reqi .EQ. 1 .and. has_reqs .EQ. 1 ) .AND. &
+            ( config_flags%mp_physics == THOMPSON .or.        &
+              config_flags%mp_physics == THOMPSONAERO .or.    &
+              config_flags%mp_physics == WSM6SCHEME )) .or.   &
+            ( has_reqc .EQ. 0 .AND. has_reqi .EQ. 0 .and. has_reqs .EQ. 0 )) .AND. &
+            ( f_qc            ) .AND. &
+            ( f_qi            ) .AND. &
+            ( f_qs            ) ) THEN
          !  everything is A-OK for FARMS
       ELSE
          CALL wrf_error_fatal ('--- ERROR: FARMS (swint_opt==2) requires a different MP scheme')
@@ -1169,7 +1171,7 @@ CONTAINS
        do j=jts,jtf
           do k=kts,ktf
           do i=its,itf
-             re_cloud(i,k,j) = 2.51E-6
+             re_cloud(i,k,j) = 0.0
           end do
           end do
        end do
@@ -1178,7 +1180,7 @@ CONTAINS
        do j=jts,jtf
           do k=kts,ktf
           do i=its,itf
-             re_ice(i,k,j) = 5.01E-6
+             re_ice(i,k,j) = 0.0
           end do
           end do
        end do
@@ -1187,7 +1189,7 @@ CONTAINS
        do j=jts,jtf
           do k=kts,ktf
           do i=its,itf
-             re_snow(i,k,j) = 10.01E-6
+             re_snow(i,k,j) = 0.0
           end do
           end do
        end do

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -943,9 +943,9 @@ CONTAINS
 
    IF ( config_flags%swint_opt .eq. 2 ) THEN
       IF (((( has_reqc .EQ. 1 .AND. has_reqi .EQ. 1 .and. has_reqs .EQ. 1 ) .AND. &
-            ( config_flags%mp_physics == THOMPSON .or.        &
-              config_flags%mp_physics == THOMPSONAERO .or.    &
-              config_flags%mp_physics == WSM6SCHEME )) .or.   &
+            ( config_flags%mp_physics == THOMPSON .OR.        &
+              config_flags%mp_physics == THOMPSONAERO .OR.    &
+              config_flags%mp_physics == WSM6SCHEME )) .OR.   &
             ( has_reqc .EQ. 0 .AND. has_reqi .EQ. 0 .and. has_reqs .EQ. 0 )) .AND. &
             ( f_qc            ) .AND. &
             ( f_qi            ) .AND. &

--- a/phys/module_ra_farms.F
+++ b/phys/module_ra_farms.F
@@ -27,26 +27,31 @@
     real, parameter :: DE_CLOUD_MIN = 5.0, DE_CLOUD_MAX = 120.0
     real, parameter :: TAU_MIN = 0.0001, TAU_MAX = 300.0
     real, parameter :: AOD550_VAL = 0.12, ANGEXP_VAL = 1.3, AERSSA_VAL = 0.85, AERASY_VAL = 0.9
+    real, parameter :: RE_CLOUD_CLIM = 8.E-6, RE_ICE_CLIM = 24.E-6, RE_SNOW_CLIM = 24.E-6
+
 
   contains
 
     subroutine Farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte,  &
            p8w, rho, dz8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
            coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-           julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+           julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2, &
+           has_reqc, has_reqi, has_reqs, cldfra)
+
 
       implicit None
 
       integer, intent(in) :: ims, ime, jms, jme, its, ite, jts, jte, kms, kme, &
           kts, kte
 
-      integer, intent(in) :: aer_opt
+      integer, intent(in) :: aer_opt, has_reqc, has_reqi, has_reqs
       real,    intent(in) :: julian
 
       real, dimension(ims:ime, jms:jme), intent(in) :: albedo, coszen_loc
 
       real, dimension(ims:ime, kms:kme, jms:jme ), intent(in) :: qv, qi, qs, qc, &
-          p8w, rho, dz8w, re_cloud, re_ice, re_snow 
+          p8w, rho, dz8w, cldfra 
+      real, dimension(ims:ime, kms:kme, jms:jme ), intent(inout) :: re_cloud, re_ice, re_snow
 
       real, dimension(ims:ime, jms:jme), intent(inout) :: aerssa2d, aerasy2d, aod5502d, angexp2d
       real, dimension(ims:ime,jms:jme), intent(inout) :: swddir2, swdown2, &
@@ -54,7 +59,7 @@
                                                          swdownc2, swddnic2
 
         ! Local
-      integer :: i, j
+      integer :: i, j, k
       real    :: tau_qv, tau_qi, tau_qs, pmw, swp, iwp, lwp, beta
       real    :: re_cloud_path, re_ice_path, re_snow_path, q_aux
       real, dimension(kms:kme) :: rhodz
@@ -71,6 +76,31 @@
              swddnic2(i, j) = 0.0
            else
              rhodz(:) = rho(i, :, j) * dz8w(i, :, j) / (1. + qv(i, :, j))
+
+             if (has_reqc == 1) then
+               do k = kts, kte
+                 if (CLDFRA (i, k, j) > 0.0 .and. re_cloud(i, k, j) == 0.0) re_cloud(i, k, j) = RE_CLOUD_CLIM
+               end do
+             else
+               re_cloud(i, :, j) = RE_CLOUD_CLIM
+             end if
+
+             if (has_reqi == 1) then
+               do k = kts, kte
+                 if (cldfra(i, k, j) > 0.0 .and. re_ice(i, k, j) == 0.0) re_ice(i, k, j) = RE_ICE_CLIM
+               end do
+             else
+               re_ice(i, :, j) = RE_ICE_CLIM
+             end if
+
+             if (has_reqs == 1) then
+               do k = kts, kte
+                 if (cldfra(i, k, j) > 0.0 .and. re_snow(i, k, j) == 0.0) re_snow(i, k, j) = RE_SNOW_CLIM
+               end do
+             else
+               re_snow(i, :, j) = RE_SNOW_CLIM
+             end if
+
                ! PMW
              pmw = integrate_1var (rhodz, qv(i, :, j), kms, kme, kts, kte)
 

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2798,7 +2798,8 @@ CONTAINS
          call farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte, &
               p8w, rho, dz8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
               coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-              julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+              julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2,  &
+              has_reqc, has_reqi, has_reqs, cldfra)
        enddo
        !$OMP END PARALLEL DO
     end if


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, effective radius unresolved hydrometeors

SOURCE: Pedro A. Jimenez and Ju Hye Kim (NCAR/RAL), and Jimy Dudhia (NCAR/MMM)

DESCRIPTION OF CHANGES: 
The parameterizations accounting for radiative effects of unresolved clouds do not provide 
effective radius. The radius is estimated based on climatologies inside the radiation 
parameterizations. The radius climatologies were missing in FARMS. We have added the 
climatologies for the effective radius for liquid, ice and snow hydrometeors. The fix is valid 
for mp = 6, 8, 28 and for all the microphysics options that do not provide effective radius. We 
have added the logic to stop and raise and exception if an incompatible microphysics is 
selected.

The default radius is changed to zero instead of a small value.

This PR is going to create a conflict with PR #1191. It is better to merge PR #1191 first, and afterwards, merge the present PR.

LIST OF MODIFIED FILES: 
M       phys/module_mp_thompson.F
M       phys/module_mp_wsm6.F
M       phys/module_physics_init.F
M       phys/module_ra_farms.F
M       phys/module_radiation_driver.F

TESTS CONDUCTED: 
1. We have run FARMS with mp = 6, 8, and 28 and the code behaves as expected. 
2. We have also run the code of this PR with mp = 2 that does not provide the effective radius 
of the hydrometeors and the code works fine. 
3. If a non-supported microphysics is selected WRF stops and prints the correct error.
4. Jenkins test is all PASS

RELEASE NOTE: Bug fix to account for the effective radius of the unresolved hydrometeors by FARMS. 
