### PR TITLE
Update PR commit message templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,23 +1,25 @@
-Use this template to give a detailed message describing the change you want to make to the code.
-If you are unclear on what should be written here, see  https://github.com/wrf-model/WRF/wiki/Making-a-good-pull-request-message for more guidance
-
-The title of this pull request should be a brief "purpose" for this change.
-
---- Delete this line and those above before hitting "Create pull request" ---
+The first line should be a single-line "purpose" for this change
 
 TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]
 
-KEYWORDS: approximately 3 to 6 words (more is always better) related to your commit, separated by commas
+KEYWORDS: 5 to 10 words related to commit, separated by commas
 
 SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member
 
-DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
+DESCRIPTION OF CHANGES:
+Problem:
+Generally or specifically, what was wrong and needed to be addressed?
 
-ISSUE: For use when this PR closes an issue. For example, if this PR closes issue number 123
+Solution:
+What was down algorithmically and in the source code to address the problem?
+
+ISSUE: For use when this PR closes an issue.
 Fixes #123
 
 LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
 
-TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
+TESTS CONDUCTED: 
+1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
+2. Are the Jenkins tests all passing?
 
 RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.

--- a/tools/commit_form.txt
+++ b/tools/commit_form.txt
@@ -6,16 +6,21 @@ KEYWORDS: 5 to 10 words related to commit, separated by commas
 
 SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member
 
-DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.
+DESCRIPTION OF CHANGES:
+Problem:
+Generally or specifically, what was wrong and needed to be addressed?
 
-ISSUE: For use when this PR closes an issue. For issue number 123
-```
+Solution:
+What was down algorithmically and in the source code to address the problem?
+
+ISSUE: For use when this PR closes an issue.
 Fixes #123
-
 
 LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
 
-TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!
+TESTS CONDUCTED: 
+1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
+2. Are the Jenkins tests all passing?
 
 RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
 


### PR DESCRIPTION
TYPE: text only

KEYWORDS: PR, commit message, template

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The older commit templates referred to WTF and had some singleton three quotes in a row (without
a closing set of quotes). There was ambiguity in the requests for what tests were to be conducted, and there
was no reference to the jenkins results.

Solution:
Small text tweaks, just update and clarify expectations from contributors. The text for the two templates is now
consistent.

LIST OF MODIFIED FILES:
modified:   .github/PULL_REQUEST_TEMPLATE
modified:   tools/commit_form.txt

TESTS CONDUCTED:
1. No source changes, but jenkins will run.