### PR TITLE
Fix MPI synchronization in real

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -228,6 +228,9 @@ CONTAINS
       CALL nl_set_nproc_y ( 1, ntasks_y )
       WRITE( wrf_err_message , * )'Ntasks in X ',ntasks_x,', ntasks in Y ',ntasks_y
       CALL wrf_message( wrf_err_message )
+#ifndef STUBMPI
+      CALL MPI_BARRIER( local_communicator, ierr )
+#endif
       RETURN
    END SUBROUTINE wrf_dm_initialize
 

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -228,7 +228,7 @@ CONTAINS
       CALL nl_set_nproc_y ( 1, ntasks_y )
       WRITE( wrf_err_message , * )'Ntasks in X ',ntasks_x,', ntasks in Y ',ntasks_y
       CALL wrf_message( wrf_err_message )
-#ifndef STUBMPI
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       CALL MPI_BARRIER( local_communicator, ierr )
 #endif
       RETURN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: mpi, real, bug

SOURCE: Marc Honnorat (EXWEXs)

DESCRIPTION OF CHANGES:
Problem:
When running real.exe on multiple processes with MPI, one or more process occasionally crashes in setup_physics_suite 
(in share/module_check_a_mundo.F). This has been linked to wrf_dm_initialize non-blocking MPI. 

The real.exe occasionally crashes in setup_physics_suite (in share/module_check_a_mundo.F#L2640) because the latter 
uses model_config_rec % physics_suite, which on some machines is not initialized. The behavior is as if the broadcast of 
model_config_rec performed just before in main/real_em.F#L124 had not been received by all processes.

I had never seen this bug before, it has only happened on one machine (an Intel-based cluster using Intel-MPI and ifort).

The current fix makes sure that all processes are well synced before proceeding with setup_physics_suite. It solves the 
issue on my machine. Since this is immediately after reading in the namelist, no performance issues are expected as this 
read and broadcast of the namelist occurs only once per real / WRF / ndown run.

Solution:
An MPI barrier is added at the end of wrf_dm_initialize to force all of the processes to be synchronized before checking 
the namelist consistency.

This is a simplification of PR #1268, which had extra white space.

ISSUE:
Fixes #1267

LIST OF MODIFIED FILES:
M external/RSL_LITE/module_dm.F

TESTS CONDUCTED:
1. On the only machine were I have seen the bug occur, this change fixes the problem. No other test was conducted since I couldn't reproduce the bug on another setup.
2. Jenkins testing is all PASS.

RELEASE NOTES: When running real.exe on multiple processes with MPI, one or more processes occasionally crash in setup_physics_suite (in share/module_check_a_mundo.F). This has been traced to the fact that wrf_dm_initialize is non-blocking from an MPI point of view.  The problem is intermittent and has only happened on one machine (an Intel-based cluster using Intel-MPI and ifort). An MPI barrier has been added at the end of wrf_dm_initialize to force all processes to be synchronized before checking namelist consistency.
