### PR TITLE
Replace "derf()" with standard "erf()" in SBM MP scheme

### DIFF
--- a/phys/module_mp_SBM_polar_radar.F
+++ b/phys/module_mp_SBM_polar_radar.F
@@ -1534,7 +1534,7 @@ public polar_hucm
                     (1.0d0-(1.0d0-fract_volume_water)*ratc))
 ! new change 18.01.09                                         (start)
       if(fract_volume_water.gt.1.0d-10) then
-         t=derf((1.0d0-fract_volume_water)/fract_volume_water-0.2d0)
+         t=erf((1.0d0-fract_volume_water)/fract_volume_water-0.2d0)
       else
          t=1.0d0
       endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: derf, SBM

SOURCE: Nicolas Baldeck (OpenMeteoData)

DESCRIPTION OF CHANGES:
Problem:
Using `derf` for a double precision error function is not standard, and causes an error
with PGI 19.10:
```
441044-PGF90-S-0038-Symbol, derf, has not been explicitly declared (module_mp_SBM_polar_radar.f90)
441136- 0 inform, 0 warnings, 1 severes, 0 fatal for calc_dc_wet_snow
```

Solution:
The Fortran standard allows the TKR (type, kind, rank) of an argument to determine which
intrinsic function is being used. The `erf` function is part of the Fortran 2008 standard, and
has been previously available for GNU, Intel, and PGI.

The scheme's original developer has approved these mods.

ISSUE:
Fixes #1245 "PGI complains about Derf symbol in module_mp_SBM_polar_radar.F"

LIST OF MODIFIED FILES:
modified:   phys/module_mp_SBM_polar_radar.F

TESTS CONDUCTED:
1. Before mods, the PGI compiler complained. After fix, code builds and runs with PGI 19.
2. With GNU 9 and Intel 19 compilers, code builds and runs as before. It is possible that older (non 2008 compliant) 
compilers will fail, but that standard is 12 years old, so not too much sympathy.
3. Status of jenkins is all pass.