### PR TITLE
Fix INTEGER interpolation and feedback Registry arguments

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -872,7 +872,7 @@ state    real   G_URB2D         ij    misc        1         -       rd=(interp_f
 state    real   RN_URB2D        ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)       "RN_URB"  "NET RADIATION ON URBAN SFC"         "W m{-2}"
 state    real   TS_URB2D        ij    misc        1         -       rd=(interp_fcnm)u=(copy_fcnm)       "TS_URB"  "SKIN TEMPERATURE"          "K"
 state    real   FRC_URB2D       ij    misc        1         -     i012rd=(interp_fcnm)u=(copy_fcnm)      "FRC_URB2D"  "URBAN FRACTION"         "dimensionless"
-state    integer   UTYPE_URB2D  ij    misc        1         -     rd=(interp_fcnm)u=(copy_fcnm)       "UTYPE_URB"  "URBAN TYPE"         "dimensionless"
+state    integer   UTYPE_URB2D  ij    misc        1         -     rd=(interp_fcni)u=(copy_fcni)       "UTYPE_URB"  "URBAN TYPE"         "dimensionless"
 state    real   TRB_URB4D       i{umap1}j   misc       1         Z     r      "TRB_URB4D" "ROOF LAYER TEMPERATURE"          "K"
 state    real   TW1_URB4D       i{umap2}j   misc       1         Z     r      "TW1_URB4D" "WALL LAYER TEMPERATURE"          "K"
 state    real   TW2_URB4D       i{umap2}j   misc       1         Z     r      "TW2_URB4D" "WALL LAYER TEMPERATURE"          "K"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1763,7 +1763,7 @@ state    real   LH_URB2D_mosaic   i{mocat}j     misc        1         -     r   
 state    real   G_URB2D_mosaic    i{mocat}j     misc        1         -     r     "G_URB2D_mosaic"               "GROUND HEAT FLUX  AT THE SURFACE"    "W m-2"
 state    real   RN_URB2D_mosaic   i{mocat}j     misc        1         -     r     "RN_URB2D_mosaic"              "NET RADIATION"                       "W m-2"
 
-state    integer   mosaic_cat_index  iuj        misc        1         Z     i012rd=(interp_fcni:lu_index)u=(copy_fcni)    "mosaic_cat_index"          "  "   ""
+state    integer   mosaic_cat_index  iuj        misc        1         Z     i012rd=(interp_fcni)u=(copy_fcni)    "mosaic_cat_index"          "  "   ""
 state    real      landusef2         iuj        misc        1         Z     i012rdu                                                  "LANDUSEF2"      "sorted landuse fraction"  ""
 
 # State vector for etampnew microphysics. Must be declared state because it is not read-once and is needed for restarting.

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1763,7 +1763,7 @@ state    real   LH_URB2D_mosaic   i{mocat}j     misc        1         -     r   
 state    real   G_URB2D_mosaic    i{mocat}j     misc        1         -     r     "G_URB2D_mosaic"               "GROUND HEAT FLUX  AT THE SURFACE"    "W m-2"
 state    real   RN_URB2D_mosaic   i{mocat}j     misc        1         -     r     "RN_URB2D_mosaic"              "NET RADIATION"                       "W m-2"
 
-state    integer   mosaic_cat_index  iuj        misc        1         Z     i012rd=(interp_mask_land_field:lu_index)u=(copy_fcnm)    "mosaic_cat_index"          "  "   ""
+state    integer   mosaic_cat_index  iuj        misc        1         Z     i012rd=(interp_fcni:lu_index)u=(copy_fcni)    "mosaic_cat_index"          "  "   ""
 state    real      landusef2         iuj        misc        1         Z     i012rdu                                                  "LANDUSEF2"      "sorted landuse fraction"  ""
 
 # State vector for etampnew microphysics. Must be declared state because it is not read-once and is needed for restarting.

--- a/Registry/registry.clm
+++ b/Registry/registry.clm
@@ -1,14 +1,14 @@
 # CLM Variables
 
-state   integer NUMC           ij       misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "NUMC"     "NUMBER OF COLUMN SUBGRIDS"   " "
-state   integer NUMP           ij       misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "NUMP"     "NUMBER OF PFT SUBGRIDS"   " "
+state   integer NUMC           ij       misc      1          Z     rd=(interp_fcni:lu_index,iswater)u=(copy_fcni)           "NUMC"     "NUMBER OF COLUMN SUBGRIDS"   " "
+state   integer NUMP           ij       misc      1          Z     rd=(interp_fcni:lu_index,iswater)u=(copy_fcni)           "NUMP"     "NUMBER OF PFT SUBGRIDS"   " "
 state   real    SABV           ij       misc      1          Z     h                                                           "SABV"     "NET VEGETATION SOLAR RADIATION" "W m-2"
 state   real    SABG           ij       misc      1          Z     h                                                           "SABG"     "NET SOIL SOLAR RADIATION"       "W m-2"
 state   real    LWUP           ij       misc      1          Z     h                                                           "LWUP"     "OUTGOING LONGWAVE RADIATION"    "W m-2"
 state  real     LHSOI          i4j      misc      1          Z      h                                                           "LHSOI"           "LH from soil"              "W/m^2"
 state  real     LHVEG          i4j      misc      1          Z      h                                                           "LHVEG"           "LH from vegetation"        "W/m^2"
 state  real     LHTRAN         i4j      misc      1          Z      h                                                           "LHTRAN"          "LH from transpiration"     "W/m^2"
-state   integer SNL            i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "SNL"      "NUMBER OF SNOW LAYERS"   " "
+state   integer SNL            i4j      misc      1          Z     rd=(interp_fcni:lu_index,iswater)u=(copy_fcni)           "SNL"      "NUMBER OF SNOW LAYERS"   " "
 state   real    SNOWDP         i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "SNOWDP"   "SUBGRID SNOW DEPTH"              "m"
 state   real    WTC            i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "WTC"      "COLUMN WEIGHT"                "fraction"
 state   real    WTP            i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "WTP"      "PFT WEIGHT"                   "fraction"

--- a/Registry/registry.clm
+++ b/Registry/registry.clm
@@ -1,14 +1,14 @@
 # CLM Variables
 
-state   integer NUMC           ij       misc      1          Z     rd=(interp_fcni:lu_index,iswater)u=(copy_fcni)           "NUMC"     "NUMBER OF COLUMN SUBGRIDS"   " "
-state   integer NUMP           ij       misc      1          Z     rd=(interp_fcni:lu_index,iswater)u=(copy_fcni)           "NUMP"     "NUMBER OF PFT SUBGRIDS"   " "
+state   integer NUMC           ij       misc      1          Z     rd=(interp_fcni)u=(copy_fcni)           "NUMC"     "NUMBER OF COLUMN SUBGRIDS"   " "
+state   integer NUMP           ij       misc      1          Z     rd=(interp_fcni)u=(copy_fcni)           "NUMP"     "NUMBER OF PFT SUBGRIDS"   " "
 state   real    SABV           ij       misc      1          Z     h                                                           "SABV"     "NET VEGETATION SOLAR RADIATION" "W m-2"
 state   real    SABG           ij       misc      1          Z     h                                                           "SABG"     "NET SOIL SOLAR RADIATION"       "W m-2"
 state   real    LWUP           ij       misc      1          Z     h                                                           "LWUP"     "OUTGOING LONGWAVE RADIATION"    "W m-2"
 state  real     LHSOI          i4j      misc      1          Z      h                                                           "LHSOI"           "LH from soil"              "W/m^2"
 state  real     LHVEG          i4j      misc      1          Z      h                                                           "LHVEG"           "LH from vegetation"        "W/m^2"
 state  real     LHTRAN         i4j      misc      1          Z      h                                                           "LHTRAN"          "LH from transpiration"     "W/m^2"
-state   integer SNL            i4j      misc      1          Z     rd=(interp_fcni:lu_index,iswater)u=(copy_fcni)           "SNL"      "NUMBER OF SNOW LAYERS"   " "
+state   integer SNL            i4j      misc      1          Z     rd=(interp_fcni)u=(copy_fcni)           "SNL"      "NUMBER OF SNOW LAYERS"   " "
 state   real    SNOWDP         i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "SNOWDP"   "SUBGRID SNOW DEPTH"              "m"
 state   real    WTC            i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "WTC"      "COLUMN WEIGHT"                "fraction"
 state   real    WTP            i4j      misc      1          Z     rd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)           "WTP"      "PFT WEIGHT"                   "fraction"

--- a/Registry/registry.noahmp
+++ b/Registry/registry.noahmp
@@ -1,5 +1,5 @@
 # For Noah-MP
-state   integer isnowxy    ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "isnow"      "no. of snow layer"                   "m3 m-3"
+state   integer isnowxy    ij      -       1      -     i02rhd=(interp_fcni:lu_index,iswater)u=(copy_fcni)    "isnow"      "no. of snow layer"                   "m3 m-3"
 state    real   tvxy       ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "tv"         "vegetation leaf temperature"         "K"
 state    real   tgxy       ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "tg"         "bulk ground temperature"             "K"
 state    real   canicexy   ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "canice"     "intercepted ice mass"                "mm"

--- a/Registry/registry.noahmp
+++ b/Registry/registry.noahmp
@@ -1,5 +1,5 @@
 # For Noah-MP
-state   integer isnowxy    ij      -       1      -     i02rhd=(interp_fcni:lu_index,iswater)u=(copy_fcni)    "isnow"      "no. of snow layer"                   "m3 m-3"
+state   integer isnowxy    ij      -       1      -     i02rhd=(interp_fcni)u=(copy_fcni)    "isnow"      "no. of snow layer"                   "m3 m-3"
 state    real   tvxy       ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "tv"         "vegetation leaf temperature"         "K"
 state    real   tgxy       ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "tg"         "bulk ground temperature"             "K"
 state    real   canicexy   ij      -       1      -     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "canice"     "intercepted ice mass"                "mm"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: nesting, configure -r8, integer

SOURCE: Yulong Ma (University of Delaware)

DESCRIPTION OF CHANGES: 
Problem:
A segmentation fault occurs when running nesting  with "./configure -r8" and using the urban 
scheme. This was traced to incorrect interpolation (Registry `d` option) and feedback  (Registry
`u` option) subroutines that are assigned in a Registry file. The `interp_fcnm` is a masked 
interpolation for real variables. For integers, the interpolation should use the only available 
option: `interp_fcni`.

Solution:
In Registry/Registry.EM_COMMON, an example of the incorrect subroutine is:
```
state    integer   UTYPE_URB2D  ij    misc        1         -     rd=(interp_fcnm)u=(copy_fcnm)       "UTYPE_URB"  "URBAN TYPE"         "dimensionless"
```
The Registry line should be:
```
state    integer   UTYPE_URB2D  ij    misc        1         -     rd=(interp_fcni)u=(copy_fcni)       "UTYPE_URB"  "URBAN TYPE"         "dimensionless"
```

LIST OF MODIFIED FILES: 
Registry/Registry.EM_COMMON: fields changed= UTYPE_URB2D, mosaic_cat_index   
Registry/registry.clm: fields changed= NUMC, NUMP, SNL   
Registry/registry.noahmp: fields changed= isnowxy   

TESTS CONDUCTED: 
1. Without mod, code seg faults during first time step.
2. With mod, code runs to completion. Fields look OK
3. Jenkins testing all PASS.

RELEASE NOTE: Using real*8, nesting, and urban caused a segmentation fault, which has been fixed. The problem was traced to a default assignment to the wrong horizontal interpolation and feedback routines.
