### PR TITLE
Fix occurrence of time for max/min of diagnostics in clWRF

### DIFF
--- a/phys/module_diag_cl.F
+++ b/phys/module_diag_cl.F
@@ -185,8 +185,16 @@ CONTAINS
           skintempclmax(i,j)=skintemp(i,j)-t273
           skintempclmean(i,j)=skintemp(i,j)-t273
           skintempclstd(i,j)=(skintemp(i,j)-t273)*(skintemp(i,j)-t273)
-	  tt2clmin(i,j) = xtime + dt/60.  ! value at end of timestep 
-          tt2clmax(i,j) = xtime + dt/60.
+          ! reinitialize times
+	  tt2clmin(i,j)       = xtime + dt/60.  ! value at end of timestep 
+          tt2clmax(i,j)       = xtime + dt/60.
+          tq2clmin(i,j)       = xtime + dt/60.
+          tq2clmax(i,j)       = xtime + dt/60.
+          tspduv10clmax(i,j)  = xtime + dt/60.
+          traincclmax(i,j)    = xtime + dt/60.
+          trainncclmax(i,j)   = xtime + dt/60.
+          tskintempclmin(i,j) = xtime + dt/60.
+          tskintempclmax(i,j) = xtime + dt/60.
         ENDDO
       ENDDO
     ENDDO
@@ -206,7 +214,7 @@ CONTAINS
             spduv10clmean,u10clstd,v10clstd,spduv10clstd)
 ! Precipitation flux
           CALL varstatisticsMAX(raincv/dt,xtimep,ime-ims+1,jme-jms+1,         &
-            raincclmax,traincclmax,raincclmean,raincclstd) 
+            raincclmax,traincclmax,raincclmean,raincclstd)
           CALL varstatisticsMAX(rainncv/dt,xtimep,ime-ims+1,jme-jms+1,        &
             rainncclmax,trainncclmax,rainncclmean,rainncclstd)
 ! Skin Temperature 

--- a/phys/module_diag_cl.F
+++ b/phys/module_diag_cl.F
@@ -186,7 +186,7 @@ CONTAINS
           skintempclmean(i,j)=skintemp(i,j)-t273
           skintempclstd(i,j)=(skintemp(i,j)-t273)*(skintemp(i,j)-t273)
           ! reinitialize times
-	  tt2clmin(i,j)       = xtime + dt/60.  ! value at end of timestep 
+          tt2clmin(i,j)       = xtime + dt/60.  ! value at end of timestep 
           tt2clmax(i,j)       = xtime + dt/60.
           tq2clmin(i,j)       = xtime + dt/60.
           tq2clmax(i,j)       = xtime + dt/60.
@@ -214,7 +214,7 @@ CONTAINS
             spduv10clmean,u10clstd,v10clstd,spduv10clstd)
 ! Precipitation flux
           CALL varstatisticsMAX(raincv/dt,xtimep,ime-ims+1,jme-jms+1,         &
-            raincclmax,traincclmax,raincclmean,raincclstd)
+            raincclmax,traincclmax,raincclmean,raincclstd) 
           CALL varstatisticsMAX(rainncv/dt,xtimep,ime-ims+1,jme-jms+1,        &
             rainncclmax,trainncclmax,rainncclmean,rainncclstd)
 ! Skin Temperature 

--- a/phys/module_diag_cl.F
+++ b/phys/module_diag_cl.F
@@ -185,6 +185,8 @@ CONTAINS
           skintempclmax(i,j)=skintemp(i,j)-t273
           skintempclmean(i,j)=skintemp(i,j)-t273
           skintempclstd(i,j)=(skintemp(i,j)-t273)*(skintemp(i,j)-t273)
+	  tt2clmin(i,j) = xtime + dt/60.  ! value at end of timestep 
+          tt2clmax(i,j) = xtime + dt/60.
         ENDDO
       ENDDO
     ENDDO


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: clWRF, maximum, minimum, time, diagnostics

SOURCE: Christopher Thomas (Climate Change Research Centre, UNSW Australia)

DESCRIPTION OF CHANGES: 
TT2MAX and TT2MIN are the times at which T2MAX and T2MIN, the max and min values of 
T2 within a diagnostic period, are achieved. This bug caused the incorrect computation of 
TT2MAX and TT2MIN for cases in which T2MAX or T2MIN occurred at the beginning of the diagnostic period under consideration. At the beginning of each diagnostic period the working 
values of T2MAX and T2MIN are reinitialized with the current value of T2, however the working 
values of TT2MAX and TT2MIN were not reinitialized with the current time value. Thus if the 
max or min actually occurred at the beginning of the diagnostic period, then TT2MAX or 
TT2MIN would contain the value assigned to it in the previous period. The bug fix corrects 
this by re-initializing TT2MAX and TT2MIN at the beginning of each diagnostic period. 

The same initialization of the time of occurrence for the max/min of the 2-m temperature was 
applied to these variables: tt2clmin, tt2clmax, tq2clmin, tq2clmax, tspduv10clmax, 
traincclmax, trainncclmax, tskintempclmin, tskintempclmax.

ISSUE: 
Closes #1193 

LIST OF MODIFIED FILES: 
M       phys/module_diag_cl.F

TESTS CONDUCTED: 
1. Tested on the WRF simulation set up for which the problem was first encountered. The fix 
changes the TT2MAX and TT2MIN values only for those points/periods for which they were 
incorrect, leaving all others unchanged. The values of TT2MAX and TT2MIN produced by the 
fix are in agreement with those computed by outputting T2 for all times steps and calculating 
TT2MAX and TT2MIN directly (using R). The tests were made using v4.1.2 but the file in 
question (module_diag_cl.F) has not changed in v4.2.
2. Here the diagnostic period for the min/max output is 24 hrs. Screenshot shows second 
24 hr period of simulation.    
Left-hand panel = before fix   
Right-hand panel = after fix   
Values for TT2MAX should range between 1440 and 2880   
Note speckling in region south of Australia, also isolated instances elsewhere. In this instance 
nothing seems to occur over land but it clearly could. Bug only manifests if the extreme value 
occurs at the beginning of the diagnostic period. 
![before_after_clwrf_fix](https://user-images.githubusercontent.com/12511990/84957679-09946e80-b13f-11ea-8861-c5cb465cdb43.png)
3. Jenkins testing is OK.

RELEASE NOTE: The calculation of the times of minimum and maximum of fields within the clWRF diagnostics module was occasionally incorrect. At the beginning of each diagnostic period the working values of diagnostic was correctly reinitialized with the current value; however the working values of occurrence of the time of the max/min values of the diagnostics were not reinitialized with the current time value. Thus if the max or min actually occurred at the beginning of the diagnostic period, then the reported time would incorrectly contain the value assigned during the previous output period.
