### PR TITLE
Remove nonstandard spacing in macro as workaround for LLVM bug 

### DIFF
--- a/phys/module_mp_fast_sbm.F
+++ b/phys/module_mp_fast_sbm.F
@@ -6052,25 +6052,25 @@ enddo
 
  ! ... (KS) - Broadcating Liquid drops
 #if (defined(DM_PARALLEL))
-   	DM_BCAST_MACRO_R16 ( FAF1 )
-   	DM_BCAST_MACRO_R16 ( FBF1 )
-   	DM_BCAST_MACRO_R16 ( FAB1 )
-   	DM_BCAST_MACRO_R16 ( FBB1 )
+   	DM_BCAST_MACRO_R16(FAF1)
+   	DM_BCAST_MACRO_R16(FBF1)
+   	DM_BCAST_MACRO_R16(FAB1)
+   	DM_BCAST_MACRO_R16(FBB1)
    ! ... (KS) - Broadcating Snow
-   	DM_BCAST_MACRO_R16 ( FAF3 )
-   	DM_BCAST_MACRO_R16 ( FBF3 )
-   	DM_BCAST_MACRO_R16 ( FAB3 )
-   	DM_BCAST_MACRO_R16 ( FBB3 )
+   	DM_BCAST_MACRO_R16(FAF3)
+   	DM_BCAST_MACRO_R16(FBF3)
+   	DM_BCAST_MACRO_R16(FAB3)
+   	DM_BCAST_MACRO_R16(FBB3)
    ! ... (KS) - Broadcating Graupel
-   	DM_BCAST_MACRO_R16 ( FAF4 )
-   	DM_BCAST_MACRO_R16 ( FBF4 )
-   	DM_BCAST_MACRO_R16 ( FAB4 )
-   	DM_BCAST_MACRO_R16 ( FBB4 )
+   	DM_BCAST_MACRO_R16(FAF4)
+   	DM_BCAST_MACRO_R16(FBF4)
+   	DM_BCAST_MACRO_R16(FAB4)
+   	DM_BCAST_MACRO_R16(FBB4)
    ! ### (KS) - Broadcating Hail
-   	DM_BCAST_MACRO_R16 ( FAF5 )
-   	DM_BCAST_MACRO_R16 ( FBF5 )
-   	DM_BCAST_MACRO_R16 ( FAB5 )
-   	DM_BCAST_MACRO_R16 ( FBB5 )
+   	DM_BCAST_MACRO_R16(FAF5)
+   	DM_BCAST_MACRO_R16(FBF5)
+   	DM_BCAST_MACRO_R16(FAB5)
+   	DM_BCAST_MACRO_R16(FBB5)
  ! ### (KS) - Broadcating Usetables array
  	  CALL wrf_dm_bcast_integer ( usetables , size ( usetables ) * IWORDSIZE )
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: macros, compiler, llvm, clang

SOURCE: Isaac Rowe (University of Kentucky)

DESCRIPTION OF CHANGES: 
Problem:
Some versions of LLVM clang cannot parse spaces near parentheses in cpp macros. For example:
```
DM_BCAST_MACRO_R16 ( FAF1 )
```
This bug has been discussed on the LLVM site: https://bugs.llvm.org/show_bug.cgi?id=18011. 

Solution:
The surrounding spaces around the  parentheses from the macros with parameters in 
phys/module_mp_fast_sbm.F were removed. 
```
DM_BCAST_MACRO_R16(FAF1)
```
Only a single file uses this "nonstandard" spacing for the cpp macros.

ISSUE: 
Fixes #1206 (Usage of macros is incompatible with clang cpp -traditional-cpp).

LIST OF MODIFIED FILES: 
phys/module_mp_fast_sbm.F

TESTS CONDUCTED: 
1. Now builds with LLVM cpp (Apple clang version 11.0.3 (clang-1103.0.32.62)). Previously received `Unclassifiable statement error` at `module_mp_fast_sbm.f90:6065:4` during next step in compilation.
2. Jenkins test all PASS.

RELEASE NOTES: A fix was provided to support building the WRF system with LLVM clang. Some versions of LLVM clang cannot correctly parse spaces near parentheses in cpp macros, and those spaces have been removed.