### PR TITLE
Update README.grid_fdda - add (max_dom) for rinblw

### DIFF
--- a/test/em_real/README.grid_fdda
+++ b/test/em_real/README.grid_fdda
@@ -47,5 +47,5 @@ To run an fdda job
  guv_sfc (max_dom)                   = 0.0003   ; nudging coefficient for sfc u and v (sec-1)
  gt_sfc (max_dom)                    = 0.0003   ; nudging coefficient for sfc temp (sec-1)
  gq_sfc (max_dom)                    = 0.0003   ; nudging coefficient for sfc qvapor (sec-1)
- rinblw                              = 250.0    ; radius
+ rinblw (max_dom)                    = 250.0    ; radius
 

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -169,7 +169,7 @@ Note, this is not a namelist.input file. Find what interests you, and cut and pa
  guv_sfc                             = 0.0003,     0.0003,     0.0003,
  gt_sfc                              = 0.0003,     0.0003,     0.0003,
  gq_sfc                              = 0.0003,     0.0003,     0.0003,
- rinblw                              = 250.,
+ rinblw(max)                         = 250.,       250.,       250., 
 
 ** Using observation nudging option (note &fdda is a separate namelist record):
 

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -169,7 +169,7 @@ Note, this is not a namelist.input file. Find what interests you, and cut and pa
  guv_sfc                             = 0.0003,     0.0003,     0.0003,
  gt_sfc                              = 0.0003,     0.0003,     0.0003,
  gq_sfc                              = 0.0003,     0.0003,     0.0003,
- rinblw(max)                         = 250.,       250.,       250., 
+ rinblw                              = 250.,       250.,       250., 
 
 ** Using observation nudging option (note &fdda is a separate namelist record):
 


### PR DESCRIPTION
TYPE: text only

KEYWORDS: readme, rinblw, max_dom

SOURCE: Peng Zimu (Peking University) and internal

DESCRIPTION OF CHANGES: 
One of the FDDA capabilities for blending observations with the gridded simulation relies on the appropriate 
observation density within a specified radius of influence, which is controlled by the option rinblw (km). To allow 
for different observations on different nests, this option is defined in the Registry as a max_domains namelist entry. 
Therefore this option should be specified for each individual domain. This PR:

1. adds (max_dom) to rinblw in test/em_real/README.grid_fdda
2. adds multiple columns for rinblw in test/em_real/examples.namelist. 

For users with nested domains, before this mod, the WRF code returned:
```
Error in rinblw, please specify a reasonable value ***
```
This update to the documentation helps users to _a priori_ correctly set rinblw for nested domains. 

LIST OF MODIFIED FILES:
M   test/em_real/examples.namelist
M   test/em_real/README.grid_fdda

TESTS CONDUCTED: 
1. After setting rinblw for nested domains, the WRF with surface-analysis nudging can run successfully.
2. Only README files changed, no tests required.

RELEASE NOTES: A modification to a couple of the README files, which helps users to correctly set rinblw when surface-analysis nudging is applied to nested domains. Previously, the rinblw was not consistently identified as a max_dom variable.
