### PR TITLE
Add dynamic lightning scheme files to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,8 @@ README.md				@wrf-model/global_owner
 /phys/module_mp_fast_sbm.F		@JS-WRF-SBM @wrf-model/physics
 /phys/module_mp_full_sbm.F		@JS-WRF-SBM @wrf-model/physics
 /phys/module_mp_SBM_polar_radar.F	@JS-WRF-SBM @wrf-model/physics
+/phys/module_ltng_pe.F                @barryhlynn @wrf-model/physics
+/phys/module_ltng_strokes.F		@barryhlynn @wrf-model/physics
 
 #	Shared Physics Between MPAS and WRF
 


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: phys, module_ltng_pe.F, module_ltng_strokes.F, CODEOWNERS

SOURCE: internal

DESCRIPTION OF CHANGES: As the new Dynamic Lightning Scheme #1226 is being put into the develop branch, added the developer (barryhlynn) and wrf-model/physics to the CODEOWNERS list for the 2 files that are being added (phys/module_ltng_pe.F and phys/module_ltng_strokes.F)

LIST OF MODIFIED FILES:
M .github/CODEOWNERS

TESTS CONDUCTED: None - text only