### PR TITLE
Fix DA use_obs_errfac for multiple outerloops

### DIFF
--- a/var/da/da_minimisation/da_get_innov_vector.inc
+++ b/var/da/da_minimisation/da_get_innov_vector.inc
@@ -285,7 +285,7 @@ subroutine da_get_innov_vector (it, num_qcstat_conv, ob, iv, grid, config_flags)
    ! [3] Optionally rescale observation errors:
    !------------------------------------------------------------------------ 
    
-   if (use_obs_errfac) call da_use_obs_errfac( iv)
+   if (use_obs_errfac .and. it == 1) call da_use_obs_errfac(iv)
 
    !------------------------------------------------------------------------  
    ! [4] Optionally add Gaussian noise to O, O-B:


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, use_obs_errfac, max_ext_its > 1

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Problem:
CWB reported seeing obs errors keep decreasing with each outerloop.

Solution:
Add a check for outerloop number, so that when use_obs_errfac=true and errfac.dat exists in the working directory, observation error factors are applied only at the first outerloop.

LIST OF MODIFIED FILES:
M       var/da/da_minimisation/da_get_innov_vector.inc

TESTS CONDUCTED: 

RELEASE NOTE: Bug fix for WRFDA's incorrectly applying errfac.dat at each outerloop when use_obs_errfac=true and max_ext_its > 1.