### PR TITLE
Radiative heat tendency bug fix for RRTMK scheme

### DIFF
--- a/phys/module_ra_rrtmg_swk.F
+++ b/phys/module_ra_rrtmg_swk.F
@@ -10172,7 +10172,7 @@ contains
 !
 !-------------------------------------------------------------------------------
    subroutine rad_rrtmg_driver(                                                &
-                       rthratensw,rthratenlw,                                  &
+                       rthratenlw,rthratensw,                                  &
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,                   &
                        swupflx, swupflxc, swdnflx, swdnflxc,                   &
                        lwupt, lwuptc, lwdnt, lwdntc,                           &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: module_ra_rrtmg_swk.F, RRTMK, RRTMG

SOURCE: James Ruppert, Penn State University

DESCRIPTION OF CHANGES: Longwave (RTHRATENLW) and shortwave (RTHRATENSW) radiative tendencies were in reversed order at start of subroutine rad_rrtmg_driver in module_ra_rrtmg_swk.F (driver for RRTMK radiation scheme). These reverse-ordered tendencies feed directly up to module_radiation_driver.F. While this bug leads to the output shortwave and longwave tendencies being in swapped positions, this bug does not affect the sum of shortwave and longwave heat tendency (RTHRATEN), so it does not affect model results.

LIST OF MODIFIED FILES:
M phys/module_ra_rrtmg_swk.F

TESTS CONDUCTED: Verified that this bug fix places the correct fields into the variables RTHRATENLW (aka RTHRATLW) and RTHRATENSW (aka RTHRATSW) as viewed through model output. Also verified that all other model output variables are not changed due to this fix in a test case by MMM.