### PR TITLE
Prevent stack smashing caused by incompatible namelist options

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1944,6 +1944,10 @@ ENDIF ghg_block
 !
    drydep_select: SELECT CASE(config_flags%gas_drydep_opt)
      CASE (WESELY)
+        IF (numgas .eq. 0) THEN
+            CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
+            &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
+        ENDIF
        CALL wrf_debug(15,'initializing dry dep (wesely)')
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: chem, drydep, wesely

SOURCE: Lukas Pilz (Heidelberg University)

DESCRIPTION OF CHANGES:
Problem:
A namelist option incompatibility between chem_opt (16) and gas_drydep_opt (1) leads to stack smashing.
When choosing a tracer-only chem_opt, numgas is 0.
If gas_drydep_opt is then 1 (as is default), in the Wesely scheme initialization (dep_init), the field dvj is initialized with size numgas (here 0).
This leads to stack smashing upon further accesses.

Solution:
A fatal error was added for when the Wesely scheme initialization is called with numgas = 0.

LIST OF MODIFIED FILES: chem/chemics_init.F

TESTS CONDUCTED:
1. Run with chem_opt = 16 and gas_drydep_opt = 1 fails appropriately
2. Run with chem_opt = 16 and gas_drydep_opt = 0 runs as it should

RELEASE NOTE: Added fatal error for incompatible chem_opt and gas_drydep_opt namelist options.