### PR TITLE
Chem: Prevent seg fault due to numgas==0

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15, "initializing dry dep (wesely)")
+        CALL wrf_debug(15,'initializing dry dep (wesely)')
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15,'initializing dry dep (wesely)') 
+        CALL wrf_debug(15, 'initializing dry dep (wesely)') 
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15, 'initializing dry dep (wesely)') 
+        CALL wrf_debug(15,  'initializing dry dep (wesely)') 
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-       CALL wrf_debug(15,'initializing dry dep (wesely)')
+        CALL wrf_debug(15,'initializing dry dep (wesely)')
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15,'initializing dry dep (wesely)')
+        CALL wrf_debug(15,"initializing dry dep (wesely)")
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15,  'initializing dry dep (wesely)') 
+        CALL wrf_debug(15, 'initializing dry dep (wesely)') 
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1944,6 +1944,10 @@ ENDIF ghg_block
 !
    drydep_select: SELECT CASE(config_flags%gas_drydep_opt)
      CASE (WESELY)
+        IF (numgas .eq. 0) THEN
+            CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
+            &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
+        ENDIF
        CALL wrf_debug(15,'initializing dry dep (wesely)')
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15,'initializing dry dep (wesely)')
+        CALL wrf_debug(15,'initializing dry dep (wesely)') 
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15, 'initializing dry dep (wesely)') 
+        CALL wrf_debug(15,'initializing dry dep (wesely)') 
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1948,7 +1948,7 @@ ENDIF ghg_block
             CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
             &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
         ENDIF
-        CALL wrf_debug(15,"initializing dry dep (wesely)")
+        CALL wrf_debug(15, "initializing dry dep (wesely)")
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: chem, drydep, wesely

SOURCE: Lukas Pilz (Heidelberg University)

DESCRIPTION OF CHANGES:
Problem:
A namelist option incompatibility between chem_opt (16) and gas_drydep_opt (1) leads to trying to access a variable
that is not available in memory. This leads to unpredictable behaviors. When choosing a tracer-only chem_opt, numgas 
is 0. If gas_drydep_opt is 1 (the default), in the Wesely scheme initialization (dep_init), the field `dvj` is initialized with 
size numgas (here 0). Accessing the variable `dvj` is an error.

Solution:
A fatal error was added for when the Wesely scheme initialization is called with numgas = 0.

This fix is in `chem/chemics_init.F` and not `share/module_check_a_mundo.F` because checking the namelist options 
would require some tricky-to-maintain hardcoding.

LIST OF MODIFIED FILES: 
chem/chemics_init.F

TESTS CONDUCTED:
1. Run with chem_opt = 16 and gas_drydep_opt = 1 fails appropriately
2. Run with chem_opt = 16 and gas_drydep_opt = 0 runs as it should
3. The jenkins testing is OK.

RELEASE NOTE: For WRF-Chem, a namelist option incompatibility between chem_opt (16) and gas_drydep_opt (1) leads to trying to access a variable that is not available in memory. This leads to unpredictable behaviors. A fatal error was added for when the Wesely scheme initialization is called with numgas = 0.