### PR TITLE
Fix DA ingesting ep (ensemble perturbation) of hydrometeors in ep_format=2

### DIFF
--- a/var/da/da_setup_structures/da_setup_flow_predictors_ep_format2.inc
+++ b/var/da/da_setup_structures/da_setup_flow_predictors_ep_format2.inc
@@ -359,6 +359,7 @@ subroutine da_setup_flow_predictors_ep_format2( ix, jy, kz, ne, ep, its, ite, jt
                read(unit=ep_unit) temp3d_r4(1:ix,1:jy,1:kz)
                temp3d = temp3d_r4
             end if
+            call wrf_dm_bcast_real(temp3d, ijk)
             te = ie + (it-1)*nens
             ep % ci(its:ite,jts:jte,kts:kte,te) = ens_scaling_inv * &
                                                   temp3d(its:ite,jts:jte,kts:kte)
@@ -393,6 +394,7 @@ subroutine da_setup_flow_predictors_ep_format2( ix, jy, kz, ne, ep, its, ite, jt
                read(unit=ep_unit) temp3d_r4(1:ix,1:jy,1:kz)
                temp3d = temp3d_r4
             end if
+            call wrf_dm_bcast_real(temp3d, ijk)
             te = ie + (it-1)*nens
             ep % sn(its:ite,jts:jte,kts:kte,te) = ens_scaling_inv * &
                                                   temp3d(its:ite,jts:jte,kts:kte)
@@ -427,6 +429,7 @@ subroutine da_setup_flow_predictors_ep_format2( ix, jy, kz, ne, ep, its, ite, jt
                read(unit=ep_unit) temp3d_r4(1:ix,1:jy,1:kz)
                temp3d = temp3d_r4
             end if
+            call wrf_dm_bcast_real(temp3d, ijk)
             te = ie + (it-1)*nens
             ep % gr(its:ite,jts:jte,kts:kte,te) = ens_scaling_inv * &
                                                   temp3d(its:ite,jts:jte,kts:kte)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, alpha_hydrometeors, ep_format=2

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Problem:
Only rootproc reads in the data, but the broadcasting from rootproc was missing for qice, qsnow and qgraup.
Non-root processors will have qrain values for qice, qsnow and qgraup.

Solution:
add call wrf_dm_bcast_real(temp3d, ijk)

LIST OF MODIFIED FILES:
M       var/da/da_setup_structures/da_setup_flow_predictors_ep_format2.inc

TESTS CONDUCTED:

RELEASE NOTE: Big fix for WRFDA incorrect ensemble perturbation values for qice, qsnow and qgraup when alpha_hydrometeors=true and ep_format=2.