### PR TITLE
Inconsistent arg types (integer kind) across subroutine call

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -44,7 +44,7 @@ RLFLAGS		=
 CC_TOOLS        =      cc 
 
 ###########################################################
-#ARCH    Linux i486 i586 i686 armv7l, gfortran compiler with gcc #serial smpar dmpar dm+sm
+#ARCH    Linux i486 i586 i686, gfortran compiler with gcc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
 DMPARALLEL      =       # 1

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -44,7 +44,7 @@ RLFLAGS		=
 CC_TOOLS        =      cc 
 
 ###########################################################
-#ARCH    Linux i486 i586 i686, gfortran compiler with gcc #serial smpar dmpar dm+sm
+#ARCH    Linux i486 i586 i686 armv7l, gfortran compiler with gcc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
 DMPARALLEL      =       # 1

--- a/external/io_int/module_io_int_read.F90
+++ b/external/io_int/module_io_int_read.F90
@@ -87,7 +87,7 @@ end module module_io_int_read
 module module_io_int_read
 
     use module_io_int_idx,           only: io_int_loc, r_info
-    use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t
+    use, intrinsic :: iso_c_binding, only: c_int32_t,c_int64_t
 
     implicit none
 

--- a/external/io_int/module_io_int_read.F90
+++ b/external/io_int/module_io_int_read.F90
@@ -87,7 +87,7 @@ end module module_io_int_read
 module module_io_int_read
 
     use module_io_int_idx,           only: io_int_loc, r_info
-    use, intrinsic :: iso_c_binding, only: c_int32_t,c_int64_t
+    use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t
 
     implicit none
 

--- a/external/io_int/module_io_int_read.F90
+++ b/external/io_int/module_io_int_read.F90
@@ -127,9 +127,9 @@ contains
     integer,                 intent(out) :: dst
     integer,                 intent(out) :: ierr
 
-    integer(c_int64_t)                  :: offset
-    integer(c_int32_t)                  :: count
-    integer                             :: tmp
+    integer(c_int64_t)                   :: offset
+    integer(c_int32_t)                   :: count
+    integer                              :: tmp
 
     call io_int_loc(varname, records, offset, count, ierr)
     if (ierr .ne. 0) then

--- a/external/io_int/module_io_int_read.F90
+++ b/external/io_int/module_io_int_read.F90
@@ -87,7 +87,7 @@ end module module_io_int_read
 module module_io_int_read
 
     use module_io_int_idx,           only: io_int_loc, r_info
-    use, intrinsic :: iso_c_binding, only: c_int32_t
+    use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t
 
     implicit none
 
@@ -127,8 +127,8 @@ contains
     integer,                 intent(out) :: dst
     integer,                 intent(out) :: ierr
 
-    integer(kind=mpi_offset_kind)       :: offset
-    integer                             :: count
+    integer(c_int64_t)                  :: offset
+    integer(c_int32_t)                  :: count
     integer                             :: tmp
 
     call io_int_loc(varname, records, offset, count, ierr)
@@ -161,8 +161,8 @@ contains
     integer,                 intent(inout) :: dst(:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i
     integer                                :: its, ite
@@ -219,8 +219,8 @@ contains
     integer,                 intent(inout) :: dst(:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j
     integer                                :: its, ite, jts, jte
@@ -279,8 +279,8 @@ contains
     integer,                 intent(inout) :: dst(:,:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j, k
     integer                                :: its, ite, jts, jte, kts, kte
@@ -343,8 +343,8 @@ contains
     real,                    intent(out) :: dst
     integer,                 intent(out) :: ierr
 
-    integer(kind=mpi_offset_kind)        :: offset
-    integer                              :: count
+    integer(c_int64_t)                   :: offset
+    integer(c_int32_t)                   :: count
     integer                              :: tmp
 
     call io_int_loc(varname, records, offset, count, ierr)
@@ -377,8 +377,8 @@ contains
     real,                    intent(inout) :: dst(:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i
     integer                                :: its, ite
@@ -435,8 +435,8 @@ contains
     real,                    intent(inout) :: dst(:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j
     integer                                :: its, ite, jts, jte
@@ -495,8 +495,8 @@ contains
     real,                    intent(inout) :: dst(:,:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j, k
     integer                                :: its, ite, jts, jte, kts, kte
@@ -559,8 +559,8 @@ contains
     character(len=*),        intent(inout) :: dst
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i
     integer, allocatable, dimension(:)     :: tmp


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: integer kind

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The nine calls to io_int_loc had inconsistent kinds of integer for the actual and dummy arguments. On every machine and
compiler previously, the integer kinds for MPI_offset and c_int64_t were identical. On the raspberry pi (using the 
default apt-get openmpi and gnu fortran), these are not identical.

Solution:
As the integers are being shared through a C interface, that integer kind was selected.

LIST OF MODIFIED FILES:
modified: external/io_int/module_io_int_read.F90

TESTS CONDUCTED: 
1. Without the mods, the WRF model did not build on a raspberry pi. With the mods, the code builds and runs. Here testing
on a raspberry pi includes the distributed memory, so the MPI_offset variable would be in use.

```
pi@raspberrypi:/media/pi/gill/WRF/test/em_quarter_ss $ mpirun -np 1 ./wrf.exe ; tail rsl.out.0000
 starting wrf task            0  of            1
Timing for main: time 0001-01-01_00:00:24 on domain   1:    0.79946 elapsed seconds
Timing for main: time 0001-01-01_00:00:36 on domain   1:    0.79981 elapsed seconds
Timing for main: time 0001-01-01_00:00:48 on domain   1:    0.80066 elapsed seconds
Timing for main: time 0001-01-01_00:01:00 on domain   1:    0.79946 elapsed seconds
Timing for main: time 0001-01-01_00:01:12 on domain   1:    0.80392 elapsed seconds
Timing for main: time 0001-01-01_00:01:24 on domain   1:    0.80236 elapsed seconds
Timing for main: time 0001-01-01_00:01:36 on domain   1:    0.80006 elapsed seconds
Timing for main: time 0001-01-01_00:01:48 on domain   1:    0.79996 elapsed seconds
Timing for main: time 0001-01-01_00:02:00 on domain   1:    0.80133 elapsed seconds
d01 0001-01-01_00:02:00 wrf: SUCCESS COMPLETE WRF
```
```
pi@raspberrypi:/media/pi/gill/WRF/test/em_quarter_ss $ mpirun -np 2 ./wrf.exe ; tail rsl.out.0000
 starting wrf task            1  of            2
 starting wrf task            0  of            2
Timing for main: time 0001-01-01_00:00:24 on domain   1:    0.53475 elapsed seconds
Timing for main: time 0001-01-01_00:00:36 on domain   1:    0.53516 elapsed seconds
Timing for main: time 0001-01-01_00:00:48 on domain   1:    0.53412 elapsed seconds
Timing for main: time 0001-01-01_00:01:00 on domain   1:    0.53324 elapsed seconds
Timing for main: time 0001-01-01_00:01:12 on domain   1:    0.53357 elapsed seconds
Timing for main: time 0001-01-01_00:01:24 on domain   1:    0.53547 elapsed seconds
Timing for main: time 0001-01-01_00:01:36 on domain   1:    0.53507 elapsed seconds
Timing for main: time 0001-01-01_00:01:48 on domain   1:    0.53406 elapsed seconds
Timing for main: time 0001-01-01_00:02:00 on domain   1:    0.53477 elapsed seconds
d01 0001-01-01_00:02:00 wrf: SUCCESS COMPLETE WRF
```
```
pi@raspberrypi:/media/pi/gill/WRF/test/em_quarter_ss $ mpirun -np 3 ./wrf.exe ; tail rsl.out.0000
 starting wrf task            0  of            3
 starting wrf task            1  of            3
 starting wrf task            2  of            3
Timing for main: time 0001-01-01_00:00:24 on domain   1:    0.48709 elapsed seconds
Timing for main: time 0001-01-01_00:00:36 on domain   1:    0.48533 elapsed seconds
Timing for main: time 0001-01-01_00:00:48 on domain   1:    0.48523 elapsed seconds
Timing for main: time 0001-01-01_00:01:00 on domain   1:    0.48553 elapsed seconds
Timing for main: time 0001-01-01_00:01:12 on domain   1:    0.48532 elapsed seconds
Timing for main: time 0001-01-01_00:01:24 on domain   1:    0.48635 elapsed seconds
Timing for main: time 0001-01-01_00:01:36 on domain   1:    0.48445 elapsed seconds
Timing for main: time 0001-01-01_00:01:48 on domain   1:    0.48409 elapsed seconds
Timing for main: time 0001-01-01_00:02:00 on domain   1:    0.48494 elapsed seconds
d01 0001-01-01_00:02:00 wrf: SUCCESS COMPLETE WRF

```
```
pi@raspberrypi:/media/pi/gill/WRF/test/em_quarter_ss $ mpirun -np 4 ./wrf.exe ; tail rsl.out.0000
 starting wrf task            3  of            4
 starting wrf task            0  of            4
 starting wrf task            1  of            4
 starting wrf task            2  of            4
Timing for main: time 0001-01-01_00:00:24 on domain   1:    0.65011 elapsed seconds
Timing for main: time 0001-01-01_00:00:36 on domain   1:    0.64889 elapsed seconds
Timing for main: time 0001-01-01_00:00:48 on domain   1:    0.64934 elapsed seconds
Timing for main: time 0001-01-01_00:01:00 on domain   1:    0.64886 elapsed seconds
Timing for main: time 0001-01-01_00:01:12 on domain   1:    0.65009 elapsed seconds
Timing for main: time 0001-01-01_00:01:24 on domain   1:    0.64658 elapsed seconds
Timing for main: time 0001-01-01_00:01:36 on domain   1:    0.64700 elapsed seconds
Timing for main: time 0001-01-01_00:01:48 on domain   1:    0.64807 elapsed seconds
Timing for main: time 0001-01-01_00:02:00 on domain   1:    0.64591 elapsed seconds
d01 0001-01-01_00:02:00 wrf: SUCCESS COMPLETE WRF
```
2. Jenkins testing is all PASS.

RELEASE NOTES: An inconsistency in the declaration of integer kinds was discovered in the seldom-used routine that processes binary formatted data. In one routine the values were declared as an MPI type (and integer kind mpi_offset_type). That argument was passed to a routine that declared the integers as c_int64_t (which is part of the standard technique now to be used when working with C). These two integer kinds must have been the same 8-byte size for all of the x86_64 Linux machines that we have used. These integer kinds are however different for at least some gfortran / openmpi combinations on ARM processors (specifically found on a raspberry pi). There is no impact to existing users. If the code previously worked (built), this changes nothing.