### PR TITLE
1st gfortran stanza target for raspberry pi (add aarch64 and armv7l)

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -44,7 +44,7 @@ RLFLAGS		=
 CC_TOOLS        =      cc 
 
 ###########################################################
-#ARCH    Linux i486 i586 i686 armv7l, gfortran compiler with gcc #serial smpar dmpar dm+sm
+#ARCH    Linux i486 i586 i686 armv7l aarch64, gfortran compiler with gcc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
 DMPARALLEL      =       # 1

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -44,7 +44,7 @@ RLFLAGS		=
 CC_TOOLS        =      cc 
 
 ###########################################################
-#ARCH    Linux i486 i586 i686 armv7l raspberrypi, gfortran compiler with gcc #serial smpar dmpar dm+sm
+#ARCH    Linux i486 i586 i686 armv7l, gfortran compiler with gcc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
 DMPARALLEL      =       # 1

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -44,7 +44,7 @@ RLFLAGS		=
 CC_TOOLS        =      cc 
 
 ###########################################################
-#ARCH    Linux i486 i586 i686 armv7l, gfortran compiler with gcc #serial smpar dmpar dm+sm
+#ARCH    Linux i486 i586 i686 armv7l raspberrypi, gfortran compiler with gcc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
 DMPARALLEL      =       # 1

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -44,7 +44,7 @@ RLFLAGS		=
 CC_TOOLS        =      cc 
 
 ###########################################################
-#ARCH    Linux i486 i586 i686, gfortran compiler with gcc #serial smpar dmpar dm+sm
+#ARCH    Linux i486 i586 i686 armv7l, gfortran compiler with gcc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
 DMPARALLEL      =       # 1


### PR DESCRIPTION
TYPE: new feature
    
KEYWORDS: raspberry pi
    
SOURCE: Daniel Zurawski and internal
  
DESCRIPTION OF CHANGES:
Additional strings, `armv7l` and `aarch64`, have been added to the first gfortran configuration stanza
so that these may be keywords for search from Raspberry Pi's `uname -a` output. No new
stanza was added for the gfortran target, so no re-numbering is required  for existing scripts that 
are reliant on such things as "32 = Gfortran for Linux with a serial build".

Associated with this PR, #1300 (Inconsistent arg types (integer kind) across subroutine call) is
also required to get the Raspberry Pi to build successfully.
 
LIST OF MODIFIED FILES:
modified:   arch/configure.defaults
    
TESTS CONDUCTED:
1. Previously, a Raspberry Pi build returned this:
``` 
*********************************************************
***              ERROR ERROR ERROR ERROR              ***
***                                                   ***
*** Configuration not found in configure.defaults     *** 
*********************************************************
``` 
2. After this PR, the configure command is able to find a target (raspian buster):
``` 
-----------------------------------------------------------------------
Please select from among the following Linux armv7l options:
    
  1. (serial)   2. (smpar)   3. (dmpar)   4. (dm+sm)   GNU (gfortran/gcc)
``` 
3. After this PR, the configure command is able to find a target (ubuntu mate):
```
------------------------------------------------------------------------
Please select from among the following Linux aarch64 options:

  1. (serial)   2. (smpar)   3. (dmpar)   4. (dm+sm)   GNU (gfortran/gcc)
```
4. Jenkins testing is all pass.
    
RELEASE NOTES: Modifications to the WRF code now permit the model to be built on a Raspberry Pi with the GNU/8 compiler.
