### PR TITLE
Fix vertical indices of c1h and c2h in ideal case init of ph_1

### DIFF
--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -1120,7 +1120,7 @@ CONTAINS
 
 !  rebalance hydrostatically
 
-      DO k  = 2,kte
+      DO k = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
                      ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
                       (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -1165,7 +1165,7 @@ CONTAINS
 
 !  rebalance hydrostatically
 
-      DO k  = 2,kte
+      DO k = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
                      ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
                       (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -1122,8 +1122,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1167,8 +1167,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1212,8 +1212,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1245,8 +1245,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
       ENDDO
@@ -1306,8 +1306,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1355,8 +1355,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ideal case, initialization

SOURCE: Tim Raupach (UNSW CCRC)

DESCRIPTION OF CHANGES:
Problem:
In ideal case initialization routines, incorrect indices were used in the calculation of ph_1 after a perturbation bubble was added.

Impact:
The calculation of perturbation geopotential ph_1 (perturbation geopotential) and Z_BASE (idealized base state height) 
were affected.
1. If hybrid coordinate option was selected, (hybrid_opt = 2), the entire ph_1 initialization is incorrect due to the offset
in the indexing of c1h and c2h (half levels vs full levels).
2. If hybrid_opt = 0, since the 1d variables are initialized kms:kme, there is no impact.

Solution:
The vertical indices were corrected in the calculations of ph_1 in the idealized initialization routine.

ISSUE:

LIST OF MODIFIED FILES:
M       dyn_em/module_initialize_ideal.F

TESTS CONDUCTED: 
1. The jenkins testing is all pass.

RELEASE NOTE: In the ideal case initialization routines, incorrect indices were used in the calculation of ph_1 after a perturbation bubble was added. For the idealized cases that do not use the hybrid vertical coordinate by default, there is no impact at all. The ideal cases with a hill had the correct hybrid formulation.