### PR TITLE
fixes irrigation channel: water not passed to the lsm

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1392,8 +1392,8 @@ CONTAINS
    REAL, PARAMETER    :: PI_GRECO=3.14159 
    INTEGER  :: end_hour, irr_start,xt24,irr_day  
    REAL :: constants_irrigation   
-   REAL,DIMENSION( ims:ime, jms:jme ) :: IRRIGATION_CHANNEL      
-   REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN),OPTIONAL::   IRRIGATION
+   REAL, DIMENSION( ims:ime, jms:jme ) :: IRRIGATION_CHANNEL      
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)   , OPTIONAL::   IRRIGATION
    REAL,  INTENT(IN),OPTIONAL::  irr_daily_amount     
    INTEGER :: phase
    INTEGER, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT),OPTIONAL :: irr_rand_field
@@ -1499,6 +1499,7 @@ CONTAINS
          IF ( PRESENT( rainshv ))RAINBL(i,j) = RAINBL(i,j) + RAINSHV(i,j)
          RAINBL(i,j) = MAX (RAINBL(i,j), 0.0)
 #if (EM_CORE==1)
+         IRRIGATION_CHANNEL(i,j) = 0.
          sf_surf_irr: SELECT CASE(sf_surf_irr_scheme)
             CASE(DRIP)
                CALL drip_irrigation(                                     &
@@ -2740,7 +2741,7 @@ CONTAINS
                 dl_u_bep,sf_bep,vl_bep                          & !O multi-layer urban
                 ,sfcheadrt,INFXSRT, soldrain                    & !hydro
                 ,SDA_HFX, SDA_QFX, HFX_BOTH, QFX_BOTH, QNORM, fasdas    & ! fasdas
-                ,RS,XLAIDYN)
+                ,RS,XLAIDYN,IRRIGATION_CHANNEL)
            ELSE
                CALL wrf_error_fatal('Lack arguments to call lsm_mosaic')
            ENDIF
@@ -2860,7 +2861,7 @@ CONTAINS
 !
 !  END FASDAS
 !
-                ,RS,XLAIDYN)
+                ,RS,XLAIDYN,IRRIGATION_CHANNEL)
          ENDIF
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &


### PR DESCRIPTION
Missing argument (irrigation_channel) to be passed to the lsm and lsm_mosaic call.

TYPE: bug fix

KEYWORDS: channel, noah, mosaic

SOURCE: Arianna Valmassoi (Uni-bonn/internal)

DESCRIPTION OF CHANGES:
Problem:
the water used for irrigation in the channel method was not passed to the lsm

Solution:
Added the argument to the calls: lsm and lsm_mosaic
Fixed an issue with no irrigation method selected when the channel fix is made.

ISSUE: For use when this PR closes an issue.
Fixes #1281 

LIST OF MODIFIED FILES: 
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
1. Do mods fix problem? Yes. 
   How can that be demonstrated, and was that test conducted? Test with the previously working version. Tested with (all 3 methods) and without irrigation.
2. Are the Jenkins tests all passing? no

RELEASE NOTE: Fixes for the channel method