### PR TITLE
Bug fix advection TKE generated by wind farms

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2782,6 +2782,7 @@ state integer nodyn_dummy - dyn_nodyn -  -  -  "" "" ""
 # Turbine drag physics.
 rconfig   integer     windfarm_opt        namelist,physics      max_domains    0       rh       "windfarm_opt"                ""      ""
 rconfig   integer     windfarm_ij         namelist,physics      1              0       rh       "windfarm_ij"                ""      ""
+rconfig   real        windfarm_tke_factor namelist,physics      1              0.25    rh       "windfarm_tke_factor"        ""      ""
 #
 # Ideal case selection
 rconfig   integer     ideal_case          namelist,ideal        1              0       rh       "ideal_case"                 ""      ""

--- a/Registry/Registry.NMM
+++ b/Registry/Registry.NMM
@@ -1433,6 +1433,7 @@ rconfig   integer     ysu_topdown_pblmix  namelist,physics      max_domains    0
 rconfig   integer     shinhong_tke_diag   namelist,physics      max_domains    0       rh       "shinhong_tke_diag"             ""      ""
 rconfig   integer     windfarm_opt        namelist,physics      max_domains    0       rh       "windfarm_opt"                ""      ""
 rconfig   integer     windfarm_ij         namelist,physics      1              0       rh       "windfarm_ij"                ""      ""
+rconfig   real        windfarm_tke_factor namelist,physics      1              0.25    rh       "windfarm_tke_factor"        ""      ""
 rconfig   integer     mfshconv            namelist,physics      max_domains    1        rh       "mfshconv"         "To activate mass flux scheme with qnse, 1=true; 0=false"      ""
 rconfig   real    BLDT                    namelist,physics	max_domains    0       h    "BLDT"          ""      ""
 rconfig   integer     cu_physics          namelist,physics	max_domains    0       rh0123       "cu_physics"            ""      ""

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -1992,6 +1992,11 @@ CONTAINS
                      &,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme   &
                      &,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte   &
                      &)
+
+                    IF (bl_mynn_tkeadvect) THEN
+                       qke_adv=qke
+                    ENDIF
+
                   ELSE
                      WRITE ( message , FMT = '(A,6(L1,1X))' )           &
                      'present: '//                                      &

--- a/phys/module_wind_fitch.F
+++ b/phys/module_wind_fitch.F
@@ -283,6 +283,7 @@ CONTAINS
 !
 ! ... PAJ ...
 !
+   real, parameter :: CORRECTION_FATOR = 0.25
    INTEGER :: nkind,k,nu,nb
    LOGICAL :: vfound
    REAL :: fac1,fac2
@@ -327,6 +328,7 @@ CONTAINS
   ! tke coefficient calculation 
 
   tkecof=thrcof-powcof
+  tkecof = CORRECTION_FATOR * tkecof
   IF(tkecof .LT. 0.) tkecof=0.
 !
   END SUBROUTINE dragcof

--- a/phys/module_wind_fitch.F
+++ b/phys/module_wind_fitch.F
@@ -60,6 +60,7 @@ MODULE module_wind_fitch
   REAL, DIMENSION(:), ALLOCATABLE :: hubheight,diameter,stc,stc2,cutin,cutout,npower
 !
   REAL :: turbws(maxvals,maxvals2),turbtc(maxvals,maxvals2),turbpw(maxvals,maxvals2)
+  REAL :: correction_factor
 !
 CONTAINS
 
@@ -283,7 +284,6 @@ CONTAINS
 !
 ! ... PAJ ...
 !
-   real, parameter :: CORRECTION_FATOR = 0.25
    INTEGER :: nkind,k,nu,nb
    LOGICAL :: vfound
    REAL :: fac1,fac2
@@ -328,7 +328,7 @@ CONTAINS
   ! tke coefficient calculation 
 
   tkecof=thrcof-powcof
-  tkecof = CORRECTION_FATOR * tkecof
+  tkecof = correction_factor * tkecof
   IF(tkecof .LT. 0.) tkecof=0.
 !
   END SUBROUTINE dragcof
@@ -352,6 +352,8 @@ CONTAINS
 
    LOGICAL, EXTERNAL :: wrf_dm_on_monitor
 !
+
+   correction_factor = config_flags%windfarm_tke_factor
       IF ( wrf_dm_on_monitor() ) THEN
 !
 ! ... PAJ: Opens the file with the location of the wind turbines ...

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1077,6 +1077,7 @@ Options for wind turbine drag parameterization:
  windfarm_ij                        = 0         ! whether to use lat-lon or i-j coordinate as wind turbine locations    
                                                 ! 0 = The coordinate of the turbines are defined in terms of lat-lon
                                                 ! 1 = The coordinate of the turbines are defined in terms of grid points
+ windfarm_tke_factor                = 0.25      ! Correction factor applied to the TKE coefficient (deafault is 0.25, Archer et al. 2020)
 
 
 Stochastic parameterization schemes:


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: advection, TKE, wind turbine

SOURCE: Cristina L. Archer, Sicheng Wu, and Yulong Ma (University of Delaware, CReW), and Pedro A. Jimenez (NCAR/RAL)
 
DESCRIPTION OF CHANGES: The TKE generated by wind turbines is not advected when the user instructs MYNN to advected the TKE. The present PR fixes this issue. Our research (Archer et al. 2020) indicates that after fixing this issue the production of TKE by wind turbines is too large and we have reduced the TKE coefficient (correction factor = 0.25) based on extensive comparison with LES results. The figure bellow summarizes this choice:

![ALL_TKE_profiles_LES_PR_figc](https://user-images.githubusercontent.com/14111759/86019874-6a943000-b9e4-11ea-96a9-8f751162778d.png)

ISSUE: N/A

LIST OF MODIFIED FILES: 
M       phys/module_pbl_driver.F
M       phys/module_wind_fitch.F
M       Registry/Registry.EM_COMMON
M       run/README.namelist
M       Registry/Registry.NMM

TESTS CONDUCTED: 
1. We have conducted simulations with and without the fix to ensure WRF is properly advecting the TKE generated by the wind turbines. 
2. The jenkins tests are OK

RELEASE NOTE: Bug fix to advect the TKE generated by the wind turbines if the user instructs MYNN to advect the TKE. There is also an empirical reduction of the wind turbines' TKE coefficient based on LES results (Archer et al. 2020).

Archer, C.L., S. Wu, Y. Ma, and P.A. Jimenez, 2020: Turbulent kinetic energy generated by wind farms is treated incorrectly in the WRF model. Mon. Wea. Rev. (Under review).
