### PR TITLE
Release v4.2.1 Fire compile error

### DIFF
--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -752,7 +752,7 @@ IF ( wrf_dm_on_monitor() ) THEN
     
 ENDIF
 
-end
+end subroutine read_namelist_fire
 
 
 subroutine init_fuel_cats(init_fuel_moisture)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: subroutine, end

SOURCE: Ted Mansell (NSSL), issue reported by Manuel Luis Aznar (University of La Laguna)

DESCRIPTION OF CHANGES: 
Compilation error generated by a subroutine which has an "end" statement but does not have an 
"end subroutine X" statement.
   * Platform: Macos High Sierra (10.13)
   * Compilers: Fortran: ifort Version 13.0.3.198 Build 20130606; cc: clang-1000.11.45.5
   * MPI: Openmpi 2.1.2

ISSUE: 
Fixes issue #1215 (Error in compiling WRF v4.2)

LIST OF MODIFIED FILES: 
phys/module_fr_fire_phys.F

TESTS CONDUCTED: 
1. Previously, the compiler complained about the syntax:
```
time mpif90 -f90=ifort -o module_fr_fire_phys.o -c -O3 -fp-model precise -w -ftz -align all -fno-alias -fno-common -FR -convert big_endian  [etc.]  module_fr_fire_phys.f90
module_fr_fire_phys.f90(755): error #6378: SUBROUTINE must be present on the end-subroutine-stmt of an internal or module subroutine
end
^
compilation aborted for module_fr_fire_phys.f90 (code 1)
```
Addition of "subroutine read_namelist_fire" resolved the error.   

2. Jenkins test passed.

RELEASE NOTE: A compiler error was raised by ifort 13 for a fire module routine due to omission of the keyword "SUBROUTINE" in the "END SUBROUTINE" statement. This has been addressed.