### PR TITLE
enhanced slope calculation at domain boundary for periodic BC

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1514,10 +1514,21 @@ endif
 !
        DO j = jts,min(jte,jde-1)
        DO i = its, min(ite,ide-1)
-          im1 = max(i-1,ids)
-          ip1 = min(i+1,ide-1)
-          jm1 = max(j-1,jds)
-          jp1 = min(j+1,jde-1)
+          if (config_flags%periodic_x ) then
+            im1 = i-1
+            ip1 = i+1
+          else
+            im1 = max(i-1,ids)
+            ip1 = min(i+1,ide-1)
+          endif
+
+          if (config_flags%periodic_y ) then
+            jm1 = j-1
+            jp1 = j+1
+          else
+            jm1 = max(j-1,jds)
+            jp1 = min(j+1,jde-1)
+          endif
           grid%toposlpx(i,j)=(grid%ht(ip1,j)-grid%ht(im1,j))*grid%msftx(i,j)*grid%rdx/(ip1-im1)
           grid%toposlpy(i,j)=(grid%ht(i,jp1)-grid%ht(i,jm1))*grid%msfty(i,j)*grid%rdy/(jp1-jm1)
           grid%lap_hgt(i,j)=(grid%ht(ip1,j)+grid%ht(im1,j)+grid%ht(i,jp1)+grid%ht(i,jm1)-grid%ht(i,j)*4.)/4.


### PR DESCRIPTION

TYPE: enhancement

KEYWORDS: slope, periodic boundary conditions

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES: In the current WRF version the slope angle on the lateral boundaries of the domain is calculated differently than in the interior of the domain. For the former, forward or backward final differences are used, for the latter central finite differences. This can lead to different shortwave fluxes for equivalent locations in mountainous terrain.
For periodic boundary conditions, the terrain outside of the domain is known and set right before.
This enhancement implements central differences also for the domain boundary to get the same shortwave flux for equivalent locations.

ISSUE: Fixes  #1008

LIST OF MODIFIED FILES: dyn_em/start_em.F

TESTS CONDUCTED: 

RELEASE NOTE: for periodic boundary conditions the slope calculation for the lateral boundaries is  made equivalent to the calculation for the interior of the domain
