### PR TITLE
Changes to support FPT, static Fortran analysis tool

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1,3 +1,5 @@
+! 11-Nay-20, John Collins, Missing continuation character inserted, line 785
+
 !WRF:MEDIATION_LAYER:SOLVER
 
 #define BENCH_START(A)
@@ -278,13 +280,13 @@ BENCH_START(rad_driver_tim)
      &        ,WARM_RAIN=grid%warm_rain ,XICE=grid%xice         ,XLAND=grid%xland    &
      &        ,XLAT=grid%xlat          ,XLONG=grid%xlong        ,YR=yr               &
            ! SSiB LSM radiation components (fds 06/2010)
-     &        ,ALSWVISDIR=grid%alswvisdir ,ALSWVISDIF=grid%alswvisdif      &  !ssib 
+     &        ,ALSWVISDIR=grid%alswvisdir ,ALSWVISDIF=grid%alswvisdif      &  !ssib
      &        ,ALSWNIRDIR=grid%alswnirdir ,ALSWNIRDIF=grid%alswnirdif      &  !ssib
      &        ,SWVISDIR=grid%swvisdir ,SWVISDIF=grid%swvisdif              &  !ssib
      &        ,SWNIRDIR=grid%swnirdir ,SWNIRDIF=grid%swnirdif              &  !ssib
      &        ,SF_SURFACE_PHYSICS=config_flags%sf_surface_physics          &  !ssib
 ! WRF-solar and aerosol variables from jararias 2013/8 and 2013/11
-     &       ,SWDDIR=grid%swddir,SWDDNI=grid%swddni,SWDDIF=grid%swddif                              & 
+     &       ,SWDDIR=grid%swddir,SWDDNI=grid%swddni,SWDDIF=grid%swddif                              &
      &       ,SWDDIRC=grid%swddirc, SWDDNIC=grid%swddnic                                            &
      &       ,Gx=grid%Gx,Bx=grid%Bx,gg=grid%gg,bb=grid%bb                                           &
      &       ,swdown_ref=grid%swdown_ref,swddir_ref=grid%swddir_ref                                 &
@@ -407,7 +409,7 @@ BENCH_START(rad_driver_tim)
      &        ,M_PS_1=grid%m_ps_1, M_PS_2=grid%m_ps_2, AEROSOLC_1=grid%aerosolc_1        &
      &        ,AEROSOLC_2=grid%aerosolc_2, M_HYBI0=grid%m_hybi                      &
      &        ,ABSTOT=grid%abstot, ABSNXT=grid%absnxt, EMSTOT=grid%emstot                &
-     &        ,RADTACTTIME=grid%radtacttime                                         &  
+     &        ,RADTACTTIME=grid%radtacttime                                         &
      &        ,ICLOUD_CU=config_flags%ICLOUD_CU                            &
      &        ,QC_CU=grid%QC_CU , QI_CU=grid%QI_CU                         &
      &        ,CALC_CLEAN_ATM_DIAG=config_flags%calc_clean_atm_diag                  &
@@ -419,26 +421,26 @@ BENCH_START(rad_driver_tim)
      &        ,TAUAER600=grid%tauaer3, TAUAER999=grid%tauaer4 & ! jcb
      &        ,GAER300=grid%gaer1, GAER400=grid%gaer2, GAER600=grid%gaer3, GAER999=grid%gaer4 & ! jcb
      &        ,WAER300=grid%waer1, WAER400=grid%waer2, WAER600=grid%waer3, WAER999=grid%waer4 & ! jcb
-     &        ,TAUAERlw1  =grid%tauaerlw1,  TAUAERlw2=grid%tauaerlw2    & 
-     &        ,TAUAERlw3  =grid%tauaerlw3,  TAUAERlw4=grid%tauaerlw4    & 
-     &        ,TAUAERlw5  =grid%tauaerlw5,  TAUAERlw6=grid%tauaerlw6    & 
-     &        ,TAUAERlw7  =grid%tauaerlw7,  TAUAERlw8=grid%tauaerlw8    & 
-     &        ,TAUAERlw9  =grid%tauaerlw9,  TAUAERlw10=grid%tauaerlw10    & 
-     &        ,TAUAERlw11 =grid%tauaerlw11, TAUAERlw12=grid%tauaerlw12    & 
-     &        ,TAUAERlw13 =grid%tauaerlw13, TAUAERlw14=grid%tauaerlw14    & 
-     &        ,TAUAERlw15 =grid%tauaerlw15, TAUAERlw16=grid%tauaerlw16   & 
+     &        ,TAUAERlw1  =grid%tauaerlw1,  TAUAERlw2=grid%tauaerlw2    &
+     &        ,TAUAERlw3  =grid%tauaerlw3,  TAUAERlw4=grid%tauaerlw4    &
+     &        ,TAUAERlw5  =grid%tauaerlw5,  TAUAERlw6=grid%tauaerlw6    &
+     &        ,TAUAERlw7  =grid%tauaerlw7,  TAUAERlw8=grid%tauaerlw8    &
+     &        ,TAUAERlw9  =grid%tauaerlw9,  TAUAERlw10=grid%tauaerlw10    &
+     &        ,TAUAERlw11 =grid%tauaerlw11, TAUAERlw12=grid%tauaerlw12    &
+     &        ,TAUAERlw13 =grid%tauaerlw13, TAUAERlw14=grid%tauaerlw14    &
+     &        ,TAUAERlw15 =grid%tauaerlw15, TAUAERlw16=grid%tauaerlw16   &
      &        ,progn=config_flags%progn                                            &
 #endif
      &         ,slope_rad=config_flags%slope_rad,topo_shading=config_flags%topo_shading     &
      &         ,shadowmask=grid%shadowmask   &
-     &         ,ht=grid%ht,dx=grid%dx,dy=grid%dy,dx2d=grid%dx2d,area2d=grid%area2d &           
-     &         ,diffuse_frac=grid%diffuse_frac &           
+     &         ,ht=grid%ht,dx=grid%dx,dy=grid%dy,dx2d=grid%dx2d,area2d=grid%area2d &
+     &         ,diffuse_frac=grid%diffuse_frac &
      &         ,IS_CAMMGMP_USED = grid%is_CAMMGMP_used    &
      &         ,cw_rad=grid%cw_rad                     &
      &         ,shcu_physics=config_flags%shcu_physics                     &
      &         ,MP_PHYSICS=CONFIG_FLAGS%MP_PHYSICS        &
      &         ,EFCG=grid%EFCG,EFCS=grid%EFCS,EFIG=grid%EFIG &
-     &         ,EFIS=grid%EFIS,EFSG=grid%EFSG,aercu_opt=config_flags%aercu_opt & 
+     &         ,EFIS=grid%EFIS,EFSG=grid%EFSG,aercu_opt=config_flags%aercu_opt &
      &         ,EFSS=grid%EFSS,QS_CU=grid%QS_CU)
 
 BENCH_END(rad_driver_tim)
@@ -506,18 +508,18 @@ BENCH_START(surf_driver_tim)
      &        ,IFNDALBSI=grid%ifndalbsi, IFNDICEDEPTH=grid%ifndicedepth   &
      &        ,IFNDSNOWSI=grid%ifndsnowsi                                 &
      &        ,ISLTYP=grid%isltyp      ,ITIMESTEP=grid%itimestep, JULIAN_IN=grid%julian                  &
-     &        ,IRRIGATION=grid%irrigation,SF_SURF_IRR_SCHEME=config_flags%sf_surf_irr_scheme  & 
-     &        ,IRR_DAILY_AMOUNT=config_flags%irr_daily_amount                                                & 
+     &        ,IRRIGATION=grid%irrigation,SF_SURF_IRR_SCHEME=config_flags%sf_surf_irr_scheme  &
+     &        ,IRR_DAILY_AMOUNT=config_flags%irr_daily_amount                                                &
      &        ,IRR_START_HOUR=config_flags%irr_start_hour,IRR_NUM_HOURS=config_flags%irr_num_hours           &
      &        ,IRR_START_JULIANDAY=config_flags%irr_start_julianday                                          &
      &        ,IRR_END_JULIANDAY=config_flags%irr_end_julianday                                              &
-     &        ,IRR_FREQ=config_flags%irr_freq,IRR_PH=config_flags%irr_ph,IRR_RAND_FIELD=grid%irr_rand_field  & 
+     &        ,IRR_FREQ=config_flags%irr_freq,IRR_PH=config_flags%irr_ph,IRR_RAND_FIELD=grid%irr_rand_field  &
      &        ,IVGTYP=grid%ivgtyp      ,LH=grid%lh              ,LOWLYR=grid%lowlyr      &
      &        ,MAVAIL=grid%mavail      ,NUM_SOIL_LAYERS=config_flags%num_soil_layers        &
      &        ,P8W=grid%p_hyd_w            ,PBLH=grid%pblh          ,PI_PHY=pi_phy      &
      &        ,PSFC=grid%psfc          ,PSHLTR=grid%pshltr      ,PSIH=psih          &
      &        ,BLDT=grid%bldt     ,CURR_SECS=curr_secs, ADAPT_STEP_FLAG=adapt_step_flag  &
-     &        ,BLDTACTTIME=grid%bldtacttime                                              & 
+     &        ,BLDTACTTIME=grid%bldtacttime                                              &
      &        ,PSIM=psim          ,P_PHY=grid%p_hyd        ,Q10=grid%q10            &
      &        ,Q2=grid%q2              ,QFX=grid%qfx            ,QSFC=grid%qsfc          &
      &        ,QSHLTR=grid%qshltr      ,QZ0=grid%qz0            ,RAINCV=grid%raincv      &
@@ -565,18 +567,18 @@ BENCH_START(surf_driver_tim)
      &        ,HUML=grid%huml, HVML=grid%hvml, F=grid%f                             &
      &        ,TMOML=grid%TMOML,ISWATER=iswater                                     &
      &        ,OML_RELAXATION_TIME=grid%OML_RELAXATION_TIME                         &
-     &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &   
+     &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &
      &        ,snowdp2d=grid%snowdp2d,          h2osno2d=grid%h2osno2d              & !lake
-     &        ,snl2d=grid%snl2d,                t_grnd2d=grid%t_grnd2d              &   
-     &        ,t_lake3d=grid%t_lake3d,          lake_icefrac3d=grid%lake_icefrac3d  & !lake  
-     &        ,z_lake3d=grid%z_lake3d,          dz_lake3d=grid%dz_lake3d            &   
+     &        ,snl2d=grid%snl2d,                t_grnd2d=grid%t_grnd2d              &
+     &        ,t_lake3d=grid%t_lake3d,          lake_icefrac3d=grid%lake_icefrac3d  & !lake
+     &        ,z_lake3d=grid%z_lake3d,          dz_lake3d=grid%dz_lake3d            &
      &        ,t_soisno3d=grid%t_soisno3d,      h2osoi_ice3d=grid%h2osoi_ice3d      & !lake
-     &        ,h2osoi_liq3d=grid%h2osoi_liq3d,  h2osoi_vol3d=grid%h2osoi_vol3d      &   
+     &        ,h2osoi_liq3d=grid%h2osoi_liq3d,  h2osoi_vol3d=grid%h2osoi_vol3d      &
      &        ,z3d=grid%z3d,                    dz3d=grid%dz3d                      & !lake
-     &        ,zi3d=grid%zi3d,                  watsat3d=grid%watsat3d              &   
-     &        ,csol3d=grid%csol3d,              tkmg3d=grid%tkmg3d                  & !lake     
-     &        ,tkdry3d=grid%tkdry3d,            tksatu3d=grid%tksatu3d              &   
-     &        ,LakeModel=grid%sf_lake_physics,  lake_min_elev=grid%lake_min_elev    & !lake  
+     &        ,zi3d=grid%zi3d,                  watsat3d=grid%watsat3d              &
+     &        ,csol3d=grid%csol3d,              tkmg3d=grid%tkmg3d                  & !lake
+     &        ,tkdry3d=grid%tkdry3d,            tksatu3d=grid%tksatu3d              &
+     &        ,LakeModel=grid%sf_lake_physics,  lake_min_elev=grid%lake_min_elev    & !lake
 #if ( EM_CORE == 1)
      &        ,LakeMask=grid%LakeMask                                               & ! lake
 #endif
@@ -612,7 +614,7 @@ BENCH_START(surf_driver_tim)
      &         T_SOISNO4=grid%t_soisno4,T_SOISNO5=grid%t_soisno5,                   &
      &         T_SOISNO6=grid%t_soisno6,T_SOISNO7=grid%t_soisno7,                   &
      &         T_SOISNO8=grid%t_soisno8,T_SOISNO9=grid%t_soisno9,                   &
-     &         T_SOISNO10=grid%t_soisno10,DZSNOW1=grid%dzsnow1,DZSNOW2=grid%dzsnow2,& 
+     &         T_SOISNO10=grid%t_soisno10,DZSNOW1=grid%dzsnow1,DZSNOW2=grid%dzsnow2,&
      &         DZSNOW3=grid%dzsnow3,DZSNOW4=grid%dzsnow4, DZSNOW5=grid%dzsnow5,     &
      &         SNOWRDS1=grid%snowrds1,SNOWRDS2=grid%snowrds2,                       &
      &         SNOWRDS3=grid%snowrds3 ,SNOWRDS4=grid%snowrds4,                      &
@@ -702,7 +704,7 @@ BENCH_START(surf_driver_tim)
      &        ,LP_URB2D=grid%lp_urb2d,HI_URB2D=grid%hi_urb2d              & !multi-layer urban
      &        ,LB_URB2D=grid%lb_urb2d,HGT_URB2D=grid%hgt_urb2d            & !multi-layer urban
      &        ,MH_URB2D=grid%mh_urb2d,STDH_URB2D=grid%stdh_urb2d          & !SLUCM
-     &        ,LF_URB2D=grid%lf_urb2d                                           & 
+     &        ,LF_URB2D=grid%lf_urb2d                                           &
      &        ,GMT=grid%gmt,XLAT=grid%xlat,XLONG=grid%xlong,JULDAY=grid%julday  &
      &        ,A_U_BEP=grid%a_u_bep,A_V_BEP=grid%a_v_bep,A_T_BEP=grid%a_t_bep   &
      &        ,A_Q_BEP=grid%a_q_bep                                             &
@@ -728,7 +730,7 @@ BENCH_START(surf_driver_tim)
      &        ,alswvisdir=grid%alswvisdir, alswvisdif=grid%alswvisdif    & !ssib
      &        ,alswnirdir=grid%alswnirdir, alswnirdif=grid%alswnirdif    & !ssib
      &        ,swvisdir=grid%swvisdir, swvisdif=grid%swvisdif            & !ssib
-     &        ,swnirdir=grid%swnirdir, swnirdif=grid%swnirdif            & !ssib 
+     &        ,swnirdir=grid%swnirdir, swnirdif=grid%swnirdif            & !ssib
      &        ,ssib_br=grid%ssib_br,  ssib_fm=grid%ssib_fm               & !ssib
      &        ,ssib_fh=grid%ssib_fh,  ssib_cm=grid%ssib_cm               & !ssib
      &        ,ssibxdd=grid%ssibxdd,  ssib_lhf=grid%ssib_lhf             & !ssib
@@ -776,10 +778,11 @@ BENCH_START(surf_driver_tim)
      &        ,iopt_sfc=config_flags%opt_sfc,   iopt_frz=config_flags%opt_frz &
      &        ,iopt_inf=config_flags%opt_inf,   iopt_rad=config_flags%opt_rad &
      &        ,iopt_alb=config_flags%opt_alb,   iopt_snf=config_flags%opt_snf &
-     &        ,iopt_tbot=config_flags%opt_tbot, iopt_stc=config_flags%opt_stc & 
-     &        ,iopt_gla=config_flags%opt_gla,   iopt_rsf=config_flags%opt_rsf & 
+     &        ,iopt_tbot=config_flags%opt_tbot, iopt_stc=config_flags%opt_stc &
+     &        ,iopt_gla=config_flags%opt_gla,   iopt_rsf=config_flags%opt_rsf &
      &        ,iopt_soil=config_flags%opt_soil, iopt_pedo=config_flags%opt_pedo &
-     &        ,iopt_crop=config_flags%opt_crop
+! 11-May-20, Missing continuation character inserted: John Collins
+     &        ,iopt_crop=config_flags%opt_crop                                       &
      &        , isnowxy=grid%isnowxy  ,    tvxy=grid%tvxy    ,    tgxy=grid%tgxy     &
      &        ,canicexy=grid%canicexy ,canliqxy=grid%canliqxy,   eahxy=grid%eahxy    &
      &        ,   tahxy=grid%tahxy    ,    cmxy=grid%cmxy    ,    chxy=grid%chxy     &
@@ -797,7 +800,7 @@ BENCH_START(surf_driver_tim)
      &        , soilcl3=grid%soilcl3  , soilcl4=grid%soilcl4                         &
      &        ,  xsaixy=grid%xsaixy   , taussxy=grid%taussxy                         &
      &        ,  t2mvxy=grid%t2mvxy   ,  t2mbxy=grid%t2mbxy                          &
-     &        ,  q2mvxy=grid%q2mvxy   ,  q2mbxy=grid%q2mbxy                          & 
+     &        ,  q2mvxy=grid%q2mvxy   ,  q2mbxy=grid%q2mbxy                          &
      &        ,  tradxy=grid%tradxy   ,   neexy=grid%neexy   ,   gppxy=grid%gppxy    &
      &        ,   nppxy=grid%nppxy    ,  fvegxy=grid%fvegxy  , runsfxy=grid%runsfxy  &
      &        , runsbxy=grid%runsbxy  ,  ecanxy=grid%ecanxy  ,  edirxy=grid%edirxy   &
@@ -810,8 +813,8 @@ BENCH_START(surf_driver_tim)
      &        ,   evgxy=grid%evgxy    ,   evbxy=grid%evbxy   ,   ghvxy=grid%ghvxy    &
      &        ,   ghbxy=grid%ghbxy    ,   irgxy=grid%irgxy   ,   ircxy=grid%ircxy    &
      &        ,   irbxy=grid%irbxy    ,    trxy=grid%trxy    ,   evcxy=grid%evcxy    &
-     &        ,chleafxy=grid%chleafxy ,  chucxy=grid%chucxy                          &                       
-     &        ,  chv2xy=grid%chv2xy   ,  chb2xy=grid%chb2xy , chstarxy=grid%chstarxy &                       
+     &        ,chleafxy=grid%chleafxy ,  chucxy=grid%chucxy                          &
+     &        ,  chv2xy=grid%chv2xy   ,  chb2xy=grid%chb2xy , chstarxy=grid%chstarxy &
            !Optional hydro variables in NOAHMP
      &        ,smcwtdxy=grid%smcwtdxy ,rechxy=grid%rechxy ,deeprechxy=grid%deeprechxy &
      &        ,fdepthxy=grid%fdepthxy, areaxy=grid%areaxy, rivercondxy=grid%rivercondxy  &
@@ -872,7 +875,7 @@ BENCH_START(surf_driver_tim)
      &        ,OM_LAT=grid%om_lat                                                  & !cy:3DPWP
      &        , okms = 1, okme=config_flags%ocean_levels                  & ! cyl:3DPWP
      &        ,rdx=grid%rdx, rdy=grid%rdy,msfu=grid%msfu,msfv=grid%msfv,msft=grid%msft &!cyl: 3DPWP
-     &        ,XTIME=grid%xtime,OM_TINI=grid%om_tini,OM_SINI=grid%om_sini,id=grid%id,omdt=config_flags%omdt &!cyl: 3DPWP 
+     &        ,XTIME=grid%xtime,OM_TINI=grid%om_tini,OM_SINI=grid%om_sini,id=grid%id,omdt=config_flags%omdt &!cyl: 3DPWP
      &        ,sf_surface_mosaic=config_flags%sf_surface_mosaic,  mosaic_cat=config_flags%mosaic_cat    &
      &        ,mosaic_cat_index=grid%mosaic_cat_index                                                   &  !danli mosaic
      &        ,landusef2=grid%landusef2,TSK_mosaic=grid%TSK_mosaic,QSFC_mosaic=grid%QSFC_mosaic         &
@@ -885,14 +888,14 @@ BENCH_START(surf_driver_tim)
      &        ,HFX_mosaic=grid%HFX_mosaic,QFX_mosaic=grid%QFX_mosaic, LH_mosaic=grid%LH_mosaic          &
      &        ,GRDFLX_mosaic=grid%GRDFLX_mosaic,SNOTIME_mosaic=grid%SNOTIME_mosaic                      &  !danli mosaic
      &        ,RS_mosaic=grid%RS_mosaic,LAI_mosaic=grid%LAI_mosaic                                      &
-     &        ,TR_URB2D_mosaic=grid%TR_URB2D_mosaic,TB_URB2D_mosaic=grid%TB_URB2D_mosaic                &  !danli mosaic 
-     &        ,TG_URB2D_mosaic=grid%TG_URB2D_mosaic,TC_URB2D_mosaic=grid%TC_URB2D_mosaic                &  !danli mosaic 
+     &        ,TR_URB2D_mosaic=grid%TR_URB2D_mosaic,TB_URB2D_mosaic=grid%TB_URB2D_mosaic                &  !danli mosaic
+     &        ,TG_URB2D_mosaic=grid%TG_URB2D_mosaic,TC_URB2D_mosaic=grid%TC_URB2D_mosaic                &  !danli mosaic
      &        ,QC_URB2D_mosaic=grid%QC_URB2D_mosaic,UC_URB2D_mosaic=grid%UC_URB2D_mosaic                &  !danli mosaic
-     &        ,TRL_URB3D_mosaic=grid%TRL_URB3D_mosaic,TBL_URB3D_mosaic=grid%TBL_URB3D_mosaic            &  !danli mosaic 
-     &        ,TGL_URB3D_mosaic=grid%TGL_URB3D_mosaic                                                   &  !danli mosaic 
-     &        ,SH_URB2D_mosaic=grid%SH_URB2D_mosaic,LH_URB2D_mosaic=grid%LH_URB2D_mosaic                &  !danli mosaic 
-     &        ,G_URB2D_mosaic=grid%G_URB2D_mosaic,RN_URB2D_mosaic=grid%RN_URB2D_mosaic                  &  !danli mosaic 
-     &        ,TS_URB2D_mosaic=grid%TS_URB2D_mosaic                                                     &  !danli mosaic 
+     &        ,TRL_URB3D_mosaic=grid%TRL_URB3D_mosaic,TBL_URB3D_mosaic=grid%TBL_URB3D_mosaic            &  !danli mosaic
+     &        ,TGL_URB3D_mosaic=grid%TGL_URB3D_mosaic                                                   &  !danli mosaic
+     &        ,SH_URB2D_mosaic=grid%SH_URB2D_mosaic,LH_URB2D_mosaic=grid%LH_URB2D_mosaic                &  !danli mosaic
+     &        ,G_URB2D_mosaic=grid%G_URB2D_mosaic,RN_URB2D_mosaic=grid%RN_URB2D_mosaic                  &  !danli mosaic
+     &        ,TS_URB2D_mosaic=grid%TS_URB2D_mosaic                                                     &  !danli mosaic
      &        ,TS_RUL2D_mosaic=grid%TS_RUL2D_mosaic                                                     &  !danli mosaic
      &        ,ZOL=grid%ZOL                                                                             &
      &        ,SDA_HFX=grid%SDA_HFX, SDA_QFX=grid%SDA_QFX,HFX_BOTH=grid%HFX_BOTH                        &  !fasdas
@@ -928,7 +931,7 @@ BENCH_START(pbl_driver_tim)
      &        ,BL_PBL_PHYSICS=config_flags%bl_pbl_physics                           &
      &        ,WINDFARM_OPT=config_flags%windfarm_opt,power=grid%power              &
      &        ,BLDT=grid%bldt, CURR_SECS=curr_secs, ADAPT_STEP_FLAG=adapt_step_flag &
-     &        ,BLDTACTTIME=grid%bldtacttime                               &  
+     &        ,BLDTACTTIME=grid%bldtacttime                               &
      &        ,BR=grid%br         ,CHKLOWQ=chklowq    ,CT=grid%ct                   &
      &        ,DT=grid%dt         ,DX=grid%dx         ,DY=grid%dy                   &
      &        ,DX2D=grid%dx2d     ,AREA2D=grid%area2d                               &
@@ -1049,7 +1052,7 @@ BENCH_START(pbl_driver_tim)
      &        ,OL1=grid%ol1,OL2=grid%ol2,OL3=grid%ol3,OL4=grid%ol4        &
      &        ,SINA=grid%sina,COSA=grid%cosa                              &
      &        ,MFSHCONV=config_flags%mfshconv                             &
-     &        ,MASSFLUX_EDKF=grid%massflux_EDKF                           & 
+     &        ,MASSFLUX_EDKF=grid%massflux_EDKF                           &
      &        ,ENTR_EDKF=grid%entr_EDKF, DETR_EDKF=grid%detr_EDKF         &
      &        ,THL_UP=grid%thl_up                                         &
      &        ,THV_UP=grid%thv_up, RT_UP=grid%rt_up ,RV_UP=grid%rv_up     &
@@ -1107,14 +1110,14 @@ BENCH_START(pbl_driver_tim)
 BENCH_END(pbl_driver_tim)
 
 !*****
-! fire 
+! fire
 
 ! Jan Mandel's call to SFIRE
 
       IF ((grid%sr_x > 0 .OR. grid%sr_y > 0) .AND. config_flags%ifire == 2) THEN
 
 BENCH_START(fire_driver_tim)
-        if(config_flags%ifire.eq.2)then 
+        if(config_flags%ifire.eq.2)then
             ! initialization moved to start_em:start_domain_em
 !            if(grid%initestep.eq.1) &
 !            call fire_driver_em_init (  grid , config_flags    &
@@ -1154,7 +1157,7 @@ BENCH_START(cu_driver_tim)
      &             ,CUDT=grid%cudt,CURR_SECS=curr_secs,ADAPT_STEP_FLAG=adapt_step_flag &
      &             ,CCLDFRA=grid%ccldfra     ,CONVCLD=grid%convcld                     &
      &             ,QCCONV=grid%qcconv     ,QICONV=grid%qiconv                         &
-     &             ,CUDTACTTIME=grid%cudtacttime                                       & 
+     &             ,CUDTACTTIME=grid%cudtacttime                                       &
      &             ,RAINC=grid%rainc   ,RAINCV=grid%raincv   ,PRATEC=grid%pratec       &
      &             ,NCA=grid%nca                                                       &
      &             ,CLDFRA_DP=grid%cldfra_dp  ,CLDFRA_SH=grid%cldfra_sh,W_UP=grid%w_up & ! ckay for subgrid cloud
@@ -1223,10 +1226,10 @@ BENCH_START(cu_driver_tim)
      &             ,ktop_deep=grid%ktop_deep                              &
      &             ,PERIODIC_X=(config_flags%polar .OR. config_flags%periodic_x)  &
      &             ,PERIODIC_Y=config_flags%periodic_y                    &
-     &             ,IS_CAMMGMP_USED = grid%is_CAMMGMP_used  & !BSINGH - TKE at the interfaces for Zhang-McFarlane Scheme 
+     &             ,IS_CAMMGMP_USED = grid%is_CAMMGMP_used  & !BSINGH - TKE at the interfaces for Zhang-McFarlane Scheme
                  ! Zhang-McFarlane outputs
      &             ,EVAPCDP3D=grid%evapcdp3d, ICWMRDP3D=grid%icwmrdp3d    & !Balwinder.Singh@pnnl.gov: For CAM's wetscavenging
-     &             ,RPRDDP3D=grid%rprddp3d                                & 
+     &             ,RPRDDP3D=grid%rprddp3d                                &
      &             ,CAPE=grid%cape ,ZMMU=grid%zmmu ,ZMMD=grid%zmmd        &
      &             ,ZMDT=grid%zmdt ,ZMDQ=grid%zmdq                        &
      &             ,DLF=grid%dlf, RLIQ=grid%rliq                          &
@@ -1365,7 +1368,7 @@ BENCH_START(shcu_driver_tim)
      &             ,QS_CURR=moist(ims,kms,jms,P_QS)                       &
      &             ,QG_CURR=moist(ims,kms,jms,P_QG)                       &
      &             ,QNC_CURR=scalar(ims,kms,jms,P_QNC)                    & !BSINGH - Neede for UWSHCU scheme
-     &             ,QNI_CURR=scalar(ims,kms,jms,P_QNI)                    & !BSINGH - Neede for UWSHCU schem 
+     &             ,QNI_CURR=scalar(ims,kms,jms,P_QNI)                    & !BSINGH - Neede for UWSHCU schem
 #if (WRF_CHEM == 1)
      &             ,CHEM=chem,chem_opt=config_flags%chem_opt              &
 #endif
@@ -1379,7 +1382,7 @@ BENCH_START(shcu_driver_tim)
      &             ,RQVSHTEN=grid%rqvshten, RQCSHTEN=grid%rqcshten        &
      &             ,RQRSHTEN=grid%rqrshten, RQISHTEN=grid%rqishten        &
      &             ,RQSSHTEN=grid%rqsshten, RQGSHTEN=grid%rqgshten        &
-     &             ,RQCNSHTEN=grid%rqcnshten, RQINSHTEN=grid%rqinshten    &  
+     &             ,RQCNSHTEN=grid%rqcnshten, RQINSHTEN=grid%rqinshten    &
      &             ,RQVBLTEN=grid%rqvblten, RQVFTEN=grid%rqvften          &
      &             ,RUSHTEN=grid%rushten, RVSHTEN=grid%rvshten            &
      &             ,RTHSHTEN=grid%rthshten, RTHRATEN=grid%rthraten        &
@@ -1408,7 +1411,7 @@ BENCH_START(shcu_driver_tim)
      &             ,ltopb=grid%ltopb, kdcldtop=grid%kdcldtop              &
      &             ,kdcldbas=grid%kdcldbas                                &
      &             ,el_pbl=grid%el_pbl                                    &
-     &             ,rthratenlw=grid%rthratenlw, rthratensw=grid%rthratensw & 
+     &             ,rthratenlw=grid%rthratenlw, rthratensw=grid%rthratensw &
      &             ,exch_h=grid%exch_h                                    &
      &             ,dnw=grid%dnw, XTIME=grid%XTIME, XTIME1=grid%XTIME1    &
      &             ,GMT=grid%gmt                                          &
@@ -1534,7 +1537,7 @@ BENCH_START(fdda_driver_tim)
 ! FASDAS
 !
                   SDA_HFX=grid%SDA_HFX, SDA_QFX=grid%SDA_QFX,      &
-                  HFX_FDDA=grid%HFX_FDDA,  & 
+                  HFX_FDDA=grid%HFX_FDDA,  &
 !
 ! END FASDAS
 !

--- a/external/io_grib2/bacio-1.3/baciof.F
+++ b/external/io_grib2/bacio-1.3/baciof.F
@@ -1,3 +1,6 @@
+! 11-May-20, John Collins, Missing :: inserted at lines 95,139,182,225,
+!  267,310,368,369,482,483,539,540
+
 C-----------------------------------------------------------------------
       MODULE BACIO_MODULE
 C$$$  F90-MODULE DOCUMENTATION BLOCK
@@ -89,7 +92,8 @@ C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
       CHARACTER(80) CMSG
-      INTEGER SIZE = 1
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE = 1
 
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
@@ -132,7 +136,8 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
-      INTEGER SIZE = 1
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE = 1
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -174,7 +179,8 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
-      INTEGER SIZE = 1
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE = 1
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -216,7 +222,8 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
-      INTEGER SIZE = 1
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE = 1
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -258,7 +265,8 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
-      INTEGER SIZE = 1
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE = 1
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -299,7 +307,8 @@ C   LANGUAGE: FORTRAN 90
 C
 C$$$
       USE BACIO_MODULE
-      INTEGER SIZE = 1
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE = 1
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -356,8 +365,9 @@ C$$$
       CHARACTER Y(NY,MY)
       DATA LUX/0/
       SAVE JY,NS,NN,Y,LUX
-      INTEGER SIZE=1
-      INTEGER ZERO=0
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE=1
+      INTEGER :: ZERO=0
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(FD(LU).LE.0) THEN
         KA=0
@@ -375,7 +385,7 @@ C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 C  UNBUFFERED I/O
       IF(BAOPTS(1).NE.1) THEN
         IF(IB.GE.0) THEN
-           
+
           IRET=BACIO(BACIO_READ,IB,JB,SIZE,NB,KA,FD(LU),CFN,A)
         ELSE
           IRET=BACIO(BACIO_READ+BACIO_NOSEEK,ZERO,JB,SIZE,NB,KA,
@@ -469,8 +479,9 @@ C$$$
       USE BACIO_MODULE
       CHARACTER A(NB)
       CHARACTER CFN
-      INTEGER SIZE=1
-      INTEGER ZERO=0
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE=1
+      INTEGER :: ZERO=0
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(FD(LU).LE.0) THEN
         KA=0
@@ -524,8 +535,9 @@ C$$$
       USE BACIO_MODULE
       CHARACTER A(NB)
       CHARACTER CFN
-      INTEGER SIZE=1
-      INTEGER ZERO=0
+! 11-May-20, John Collins, inserted ::
+      INTEGER :: SIZE=1
+      INTEGER :: ZERO=0
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(FD(LU).LE.0) THEN
         RETURN

--- a/frame/Makefile
+++ b/frame/Makefile
@@ -1,4 +1,5 @@
-#
+# Makefile for /frame
+# Modified for fpt to suppress deletion of xx*.f90 and yy*.f90
 
 LN      =       ln -sf
 MAKE    =       make -i -r
@@ -89,82 +90,82 @@ $(LIBTARGET) :  $(MODULES) $(OBJS) $(SPECIAL) $(NLOBJS) $(ALOBJS)
 nl_set_0_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=0 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx0.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx0.f90
-	$(RM) xx0.f90
+#	$(RM) xx0.f90
 
 nl_set_1_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=1 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx1.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx1.f90
-	$(RM) xx1.f90
+#	$(RM) xx1.f90
 
 nl_set_2_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=2 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx2.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx2.f90
-	$(RM) xx2.f90
+#	$(RM) xx2.f90
 
 nl_set_3_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=3 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx3.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx3.f90
-	$(RM) xx3.f90
+#	$(RM) xx3.f90
 
 nl_set_4_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=4 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx4.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx4.f90
-	$(RM) xx4.f90
+#	$(RM) xx4.f90
 
 nl_set_5_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=5 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx5.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx5.f90
-	$(RM) xx5.f90
+#	$(RM) xx5.f90
 
 nl_set_6_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=6 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx6.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx6.f90
-	$(RM) xx6.f90
+#	$(RM) xx6.f90
 
 nl_set_7_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=7 -I../inc -DNL_set_ROUTINES nl_access_routines.F > xx7.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) xx7.f90
-	$(RM) xx7.f90
+#	$(RM) xx7.f90
 
 nl_get_0_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=0 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy0.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy0.f90
-	$(RM) yy0.f90
+#	$(RM) yy0.f90
 
 nl_get_1_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=1 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy1.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy1.f90
-	$(RM) yy1.f90
+#	$(RM) yy1.f90
 
 nl_get_2_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=2 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy2.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy2.f90
-	$(RM) yy2.f90
+#	$(RM) yy2.f90
 
 nl_get_3_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=3 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy3.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy3.f90
-	$(RM) yy3.f90
+#	$(RM) yy3.f90
 
 nl_get_4_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=4 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy4.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy4.f90
-	$(RM) yy4.f90
+#	$(RM) yy4.f90
 
 nl_get_5_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=5 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy5.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy5.f90
-	$(RM) yy5.f90
+#	$(RM) yy5.f90
 
 nl_get_6_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=6 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy6.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy6.f90
-	$(RM) yy6.f90
+#	$(RM) yy6.f90
 
 nl_get_7_routines.o : nl_access_routines.F module_configure.o
 	$(CPP) -DNNN=7 -I../inc -DNL_get_ROUTINES nl_access_routines.F > yy7.f90
 	$(FC) -o $@ -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS_NO_G) $(MODULE_DIRS) $(FCSUFFIX) yy7.f90
-	$(RM) yy7.f90
+#	$(RM) yy7.f90
 
 wrf_num_bytes_between.o :
 	$(CC) -c $(CFLAGS) wrf_num_bytes_between.c

--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -1,14 +1,17 @@
+! 11-May-20, John Collins, additional + sign removed line 3033
+
+
 !WRF:MODEL_LAYER:PHYSICS
 !
 ! translated from NN f77 to F90 and put into WRF by Mariusz Pagowski
 ! NOAA/GSD & CIRA/CSU, Feb 2008
 ! changes to original code:
 ! 1. code is 1D (in z)
-! 2. no advection of TKE, covariances and variances 
+! 2. no advection of TKE, covariances and variances
 ! 3. Cranck-Nicholson replaced with the implicit scheme
 ! 4. removed terrain dependent grid since input in WRF in actual
 !    distances in z[m]
-! 5. cosmetic changes to adhere to WRF standard (remove common blocks, 
+! 5. cosmetic changes to adhere to WRF standard (remove common blocks,
 !            intent etc)
 !-------------------------------------------------------------------
 !Modifications implemented by Joseph Olson and Jaymes Kenyon NOAA/GSD/MDB - CU/CIRES
@@ -17,7 +20,7 @@
 ! 1. Addition of BouLac mixing length in the free atmosphere.
 ! 2. Changed the turbulent mixing length to be integrated from the
 !    surface to the top of the BL + a transition layer depth.
-! v3.4.1:    Option to use Kitamura/Canuto modification which removes 
+! v3.4.1:    Option to use Kitamura/Canuto modification which removes
 !            the critical Richardson number and negative TKE (default).
 !            Hybrid PBL height diagnostic, which blends a theta-v-based
 !            definition in neutral/convective BL and a TKE-based definition
@@ -27,29 +30,29 @@
 ! v3.5.1:    Fog deposition related changes.
 ! v3.6.0:    Removed fog deposition from the calculation of tendencies
 !            Added mixing of qc, qi, qni
-!            Added output for wstar, delta, TKE_PBL, & KPBL for correct 
-!                   coupling to shcu schemes  
+!            Added output for wstar, delta, TKE_PBL, & KPBL for correct
+!                   coupling to shcu schemes
 ! v3.8.0:    Added subgrid scale cloud output for coupling to radiation
 !            schemes (activated by setting icloud_bl =1 in phys namelist).
 !            Added WRF_DEBUG prints (at level 3000)
 !            Added Tripoli and Cotton (1981) correction.
 !            Added namelist option bl_mynn_cloudmix to test effect of mixing
-!                cloud species (default = 1: on). 
+!                cloud species (default = 1: on).
 !            Added mass-flux option (bl_mynn_edmf, = 1 for DMP mass-flux, 0: off).
-!                Related options: 
+!                Related options:
 !                 bl_mynn_edmf_mom = 1 : activate momentum transport in MF scheme
 !                 bl_mynn_edmf_tke = 1 : activate TKE transport in MF scheme
 !            Added mixing length option (bl_mynn_mixlength, see notes below)
 !            Added more sophisticated saturation checks, following Thompson scheme
 !            Added new cloud PDF option (bl_mynn_cloudpdf = 2) from Chaboureau
-!                and Bechtold (2002, JAS, with mods) 
+!                and Bechtold (2002, JAS, with mods)
 !            Added capability to mix chemical species when env variable
 !                WRF_CHEM = 1, thanks to Wayne Angevine.
 !            Added scale-aware mixing length, following Junshi Ito's work
 !                Ito et al. (2015, BLM).
 ! v3.9.0    Improvement to the mass-flux scheme (dynamic number of plumes,
 !                better plume/cloud depth, significant speed up, better cloud
-!                fraction). 
+!                fraction).
 !            Added Stochastic Parameter Perturbation (SPP) implementation.
 !            Many miscellaneous tweaks to the mixing lengths and stratus
 !                component of the subgrid clouds.
@@ -59,7 +62,7 @@
 !            Further refinement of mass-flux scheme from SCM experiments with
 !                Wayne Angevine: switch to linear entrainment and back to
 !                Simpson and Wiggert-type w-equation.
-!            Addition of TKE production due to radiation cooling at top of 
+!            Addition of TKE production due to radiation cooling at top of
 !                clouds (proto-version); not activated by default.
 !            Some code rewrites to move if-thens out of loops in an attempt to
 !                improve computational efficiency.
@@ -69,7 +72,7 @@
 !                component of the subgrid-scale (SGS) clouds.
 ! v4.1       Big improvements in downward SW radiation due to revision of subgrid clouds
 !                - better cloud fraction and subgrid scale mixing ratios.
-!                - may experience a small cool bias during the daytime now that high 
+!                - may experience a small cool bias during the daytime now that high
 !                  SW-down bias is greatly reduced...
 !            Some tweaks to increase the turbulent mixing during the daytime for
 !                bl_mynn_mixlength option 2 to alleviate cool bias (very small impact).
@@ -103,7 +106,7 @@
 !                a very small, but primarily  positive, impact on SW-down biases.
 !            Tweak to calculation of KPBL - urged by Laura Fowler - to make more intuitive.
 !            Tweak to temperature range of blending for saturation check (water to ice). This
-!                slightly reduces excessive SGS clouds in polar region. No impact warm clouds. 
+!                slightly reduces excessive SGS clouds in polar region. No impact warm clouds.
 !            Added namelist option bl_mynn_output (0 or 1) to suppress or activate the
 !                allocation and output of 10 3D variables. Most people will want this
 !                set to 0 (default) to save memory and disk space.
@@ -171,7 +174,7 @@ MODULE module_bl_mynn
        &cpv, cliq, cice
 
   USE module_state_description, only: param_first_scalar, &
-       &p_qc, p_qr, p_qi, p_qs, p_qg, p_qnc, p_qni 
+       &p_qc, p_qr, p_qi, p_qs, p_qg, p_qnc, p_qni
 
   IMPLICIT NONE
 
@@ -215,7 +218,7 @@ MODULE module_bl_mynn
        &e4c = 12.0*a1*a2*cc2, &
        &e5c =  6.0*a1*a1
 
-! Constants for min tke in elt integration (qmin), max z/L in els (zmax), 
+! Constants for min tke in elt integration (qmin), max z/L in els (zmax),
 ! and factor for eddy viscosity for TKE (Kq = Sqfac*Km):
   REAL, PARAMETER :: qmin=0.0, zmax=1.0, Sqfac=3.0
 ! Note that the following mixing-length constants are now specified in mym_length
@@ -234,10 +237,10 @@ MODULE module_bl_mynn
                       onethird = 1./3., twothirds = 2./3.
 
   !Use Canuto/Kitamura mod (remove Ric and negative TKE) (1:yes, 0:no)
-  !For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the 
+  !For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the
   !Meteorological Society of Japan, Vol. 88, No. 5, pp. 857-864, 2010).
   !Note that this change required further modification of other parameters
-  !above (c2, c3). If you want to remove this option, set c2 and c3 constants 
+  !above (c2, c3). If you want to remove this option, set c2 and c3 constants
   !(above) back to NN2009 values (see commented out lines next to the
   !parameters above). This only removes the negative TKE problem
   !but does not necessarily improve performance - neutral impact.
@@ -266,8 +269,8 @@ MODULE module_bl_mynn
 ! JAYMES-
 ! Constants used for empirical calculations of saturation
 ! vapor pressures (in function "esat") and saturation mixing ratios
-! (in function "qsat"), reproduced from module_mp_thompson.F, 
-! v3.6 
+! (in function "qsat"), reproduced from module_mp_thompson.F,
+! v3.6
   REAL, PARAMETER:: J0= .611583699E03
   REAL, PARAMETER:: J1= .444606896E02
   REAL, PARAMETER:: J2= .143177157E01
@@ -291,25 +294,25 @@ MODULE module_bl_mynn
 
 !JOE & JAYMES'S mods
 !
-! Mixing Length Options 
+! Mixing Length Options
 !   specifed through namelist:  bl_mynn_mixlength
 !   added:  16 Apr 2015
 !
-! 0: Uses original MYNN mixing length formulation (except elt is calculated from 
+! 0: Uses original MYNN mixing length formulation (except elt is calculated from
 !    a 10-km vertical integration).  No scale-awareness is applied to the master
-!    mixing length (el), regardless of "scaleaware" setting. 
+!    mixing length (el), regardless of "scaleaware" setting.
 !
-! 1 (*DEFAULT*): Instead of (0), uses BouLac mixing length in free atmosphere.  
+! 1 (*DEFAULT*): Instead of (0), uses BouLac mixing length in free atmosphere.
 !    This helps remove excessively large mixing in unstable layers aloft.  Scale-
-!    awareness in dx is available via the "scaleaware" setting.  As of Apr 2015, 
+!    awareness in dx is available via the "scaleaware" setting.  As of Apr 2015,
 !    this mixing length formulation option is used in the ESRL RAP/HRRR configuration.
 !
-! 2: As in (1), but elb is lengthened using separate cloud mixing length functions 
-!    for statically stable and unstable regimes.  This elb adjustment is only 
-!    possible for nonzero cloud fractions, such that cloud-free cells are treated 
-!    as in (1), but BouLac calculation is used more sparingly - when elb > 500 m. 
+! 2: As in (1), but elb is lengthened using separate cloud mixing length functions
+!    for statically stable and unstable regimes.  This elb adjustment is only
+!    possible for nonzero cloud fractions, such that cloud-free cells are treated
+!    as in (1), but BouLac calculation is used more sparingly - when elb > 500 m.
 !    This is to reduce the computational expense that comes with the BouLac calculation.
-!    Also, This option is  scale-aware in dx if "scaleaware" = 1. (Following Ito et al. 2015). 
+!    Also, This option is  scale-aware in dx if "scaleaware" = 1. (Following Ito et al. 2015).
 !
 !JOE & JAYMES- end
 
@@ -448,7 +451,7 @@ CONTAINS
 !     # As to dtl, ...gh, see subroutine mym_turbulence.
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_initialize (                                & 
+  SUBROUTINE  mym_initialize (                                &
        &            kts,kte,                                  &
        &            dz, zw,                                   &
        &            u, v, thl, qw,                            &
@@ -462,7 +465,7 @@ CONTAINS
        &            spp_pbl,rstoch_col)
 !
 !-------------------------------------------------------------------
-    
+
     INTEGER, INTENT(IN)   :: kts,kte
     INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
     LOGICAL, INTENT(IN)   :: INITIALIZE_QKE
@@ -557,9 +560,9 @@ CONTAINS
 !   **  Strictly, vkz*h(i,j) -> vk*( 0.5*dz(1)*h(i,j)+z0 )  **
        vkz = vk*0.5*dz(kts)
        elv = 0.5*( el(kts+1)+el(kts) ) /  vkz
-       IF (INITIALIZE_QKE)THEN 
+       IF (INITIALIZE_QKE)THEN
           !qke(kts) = ust**2 * ( b1*pmz*elv    )**(2.0/3.0)
-          qke(kts) = 1.0 * MAX(ust,0.02)**2 * ( b1*pmz*elv    )**(2.0/3.0) 
+          qke(kts) = 1.0 * MAX(ust,0.02)**2 * ( b1*pmz*elv    )**(2.0/3.0)
        ENDIF
 
        phm      = phh*b2 / ( b1*pmz/elv**2 )**(1.0/3.0)
@@ -607,7 +610,7 @@ CONTAINS
 !    RETURN
 
   END SUBROUTINE mym_initialize
-  
+
 !
 ! ==================================================================
 !     SUBROUTINE  mym_level2:
@@ -750,7 +753,7 @@ CONTAINS
 !     NOTE: the mixing lengths are meant to be calculated at the full-
 !           sigmal levels (or interfaces beween the model layers).
 !
-  SUBROUTINE  mym_length (                     & 
+  SUBROUTINE  mym_length (                     &
     &            kts,kte,                      &
     &            dz, zw,                       &
     &            rmo, flt, flq,                &
@@ -761,7 +764,7 @@ CONTAINS
     &            zi,theta,                     &
     &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength,&
     &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf)
-    
+
 !-------------------------------------------------------------------
 
     INTEGER, INTENT(IN)   :: kts,kte
@@ -797,7 +800,7 @@ CONTAINS
             alp6       ! for mass-flux/
 
     !THE FOLLOWING LIMITS DO NOT DIRECTLY AFFECT THE ACTUAL PBLH.
-    !THEY ONLY IMPOSE LIMITS ON THE CALCULATION OF THE MIXING LENGTH 
+    !THEY ONLY IMPOSE LIMITS ON THE CALCULATION OF THE MIXING LENGTH
     !SCALES SO THAT THE BOULAC MIXING LENGTH (IN FREE ATMOS) DOES
     !NOT ENCROACH UPON THE BOUNDARY LAYER MIXING LENGTH (els, elb & elt).
     REAL, PARAMETER :: minzi = 300.  !min mixed-layer height
@@ -845,7 +848,7 @@ CONTAINS
         END DO
 
         elt = 1.0e-5
-        vsc = 1.0e-5        
+        vsc = 1.0e-5
 
         !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
         k = kts+1
@@ -962,7 +965,7 @@ CONTAINS
 
            !   **  Length scale limited by the buoyancy effect  **
            IF ( dtv(k) .GT. 0.0 ) THEN
-              bv  = SQRT( gtr*dtv(k) ) 
+              bv  = SQRT( gtr*dtv(k) )
               elb = alp2*qkw(k) / bv &                ! formulation,
                   &       *( 1.0 + alp3/alp2*&       ! except keep
                   &SQRT( vsc/( bv*elt ) ) )          ! elb bounded by
@@ -1158,7 +1161,7 @@ CONTAINS
 
 
      !----------------------------------
-     ! FIND DISTANCE UPWARD             
+     ! FIND DISTANCE UPWARD
      !----------------------------------
      zup=0.
      dlu=zw(kte+1)-zw(k)-dz(k)/2.
@@ -1209,7 +1212,7 @@ CONTAINS
      endif
 
      !----------------------------------
-     ! FIND DISTANCE DOWN               
+     ! FIND DISTANCE DOWN
      !----------------------------------
      zdo=0.
      zdo_sup=0.
@@ -1257,7 +1260,7 @@ CONTAINS
      endif
 
      !----------------------------------
-     ! GET MINIMUM (OR AVERAGE)         
+     ! GET MINIMUM (OR AVERAGE)
      !----------------------------------
      !The surface layer length scale can exceed z for large z/L,
      !so keep maximum distance down > z.
@@ -1289,7 +1292,7 @@ CONTAINS
 !          length scales, and also considers the distance to the
 !          surface.
 !
-!      dlu = the distance a parcel can be lifted upwards give a finite 
+!      dlu = the distance a parcel can be lifted upwards give a finite
 !            amount of TKE.
 !      dld = the distance a parcel can be displaced downwards given a
 !            finite amount of TKE.
@@ -1326,11 +1329,11 @@ CONTAINS
         if (iz .lt. kte) then      !cant integrate upwards from highest level
 
           found = 0
-          izz=iz       
-          DO WHILE (found .EQ. 0) 
+          izz=iz
+          DO WHILE (found .EQ. 0)
 
             if (izz .lt. kte) then
-              dzt=dz(izz)                    ! layer depth above 
+              dzt=dz(izz)                    ! layer depth above
               zup=zup-beta*theta(iz)*dzt     ! initial PE the parcel has at iz
               !print*,"  ",iz,izz,theta(izz),dz(izz)
               zup=zup+beta*(theta(izz+1)+theta(izz))*dzt/2. ! PE gained by lifting a parcel to izz+1
@@ -1349,7 +1352,7 @@ CONTAINS
                     else
                        tl=0.
                     endif
-                 endif            
+                 endif
                  dlu(iz)=zzz-dzt+tl
                  !print*,"  FOUND Dup:",dlu(iz)," z=",zw(izz)," tl=",tl
                  found =1
@@ -1363,7 +1366,7 @@ CONTAINS
           ENDDO
 
         endif
-                   
+
         !----------------------------------
         ! FIND DISTANCE DOWN
         !----------------------------------
@@ -1376,8 +1379,8 @@ CONTAINS
         if (iz .gt. kts) then  !cant integrate downwards from lowest level
 
           found = 0
-          izz=iz       
-          DO WHILE (found .EQ. 0) 
+          izz=iz
+          DO WHILE (found .EQ. 0)
 
             if (izz .gt. kts) then
               dzt=dz(izz-1)
@@ -1398,7 +1401,7 @@ CONTAINS
                     else
                        tl=0.
                     endif
-                 endif            
+                 endif
                  dld(iz)=zzz-dzt+tl
                  !print*,"  FOUND Ddown:",dld(iz)," z=",zw(izz)," tl=",tl
                  found = 1
@@ -1428,7 +1431,7 @@ CONTAINS
         !Apply soft limit (only impacts very large lb; lb=100 by 5%, lb=500 by 20%).
         lb1(iz) = lb1(iz)/(1. + (lb1(iz)/Lmax))
         lb2(iz) = lb2(iz)/(1. + (lb2(iz)/Lmax))
- 
+
         if (iz .eq. kte) then
            lb1(kte) = lb1(kte-1)
            lb2(kte) = lb2(kte-1)
@@ -1437,7 +1440,7 @@ CONTAINS
         !print*,"IN MYNN-BouLac",iz,dld(iz),dlu(iz)
 
      ENDDO
-                   
+
   END SUBROUTINE boulac_length
 !
 ! ==================================================================
@@ -1504,7 +1507,7 @@ CONTAINS
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
     REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,& 
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,&
          &ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1D,edmf_w1,edmf_a1,edmf_qc1,&
          &TKEprodTD
 
@@ -1839,9 +1842,9 @@ CONTAINS
        cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
        IF (edmf_a1(k) > 0.001 .OR. cldavg > 0.02) THEN
            cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
-           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &                           
+           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
            !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
-           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &                           
+           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
            !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
 
            ! for mass-flux columns
@@ -1910,7 +1913,7 @@ CONTAINS
        !!!qSHEAR1D(k)=-(upwp*dudz + vpwp*dvdz)
        qSHEAR1D(k) = elq*sm(k)*gm(k)
 
-       !!!Buoyancy Term    
+       !!!Buoyancy Term
        !!!qBUOY1D(k)=g*Tpwp/thl(k)
        !qBUOY1D(k)= elq*(sh(k)*gh(k) + gamv)
        qBUOY1D(k) = elq*(sh(k)*(-dTdz*g/thl(k)) + gamv)
@@ -2018,7 +2021,7 @@ CONTAINS
        &)
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(IN) :: kts,kte    
+    INTEGER, INTENT(IN) :: kts,kte
 
 #ifdef HARDCODE_VERTICAL
 # define kts 1
@@ -2123,13 +2126,13 @@ CONTAINS
 !       qke(k)=max(d(k-kts+1), 1.e-4)
        qke(k)=max(x(k), 1.e-4)
     ENDDO
-      
+
 
     IF ( levflag .EQ. 3 ) THEN
 !
 !  Modified: Dec/22/2005, from here
 !   **  dfq for the scalar variance is 1.0*dfm.  **
-!       CALL coefvu ( dfq, 1.0 ) make change here 
+!       CALL coefvu ( dfq, 1.0 ) make change here
 !  Modified: Dec/22/2005, up to here
 !
 !   **  Prediction of the temperature variance  **
@@ -2137,11 +2140,11 @@ CONTAINS
        DO k = kts,kte-1
           b2l = b2*0.5*( el(k+1)+el(k) )
           bp(k) = 2.*qkw(k) / b2l
-          rp(k) = pdt(k+1) + pdt(k) 
+          rp(k) = pdt(k+1) + pdt(k)
        END DO
-       
+
 !zero gradient for tsq at bottom and top
-       
+
 !!       a(1)=0.
 !!       b(1)=1.
 !!       c(1)=-1.
@@ -2169,22 +2172,22 @@ CONTAINS
 
 !       CALL tridiag(kte,a,b,c,d)
     CALL tridiag2(kte,a,b,c,d,x)
-       
+
        DO k=kts,kte
 !          tsq(k)=d(k-kts+1)
            tsq(k)=x(k)
        ENDDO
-       
+
 !   **  Prediction of the moisture variance  **
 !!       DO k = kts+1,kte-1
        DO k = kts,kte-1
           b2l = b2*0.5*( el(k+1)+el(k) )
           bp(k) = 2.*qkw(k) / b2l
-          rp(k) = pdq(k+1) +pdq(k) 
+          rp(k) = pdq(k+1) +pdq(k)
        END DO
-       
+
 !zero gradient for qsq at bottom and top
-       
+
 !!       a(1)=0.
 !!       b(1)=1.
 !!       c(1)=-1.
@@ -2209,7 +2212,7 @@ CONTAINS
        b(kte)=1.
        c(kte)=0.
        d(kte)=0.
-       
+
 !       CALL tridiag(kte,a,b,c,d)
        CALL tridiag2(kte,a,b,c,d,x)
 
@@ -2217,17 +2220,17 @@ CONTAINS
 !          qsq(k)=d(k-kts+1)
            qsq(k)=x(k)
        ENDDO
-       
+
 !   **  Prediction of the temperature-moisture covariance  **
 !!       DO k = kts+1,kte-1
        DO k = kts,kte-1
           b2l = b2*0.5*( el(k+1)+el(k) )
           bp(k) = 2.*qkw(k) / b2l
-          rp(k) = pdc(k+1) + pdc(k) 
+          rp(k) = pdc(k+1) + pdc(k)
        END DO
-       
+
 !zero gradient for tqcov at bottom and top
-       
+
 !!       a(1)=0.
 !!       b(1)=1.
 !!       c(1)=-1.
@@ -2255,12 +2258,12 @@ CONTAINS
 
 !       CALL tridiag(kte,a,b,c,d)
     CALL tridiag2(kte,a,b,c,d,x)
-       
+
        DO k=kts,kte
 !          cov(k)=d(k-kts+1)
           cov(k)=x(k)
        ENDDO
-       
+
     ELSE
 !!       DO k = kts+1,kte-1
        DO k = kts,kte-1
@@ -2274,7 +2277,7 @@ CONTAINS
           qsq(k) = b2l*( pdq(k+1)+pdq(k) )
           cov(k) = b2l*( pdc(k+1)+pdc(k) )
        END DO
-       
+
 !!       tsq(kts)=tsq(kts+1)
 !!       qsq(kts)=qsq(kts+1)
 !!       cov(kts)=cov(kts+1)
@@ -2282,7 +2285,7 @@ CONTAINS
        tsq(kte)=tsq(kte-1)
        qsq(kte)=qsq(kte-1)
        cov(kte)=cov(kte-1)
-      
+
     END IF
 
 #ifdef HARDCODE_VERTICAL
@@ -2291,7 +2294,7 @@ CONTAINS
 #endif
 
   END SUBROUTINE mym_predict
-  
+
 ! ==================================================================
 !     SUBROUTINE  mym_condensation:
 !
@@ -2381,7 +2384,7 @@ CONTAINS
     REAL :: qw_pert
 
 ! First, obtain an estimate for the tropopause height (k), using the method employed in the
-! Thompson subgrid-cloud scheme.  This height will be a consideration later when determining 
+! Thompson subgrid-cloud scheme.  This height will be a consideration later when determining
 ! the "final" subgrid-cloud properties.
 ! JAYMES:  added 3 Nov 2016, adapted from G. Thompson
 
@@ -2391,7 +2394,7 @@ CONTAINS
        ht1 = 44307.692 * (1.0 - (p(k)/101325.)**0.190)
        ht2 = 44307.692 * (1.0 - (p(k+2)/101325.)**0.190)
        if ( (((theta2-theta1)/(ht2-ht1)) .lt. 10./1500. ) .AND.       &
-     &                       (ht1.lt.19000.) .and. (ht1.gt.4000.) ) then 
+     &                       (ht1.lt.19000.) .and. (ht1.gt.4000.) ) then
           goto 86
        endif
     ENDDO
@@ -2487,7 +2490,7 @@ CONTAINS
            alp(k) = 1.0/( 1.0+dqsl*xlvcp )
            bet(k) = dqsl*exner(k)
 
-           if (k .eq. kts) then 
+           if (k .eq. kts) then
              dzk = 0.5*dz(k)
            else
              dzk = dz(k)
@@ -2501,7 +2504,7 @@ CONTAINS
            q1(k)   = qmq(k) / sgm(k)
            cldfra_bl1D(K) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
 
-           !now compute estimated lwc for PBL scheme's use 
+           !now compute estimated lwc for PBL scheme's use
            !qll IS THE NORMALIZED LIQUID WATER CONTENT (Sommeria and
            !Deardorff (1977, eq 29a). rrp = 1/(sqrt(2*pi)) = 0.3989
            q1k  = q1(k)
@@ -2593,9 +2596,9 @@ CONTAINS
                                         !   lfac(3 km)  = 5.0
                                         !   lfac(13 km) = 6.0
            ls = MAX(MIN(lfac*el(k),600.),ls_min)  ! Bounded:  ls_min < ls < 600 m
-                   ! Note: CB02 use 900 m as a constant free-atmosphere length scale. 
+                   ! Note: CB02 use 900 m as a constant free-atmosphere length scale.
 
-                   ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the 
+                   ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the
                    ! MYNN master length scale (el) must exceed 60 m before ls
                    ! becomes responsive to el, otherwise ls = ls_min = 300 m.
 
@@ -2652,15 +2655,15 @@ CONTAINS
            !based on collocated explicit clouds.  Otherise, use a simple temperature-dependent partitioning.
            IF ( qc(k) + qi(k) > 0.0 ) THEN ! explicit condensate exists, so attempt to retain its phase partitioning
               IF ( qi(k) == 0.0 ) THEN       ! explicit contains no ice; assume subgrid liquid
-                liq_frac = 1.0  
+                liq_frac = 1.0
               ELSE IF ( qc(k) == 0.0 ) THEN  ! explicit contains no liquid; assume subgrid ice
                 liq_frac = 0.0
-              ELSE IF ( (qc(k) >= 1.E-10) .AND. (qi(k) >= 1.E-10) ) THEN  ! explicit contains mixed phase of workably 
-                                                                          ! large amounts; assume subgrid follows 
+              ELSE IF ( (qc(k) >= 1.E-10) .AND. (qi(k) >= 1.E-10) ) THEN  ! explicit contains mixed phase of workably
+                                                                          ! large amounts; assume subgrid follows
                                                                           ! same partioning
                 liq_frac = qc(k) / ( qc(k) + qi(k) )
-              ELSE 
-                liq_frac = MIN(1.0, MAX(0.0, (t-238.)/31.)) ! explicit contains mixed phase, but at least one 
+              ELSE
+                liq_frac = MIN(1.0, MAX(0.0, (t-238.)/31.)) ! explicit contains mixed phase, but at least one
                                                                    ! species is very small, so make a temperature-
                                                                    ! depedent guess
               ENDIF
@@ -2677,11 +2680,11 @@ CONTAINS
               qc_bl1D(k)  = 0.
               qi_bl1D(k)  = 0.
            endif
-       
+
            !Buoyancy-flux-related calculations follow...
            ! "Fng" represents the non-Gaussian transport factor
-           ! (non-dimensional) from Bechtold et al. 1995 
-           ! (hereafter BCMT95), section 3(c).  Their suggested 
+           ! (non-dimensional) from Bechtold et al. 1995
+           ! (hereafter BCMT95), section 3(c).  Their suggested
            ! forms for Fng (from their Eq. 20) are:
            !IF (q1k < -2.) THEN
            !  Fng = 2.-q1k
@@ -2705,21 +2708,21 @@ CONTAINS
            Fng = MIN(Fng, 20.)
 
            xl    = xl_blend(t)
-           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
-                             ! "b" in CB02 (i.e., b(k) above) by a factor 
+           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from
+                             ! "b" in CB02 (i.e., b(k) above) by a factor
                              ! of T/theta.  Strictly, b(k) above is formulated in
                              ! terms of sat. mixing ratio, but bb in BCMT95 is
                              ! cast in terms of sat. specific humidity.  The
-                             ! conversion is neglected here. 
+                             ! conversion is neglected here.
            qww   = 1.+0.61*qw(k)
            alpha = 0.61*th(k)
            beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
            vt(k) = qww   - MIN(cldfra_bl1D(K),0.5)*beta*bb*Fng   - 1.
            vq(k) = alpha + MIN(cldfra_bl1D(K),0.5)*beta*a(k)*Fng - tv0
-           ! vt and vq correspond to beta-theta and beta-q, respectively,  
+           ! vt and vq correspond to beta-theta and beta-q, respectively,
            ! in NN09, Eq. B8.  They also correspond to the bracketed
            ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
-           ! The "-1" and "-tv0" terms are included for consistency with 
+           ! The "-1" and "-tv0" terms are included for consistency with
            ! the legacy vt and vq formulations (above).
 
            ! dampen the amplification factor (cld_factor) with height in order
@@ -2918,7 +2921,7 @@ CONTAINS
 !    c(kte)=0.
 !    d(kte)=0.
 
-!! specified gradient at the top 
+!! specified gradient at the top
 !    a(kte)=-1.
 !    b(kte)=1.
 !    c(kte)=0.
@@ -3014,7 +3017,7 @@ CONTAINS
 !           &         sub_thl(k)*delt + det_thl(k)*delt
 !    ENDDO
 
-!rho-weighted:                                                                                                           
+!rho-weighted:
     a(k)=  -dtz(k)*khdz(k)/rho(k)
     b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)
     c(k)=  -dtz(k)*khdz(k+1)/rho(k)           - 0.5*dtz(k)*s_aw(k+1)
@@ -3026,8 +3029,9 @@ CONTAINS
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
            &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
        c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)
+! 11-May-20, John Collins, additional + sign removed
        d(k)=thl(k) + tcd(k)*delt + dtz(k)*(s_awthl(k)-s_awthl(k+1)) + &
-          &       + diss_heat(k)*delt*dheat_opt + &
+          &         diss_heat(k)*delt*dheat_opt + &
           &         sub_thl(k)*delt + det_thl(k)*delt
     ENDDO
 
@@ -3063,7 +3067,7 @@ IF (bl_mynn_mixqt > 0) THEN
  !============================================
  ! MIX total water (sqw = sqc + sqv + sqi)
  ! NOTE: no total water tendency is output; instead, we must calculate
- !       the saturation specific humidity and then 
+ !       the saturation specific humidity and then
  !       subtract out the moisture excess (sqc & sqi)
  !============================================
 
@@ -3251,7 +3255,7 @@ ELSE
 ENDIF
 
 !============================================
-! MIX CLOUD ICE ( sqi )                      
+! MIX CLOUD ICE ( sqi )
 !============================================
 IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
 
@@ -3283,10 +3287,10 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
     ENDDO
 
 !! no flux at the top
-!    a(kte)=-1.       
-!    b(kte)=1.        
-!    c(kte)=0.        
-!    d(kte)=0.        
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
 
 !! specified gradient at the top
 !assume gradqw_top=gradqv_top
@@ -3353,8 +3357,8 @@ ELSE
 ENDIF
 
 !!============================================
-!! cloud water number concentration (qnc)     
-!! include non-local transport                
+!! cloud water number concentration (qnc)
+!! include non-local transport
 !!============================================
   IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNC .AND. &
       bl_mynn_mixscalars > 0) THEN
@@ -3483,7 +3487,7 @@ ENDIF
 !! Note that the momentum tendencies are calculated above.
 !!============================================
 
-    IF (bl_mynn_mixqt > 0) THEN 
+    IF (bl_mynn_mixqt > 0) THEN
       DO k=kts,kte
          t  = th(k)*exner(k)
          !SATURATED VAPOR PRESSURE
@@ -3532,7 +3536,7 @@ ENDIF
             Dqc(k)=(sqc2(k)/(1.-sqv2(k)) - qc(k))/delt
             IF(Dqc(k)*delt + qc(k) < 0.) THEN
               !print*,'  neg qc:',qsl,sqw2(k),sqi2(k),sqc2(k),qc(k),tk(k)
-              Dqc(k)=-qc(k)/delt 
+              Dqc(k)=-qc(k)/delt
             ENDIF
          ENDDO
       ELSE
@@ -3549,7 +3553,7 @@ ENDIF
            !IF(sqc2(k)>1.e-9)qnc2(k)=MAX(qnc2(k),1.e6)
            Dqnc(k) = (qnc2(k)-qnc(k))/delt
            !IF(Dqnc(k)*delt + qnc(k) < 0.)Dqnc(k)=-qnc(k)/delt
-         ENDDO 
+         ENDDO
       ELSE
          DO k=kts,kte
            Dqnc(k) = 0.
@@ -3767,30 +3771,30 @@ ENDIF
 
 !! to solve system of linear eqs on tridiagonal matrix n times n
 !! after Peaceman and Rachford, 1955
-!! a,b,c,d - are vectors of order n 
+!! a,b,c,d - are vectors of order n
 !! a,b,c - are coefficients on the LHS
 !! d - is initially RHS on the output becomes a solution vector
-    
+
 !-------------------------------------------------------------------
 
     INTEGER, INTENT(in):: n
     REAL, DIMENSION(n), INTENT(in) :: a,b
     REAL, DIMENSION(n), INTENT(inout) :: c,d
-    
+
     INTEGER :: i
     REAL :: p
     REAL, DIMENSION(n) :: q
-    
+
     c(n)=0.
     q(1)=-c(1)/b(1)
     d(1)=d(1)/b(1)
-    
+
     DO i=2,n
        p=1./(b(i)+a(i)*q(i-1))
        q(i)=-c(i)*p
        d(i)=(d(i)-a(i)*d(i-1))*p
     ENDDO
-    
+
     DO i=n-1,1,-1
        d(i)=d(i)+q(i)*d(i+1)
     ENDDO
@@ -3834,17 +3838,17 @@ ENDIF
 ! ==================================================================
        subroutine tridiag3(kte,a,b,c,d,x)
 
-!ccccccccccccccccccccccccccccccc                                                                   
-! Aim: Inversion and resolution of a tridiagonal matrix                                            
-!          A X = D                                                                                 
-! Input:                                                                                           
-!  a(*) lower diagonal (Ai,i-1)                                                                  
-!  b(*) principal diagonal (Ai,i)                                                                
-!  c(*) upper diagonal (Ai,i+1)                                                                  
-!  d                                                                                               
-! Output                                                                                           
-!  x     results                                                                                   
-!ccccccccccccccccccccccccccccccc                                                                   
+!ccccccccccccccccccccccccccccccc
+! Aim: Inversion and resolution of a tridiagonal matrix
+!          A X = D
+! Input:
+!  a(*) lower diagonal (Ai,i-1)
+!  b(*) principal diagonal (Ai,i)
+!  c(*) upper diagonal (Ai,i+1)
+!  d
+! Output
+!  x     results
+!ccccccccccccccccccccccccccccccc
 
        implicit none
         integer,intent(in)   :: kte
@@ -3895,7 +3899,7 @@ ENDIF
        &RQNCBLTEN,RQNIBLTEN,            &
        &RQNWFABLTEN,RQNIFABLTEN,        &
        &exch_h,exch_m,                  &
-       &Pblh,kpbl,                      & 
+       &Pblh,kpbl,                      &
        &el_pbl,                         &
        &dqke,qWT,qSHEAR,qBUOY,qDISS,    & !JOE-TKE BUDGET
        &wstar,delta,                    & !JOE-added for grims
@@ -3920,7 +3924,7 @@ ENDIF
        &,IDS,IDE,JDS,JDE,KDS,KDE        &
        &,IMS,IME,JMS,JME,KMS,KME        &
        &,ITS,ITE,JTS,JTE,KTS,KTE)
-    
+
 !-------------------------------------------------------------------
 
     INTEGER, INTENT(in) :: initflag
@@ -3942,7 +3946,7 @@ ENDIF
 
     LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
                            FLAG_QNWFA,FLAG_QNIFA
-    
+
     INTEGER,INTENT(IN) :: &
          & IDS,IDE,JDS,JDE,KDS,KDE &
          &,IMS,IME,JMS,JME,KMS,KME &
@@ -3959,7 +3963,7 @@ ENDIF
 !                         = 3;  Level 3
 ! grav_settling = 1 when gravitational settling accounted for
 ! grav_settling = 0 when gravitational settling NOT accounted for
-    
+
     REAL, INTENT(in) :: delt
 !WRF
     REAL, INTENT(in) :: dx
@@ -3997,7 +4001,7 @@ ENDIF
     REAL, DIMENSION(IMS:IME,JMS:JME) :: &
          &Psig_bl,Psig_shcu
 
-    INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: & 
+    INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: &
          &KPBL,nupdraft,ktop_plume
 
     REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(OUT) :: &
@@ -4039,7 +4043,7 @@ ENDIF
 
     REAL, DIMENSION(KTS:KTE) :: thetav,sh,u1,v1,w1,p1,ex1,dz1,th1,tk1,rho1,&
            & qke1,tsq1,qsq1,cov1,qv1,qi1,qc1,du1,dv1,dth1,dqv1,dqc1,dqi1, &
-           & k_m1,k_h1,qni1,dqni1,qnc1,dqnc1,qnwfa1,qnifa1,dqnwfa1,dqnifa1 
+           & k_m1,k_h1,qni1,dqni1,qnc1,dqnc1,qnwfa1,qnifa1,dqnwfa1,dqnifa1
 
 !JOE: mass-flux variables
     REAL, DIMENSION(KTS:KTE) :: dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf
@@ -4077,7 +4081,7 @@ ENDIF
 
     LOGICAL :: INITIALIZE_QKE
 
-! Stochastic fields 
+! Stochastic fields
      INTEGER,  INTENT(IN)                                               ::spp_pbl
      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN),OPTIONAL  ::pattern_spp_pbl
      REAL, DIMENSION(KTS:KTE)                         ::    rstoch_col
@@ -4090,7 +4094,7 @@ ENDIF
 !***  Begin debugging
     IMD=(IMS+IME)/2
     JMD=(JMS+JME)/2
-!***  End debugging 
+!***  End debugging
 
 !WRF
     JTF=MIN0(JTE,JDE-1)
@@ -4140,7 +4144,7 @@ ENDIF
           INITIALIZE_QKE = .TRUE.
           !print*,"not restart nor cycling, must initialize QKE"
        ENDIF
- 
+
        Sh3D(its:ite,kts:kte,jts:jte)=0.
        el_pbl(its:ite,kts:kte,jts:jte)=0.
        tsq(its:ite,kts:kte,jts:jte)=0.
@@ -4228,8 +4232,8 @@ ENDIF
                    sqi(k)=0.0
                    sqw(k)=sqv(k)+sqc(k)
                    thl(k)=th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
-                   !Use form from Tripoli and Cotton (1981) with their 
-                   !suggested min temperature to improve accuracy.      
+                   !Use form from Tripoli and Cotton (1981) with their
+                   !suggested min temperature to improve accuracy.
                    !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
                    !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
                    IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
@@ -4250,7 +4254,7 @@ ENDIF
                    zw(k)=zw(k-1)+dz(i,k-1,j)
                 ENDIF
                 IF (INITIALIZE_QKE) THEN
-                   !Initialize tke for initial PBLH calc only - using 
+                   !Initialize tke for initial PBLH calc only - using
                    !simple PBLH form of Koracin and Berkowicz (1988, BLM)
                    !to linearly taper off tke towards top of PBL.
                    qke1(k)=5.*ust(i,j) * MAX((ust(i,j)*700. - zw(k))/(MAX(ust(i,j),0.01)*700.), 0.01)
@@ -4275,7 +4279,7 @@ ENDIF
 !             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
              CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
                &  Qke1,zw,dz1,xland(i,j),KPBL(i,j))
-             
+
              IF (scaleaware > 0.) THEN
                 CALL SCALE_AWARE(dx,PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
              ELSE
@@ -4283,7 +4287,7 @@ ENDIF
                 Psig_shcu(i,j)=1.0
              ENDIF
 
-             CALL mym_initialize (             & 
+             CALL mym_initialize (             &
                   &kts,kte,                    &
                   &dz1, zw, u1, v1, thl, sqv,  &
                   &PBLH(i,j), th1, sh,         &
@@ -4369,7 +4373,7 @@ ENDIF
                 thl(k)= th(i,k,j) - xlvcp/exner(i,k,j)*sqc(k) &
                      &            - xlscp/exner(i,k,j)*sqi(k)
                 !Use form from Tripoli and Cotton (1981) with their
-                !suggested min temperature to improve accuracy.    
+                !suggested min temperature to improve accuracy.
                 !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
                 !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
                 !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
@@ -4388,7 +4392,7 @@ ENDIF
                 sqw(k)= sqv(k)+sqc(k)
                 thl(k)= th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
                 !Use form from Tripoli and Cotton (1981) with their
-                !suggested min temperature to improve accuracy.    
+                !suggested min temperature to improve accuracy.
                 !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
                 !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
                 IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
@@ -4399,7 +4403,7 @@ ENDIF
                    sqi9=0.0
                 ENDIF
                 thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
-                      &           - xlscp/exner(i,k,j)*sqi9 
+                      &           - xlscp/exner(i,k,j)*sqi9
             ENDIF
             thetav(k)=th(i,k,j)*(1.+0.608*sqv(k))
             thvl(k)=thlsg(k)*(1.+0.61*sqv(k))
@@ -4666,10 +4670,10 @@ ENDIF
                    !if (kk.eq.kpbl(i,j)-1 .and. cloudflg .and. we.lt.0.0) then
                    !   KHtopdown(kk) = 0.0
                    !endif
-                   
+
                    !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
                    !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
-                   !An analytic profile controls the magnitude of this TKE prod in the vertical. 
+                   !An analytic profile controls the magnitude of this TKE prod in the vertical.
                    TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh(i,j),100.)*zfacent(kk)
                    TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
                 ENDDO
@@ -4726,7 +4730,7 @@ ENDIF
 
           ENDIF
 
-          CALL mym_turbulence (                  & 
+          CALL mym_turbulence (                  &
                &kts,kte,levflag,                 &
                &dz1, zw, u1, v1, thl, sqc, sqw,  &
                &qke1, tsq1, qsq1, cov1,          &
@@ -4739,7 +4743,7 @@ ENDIF
                &Pdt,Pdq,Pdc,                     &
                &qWT1,qSHEAR1,qBUOY1,qDISS1,      &
                &bl_mynn_tkebudget,               &
-               &Psig_bl(i,j),Psig_shcu(i,j),     &     
+               &Psig_bl(i,j),Psig_shcu(i,j),     &
                &cldfra_bl1D,bl_mynn_mixlength,   &
                &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
                &TKEprodTD,                       &
@@ -4815,7 +4819,7 @@ ENDIF
     ENDIF
 #endif
 
- 
+
           CALL retrieve_exchange_coeffs(kts,kte,&
                &dfm, dfh, dz1, K_m1, K_h1)
 
@@ -4850,11 +4854,11 @@ ENDIF
                !DIAGNOSTIC-DECAY FOR SUBGRID-SCALE CLOUDS
                IF (CLDFRA_BL1D(k) < cldfra_bl1D_old(k)) THEN
                   !DECAY TIMESCALE FOR CALM CONDITION IS THE EDDY TURNOVER
-                  !TIMESCALE, BUT FOR WINDY CONDITIONS, IT IS THE ADVECTIVE 
+                  !TIMESCALE, BUT FOR WINDY CONDITIONS, IT IS THE ADVECTIVE
                   !TIMESCALE. USE THE MINIMUM OF THE TWO.
                   ts_decay = MIN( 1800., 3.*dx/MAX(SQRT(u1(k)**2 + v1(k)**2),1.0) )
                   cldfra_bl(i,k,j)= MAX(cldfra_bl1D(k),cldfra_bl1D_old(k)-(0.25*delt/ts_decay))
-                  ! qc_bl2 and qi_bl2 are decay rates 
+                  ! qc_bl2 and qi_bl2 are decay rates
                   qc_bl2          = MAX(qc_bl1D(k),qc_bl1D_old(k))
                   qc_bl2          = MAX(qc_bl2,1.0E-5)
                   qi_bl2          = MAX(qi_bl1D(k),qi_bl1D_old(k))
@@ -4921,7 +4925,7 @@ ENDIF
                IF ( ABS(vt(k)) > 0.8 )print*,&
                   "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vt=",vt(k)
                IF ( ABS(vq(k)) > 6000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vq=",vq(k) 
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vq=",vq(k)
                IF ( exch_m(i,k,j) < 0. .OR. exch_m(i,k,j)> 2000.)print*,&
                   "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," exxch_m=",exch_m(i,k,j)
                IF ( vdfg(i,j) < 0. .OR. vdfg(i,j)>5. )print*,&
@@ -4992,8 +4996,8 @@ ENDIF
     INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,                    &
          &                IMS,IME,JMS,JME,KMS,KME,                    &
          &                ITS,ITE,JTS,JTE,KTS,KTE
-    
-    
+
+
     REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
          &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,                 &
          &RQCBLTEN,RQIBLTEN,& !RQNIBLTEN,RQNCBLTEN       &
@@ -5003,11 +5007,11 @@ ENDIF
 !         &qc_bl,cldfra_bl
 
     INTEGER :: I,J,K,ITF,JTF,KTF
-    
+
     JTF=MIN0(JTE,JDE-1)
     KTF=MIN0(KTE,KDE-1)
     ITF=MIN0(ITE,IDE-1)
-    
+
     IF(.NOT.RESTART)THEN
        DO J=JTS,JTF
           DO K=KTS,KTF
@@ -5040,13 +5044,13 @@ ENDIF
     !---------------------------------------------------------------
     !             NOTES ON THE PBLH FORMULATION
     !
-    !The 1.5-theta-increase method defines PBL heights as the level at 
-    !which the potential temperature first exceeds the minimum potential 
-    !temperature within the boundary layer by 1.5 K. When applied to 
+    !The 1.5-theta-increase method defines PBL heights as the level at
+    !which the potential temperature first exceeds the minimum potential
+    !temperature within the boundary layer by 1.5 K. When applied to
     !observed temperatures, this method has been shown to produce PBL-
-    !height estimates that are unbiased relative to profiler-based 
+    !height estimates that are unbiased relative to profiler-based
     !estimates (Nielsen-Gammon et al. 2008). However, their study did not
-    !include LLJs. Banta and Pichugina (2008) show that a TKE-based 
+    !include LLJs. Banta and Pichugina (2008) show that a TKE-based
     !threshold is a good estimate of the PBL height in LLJs. Therefore,
     !a hybrid definition is implemented that uses both methods, weighting
     !the TKE-method more during stable conditions (PBLH < 400 m).
@@ -5102,7 +5106,7 @@ ENDIF
 
     zi=0.
     k = kthv+1
-!    DO WHILE (zi .EQ. 0.) 
+!    DO WHILE (zi .EQ. 0.)
     DO k=kts+1,kte-1
        IF (thetav1D(k) .GE. (minthv + delt_thv))THEN
           zi = zw1D(k) - dz1D(k-1)* &
@@ -5117,18 +5121,18 @@ ENDIF
 
     !FOR STABLE BOUNDARY LAYERS, USE TKE METHOD TO COMPLEMENT THE
     !THETAV-BASED DEFINITION (WHEN THE THETA-V BASED PBLH IS BELOW ~0.5 KM).
-    !THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE 
+    !THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE
     !WHEN THE THETA-V-BASED DEFINITION IS ABOVE ~1 KM.
     ktke = 1
     maxqke = MAX(Qke1D(kts),0.)
     !Use 5% of tke max (Kosovic and Curry, 2000; JAS)
     !TKEeps = maxtke/20. = maxqke/40.
     TKEeps = maxqke/40.
-    TKEeps = MAX(TKEeps,0.02) !0.025) 
+    TKEeps = MAX(TKEeps,0.02) !0.025)
     PBLH_TKE=0.
 
     k = ktke+1
-!    DO WHILE (PBLH_TKE .EQ. 0.) 
+!    DO WHILE (PBLH_TKE .EQ. 0.)
     DO k=kts+1,kte-1
        !QKE CAN BE NEGATIVE (IF CKmod == 0)... MAKE TKE NON-NEGATIVE.
        qtke  =MAX(Qke1D(k)/2.,0.)      ! maximum TKE
@@ -5145,7 +5149,7 @@ ENDIF
        IF (PBLH_TKE .NE. 0.) exit
     ENDDO
 
-    !With TKE advection turned on, the TKE-based PBLH can be very large 
+    !With TKE advection turned on, the TKE-based PBLH can be very large
     !in grid points with convective precipitation (> 8 km!),
     !so an artificial limit is imposed to not let PBLH_TKE exceed the
     !theta_v-based PBL height +/- 350 m.
@@ -5158,7 +5162,7 @@ ENDIF
     IF (maxqke <= 0.05) THEN
        !Cold pool situation - default to theta_v-based def
     ELSE
-       !BLEND THE TWO PBLH TYPES HERE: 
+       !BLEND THE TWO PBLH TYPES HERE:
        zi=PBLH_TKE*(1.-wt) + zi*wt
     ENDIF
 
@@ -5176,7 +5180,7 @@ ENDIF
 #endif
 
   END SUBROUTINE GET_PBLH
-  
+
 ! ==================================================================
 ! Dynamic Multi-Plume (DMP) Mass-Flux Scheme
 !
@@ -5187,7 +5191,7 @@ ENDIF
 !  2) transport of TKE (extra namelist option)
 !  3) Chaboureau-Bechtold cloud fraction & coupling to radiation (when icloud_bl > 0)
 !  4) some extra limits for numerical stability
-! This scheme remains under development, so consider it experimental code. 
+! This scheme remains under development, so consider it experimental code.
 !
   SUBROUTINE DMP_mf(                       &
                  & kts,kte,dt,zw,dz,p,      &
@@ -5200,11 +5204,11 @@ ENDIF
                  & exner,vt,vq,sgm,         &
                  & ust,flt,flq,flqv,flqc,   &
                  & pblh,kpbl,DX,landsea,ts, &
-            ! outputs - updraft properties   
+            ! outputs - updraft properties
                  & edmf_a,edmf_w,           &
                  & edmf_qt,edmf_thl,        &
                  & edmf_ent,edmf_qc,        &
-            ! outputs - variables needed for solver 
+            ! outputs - variables needed for solver
                  & s_aw,s_awthl,s_awqt,     &
                  & s_awqv,s_awqc,           &
                  & s_awu,s_awv,s_awqke,     &
@@ -5228,7 +5232,7 @@ ENDIF
             ! output info
                  &nup2,ktop,maxmf,ztop,     &
             ! unputs for stochastic perturbations
-                 &spp_pbl,rstoch_col) 
+                 &spp_pbl,rstoch_col)
 
   ! inputs:
      INTEGER, INTENT(IN) :: KTS,KTE,KPBL,momentum_opt,tke_opt,scalar_opt
@@ -5238,7 +5242,7 @@ ENDIF
 # define kte HARDCODE_VERTICAL
 #endif
 
-! Stochastic 
+! Stochastic
      INTEGER,  INTENT(IN)          :: spp_pbl
      REAL, DIMENSION(KTS:KTE)      :: rstoch_col
 
@@ -5296,8 +5300,8 @@ ENDIF
      REAL,PARAMETER :: &
           &Wa=2./3., &
           &Wb=0.002,&
-          &Wc=1.5 
-        
+          &Wc=1.5
+
   ! Lateral entrainment parameters ( L0=100 and ENT0=0.1) were taken from
   ! Suselj et al (2013, jas). Note that Suselj et al (2014,waf) use L0=200 and ENT0=0.2.
      REAL,PARAMETER :: &
@@ -5364,7 +5368,7 @@ ENDIF
    !parameter "Csub" determines the propotion of upward vertical velocity that contributes to
    !environmenatal subsidence. Some portion is expected to be compensated by downdrafts instead of
    !gentle environmental subsidence. 1.0 assumes all upward vertical velocity in the mass-flux scheme
-   !is compensated by "gentle" environmental subsidence. 
+   !is compensated by "gentle" environmental subsidence.
    REAL, PARAMETER :: Csub=0.25
 
 ! check the inputs
@@ -5471,12 +5475,12 @@ ENDIF
   !print*," maxw=", maxw," Psig_w=",Psig_w," Psig_shcu=",Psig_shcu
 
   fltv = flt + svp1*flq
-  !PRINT*," fltv=",fltv," zi=",pblh 
+  !PRINT*," fltv=",fltv," zi=",pblh
 
   !Completely shut off MF scheme for strong resolved-scale vertical velocities.
   IF(Psig_w == 0.0 .and. fltv > 0.0) fltv = -1.*fltv
 
-! if surface buoyancy is positive we do integration, otherwise not, and make sure that 
+! if surface buoyancy is positive we do integration, otherwise not, and make sure that
 ! PBLH > twice the height of the surface layer (set at z0 = 50m)
 ! Also, ensure that it is at least slightly superadiabatic up through 50 m
       superadiabatic = .false.
@@ -5485,7 +5489,7 @@ ENDIF
   ELSE
      hux = -0.005  ! LAND    ! dT/dz must be < - 0.5 K per 100 m.
   ENDIF
-  DO k=1,MAX(1,k50-1) !use "-1" because k50 used interface heights (zw). 
+  DO k=1,MAX(1,k50-1) !use "-1" because k50 used interface heights (zw).
     IF (k == 1) then
       IF ((th(k)-ts)/(0.5*dz(k)) < hux) THEN
         superadiabatic = .true.
@@ -5513,7 +5517,7 @@ ENDIF
   ! Criteria (1)
     NUP2 = max(1,min(NUP,INT(dx*dcut/dl)))
   !Criteria (2)
-    maxwidth = 1.2*PBLH 
+    maxwidth = 1.2*PBLH
   ! Criteria (3)
     maxwidth = MIN(maxwidth,0.75*cloud_base)
   ! Criteria (4)
@@ -5538,7 +5542,7 @@ ENDIF
     ! Find coef C for number size density N
     cn = 0.
     d=-1.9  !set d to value suggested by Neggers 2015 (JAMES).
-    !d=-1.9 + .2*tanh((fltv - 0.05)/0.15) 
+    !d=-1.9 + .2*tanh((fltv - 0.05)/0.15)
     do I=1,NUP !NUP2
        IF(I > NUP2) exit
        l  = dl*I                            ! diameter of plume
@@ -5555,12 +5559,12 @@ ENDIF
        UPA(1,I) = N*l*l/(dx*dx) * dl        ! fractional area of plume n
        ! Make updraft area (UPA) a function of the buoyancy flux
 !       acfac = .5*tanh((fltv - 0.03)/0.09) + .5
-!       acfac = .5*tanh((fltv - 0.02)/0.09) + .5 
+!       acfac = .5*tanh((fltv - 0.02)/0.09) + .5
        acfac = .5*tanh((fltv - 0.01)/0.09) + .5
 
        !add a windspeed-dependent adjustment to acfac that tapers off
        !the mass-flux scheme linearly above sfc wind speeds of 20 m/s:
-       acfac = acfac*(1. - MIN(MAX(wspd_pbl - 20.0, 0.0), 10.0)/10.) 
+       acfac = acfac*(1. - MIN(MAX(wspd_pbl - 20.0, 0.0), 10.0)/10.)
 
        UPA(1,I)=UPA(1,I)*acfac
        An2 = An2 + UPA(1,I)                 ! total fractional area of all plumes
@@ -5594,7 +5598,7 @@ ENDIF
     sigmaTH=csigma*thstar*(z0/pblh)**(-1./3.)
 
     !Note: Given the pwmin & pwmax set above, these max/mins are
-    !      rarely exceeded. 
+    !      rarely exceeded.
     wmin=MIN(sigmaW*pwmin,0.05)
     wmax=MIN(sigmaW*pwmax,0.4)
 
@@ -5615,7 +5619,7 @@ ENDIF
        UPQC(1,I)=0
        !UPQC(1,I)=(QC(KTS)*DZ(KTS+1)+QC(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
        UPQT(1,I)=(QT(KTS)*DZ(KTS+1)+QT(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))&
-           &     +exc_fac*UPW(1,I)*sigmaQT/sigmaW       
+           &     +exc_fac*UPW(1,I)*sigmaQT/sigmaW
        UPTHV(1,I)=(THV(KTS)*DZ(KTS+1)+THV(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1)) &
            &     +exc_fac*UPW(1,I)*sigmaTH/sigmaW
 !was       UPTHL(1,I)= UPTHV(1,I)/(1.+svp1*UPQT(1,I))  !assume no saturated parcel at surface
@@ -5662,7 +5666,7 @@ ENDIF
           ENT(k,i) = 0.31/(MIN(MAX(UPW(K-1,I),wmin),1.9)*l)
           !Entrainment from Negggers (2015, JAMES)
           !ENT(k,i) = 0.02*l**-0.35 - 0.0009
-          !Minimum background entrainment 
+          !Minimum background entrainment
           ENT(k,i) = max(ENT(k,i),0.0003)
           !ENT(k,i) = max(ENT(k,i),0.05/ZW(k))  !not needed for Tian and Kuang
           !JOE - increase entrainment for plumes extending very high.
@@ -5805,7 +5809,7 @@ ENDIF
           detturb  = 0.00008
           oow      = -0.060/MAX(1.0,(0.5*(Wn+UPW(K-1,I))))   !coef for dynamical detrainment rate
           detrate  = MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0002) ! dynamical detrainment rate (m^-1)
-          detrateUV= MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0001) ! dynamical detrainment rate (m^-1) 
+          detrateUV= MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0001) ! dynamical detrainment rate (m^-1)
           envm_thl(k)=envm_thl(k) + (0.5*(thl_ent + UPTHL(K-1,I)) - thl(k))*detrate*aratio*MIN(dzp,300.)
           qv_ent = 0.5*(MAX(qt_ent-qc_ent,0.) + MAX(UPQT(K-1,I)-UPQC(K-1,I),0.))
           envm_sqv(k)=envm_sqv(k) + (qv_ent-QV(K))*detrate*aratio*MIN(dzp,300.)
@@ -5868,7 +5872,7 @@ ENDIF
     ENDDO
   ELSE
     !At least one of the conditions was not met for activating the MF scheme.
-    NUP2=0. 
+    NUP2=0.
   END IF !end criteria for mass-flux scheme
 
   ktop=MIN(ktop,KTE-1)  !  Just to be safe...
@@ -6054,7 +6058,7 @@ ENDIF
           sub_thl(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
                       (thl(k+1)-thl(k))/dzi(k)
           sub_sqv(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
-                      (qv(k+1)-qv(k))/dzi(k) 
+                      (qv(k+1)-qv(k))/dzi(k)
        ENDDO
 
        DO k=KTS,KTE-1
@@ -6080,7 +6084,7 @@ ENDIF
     ENDIF !end subsidence/env detranment
 
     !First, compute exner, plume theta, and dz centered at interface
-    !Here, k=1 is the top of the first model layer. These values do not 
+    !Here, k=1 is the top of the first model layer. These values do not
     !need to be defined at k=kte (unused level).
     DO K=KTS,KTE-1
        exneri(k) = (exner(k)*DZ(k+1)+exner(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
@@ -6090,7 +6094,7 @@ ENDIF
 
 !JOE: ADD CLDFRA_bl1d, qc_bl1d. Note that they have already been defined in
 !     mym_condensation. Here, a shallow-cu component is added, but no cumulus
-!     clouds can be added at k=1 (start loop at k=2).  
+!     clouds can be added at k=1 (start loop at k=2).
     DO K=KTS+1,KTE-2
         IF(k > KTOP) exit
         IF(0.5*(edmf_qc(k)+edmf_qc(k-1))>0.0)THEN
@@ -6107,7 +6111,7 @@ ENDIF
             !SATURATED VAPOR PRESSURE
             esat = esat_blend(t)
             !SATURATED SPECIFIC HUMIDITY
-            qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat)) 
+            qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
 
             !condensed liquid in the plume on mass levels
             IF (edmf_qc(k)>0.0 .AND. edmf_qc(k-1)>0.0)THEN
@@ -6118,7 +6122,7 @@ ENDIF
 
             !COMPUTE CLDFRA & QC_BL FROM MASS-FLUX SCHEME and recompute vt & vq
 
-            xl = xl_blend(tk(k))                ! obtain blended heat capacity 
+            xl = xl_blend(tk(k))                ! obtain blended heat capacity
             tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
             qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
                                                 !   at tl and p
@@ -6126,7 +6130,7 @@ ENDIF
                                                 ! CB02, Eqn. 4
             cpm = cp + qt(k)*cpv                ! CB02, sec. 2, para. 1
             a   = 1./(1. + xl*rsl/cpm)          ! CB02 variable "a"
-            b9  = a*rsl                         ! CB02 variable "b" 
+            b9  = a*rsl                         ! CB02 variable "b"
 
             q2p  = xlvcp/exner(k)
             pt = thl(k) +q2p*QCp*0.5*(edmf_a(k)+edmf_a(k-1)) ! potential temp (env + plume)
@@ -6166,8 +6170,8 @@ ENDIF
 
             ! Update cloud fractions and specific humidities in grid cells
             ! where the mass-flux scheme is active. Now, we also use the
-            ! stratus component of the SGS clouds as well. The stratus cloud 
-            ! fractions (Ac_strat) are reduced slightly to give way to the 
+            ! stratus component of the SGS clouds as well. The stratus cloud
+            ! fractions (Ac_strat) are reduced slightly to give way to the
             ! mass-flux SGS cloud fractions (Ac_mf).
             IF (cldfra_bl1d(k) < 0.5) THEN
                IF (mf_cf > 0.5*(edmf_a(k)+edmf_a(k-1))) THEN
@@ -6179,7 +6183,7 @@ ENDIF
                   !dillute Qc from updraft area to larger cloud area
                   qc_mf      = QCp*0.5*(edmf_a(k)+edmf_a(k-1))/mf_cf
                   !The mixing ratios from the stratus component are not well
-                  !estimated in shallow-cumulus regimes. Ensure stratus clouds 
+                  !estimated in shallow-cumulus regimes. Ensure stratus clouds
                   !have mixing ratio similar to cumulus
                   QCs        = MIN(MAX(qc_bl1d(k), 0.5*qc_mf), 5E-4)
                   qc_bl1d(k) = (qc_mf*Ac_mf + QCs*Ac_strat)/cldfra_bl1d(k)
@@ -6226,26 +6230,26 @@ ENDIF
 
     !modify output (negative: dry plume, positive: moist plume)
     IF (ktop > 0) THEN
-      maxqc = maxval(edmf_qc(1:ktop)) 
+      maxqc = maxval(edmf_qc(1:ktop))
       IF ( maxqc < 1.E-8) maxmf = -1.0*maxmf
     ENDIF
 
 !
-! debugging   
+! debugging
 !
-IF (edmf_w(1) > 4.0) THEN 
+IF (edmf_w(1) > 4.0) THEN
 ! surface values
     print *,'flq:',flq,' fltv:',fltv
     print *,'pblh:',pblh,' wstar:',wstar
     print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
 ! means
 !   print *,'u:',u
-!   print *,'v:',v  
+!   print *,'v:',v
 !   print *,'thl:',thl
 !   print *,'thv:',thv
 !   print *,'qt:',qt
 !   print *,'p:',p
- 
+
 ! updrafts
 ! DO I=1,NUP2
 !   print *,'up:A',i
@@ -6254,22 +6258,22 @@ IF (edmf_w(1) > 4.0) THEN
 !   print*,UPW(:,i)
 !   print *,'up:thv',i
 !   print *,UPTHV(:,i)
-!   print *,'up:thl',i 
+!   print *,'up:thl',i
 !   print *,UPTHL(:,i)
 !   print *,'up:qt',i
 !   print *,UPQT(:,i)
 !   print *,'up:tQC',i
 !   print *,UPQC(:,i)
 !   print *,'up:ent',i
-!   print *,ENT(:,i)   
+!   print *,ENT(:,i)
 ! ENDDO
- 
+
 ! mean updrafts
    print *,' edmf_a',edmf_a(1:14)
    print *,' edmf_w',edmf_w(1:14)
    print *,' edmf_qt:',edmf_qt(1:14)
    print *,' edmf_thl:',edmf_thl(1:14)
- 
+
 ENDIF !END Debugging
 
 
@@ -6297,7 +6301,7 @@ real :: diff,exn,t,th,qs,qcold
 ! rcp ... Rd/cp
 ! xlv ... latent heat for water (2.5e6)
 ! cp
-! rvord .. rv/rd  (1.6) 
+! rvord .. rv/rd  (1.6)
 
 ! number of iterations
   niter=50
@@ -6307,7 +6311,7 @@ real :: diff,exn,t,th,qs,qcold
   EXN=(P/p1000mb)**rcp
   !QC=0.  !better first guess QC is incoming from lower level, do not set to zero
   do i=1,NITER
-     T=EXN*THL + xlvcp*QC        
+     T=EXN*THL + xlvcp*QC
      QS=qsat_blend(T,P)
      QCOLD=QC
      QC=0.5*QC + 0.5*MAX((QT-QS),0.)
@@ -6335,7 +6339,7 @@ real :: diff,exn,t,th,qs,qcold
   !THV= TH*(1. + 0.608*QT)
 
   !print *,'t,p,qt,qs,qc'
-  !print *,t,p,qt,qs,qc 
+  !print *,t,p,qt,qs,qc
 
 
 end subroutine condensation_edmf
@@ -6400,13 +6404,13 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
     Psig_shcu= ((dxdh**2) + 0.145*(dxdh**0.667))/((dxdh**2) +0.172*(dxdh**0.667) + 0.170)
 
     ! Hyeyum Hailey Shin and Song-You Hong 2013, w'theta' in PBL
-    !Psig(i)= 0.5 + 0.5*((dxdh**2) -0.098)/((dxdh**2) + 0.106) 
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) -0.098)/((dxdh**2) + 0.106)
     ! Hyeyum Hailey Shin and Song-You Hong 2013, w'theta' in entrainment zone
     !Psig(i)= 0.5 + 0.5*((dxdh**2) - 0.112*(dxdh**0.25) -0.071)/((dxdh**2)
     !+ 0.054*(dxdh**0.25) + 0.10)
 
     !print*,"in scale_aware; dx, dxdh, Psig(i)=",dx,dxdh,Psig(i)
-    !If(Psig_bl(i) < 0.0 .OR. Psig(i) > 1.)print*,"dx, dxdh, Psig(i)=",dx,dxdh,Psig_bl(i) 
+    !If(Psig_bl(i) < 0.0 .OR. Psig(i) > 1.)print*,"dx, dxdh, Psig(i)=",dx,dxdh,Psig_bl(i)
     If(Psig_bl > 1.0) Psig_bl=1.0
     If(Psig_bl < 0.0) Psig_bl=0.0
 
@@ -6417,27 +6421,27 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
 ! =====================================================================
 
-  FUNCTION esat_blend(t) 
+  FUNCTION esat_blend(t)
 ! JAYMES- added 22 Apr 2015
-! 
-! This calculates saturation vapor pressure.  Separate ice and liquid functions 
-! are used (identical to those in module_mp_thompson.F, v3.6).  Then, the 
-! final returned value is a temperature-dependant "blend".  Because the final 
-! value is "phase-aware", this formulation may be preferred for use throughout 
+!
+! This calculates saturation vapor pressure.  Separate ice and liquid functions
+! are used (identical to those in module_mp_thompson.F, v3.6).  Then, the
+! final returned value is a temperature-dependant "blend".  Because the final
+! value is "phase-aware", this formulation may be preferred for use throughout
 ! the module (replacing "svp").
 
       IMPLICIT NONE
-      
+
       REAL, INTENT(IN):: t
       REAL :: esat_blend,XC,ESL,ESI,chi
 
       XC=MAX(-80.,t-273.16)
 
-! For 253 < t < 273.16 K, the vapor pressures are "blended" as a function of temperature, 
-! using the approach of Chaboureau and Bechtold (2002), JAS, p. 2363.  The resulting 
+! For 253 < t < 273.16 K, the vapor pressures are "blended" as a function of temperature,
+! using the approach of Chaboureau and Bechtold (2002), JAS, p. 2363.  The resulting
 ! values are returned from the function.
       IF (t .GE. 273.16) THEN
-          esat_blend = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
+          esat_blend = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
       ELSE IF (t .LE. 253.) THEN
           esat_blend = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
       ELSE
@@ -6462,7 +6466,7 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
       CHARACTER(LEN=1) :: wrt
       REAL :: qsat_blend,XC,ESL,ESI,RSLF,RSIF,chi
 
-      IF ( .NOT. PRESENT(waterice) ) THEN 
+      IF ( .NOT. PRESENT(waterice) ) THEN
           wrt = 'b'
       ELSE
           wrt = waterice
@@ -6471,8 +6475,8 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
       XC=MAX(-80.,t-273.16)
 
       IF ((t .GE. 273.16) .OR. (wrt .EQ. 'w')) THEN
-          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
-          qsat_blend = 0.622*ESL/(P-ESL) 
+          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
+          qsat_blend = 0.622*ESL/(P-ESL)
       ELSE IF (t .LE. 253.) THEN
           ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
           qsat_blend = 0.622*ESI/(P-ESI)

--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -1,3 +1,4 @@
+! 11-May-20, John Collins: Changed end statement at line 756
 !
 module module_fr_fire_phys
 
@@ -6,7 +7,7 @@ use module_fr_fire_util
 
 PRIVATE
 
-! subroutines and functions 
+! subroutines and functions
 PUBLIC:: init_fuel_cats,fire_ros,heat_fluxes,set_nfuel_cat,set_fire_params,write_fuels_m
 PUBLIC:: fuel_moisture,advance_moisture,read_namelist_fire
 
@@ -19,14 +20,14 @@ PUBLIC::fire_params
 ! arrays passed to fire_ros
 type fire_params
 real,pointer,dimension(:,:):: vx,vy                ! wind velocity (m/s)
-real,pointer,dimension(:,:):: zsf                  ! terrain height (m) 
-real,pointer,dimension(:,:):: dzdxf,dzdyf          ! terrain grad (1) 
+real,pointer,dimension(:,:):: zsf                  ! terrain height (m)
+real,pointer,dimension(:,:):: dzdxf,dzdyf          ! terrain grad (1)
 real,pointer,dimension(:,:):: bbb,betafl,phiwc,r_0 ! spread formula coefficients
 real,pointer,dimension(:,:):: fgip                 ! init mass of surface fuel (kg/m^2)
 real,pointer,dimension(:,:):: ischap               ! if fuel is chaparral and want rate of spread treated differently
 real,pointer,dimension(:,:):: iboros               ! fire instensity over rate of spread -> avialable fuel x heat of combustion
-real,pointer,dimension(:,:):: fuel_time            ! time to burn to 1/e (s) 
-real,pointer,dimension(:,:):: fmc_g                ! fuel moisture contents, ground (1) 
+real,pointer,dimension(:,:):: fuel_time            ! time to burn to 1/e (s)
+real,pointer,dimension(:,:):: fmc_g                ! fuel moisture contents, ground (1)
 end type fire_params
 
 ! use as
@@ -55,10 +56,10 @@ end type fire_params
 !  1. change parameter max_moisture_classes below
 !  2. change the default of nfmc to the same value in Registry/registry.fire
 !  3. add the appropriate lines real::fmc_gw<number>= <default values>
-!  4. add default 
+!  4. add default
 
 !*** dimensions
-  INTEGER, PARAMETER :: mfuelcats = 30     ! allowable number of fuel categories 
+  INTEGER, PARAMETER :: mfuelcats = 30     ! allowable number of fuel categories
   INTEGER, PARAMETER ::max_moisture_classes=5
 !***
 
@@ -70,16 +71,16 @@ end type fire_params
    integer::itmp
    CHARACTER (len=80), DIMENSION(max_moisture_classes), save :: moisture_class_name
   REAL, save:: fmc_1h, fmc_10h, fmc_100h, fmc_1000h, fmc_live
-    
+
   data moisture_class_name /'1-h','10-h','100-h','1000-h','Live'/
-  data drying_lag          /1., 10., 100., 1000.,1e9/  ! time lag (h) approaching equilibrium moisture 
+  data drying_lag          /1., 10., 100., 1000.,1e9/  ! time lag (h) approaching equilibrium moisture
   data wetting_lag         /1.4,14., 140., 1400.,1e9/  ! time lag (h) for approaching saturation in rain
   data saturation_moisture /2.5, 2.5, 2.5 ,2.5, 2.5/  ! saturation moisture contents (1) in rain
-  data saturation_rain     /8.0, 8.0, 8.0, 8.0, 8.0/  ! stronger rain matters only in duration (mm/h) 
+  data saturation_rain     /8.0, 8.0, 8.0, 8.0, 8.0/  ! stronger rain matters only in duration (mm/h)
   data rain_threshold      /0.05,0.05,0.05,0.05,0.05/ ! rain intensity this small is same as nothing
-  data drying_model        /1,   1,   1,   1,   1 / ! future proofing 
+  data drying_model        /1,   1,   1,   1,   1 / ! future proofing
   data wetting_model       /1,   1,   1,   1,   1 / ! future proofing
-  data fmc_gc_initialization/2,  2,   2,   2,   3 / ! initialization 0=input, 1=from fuelmc_g, 
+  data fmc_gc_initialization/2,  2,   2,   2,   3 / ! initialization 0=input, 1=from fuelmc_g,
                                                     ! 2=from equilibrium, 3=from fmc_1h,...,fmc_live
   data fmc_gc_initial_value/0.,  0.,  0.,  0.,  0./ ! initial value used in the model, to be the actual value fmc_1h,...,fmc_live or read in
   data fmc_1h /0.08/, fmc_10h/0.08/, fmc_100h/0.08/, fmc_1000h/0.08/, fmc_live/0.3/
@@ -108,7 +109,7 @@ end type fire_params
 !
 !  Data arrays indexed by fuel category:
 !       FGI            INITIAL TOTAL MASS OF SURFACE FUEL (KG/M**2)
-!       FUELDEPTHM     FUEL DEPTH, IN M  (CONVERTED TO FT)              
+!       FUELDEPTHM     FUEL DEPTH, IN M  (CONVERTED TO FT)
 !       SAVR           FUEL PARTICLE SURFACE-AREA-TO-VOLUME RATIO, 1/FT
 !                         GRASS: 3500., 10 hr fuel: 109.,  100 hr fuel: 30.
 !       FUELMCE        MOISTURE CONTENT OF EXTINCTION; 0.30 FOR MANY DEAD FUELS; 0.15 FOR GRASS
@@ -121,7 +122,7 @@ end type fire_params
 !       FCT            BURN OUT TIME FOR CANOPY FUEL, AFTER DRY (S)
 !       ichap          Set=1 if fuel is chaparral and want the rate of spread treated differently, 0 if not
 !D      FCI            INITIAL TOTAL MASS OF CANOPY FUEL
-!D      FCBR           FUEL CANOPY BURN RATE (KG/M**2/S) 
+!D      FCBR           FUEL CANOPY BURN RATE (KG/M**2/S)
 
 ! =============================================================================
 ! Anderson 13 surface fire fuel models, along with some
@@ -133,7 +134,7 @@ end type fire_params
 !  FUEL MODEL 3: Tall grass (2.5 ft)
 !  --- Shrub-dominated fuel models
 !  FUEL MODEL 4: Chaparral (6 ft)
-!  FUEL MODEL 5: Brush (2 ft) 
+!  FUEL MODEL 5: Brush (2 ft)
 !  FUEL MODEL 6: Dormant brush, hardwood slash
 !  FUEL MODEL 7: Southern rough
 !  --- Forest litter-dominated fuel models
@@ -144,7 +145,7 @@ end type fire_params
 !  FUEL MODEL 11: Light logging slash
 !  FUEL MODEL 12: Medium logging slash
 !  FUEL MODEL 13: Heavy logging slash
-!  --- Fuel-free 
+!  --- Fuel-free
 !  FUEL MODEL 14: no fuel
 
 ! scalar fuel coefficients
@@ -166,7 +167,7 @@ end type fire_params
 ! fuel categorytables
    INTEGER, PARAMETER :: nf=14              ! number of fuel categories in data stmts
    INTEGER, SAVE      :: nfuelcats = 13     ! number of fuel categories that are specified
-   INTEGER, PARAMETER :: zf = mfuelcats-nf  ! number of zero fillers in data stmt 
+   INTEGER, PARAMETER :: zf = mfuelcats-nf  ! number of zero fillers in data stmt
    INTEGER, SAVE      :: no_fuel_cat = 14   ! special category outside of 1:nfuelcats
    CHARACTER (len=80), DIMENSION(mfuelcats ), save :: fuel_name
    INTEGER, DIMENSION( mfuelcats ), save :: ichap
@@ -191,14 +192,14 @@ end type fire_params
      '13: Heavy logging slash', &
      '14: no fuel', zf* ' '/
 
-   DATA windrf /0.36, 0.36, 0.44,  0.55,  0.42,  0.44,  0.44, &     
+   DATA windrf /0.36, 0.36, 0.44,  0.55,  0.42,  0.44,  0.44, &
                 0.36, 0.36, 0.36,  0.36,  0.43,  0.46,  1e-7, zf*0 /
    DATA fueldepthm /0.305,  0.305,  0.762, 1.829, 0.61,  0.762,0.762, &
                     0.0610, 0.0610, 0.305, 0.305, 0.701, 0.914, 0.305,zf*0. /
    DATA savr / 3500., 2784., 1500., 1739., 1683., 1564., 1562.,  &
                1889., 2484., 1764., 1182., 1145., 1159., 3500., zf*0. /
    DATA fuelmce / 0.12, 0.15, 0.25, 0.20, 0.20, 0.25, 0.40,  &
-                  0.30, 0.25, 0.25, 0.15, 0.20, 0.25, 0.12 , zf*0. / 
+                  0.30, 0.25, 0.25, 0.15, 0.20, 0.25, 0.12 , zf*0. /
    DATA fueldens / nf * 32., zf*0. /   ! 32 if solid, 19 if rotten.
    DATA st / nf* 0.0555 , zf*0./
    DATA se / nf* 0.010 , zf*0./
@@ -206,7 +207,7 @@ end type fire_params
 !              (5)-(7) could be 60-120; (8)-(10) could be 300-1600;
 !              (11)-(13) could be 300-1600
    DATA weight / 7.,  7.,  7., 180., 100., 100., 100.,  &
-              900., 900., 900., 900., 900., 900., 7. , zf*0./ 
+              900., 900., 900., 900., 900., 900., 7. , zf*0./
 ! ----- 1.12083 is 5 tons/acre.  5-50 tons/acre orig., 100-300 after blowdown
    DATA fci_d / 0., 0., 0., 1.123, 0., 0., 0.,  &
             1.121, 1.121, 1.121, 1.121, 1.121, 1.121, 0., zf*0./
@@ -265,8 +266,8 @@ real,intent(inout),dimension(ims:ime,nfmc,jms:jme):: fmc_gc
 real,intent(out),dimension(ifms:ifme,jfms:jfme):: fmc_g ! fuel data
 
 !**** local
-real, dimension(its-1:ite+1,jts-1:jte+1):: fmc_k  ! copy of fmc_gc(:,k,:) 
-real, dimension(ifts-1:ifte+1,jfts-1:jfte+1):: fmc_f      ! interpolation of fmc_gc(:,k,:) to the fire grid 
+real, dimension(its-1:ite+1,jts-1:jte+1):: fmc_k  ! copy of fmc_gc(:,k,:)
+real, dimension(ifts-1:ifte+1,jfts-1:jfte+1):: fmc_f      ! interpolation of fmc_gc(:,k,:) to the fire grid
 integer::i,j,k,n
 integer::ibs,ibe,jbs,jbe
 character(len=128)::msg
@@ -338,7 +339,7 @@ subroutine advance_moisture(    &
     nfmc,                       & ! dimension of moisture fields
     moisture_dt,                & ! timestep = time step time elapsed from the last call
     fmep_decay_tlag,            & ! moisture extended model assimilated diffs. decay time lag
-    rainc, rainnc,              & ! accumulated rain 
+    rainc, rainnc,              & ! accumulated rain
     t2, q2, psfc,               & ! temperature (K), vapor contents (kg/kg), pressure (Pa) at the surface
     rain_old,                   & ! previous value of accumulated rain
     t2_old, q2_old, psfc_old,   & ! previous values of the atmospheric state at surface
@@ -359,11 +360,11 @@ integer, intent(in)::           &
     nfmc                          ! number of moisture fields
 real, intent(in):: moisture_dt, fmep_decay_tlag
 real, intent(in), dimension(ims:ime,jms:jme):: t2, q2, psfc, rainc, rainnc
-real, intent(inout), dimension(ims:ime,jms:jme):: t2_old, q2_old, psfc_old, rain_old 
+real, intent(inout), dimension(ims:ime,jms:jme):: t2_old, q2_old, psfc_old, rain_old
 real, intent(inout), dimension(ims:ime,nfmc,jms:jme):: fmc_gc
 real, intent(inout), dimension(ims:ime,2,jms:jme):: fmep
 real, intent(out), dimension(ims:ime,nfmc,jms:jme):: fmc_equi, fmc_lag
-real, intent(out), dimension(ims:ime,jms:jme)::rh_fire 
+real, intent(out), dimension(ims:ime,jms:jme)::rh_fire
 
 !*** global
 ! fuel properties moisture set by init_fuel_cats
@@ -372,7 +373,7 @@ real, intent(out), dimension(ims:ime,jms:jme)::rh_fire
 integer:: i,j,k
 real::rain_int, T, P, Q, QRS, ES, RH, tend, EMC_d, EMC_w, EMC, R, rain_diff, fmc, rlag, equi, &
     d, w, rhmax, rhmin, change, rainmax,rainmin, fmc_old, H, deltaS, deltaE
-real, parameter::tol=1e-2 ! relative change larger than that will switch to exponential ode solver 
+real, parameter::tol=1e-2 ! relative change larger than that will switch to exponential ode solver
 character(len=256)::msg
 integer::msglevel=2
 logical, parameter::check_data=.true.,check_rh=.false.
@@ -401,7 +402,7 @@ call print_2d_stats(its,ite,jts,jte,ims,ime,jms,jme,t2,'T2')
 call print_2d_stats(its,ite,jts,jte,ims,ime,jms,jme,q2,'Q2')
 call print_2d_stats(its,ite,jts,jte,ims,ime,jms,jme,psfc,'PSFC')
 
-if(initialize) then 
+if(initialize) then
     call message('advance_moisture: initializing, copying surface variables to old')
     call copy2old
 else
@@ -415,7 +416,7 @@ if(check_data)then
 !$OMP CRITICAL(SFIRE_PHYS_CRIT)
                  write(msg,'(a,2i4,a,3e12.2)')'At i j',i,j,' t2 psfc q2 are ',t2(i,j),psfc(i,j),q2(i,j)
 !$OMP END CRITICAL(SFIRE_PHYS_CRIT)
-                 call message(msg) 
+                 call message(msg)
                  call crash('invalid data passed from WRF, must have t2 psfc>0, q2 >= 0')
             endif
         enddo
@@ -435,7 +436,7 @@ do j=jts,jte
             ! compute the rain intensity from the difference of accumulated rain
             rain_diff = ((rainc(i,j) + rainnc(i,j)) - rain_old(i,j))
             if(moisture_dt > 0.)then
-                rain_int  = 3600. * rain_diff / moisture_dt 
+                rain_int  = 3600. * rain_diff / moisture_dt
             else
                 rain_int  = 0.
             endif
@@ -455,15 +456,15 @@ do j=jts,jte
             ! function rh_from_q from Adam Kochanski following Murphy and Koop, Q.J.R. Meteorol. Soc (2005) 131 1539-1565 eq. (10)
             epsilon = 0.622 ! Molecular weight of water (18.02 g/mol) to molecular weight of dry air (28.97 g/mol)
             ! vapor pressure [Pa]
-            Pw=q*P/(epsilon+(1-epsilon)*q); 
+            Pw=q*P/(epsilon+(1-epsilon)*q);
             ! saturation vapor pressure [Pa]
             Pws= exp( 54.842763 - 6763.22/T - 4.210 * log(T) + 0.000367*T + &
                 tanh(0.0415*(T - 218.8)) * (53.878 - 1331.22/T - 9.44523 * log(T) + 0.014025*T))
             !realtive humidity [1]
             RH = Pw/Pws
             rh_fire(i,j)=RH
-            rhmax=max(RH,rhmax)         
-            rhmin=min(RH,rhmin)         
+            rhmax=max(RH,rhmax)
+            rhmin=min(RH,rhmin)
 
             deltaE = fmep(i,1,j)
             deltaS = fmep(i,2,j)
@@ -475,11 +476,11 @@ do j=jts,jte
 !$OMP CRITICAL(SFIRE_PHYS_CRIT)
                     write(msg,'(a,2i6,5(a,f10.2))')'At i,j ',i,j,' RH=',RH, &
                         ' from T=',T,' P=',P,' Q=',Q
-                    call message(msg) 
+                    call message(msg)
                     call crash('Relative humidity must be between 0 and 1, saturated water contents must be >0')
 !$OMP END CRITICAL(SFIRE_PHYS_CRIT)
                 endif
-            endif 
+            endif
             !print *,'ADV_MOIST i=',i,' j=',j,' T=',T,' P=',P,' Q=',Q,' ES=',ES,' QRS=',QRS,' RH=',RH
 
             if (R > 0.) then
@@ -503,7 +504,7 @@ do j=jts,jte
                     rlag=rec_drying_lag_sec(k)
                 end select
             endif
-            !*** MODELS THAT ARE NOT OF THE EXPONENTIAL TIME LAG KIND 
+            !*** MODELS THAT ARE NOT OF THE EXPONENTIAL TIME LAG KIND
             ! ARE RESPONSIBLE FOR THEIR OWN LOGIC, THESE MODELS
             ! SHOULD COMPUTE fmc_gc(i,k,j) DIRECTLY AND SET TLAG < 0
             !
@@ -520,9 +521,9 @@ do j=jts,jte
                 else
                     call crash('bad value of fmc_gc_initialization(k), must be between 0 and 2')
                 endif
-                equi = max(min(fmc_old, EMC_d),EMC_w) ! take lower or upper equilibrium value 
+                equi = max(min(fmc_old, EMC_d),EMC_w) ! take lower or upper equilibrium value
 
-                change = moisture_dt * rlag 
+                change = moisture_dt * rlag
 
                 if(change  < tol)then
                      if(fire_print_msg.ge.3)call message('midpoint method')
@@ -536,7 +537,7 @@ do j=jts,jte
                 ! diagnostics out
                 fmc_equi(i,k,j)=equi
                 fmc_lag(i,k,j)=1.0/(3600.0*rlag)
-                 
+
                 ! diagnostic prints
                 if(fire_print_msg.ge.3)then
 !$OMP CRITICAL(SFIRE_PHYS_CRIT)
@@ -571,12 +572,12 @@ enddo
 if(fire_print_msg.ge.2)then
 !$OMP CRITICAL(SFIRE_PHYS_CRIT)
     write(msg,2)'Rain intensity    min',rainmin,  ' max',rainmax,' mm/h'
-    call message(msg) 
+    call message(msg)
     if(rainmin <0.)then
         call message('WARNING rain accumulation must increase')
     endif
     write(msg,2)'Relative humidity min',100*rhmin,' max',100*rhmax,'%'
-    call message(msg) 
+    call message(msg)
     if(.not.(rhmax<=1.0 .and. rhmin>=0))then
         call message('WARNING Relative humidity must be between 0 and 100%')
     endif
@@ -615,8 +616,8 @@ end subroutine advance_moisture
 
 subroutine read_namelist_fire(init_fuel_moisture)
 implicit none
-!*** purpose: read namelist.fire 
-!*** arguments: 
+!*** purpose: read namelist.fire
+!*** arguments:
 logical, intent(in)::init_fuel_moisture
 logical, external:: wrf_dm_on_monitor
 #ifdef _OPENMP
@@ -628,7 +629,7 @@ character(len=128):: msg
 real:: rat
 !*** executable
 
-! read 
+! read
 namelist /fuel_scalars/ cmbcnst,hfgl,fuelmc_g,fuelmc_c,nfuelcats,no_fuel_cat
 namelist /fuel_categories/ fuel_name,windrf,fgi,fueldepthm,savr, &
     fuelmce,fueldens,st,se,weight,fci_d,fct,ichap,fgi_1h,fgi_10h,fgi_100h,fgi_1000h,fgi_live
@@ -649,7 +650,7 @@ IF ( wrf_dm_on_monitor() ) THEN
     iounit=open_text_file('namelist.fire','read',allow_fail=.true.)
     if(iounit < 0)then
        call message('File namelist.fire not found, using defaults',level=0)
-    else  
+    else
        read(iounit,fuel_scalars,iostat=io)
        if(io < 0)then
            call message('Namelist fuel_scalars not found, using defaults',level=0)
@@ -690,7 +691,7 @@ IF ( wrf_dm_on_monitor() ) THEN
     endif
 
     ! convert fuel loads in the fuel classes to internal as weights adding up to one
-    ! 
+    !
     ! copy the fuel weights and scale to 1
 
     ! just checking
@@ -749,16 +750,16 @@ IF ( wrf_dm_on_monitor() ) THEN
             enddo
     enddo
 
-    
+
 ENDIF
 
-end subroutine read_namelist_fire
-
+!!! end	John Collins, 11-May-20  end replaced by END SUBROUTINE
+END SUBROUTINE read_namelist_fire
 
 subroutine init_fuel_cats(init_fuel_moisture)
 implicit none
 !*** purpose: initialize fuel tables and variables by constants
-!*** arguments: 
+!*** arguments:
 logical, intent(in)::init_fuel_moisture
 logical, external:: wrf_dm_on_monitor
 #ifdef _OPENMP
@@ -820,7 +821,7 @@ enddo
 
 fuelheat = cmbcnst * 4.30e-04     ! convert J/kg to BTU/lb
 
-! compute derived fuel category coefficients 
+! compute derived fuel category coefficients
 
 DO i = 1,nfuelcats
     fci(i) = (1.+fuelmc_c)*fci_d(i)
@@ -925,13 +926,13 @@ if(init_fuel_moisture)then
         write(msg,7)'fmc_gc_initialization  ',(fmc_gc_initialization(ii),ii=i,k)
         call message(msg)
         write(msg,8)'wetting_lag (h)        ',(wetting_lag(ii),ii=i,k)
-        call message(msg)    
+        call message(msg)
         write(msg,8)'saturation_moisture (1)',(saturation_moisture(ii),ii=i,k)
-        call message(msg)    
+        call message(msg)
         write(msg,8)'saturation_rain (mm/h) ',(saturation_rain(ii),ii=i,k)
-        call message(msg)    
+        call message(msg)
         write(msg,8)'rain_threshold (mm/h)  ',(rain_threshold(ii),ii=i,k)
-        call message(msg)    
+        call message(msg)
     enddo
     call message(' ')
     call message('**********************************************************')
@@ -954,8 +955,8 @@ integer:: iounit,k,j,i
 type(fire_params)::fp
 !type fire_params
 !real,pointer,dimension(:,:):: vx,vy                ! wind velocity (m/s)
-!real,pointer,dimension(:,:):: zsf                  ! terrain height (m) 
-!real,pointer,dimension(:,:):: dzdxf,dzdyf          ! terrain grad (1) 
+!real,pointer,dimension(:,:):: zsf                  ! terrain height (m)
+!real,pointer,dimension(:,:):: dzdxf,dzdyf          ! terrain grad (1)
 !real,pointer,dimension(:,:):: bbb,betafl,phiwc,r_0 ! spread formula coefficients
 !real,pointer,dimension(:,:):: fgip                 ! init mass of surface fuel (kg/m^2)
 !real,pointer,dimension(:,:):: ischap               ! 1 if chapparal
@@ -975,7 +976,7 @@ fp%phiwc=>phiwc
 fp%r_0=>r_0
 fp%fgip=>fgip
 fp%ischap=>ischap
-fp%iboros=>iboros 
+fp%iboros=>iboros
 fp%fmc_g=>fmc_g
 
 iounit = open_text_file('fuels.m','write')
@@ -1002,14 +1003,14 @@ do k=1,nfuelcats
     call write_var(k,'fuelheat',fuelheat,'FUEL PARTICLE LOW HEAT CONTENT, BTU/LB')
     call write_var(k,'fuelmc_g',fuelmc_g,'FUEL PARTICLE (SURFACE) MOISTURE CONTENT')
     call write_var(k,'fuelmc_c',fuelmc_c,'FUEL PARTICLE (CANOPY) MOISTURE CONTENT')
-    ! set up fuel arrays 
+    ! set up fuel arrays
     !subroutine set_fire_params( &
     !                       ifds,ifde,jfds,jfde, &
     !                       ifms,ifme,jfms,jfme, &
     !                       ifts,ifte,jfts,jfte, &
     !                       fdx,fdy,nfuel_cat0,  &
     !                       nfuel_cat,fuel_time, &
-    !                       fp ) 
+    !                       fp )
     nfuel_cat = k
     call set_fire_params( &
                            1,2,1,nsteps, &
@@ -1017,7 +1018,7 @@ do k=1,nfuelcats
                            1,2,1,nsteps, &
                            0.,0.,k,  &
                            nfuel_cat,fuel_time, &
-                           fp ) 
+                           fp )
     ! set up windspeed and slope table
     propx=1.
     propy=0.
@@ -1047,7 +1048,7 @@ do k=1,nfuelcats
     enddo
 enddo
 13 format('fuel(',i3,').',a,'(',i3,')=',g12.5e2,';% ',a)
- 
+
 close(iounit)
 ! stop
 
@@ -1076,7 +1077,7 @@ subroutine set_fire_params( &
                            ifts,ifte,jfts,jfte, &
                            fdx,fdy,nfuel_cat0,  &
                            nfuel_cat,fuel_time, &
-                           fp ) 
+                           fp )
 
 implicit none
 
@@ -1104,12 +1105,12 @@ integer::nerr
 character(len=128)::msg
 
 integer :: kk
-integer,parameter :: nf_sb = 204 ! maximum category on 
+integer,parameter :: nf_sb = 204 ! maximum category on
 integer,dimension(1:nf_sb) :: ksb ! Anderson82 + S&B2005 fuel categories array
 
 !*** executable
 
-!*** Scott & Burgan ***! 
+!*** Scott & Burgan ***!
 ! assign no fuel by default to all the categories
 do kk=1,nf_sb
    ksb(kk)=14
@@ -1188,10 +1189,10 @@ ksb(204)=13
 nerr=0
 do j=jfts,jfte
    do i=ifts,ifte
-     ! fuel category 
+     ! fuel category
      k=ksb(int(nfuel_cat(i,j))) ! DME S&B05
-     if(k.eq.no_fuel_cat)then   ! no fuel 
-        fp%fgip(i,j)=0.            ! no mass 
+     if(k.eq.no_fuel_cat)then   ! no fuel
+        fp%fgip(i,j)=0.            ! no mass
         fp%ischap(i,j)=0.
         fp%betafl(i,j)=1.          ! DME: set to 1.0 to prevent fp%betafl(i,j)**(-0.3) to be Inf in fire_ros
         fp%bbb(i,j)=1.             !
@@ -1205,7 +1206,7 @@ do j=jfts,jfte
             k=nfuel_cat0
             nerr=nerr+1
         endif
-   
+
         if(k.lt.1.or.k.gt.nfuelcats)then
 !$OMP CRITICAL(FIRE_PHYS_CRIT)
             write(msg,'(3(a,i5))')'nfuel_cat(', i ,',',j,')=',k
@@ -1215,10 +1216,10 @@ do j=jfts,jfte
         endif
 
         fuel_time(i,j)=weight(k)/0.85 ! cell based
-        
+
         ! set fuel time constant: weight=1000 => 40% decrease over 10 min
-        ! fuel decreases as exp(-t/fuel_time) 
-        ! exp(-600*0.85/1000) = approx 0.6 
+        ! fuel decreases as exp(-t/fuel_time)
+        ! exp(-600*0.85/1000) = approx 0.6
 
         fp%ischap(i,j)=ichap(k)
         fp%fgip(i,j)=fgi(k)
@@ -1228,7 +1229,7 @@ do j=jfts,jfte
 
         !     ...Settings of fire spread parameters from Rothermel follows. These
         !        don't need to be recalculated later.
-        
+
         bmst     = fp%fmc_g(i,j) / (1.+fp%fmc_g(i,j))
         fuelloadm= (1.-bmst) * fgi(k)  !  fuelload without moisture
         fuelload = fuelloadm * (.3048)**2 * 2.205    ! to lb/ft^2
@@ -1289,13 +1290,13 @@ subroutine heat_fluxes(dt,fp,                     &
         grnhft,grnqft)                              !out
 implicit none
 
-!*** purpose        
+!*** purpose
 ! compute the heat fluxes on the fire grid cells
 
 !*** arguments
 type(fire_params), intent(in)::fp
 real, intent(in)::dt          ! dt  the fire time step (the fire model advances time by this)
-integer, intent(in)::ifts,ifte,jfts,jfte,ifms,ifme,jfms,jfme,iffs,iffe,jffs,jffe   ! dimensions                   
+integer, intent(in)::ifts,ifte,jfts,jfte,ifms,ifme,jfms,jfme,iffs,iffe,jffs,jffe   ! dimensions
 real, intent(in),dimension(ifms:ifme,jfms:jfme):: fgip
 real, intent(in),dimension(iffs:iffe,jffs:jffe):: fuel_frac_burnt
 real, intent(out),dimension(ifms:ifme,jfms:jfme):: grnhft,grnqft
@@ -1305,7 +1306,7 @@ integer::i,j
 real:: dmass,bmst
 logical::latent
 
-!*** executable        
+!*** executable
 do j=jfts,jfte
     do i=ifts,ifte
          dmass =                     &     ! surface fuel dry mass burnt this call (kg/m^2)
@@ -1322,7 +1323,7 @@ end subroutine heat_fluxes
 
 !
 !**********************
-!            
+!
 
 
 subroutine set_nfuel_cat(   &
@@ -1334,7 +1335,7 @@ implicit none
 
 ! set fuel distributions for testing
 integer, intent(in)::   ifts,ifte,jfts,jfte,               &
-                        ifms,ifme,jfms,jfme               
+                        ifms,ifme,jfms,jfme
 
 integer, intent(in)::ifuelread,nfuel_cat0
 real, intent(in), dimension(ifms:ifme, jfms:jfme)::zsf
@@ -1348,13 +1349,13 @@ real:: t1
 character(len=128)msg
 
 !$OMP CRITICAL(FIRE_PHYS_CRIT)
-    write(msg,'(a,i3)')'set_nfuel_cat: ifuelread=',ifuelread 
+    write(msg,'(a,i3)')'set_nfuel_cat: ifuelread=',ifuelread
 !$OMP END CRITICAL(FIRE_PHYS_CRIT)
     call message(msg)
 
 if (ifuelread .eq. -1 .or. ifuelread .eq. 2) then
 !$OMP CRITICAL(FIRE_PHYS_CRIT)
-    call message('set_nfuel_cat: assuming nfuel_cat initialized already') 
+    call message('set_nfuel_cat: assuming nfuel_cat initialized already')
     call message(msg)
 !$OMP END CRITICAL(FIRE_PHYS_CRIT)
 else if (ifuelread .eq. 0) then
@@ -1368,7 +1369,7 @@ else if (ifuelread .eq. 0) then
     write(msg,'(a,i3)')'set_nfuel_cat: fuel initialized with category',nfuel_cat0
 !$OMP END CRITICAL(FIRE_PHYS_CRIT)
     call message(msg)
-         
+
 else if (ifuelread .eq. 1) then
 !
 !         make dependent on altitude (co mountains/forest vs. plains)
@@ -1404,20 +1405,20 @@ else
 endif
 !     .............end  load fuel categories (or constant) here.
 
-end subroutine set_nfuel_cat            
+end subroutine set_nfuel_cat
 
 !
 !**********************
-!            
+!
 
 subroutine fire_ros(ros_base,ros_wind,ros_slope, &
 propx,propy,i,j,fp)
 
 implicit none
 
-! copied with the following changes ONLY: 
+! copied with the following changes ONLY:
 !   0.5*(speed + abs(speed)) -> max(speed,0.)
-!   index l -> j 
+!   index l -> j
 !   not using nfuel_cat here - cell info was put into arrays passed as arguments
 !       in include file to avoid transcription errors when used elsewhere
 !   betaop is absorbed in phiwc, see module_fr_fire_model/fire_startup
@@ -1427,10 +1428,10 @@ implicit none
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !     ... calculates fire spread rate with McArthur formula or Rothermel
 !           using fuel type of fuel cell
-!      
+!
 !         m/s =(ft/min) *.3048/60. =(ft/min) * .00508   ! conversion rate
 !         ft/min = m/s * 2.2369 * 88. = m/s *  196.850 ! conversion rate
-!      
+!
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 !*** arguments
@@ -1457,7 +1458,7 @@ scale=1.
 nvx=propx/scale
 nvy=propy/scale
 if (fire_advection.ne.0) then ! from flags in module_fr_fire_util
-    ! wind speed is total speed 
+    ! wind speed is total speed
     speed =  sqrt(fp%vx(i,j)*fp%vx(i,j)+ fp%vy(i,j)*fp%vy(i,j))+tiny(speed)
     ! slope is total slope
     tanphi = sqrt(fp%dzdxf(i,j)*fp%dzdxf(i,j) + fp%dzdyf(i,j)*fp%dzdyf(i,j))+tiny(tanphi)
@@ -1477,7 +1478,7 @@ endif
 if (.not. fp%ischap(i,j) > 0.) then      ! if fuel is not chaparral, calculate rate of spread one of these ways
     if (ibeh .eq. 1) then                ! use Rothermel formula
 !       ... if wind is 0 or into fireline, phiw = 0, &this reduces to backing ros.
-        spdms = max(speed,0.)            ! 
+        spdms = max(speed,0.)            !
         umidm = min(spdms,30.)           ! max input wind spd is 30 m/s   !param!
         umid = umidm * 196.850           ! m/s to ft/min
         !  eqn.: phiw = c * umid**bbb(i,j) * (fp%betafl(i,j)/betaop)**(-e) ! wind coef
@@ -1490,7 +1491,7 @@ if (.not. fp%ischap(i,j) > 0.) then      ! if fuel is not chaparral, calculate r
         ros_base = fp%r_0(i,j) * .00508
         ros_wind = ros_base*phiw
         ros_slope= ros_base*phis
-        
+
 
     else                                   ! McArthur formula (Australian)
         ! rosm = 0.18*exp(0.8424*max(speed,0.))
@@ -1501,10 +1502,10 @@ if (.not. fp%ischap(i,j) > 0.) then      ! if fuel is not chaparral, calculate r
 !
 else   ! chaparral
 !        .... spread rate has no dependency on fuel character, only windspeed.
-    spdms = max(speed,0.)      
+    spdms = max(speed,0.)
     ! rosm = 1.2974 * spdms**1.41       ! spread rate, m/s
     ! note: backing ros is 0 for chaparral without setting nozero value below
-    !sp_n=.03333  
+    !sp_n=.03333
     ! chaparral backing fire spread rate 0.033 m/s   ! param!
     !rosm= max(rosm, sp_n)   ! no less than backing r.o.s.
 
@@ -1540,6 +1541,6 @@ real, intent(in)::u,v
 nrm2=sqrt(u*u+v*v)
 end function nrm2
 
-end subroutine fire_ros 
+end subroutine fire_ros
 
 end module module_fr_fire_phys


### PR DESCRIPTION
TYPE: New feature

KEYWORDS: Static analysis, regression testing

SOURCE: John Collins (SimCon / Edge Hill University)

CHANGES:
The WRF code has a large number of nonstandard constructs that have been in the code for a while. Part of the capability 
of the FPT static analysis tool is to discover noncompliant Fortran syntax and usage. A few issues in the existing WRF 
code preclude the FPT utility from running on WRF, including outright Fortran bugs. The bugs are removed. Additionally,
the temporary files in the frame directory associated with the automatic code generation of namelist configuration
processing are no longer removed by the Makefile.

This is an initial step. Once the WRF code is suitable for automatic use by FPT, then a second PR will introduce the 
required exemplar files for comparison.

MODIFIED FILES:
dyn_em/module_first_rk_step_part1.F
   * Inserted missing continuation character line 782

external/io_grib2/bacio-1.3/bacio.F
   * Inserted missing :: delimiters at lines 92,135,177,219,261,302,359,360,472,473,527,528

frame/Makefile
* Commented-out deletion of xx*.f90 and yy*.f90.    
* These are needed for the regression test and are deleted by the `clean` script

phys/module_bl_mynn.F
   * Additional + sign deleted at line 3030

phys/module_fr_fire_phys.F
   * END changed to END SUBROUTINE at line 755

TESTS CONDUCTED:  
1. fpt regression tests
2. Jenkins is all PASS.

RELEASE NOTE: Changes to implement static analysis regression testing of WRF.  Please see:
http://simconglobal.com/WRF_Workshop_June_2011_Poster_Automatic_Detection_of_Software_Errors_in_WRF.pdf
http://simconglobal.com/WRF_Workshop_June_2012_Poster_QA_Analysis_of_the_WRF_Program.pdf
http://simconglobal.com/collins_et_al_2013_automated_quality_assurance_analysis_wrf_a_case_study.pdf