### PR TITLE
Fix 1d advection testing program, broken with hybrid vert coord

### DIFF
--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -2,7 +2,7 @@
 !WRF:MODEL_LAYER:DYNAMICS
 !
 #if ( defined(ADVECT_KERNEL) )
-! cpp -traditional -C -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
+! cpp -traditional-cpp -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
 ! gfortran -ffree-form -ffree-line-length-none advection_kernel.f90
 ! ./a.out
 MODULE advection_kernel

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -10558,7 +10558,8 @@ PROGRAM feeder
                                             msfty
    REAL , DIMENSION( : ), ALLOCATABLE :: fzm, &
                                   fzp, &
-                                  rdzw, znw,dnw, rdnw, dn, rdn
+                                  rdzw, znw,dnw, rdnw, dn, rdn, &
+                                  c1, c2
    REAL :: rdx, &
            rdy, &
            dt
@@ -10607,6 +10608,8 @@ PROGRAM feeder
    ALLOCATE (rdnw( kms:kme ) )
    ALLOCATE ( dn ( kms:kme ) )
    ALLOCATE (rdn ( kms:kme ) )
+   ALLOCATE ( c1 ( kms:kme ) )
+   ALLOCATE ( c2 ( kms:kme ) )
    PRINT *,'CALL init'
    CALL init ( config_flags)
    CALL tophat ( field , MAX_SCALARS ,&
@@ -10649,6 +10652,10 @@ PROGRAM feeder
     fzp(k) = .5* dnw(k  )/dn(k)
     fzm(k) = .5* dnw(k-1)/dn(k)
    ENDDO
+   DO k = kts,kte
+      c1(k) = 1. ! This is d(B)/d(eta), so assuming no hyb coord
+      c2(k) = 0. ! This (1 - c1)*(p00 - ptop)
+   ENDDO
 
    time_step = 5
    dt = time_step
@@ -10668,8 +10675,8 @@ PROGRAM feeder
          CALL advect_scalar    ( field(ims,kms,jms,im), &
                                  field_old(ims,kms,jms,im), &
                                  tendency(ims,kms,jms), &
-                                 ru, rv, rom,                   &
-                                 mut, time_step/3, config_flags,  &
+                                 ru, rv, rom, c1, c2,           &
+                                 mut, time_step/3, config_flags,&
                                  msfux, msfuy, msfvx, msfvy,    &
                                  msftx, msfty,                  &
                                  fzm, fzp,                      &
@@ -10685,8 +10692,8 @@ PROGRAM feeder
          CALL advect_scalar    ( field(ims,kms,jms,im), &
                                  field_old(ims,kms,jms,im), &
                                  tendency(ims,kms,jms), &
-                                 ru, rv, rom,                   &
-                                 mut, time_step/2, config_flags,  &
+                                 ru, rv, rom, c1, c2,           &
+                                 mut, time_step/2, config_flags,&
                                  msfux, msfuy, msfvx, msfvy,    &
                                  msftx, msfty,                  &
                                  fzm, fzp,                      &
@@ -10703,7 +10710,7 @@ PROGRAM feeder
             CALL advect_scalar    ( field(ims,kms,jms,im), &
                                     field_old(ims,kms,jms,im), &
                                     tendency(ims,kms,jms), &
-                                    ru, rv, rom,                   &
+                                    ru, rv, rom, c1, c2,           &
                                     mut, time_step, config_flags,  &
                                     msfux, msfuy, msfvx, msfvy,    &
                                     msftx, msfty,                  &
@@ -10718,7 +10725,8 @@ PROGRAM feeder
                                     tendency(ims,kms,jms), &
                                     h_tendency(ims,kms,jms), &
                                     z_tendency(ims,kms,jms), &
-                                    ru, rv, rom, mut, mub, mu_old, &
+                                    ru, rv, rom, c1, c2, &
+                                    mut, mub, mu_old, &
                                     time_step, config_flags, tenddec, &
                                     msfux, msfuy, msfvx, msfvy, &
                                     msftx, msfty, fzm, fzp, &
@@ -10732,7 +10740,8 @@ PROGRAM feeder
                                     tendency(ims,kms,jms), &
                                     h_tendency(ims,kms,jms), &
                                     z_tendency(ims,kms,jms), &
-                                    ru, rv, rom, mut, mub, mu_old, &
+                                    ru, rv, rom, c1, c2, &
+                                    mut, mub, mu_old, &
                                     config_flags, tenddec, &
                                     msfux, msfuy, msfvx, msfvy, &
                                     msftx, msfty, fzm, fzp, &
@@ -10744,7 +10753,7 @@ PROGRAM feeder
             CALL advect_scalar_weno ( field(ims,kms,jms,im), &
                                    field_old(ims,kms,jms,im), &
                                    tendency(ims,kms,jms), &
-                             ru, rv, rom,                   &
+                             ru, rv, rom, c1, c2,           &
                              mut, time_step, config_flags,  &
                              msfux, msfuy, msfvx, msfvy,    &
                              msftx, msfty,                  &
@@ -10757,7 +10766,7 @@ PROGRAM feeder
             CALL advect_scalar_wenopd ( field(ims,kms,jms,im), &
                                         field_old(ims,kms,jms,im), &
                                         tendency(ims,kms,jms), &
-                                ru, rv, rom,                   &
+                                ru, rv, rom, c1, c2,           &
                                 mut, mub, mu_old,              &
                                 time_step, config_flags,       &
                                 msfux, msfuy, msfvx, msfvy,    &
@@ -10803,7 +10812,7 @@ PROGRAM feeder
    print *,' '
    print *,'Lines to input to gnuplot'
    print *,' '
-   print *,"set term x11"
+   print *,"set terminal x11"
    IF      (config_flags%scalar_adv_opt .EQ. 0 ) THEN
       print *,'set title "Scalar Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 1 ) THEN
@@ -10812,7 +10821,7 @@ PROGRAM feeder
       print *,'set title "Mono Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
       print *,'set title "WENO Advection" font ",20"'
-   ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
+   ELSE IF (config_flags%scalar_adv_opt .EQ. 4 ) THEN
       print *,'set title "WENO PD Advection" font ",20"'
    END IF
    print *,"set yrange[-20:120]"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: advection, program, 1d

SOURCE: internal

DESCRIPTION OF CHANGES: 
There were two types of problems. First the original cpp commands were broken. The cpp command was commented out, 
but it is used to build the source code, with cut and paste). The second problem is caused by the modification of the 
advection interface with the release of v4.0.

First Problem and Solution:
1. Original suggested using `cpp -traditional`. This is an incorrect cpp option. The flag is supposed to be 
`cpp -traditional-cpp`.

2. Original suggested using `cpp -C -P`. The `-C` flag puts these GNU comments in the code (which is OK if you 
are writing in the C language).
```
/* Copyright (C) 1991-2012 Free Software Foundation, Inc.
   This file is part of the GNU C Library.

   The GNU C Library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2.1 of the License, or (at your option) any later version.

   The GNU C Library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   Lesser General Public License for more details.

   You should have received a copy of the GNU Lesser General Public
   License along with the GNU C Library; if not, see
   <http://www.gnu.org/licenses/>.  */

```

Second Problem:
The existing advection testing program had not been updated to assume the existence of the hybrid vertical coordinate.
That meant a few variables in the calls to the scalar advection routines (c1 and c2) were missing. The advection testing
tool would not compile.

Second Solution:
Initialize the 1d arrays c1 and c2 to terrain-following coordinate settings (c1=1, c2=0), and pass those args into the 
WRF scalar advection drivers. The simplified settings are not important since this is just for a 1d advection.

LIST OF MODIFIED FILES: 
modified: dyn_em/module_advection_em.F

TESTS CONDUCTED: 
1. All of the changes are inside of ifdefs, so there is no impact to the compilable WRF code. The advection main program
had the interfaces updated to match the current advection drivers.
2. Previously, the advection testing code did not compile. Now the tester program builds and runs. Here are the results 
after 0, 1200, 1400, 1600, 1800, and 2000 full time steps (each full time step is constructed of three small time steps). 
Results from the advection schemes scalar_adv_opt = 0 (standard scalar advection), 1 (positive definite), 2 (monotonic), 
3 (WENO), and 4 (WENO PD) are shown. Every 200 full steps, the square wave should be back in the original location.

![Screen Shot 2020-07-09 at 12 45 43 PM](https://user-images.githubusercontent.com/12666234/87082836-d0549900-c1e8-11ea-86b1-2af0da0e2a03.png)

![Screen Shot 2020-07-09 at 12 47 18 PM](https://user-images.githubusercontent.com/12666234/87082876-dba7c480-c1e8-11ea-90b8-93397b1e4f01.png)

![Screen Shot 2020-07-09 at 12 42 29 PM](https://user-images.githubusercontent.com/12666234/87082905-e5c9c300-c1e8-11ea-8ed6-2699f156acbd.png)

![Screen Shot 2020-07-09 at 12 49 10 PM](https://user-images.githubusercontent.com/12666234/87082917-ed896780-c1e8-11ea-90c8-5e85f1049f3d.png)

![Screen Shot 2020-07-09 at 12 52 12 PM](https://user-images.githubusercontent.com/12666234/87082930-f4b07580-c1e8-11ea-8482-e937a8f9b908.png)

RELEASE NOTE: I don't want to support this, so no release information.
