### PR TITLE
Disable TUV diagnostics unless debugging

### DIFF
--- a/chem/rxn.F
+++ b/chem/rxn.F
@@ -157,10 +157,11 @@
       integer, intent(in) :: nw
       real, intent(in)    :: wl(nw)
 
-      integer :: astat, m, n
+      integer :: astat, m, n, debug_level
       character(len=256) :: emsg
 
       call set_initialization( status=.true. )
+      call get_wrf_debug_level( debug_level )
 
       if( .not. allocated( xsqy_tab ) ) then
          allocate( xsqy_tab(kj),stat=astat )
@@ -200,7 +201,9 @@
       npht_tab = 2
       call setup_sub_calls( the_subs,npht_tab )
 
-      call diagnostics
+      IF ( 100 .LE. debug_level ) THEN
+        call diagnostics
+      ENDIF
 
       call rdxs_init( nw, wl )
 


### PR DESCRIPTION
TYPE: bug

KEYWORDS: photolysis scheme, TUV, diagnostics, debug_level

SOURCE: Xin Zhang (NUIST)

DESCRIPTION OF CHANGES: 
Problem:
When using WRF-Chem with the new Photolysis option (phot_opt = 4) activated, the model spends too much time 
writing the TUV.diags. These diagnostics should only used for debugging photolysis rates. The diagnostics should be 
enabled only for an explicitly requested debug value.

Solution:
Enable TUV diagnostics only when `debug_level >= 100`.

ISSUE: 
Fixes #1242 Speed up writing the TUV.diags file

LIST OF MODIFIED FILES:
M chem/rxn.F

TESTS CONDUCTED:
1. TUV init is much quicker and the WRF-Chem one domain simulation test is successful.
The time is the time of the diagnostics call.

Here's the table if `debug_level = 0`:

|               | Before Commit | After Commit |
| --------| ---------------| -------------  |
| 24 cores |             1s        |      skip            |
|120 cores |    10 min         |     skip             |

If I change `debug_level` to 100, this is the result:

|               | Before Commit | After Commit |
| --------| ---------------| -------------  |
| 24 cores |             1s        |            1s         |
|120 cores |      10 min       |        10 min     |

2. Jenkins test is successful.

RELEASE NOTE: When using WRF-Chem with the new Photolysis option (phot_opt = 4) activated, the model spent too much time on looping and writing the TUV.diags which is only used for debugging photolysis rates. The diagnostics are now enabled only for debug_level >=100.