### PR TITLE
bug fix for VarBC when num_fgat_time > 1

### DIFF
--- a/var/da/da_minimisation/da_get_innov_vector.inc
+++ b/var/da/da_minimisation/da_get_innov_vector.inc
@@ -26,6 +26,7 @@ subroutine da_get_innov_vector (it, num_qcstat_conv, ob, iv, grid, config_flags)
    real, dimension(:,:,:), allocatable :: hr_rainc, hr_rainnc
    real, dimension(:,:),   allocatable :: savegridrainc, savegridrainnc
    integer            :: fgat_rain
+   integer            :: inst
 
    if (trace_use) call da_trace_entry("da_get_innov_vector") 
 
@@ -189,10 +190,40 @@ subroutine da_get_innov_vector (it, num_qcstat_conv, ob, iv, grid, config_flags)
 
 #if defined(RTTOV) || defined(CRTM)
    if (use_rad) then
+      iv%time = num_fgat_time
+      iv%instid(:)%info%n1 = 1
+      iv%instid(:)%info%n2 = iv%instid(:)%info%plocal(num_fgat_time)
+
+      !------------------------------------------------------------------------
+      ! Perform (Variational) bias correction
+      !------------------------------------------------------------------------
       if ( use_varbc .or. freeze_varbc ) then
-         if ( num_fgat_time > 1 ) call da_varbc_coldstart(iv)
+         call da_varbc_coldstart(iv)
+         call da_varbc_direct(iv)
       end if
+
+      !------------------------------------------------------------------------
+      ! Perform QC check
+      !------------------------------------------------------------------------
+      if (qc_rad) call da_qc_rad(it, ob, iv)
+
+      !------------------------------------------------------------------------
+      ! Compute preconditioning for Variational bias correction
+      !------------------------------------------------------------------------
+      !varbc preconditioning shoud be done after get_innov_vector is done for all time slots
       if ( use_varbc .and. it == 1 ) call da_varbc_precond(iv)
+
+      !------------------------------------------------------------------------
+      ! Prepare (QCed) bias statistics files
+      !------------------------------------------------------------------------
+      if (biasprep) then
+         do inst = 1, iv%num_inst
+            write(unit=stdout,fmt='(A,A)') 'Preparing bias statistics files for ', &
+                  trim(iv%instid(inst)%rttovid_string)
+            call da_biasprep(inst,ob,iv)
+         end do
+      end if
+
    end if
 #endif
 

--- a/var/da/da_minimisation/da_minimisation.f90
+++ b/var/da/da_minimisation/da_minimisation.f90
@@ -47,7 +47,7 @@ module da_minimisation
       satem, radar, ssmi_rv, ssmi_tb, ssmt1, ssmt2, airsr, pilot, airep,tamdar, tamdar_sfc, rain, &
       bogus, buoy, qscat,pseudo, radiance, monitor_on, max_ext_its, use_rttov_kmatrix,&
       use_crtm_kmatrix,precondition_cg, precondition_factor, use_varbc, varbc_factor, &
-      num_procs, myproc, use_gpspwobs, use_rainobs, use_gpsztdobs, &
+      biasprep, qc_rad, num_procs, myproc, use_gpspwobs, use_rainobs, use_gpsztdobs, &
       use_radar_rf, radar_rf_opt,radar_rf_rscl,radar_rv_rscl,use_radar_rhv,use_radar_rqv,pseudo_var, num_pseudo, &
       num_ob_indexes, num_ob_vars, npres_print, pptop, ppbot, qcstat_conv_unit, gas_constant, &
       orthonorm_gradient, its, ite, jts, jte, kts, kte, ids, ide, jds, jde, kds, kde, cp, &
@@ -120,7 +120,8 @@ module da_minimisation
    use da_radiance, only : da_calculate_grady_rad, da_write_filtered_rad, &
       da_get_innov_vector_radiance, satinfo
    use da_radiance1, only : da_ao_stats_rad,da_oi_stats_rad, &
-      da_write_iv_rad_ascii,da_residual_rad,da_jo_and_grady_rad
+      da_write_iv_rad_ascii,da_residual_rad,da_jo_and_grady_rad, &
+      da_biasprep, da_qc_rad
 #endif
    use da_radar, only :  da_calculate_grady_radar, da_ao_stats_radar, &
       da_oi_stats_radar, da_get_innov_vector_radar, da_residual_radar, &
@@ -161,7 +162,7 @@ module da_minimisation
    use da_transfer_model, only : da_transfer_wrftltoxa,da_transfer_xatowrftl, &
       da_transfer_xatowrftl_adj,da_transfer_wrftltoxa_adj
 #if defined(RTTOV) || defined(CRTM)
-   use da_varbc, only : da_varbc_tl,da_varbc_adj,da_varbc_precond,da_varbc_coldstart
+   use da_varbc, only : da_varbc_tl,da_varbc_adj,da_varbc_precond,da_varbc_coldstart, da_varbc_direct
 #endif
    use da_vtox_transforms, only : da_transform_vtox,da_transform_vtox_adj,da_transform_xtoxa,da_transform_xtoxa_adj
    use da_vtox_transforms, only : da_copy_xa, da_add_xa, da_transform_vpatox, da_transform_vpatox_adj

--- a/var/da/da_radiance/da_get_innov_vector_radiance.inc
+++ b/var/da/da_radiance/da_get_innov_vector_radiance.inc
@@ -53,40 +53,13 @@ subroutine da_get_innov_vector_radiance (it, grid, ob, iv)
    if (use_varbc .or. freeze_varbc) then
       call da_varbc_pred(iv)
       !varbc coldstart can not be done here when num_fgat_time>1
-      if ( num_fgat_time == 1 ) then
-         call da_varbc_coldstart(iv)  
-      end if
-      call da_varbc_direct(iv)      
+      !because da_varbc_coldstart uses all obs from all time slots
    else if (biascorr) then
       do inst = 1, iv%num_inst                 ! loop for sensor
          write(unit=stdout,fmt='(A,A)') 'Performing bias correction for ', &
             trim(iv%instid(inst)%rttovid_string)
          call da_biascorr(inst,ob,iv)
       end do                                   ! end loop for sensor
-   end if
-
-   !------------------------------------------------------------------------
-   ! [3.0] Perform QC check
-   !------------------------------------------------------------------------
-   if (qc_rad) then
-      call da_qc_rad(it, ob, iv)
-   end if
-
-   !------------------------------------------------------------------------
-   ! [4.0] Compute preconditioning for Variational bias correction
-   !------------------------------------------------------------------------
-   !varbc preconditioning shoud be done after get_innov_vector is done for all time slots
-   !if (use_varbc .and. it == 1) call da_varbc_precond(iv)  !moved to da_get_innov_vector.inc
-   
-   !------------------------------------------------------------------------
-   ! [5.0] Prepare (QCed) bias statistics files
-   !------------------------------------------------------------------------
-   if (biasprep) then
-      do inst = 1, iv%num_inst
-         write(unit=stdout,fmt='(A,A)') 'Preparing bias statistics files for ', &
-            trim(iv%instid(inst)%rttovid_string)
-         call da_biasprep(inst,ob,iv)
-      end do
    end if
 
    if(trace_use) call  da_trace_exit("da_get_innov_vector_radiance")


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Variational Bias Correction, num_fgat_time>1, 4DVar, FGAT

SOURCE: Yali Wu (NCAR)

DESCRIPTION OF CHANGES: 
This is bug fixes for VarBC in 4DVar or FGAT model. The innovations were incorrect for time>1, because the ordering of the VarBC and radiance quality control processes were inconsistent. The issue is resolved by moving forward operator of VarBC and radiance QC routine to a higher level subroutine da_get_innov_vector.inc.

The general procedure for doing VarBC in WRFDA is:
1. calculate bias predictors (da_varbc_pred)
2. call da_varbc_coldstart
3. apply forward operator of bias correction to radiance innovation (da_varbc_direct)
4. radiance da_qc procedures
5. calculate covariance matrix b/w bias predictors for VarBC preconditioning (da_varbc_precond).

Previously, VarBC worked correctly for cases when num_fgat_time=1. However, when num_fgat_time > 1, there 
are two bugs that need to be fixed. 
   * First, bias is applied to innovations before cold_varbc is calculated in cases of time slot >1. 
   * Second, the order of conducting varbc and da_qc is unclear: for the first time slot, varbc is done before 
da_qc, but for other time slots when num_fgat_time>1, da_qc is done before VarBC.

This PR fixed the issues mentioned above and worked properly in 4DVAR experiments.

LIST OF MODIFIED FILES:
M var/da/da_minimisation/da_get_innov_vector.inc
M var/da/da_minimisation/da_minimisation.f90
M var/da/da_radiance/da_get_innov_vector_radiance.inc

TESTS CONDUCTED: 
1. WRF DA regression tests conducted on Cheyenne.
2. Jenkins testing all PASS.

RELEASE NOTES: Previously, VarBC worked correctly for cases when num_fgat_time=1 (i.e., 3DVar or hybrid-3DEnVar mode). However, when num_fgat_time > 1, there were two bugs. First, bias was applied to innovations before cold_varbc was calculated in case of number of time slots >1. Second, the order of conducting VarBC and radiance QC was not consistent: for the first time slot, VarBC was done before da_qc, but for other time slots when num_fgat_time>1, radiance QC was done before VarBC. These two issues have been addressed.