### PR TITLE
additional factor when converting surface heat fluxes from dry to moist theta

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -8050,6 +8050,9 @@ END SUBROUTINE phy_bc
      DO i = i_start, i_end
         nlflux_rho(i,k,j) = nlflux(i,k,j) * &
                            (fnm(k)*rho (i,k,j)+fnp(k)*rho (i,k-1,j))
+        IF(config_flags%use_theta_m == 1)THEN
+             nlflux_rho(i,k,j) = nlflux_rho(i,k,j)*(1.+rvovrd*moist(i,k,j,P_QV))
+        ENDIF
      ENDDO
      ENDDO
      ENDDO

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -4278,7 +4278,6 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
   CASE (0,2) ! with fixed surface heat flux given in the namelist
     heat_flux = config_flags%tke_heat_flux  ! constant heat flux value
                                             ! set in namelist.input
-
     DO j = j_start, j_end
     DO i = i_start, i_end
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
@@ -4300,7 +4299,6 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
 
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
        heat_flux = hfx(i,j)/cpm
-
        if(config_flags%use_theta_m == 1)THEN
          rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
              -g*heat_flux*(1.+rvovrd*moist(i,kts,j,P_QV))/dnw(kts) &
@@ -7723,7 +7721,7 @@ END SUBROUTINE phy_bc
    INTEGER :: i_start, i_end, j_start, j_end
  
    REAL :: V0_u,V0_v,ustar,beta
-   REAL :: heat_flux, moist_flux
+   REAL :: heat_flux, moist_flux, qfac
    REAL :: cpm,rdz_w,rhoavg_u,rhoavg_v,rdz_z
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -8050,9 +8048,6 @@ END SUBROUTINE phy_bc
      DO i = i_start, i_end
         nlflux_rho(i,k,j) = nlflux(i,k,j) * &
                            (fnm(k)*rho (i,k,j)+fnp(k)*rho (i,k-1,j))
-        IF(config_flags%use_theta_m == 1)THEN
-             nlflux_rho(i,k,j) = nlflux_rho(i,k,j)*(1.+rvovrd*moist(i,k,j,P_QV))
-        ENDIF
      ENDDO
      ENDDO
      ENDDO
@@ -8103,17 +8098,23 @@ END SUBROUTINE phy_bc
                   - dt*rdz_w*nlflux_rho(i,k+1,j)        &
                   + dt*rdz_w*hfx(i,j)/cpm
           ELSE
+             qfac = 1.+rvovrd*moist(i,kts,j,P_QV)
              d(k) = var_mix(i,kts,j)                    &
-                  - dt*rdz_w*nlflux_rho(i,k+1,j)        &
-                  + dt*rdz_w*((1.+rvovrd*moist(i,kts,j,P_QV))*hfx(i,j)/cpm+1.61*theta(i,kts,j)*qfx(i,j))
+                  - dt*rdz_w*nlflux_rho(i,k+1,j)*qfac   &
+                  + dt*rdz_w*(qfac*hfx(i,j)/cpm+1.61*theta(i,kts,j)*qfx(i,j))
           ENDIF
  
           DO  k = kts+1, ktf-1
             rdz_w = -g/dnw(k)/(c1h(k)*mu(i,j) + c2h(k))
+            IF(config_flags%use_theta_m == 1)THEN
+                qfac = 1.+rvovrd*moist(i,k,j,P_QV)
+            ELSE
+                qfac = 1.
+            ENDIF
             a(k)  = -rdz_w*rdz(i,k,j)*xkxavg(i,k,j)*dt
             b(k)  = 1.+rdz_w*(rdz(i,k+1,j)*xkxavg(i,k+1,j)+rdz(i,k,j)*xkxavg(i,k,j))*dt
             c(k)  = -rdz_w*rdz(i,k+1,j)*xkxavg(i,k+1,j)*dt
-            d(k)  = -rdz_w*(nlflux_rho(i,k+1,j)-nlflux_rho(i,k,j))*dt + var_mix(i,k,j)
+            d(k)  = -rdz_w*(nlflux_rho(i,k+1,j)-nlflux_rho(i,k,j))*qfac*dt + var_mix(i,k,j)
           ENDDO
  
             a(ktf) = 0.

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -4278,6 +4278,10 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
   CASE (0,2) ! with fixed surface heat flux given in the namelist
     heat_flux = config_flags%tke_heat_flux  ! constant heat flux value
                                             ! set in namelist.input
+    IF (config_flags%use_theta_m == 1)THEN
+      heat_flux = heat_flux * (1. + rvovrd * moist(i,kts,j,P_QV))
+    ENDIF
+
     DO j = j_start, j_end
     DO i = i_start, i_end
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
@@ -4297,6 +4301,10 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
 
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
        heat_flux = hfx(i,j)/cpm
+       IF (config_flags%use_theta_m == 1)THEN
+         heat_flux = heat_flux * (1. + rvovrd * moist(i,kts,j,P_QV))
+       ENDIF
+
        rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
             -g*heat_flux/dnw(kts)
        if(config_flags%use_theta_m == 1)THEN
@@ -8096,7 +8104,7 @@ END SUBROUTINE phy_bc
           ELSE
              d(k) = var_mix(i,kts,j)                    &
                   - dt*rdz_w*nlflux_rho(i,k+1,j)        &
-                  + dt*rdz_w*(hfx(i,j)/cpm+1.61*theta(i,kts,j)*qfx(i,j))
+                  + dt*rdz_w*((1.+rvovrd*moist(i,kts,j,P_QV))*hfx(i,j)/cpm+1.61*theta(i,kts,j)*qfx(i,j))
           ENDIF
  
           DO  k = kts+1, ktf-1

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -4278,19 +4278,18 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
   CASE (0,2) ! with fixed surface heat flux given in the namelist
     heat_flux = config_flags%tke_heat_flux  ! constant heat flux value
                                             ! set in namelist.input
-    IF (config_flags%use_theta_m == 1)THEN
-      heat_flux = heat_flux * (1. + rvovrd * moist(i,kts,j,P_QV))
-    ENDIF
 
     DO j = j_start, j_end
     DO i = i_start, i_end
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
        hfx(i,j)=heat_flux*cpm*rho(i,kts,j)         ! provided for output only
-       rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
-             -g*heat_flux*rho(i,kts,j)/dnw(kts)
        if(config_flags%use_theta_m == 1)THEN
          rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
+             -g*heat_flux*(1.+rvovrd*moist(i,kts,j,P_QV))*rho(i,kts,j)/dnw(kts) &
              -g*1.61*theta(i,kts,j)*qfx(i,j)/dnw(kts)
+       ELSE
+         rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
+             -g*heat_flux*rho(i,kts,j)/dnw(kts)
        ENDIF
     ENDDO
     ENDDO
@@ -4301,15 +4300,14 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
 
        cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
        heat_flux = hfx(i,j)/cpm
-       IF (config_flags%use_theta_m == 1)THEN
-         heat_flux = heat_flux * (1. + rvovrd * moist(i,kts,j,P_QV))
-       ENDIF
 
-       rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
-            -g*heat_flux/dnw(kts)
        if(config_flags%use_theta_m == 1)THEN
          rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
+             -g*heat_flux*(1.+rvovrd*moist(i,kts,j,P_QV))/dnw(kts) &
              -g*1.61*theta(i,kts,j)*qfx(i,j)/dnw(kts)
+       ELSE
+         rt_tendf(i,kts,j)=rt_tendf(i,kts,j)  &
+             -g*heat_flux/dnw(kts)
        ENDIF
 
     ENDDO


### PR DESCRIPTION
To close the dry theta budget at the lowest grid point when use_theta_m is enabled, the surface heat fluxes, and in the case of km_opt=5 also the non-local heat flux, are multiplied with 1+Rv/Rd*qv.

TYPE: bug fix

KEYWORDS: surface heat flux, use_theta_m, moist theta, non-local flux, 3D TKE

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES: The conversion of surface heat fluxes from dry to moist theta in WRF is inconsistent. This leads to an unclosed dry theta budget at the lowest grid point. The surface sensible heat flux in the routines `vertical_diffusion_2` and `vertical_diffusion_implicit` should be multiplied with <img src="https://latex.codecogs.com/svg.latex?1+\frac{R_{v}}{R_{d}}q"  /> as is derived below.
Using Reynold's decomposition and averaging we can show for the perturbation moist theta:
<img src="https://latex.codecogs.com/svg.latex?\theta_{m}'=(\theta(1+q\alpha))'=\theta(1+q\alpha)-\overline{\theta(1+q\alpha)}=\theta-\overline{\theta}+\alpha(q\theta-\overline{q\theta})=\\=\theta'+\alpha\left[(\overline{\theta}+\theta')(\overline{q}+q')-\overline{\theta}\overline{q}-\overline{\theta'q'}\right]=\theta'(1+\alpha\overline{q})+\alpha\left[\overline{\theta}q'+\theta'q'-\overline{\theta'q'}\right]"  /> 
with water vapor mixing ratio q and
 <img src="https://latex.codecogs.com/svg.latex?\alpha=\frac{R_{v}}{R_{d}}\approx1.61"  />

This yields for the converted surface heat flux:
<img src="https://latex.codecogs.com/svg.latex?\overline{w'\theta_{m}'}_0=(1+\alpha\overline{q}_0)\overline{w'\theta'}_0+\alpha\overline{\theta}_0\,\overline{w'q'}_0+\alpha\overline{w'\theta'q'}_0\approx(1+\alpha\overline{q}_0)\overline{w'\theta'}_0+\alpha\overline{\theta}_0\,\overline{w'q'}_0"  />
The triple correlation in the equation above cannot be easily estimated in WRF, but judging from my tests it probably has a negligible impact.
Instead of the given equation, WRF uses:
<img src="https://latex.codecogs.com/svg.latex?\overline{w'\theta_{m}'}_0=\overline{w'\theta'}_0+\alpha\overline{\theta}_0\overline{w'q'}_0 "  />
We therefore multiplied the surface heat flux with <img src="https://latex.codecogs.com/svg.latex?1+\alpha\overline{q}_0" />, when `use_theta_m=1`.
For `km_opt=5`, also the contribution from the non-local heat flux is multiplied with a correction factor.

LIST OF MODIFIED FILES: dyn_em/module_diffusion_em.F 

TESTS CONDUCTED: checked the dry theta budget of a simulation with use_theta_m=1: simple idealized LES once with model-computed surface heat flux and once with prescribed heat fluxes, RRTMG radiation, no microphysics, zero eddy diffusivities. Changed the code to output advection, SGS diffusion and radiation tendencies for dry theta (regardless of use_theta_m and without changing the tendencies used by the model). These forcing tendencies are averaged online over 30 minutes. The sum of the forcing terms is plotted against the actual tendency of dry theta  (change of instantaneous dry theta between the half-hourly time stamps divided by 30 minutes) for all gridpoints and time stamps. All tendency terms are divided by the dry air mass to obtain more familiar units. The modified code fixes the issue of an unclosed dry theta budget at the lowest gridpoint (see attached figures). The simulations were repeated for km_opt=5.

RELEASE NOTE: To close the dry theta budget at the lowest grid point when use_theta_m is enabled, the surface heat fluxes, and in the case of km_opt=5 also the non-local heat flux, are multiplied with 1+Rv/Rd*qv.

![test_fluxes_flat_thd_3rd+5th](https://user-images.githubusercontent.com/17001470/88155314-389f7380-cc08-11ea-9dac-f7ec6cceeaed.png)
![test_fluxes_flat_thdm_3rd+5th](https://user-images.githubusercontent.com/17001470/88155312-3806dd00-cc08-11ea-8226-4ed46c5c556e.png)
![test_fluxes_flat_fixed-sfc-fluxes_thdm_3rd+5th](https://user-images.githubusercontent.com/17001470/88155315-39380a00-cc08-11ea-8cbd-6b9fd6217c1c.png)
