### PR TITLE
Add a new E-epsilon PBL scheme:

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -956,6 +956,11 @@ state   real   ZOL            ij     misc        1         -     -         "ZOL"
 state   real   WSTAR_YSU      ij     misc        1         -     -        "WSTAR_YSU"           "mixed-layer velocity scale from ysupbl" "m/s"
 state   real   DELTA_YSU      ij     misc        1         -     -        "DELTA_YSU"           "entrainment layer depth from ysupbl"    "m"
 
+# EEPS PBL  scheme
+state   real   pep_pbl        ikj    misc        1         -     hr        "PEP_PBL"            "TKE dissipation rate from EEPS"    "m2 s-3"
+state   real   pek_adv        ikjftb  scalar      1         -      i0rusdf=(bdy_interp:dt) "pek_adv"       "TKE from EEPS"      "m2 s-2"
+state   real   pep_adv        ikjftb  scalar      1         -      i0rusdf=(bdy_interp:dt) "pep_adv"       "TKE dissipating rate from EEPS"      "m2 s-3"
+
 # MYJ PBL variables; GBM PBL: EXCH_H, EXCH_M
 state    real   EXCH_H          ikj     misc        1         Z     r         "EXCH_H"               "SCALAR EXCHANGE COEFFICIENTS "                "m2 s-1"
 state    real   EXCH_M          ikj     misc        1         Z     r         "EXCH_M"               "EXCHANGE COEFFICIENTS "                       "m2 s-1"
@@ -2934,6 +2939,7 @@ package   camuwpblscheme bl_pbl_physics==9           -             state:tauresx
 package   temfpblscheme  bl_pbl_physics==10          -             state:te_temf,kh_temf,km_temf,shf_temf,qf_temf,uw_temf,vw_temf,wupd_temf,mf_temf,thup_temf,qlup_temf,qtup_temf,cf3d_temf,hd_temf,lcl_temf,hct_temf,cfm_temf
 package   shinhongscheme bl_pbl_physics==11          -             state:el_pbl,tke_pbl
 package   gbmpblscheme   bl_pbl_physics==12          -             state:exch_tke,el_pbl,tke_pbl
+package   eepsscheme     bl_pbl_physics==16          -             scalar:pek_adv,pep_adv;state:tke_pbl,pep_pbl
 package   mrfscheme      bl_pbl_physics==99          -             -
 
 package   mynn_tkebudget bl_mynn_tkebudget==1        -             state:qSHEAR,qBUOY,qDISS,qWT,dqke

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1043,6 +1043,10 @@ BENCH_START(pbl_driver_tim)
      &        ,spp_pbl=config_flags%spp_pbl                               &
      &        ,pattern_spp_pbl=grid%pattern_spp_pbl                       &
      &        ,restart=config_flags%restart,cycling=config_flags%cycling  &
+!EEPS for ARW
+     &        ,pep=grid%pep_pbl                                           &
+     &        ,PEK_ADV=scalar(ims,kms,jms,P_pek_adv)                      &!TKEadvection
+     &        ,PEP_ADV=scalar(ims,kms,jms,P_pep_adv)                      &!TKEadvection
 !GWD for ARW
      &        ,GWD_OPT=config_flags%gwd_opt &
      &        ,DTAUX3D=grid%dtaux3d,DTAUY3D=grid%dtauy3d &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1054,6 +1054,7 @@ endif
                       grid%levsiz, num_ozmixm, num_aerosolc, grid%paerlev,  &
                       grid%alevsiz, grid%no_src_types,                      &
                       grid%tmn,grid%xland,grid%znt,grid%z0,grid%ust,grid%mol,grid%pblh,grid%tke_pbl,    &
+                      grid%pep_pbl,                             & ! EEPS
                       grid%exch_h,grid%thc,grid%snowc,grid%mavail,grid%hfx,grid%qfx,grid%rainbl, &
                       grid%tslb,grid%zs,grid%dzs,config_flags%num_soil_layers,grid%warm_rain,  &
                       grid%adv_moist_cond, grid%is_CAMMGMP_used,                               &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1054,7 +1054,6 @@ endif
                       grid%levsiz, num_ozmixm, num_aerosolc, grid%paerlev,  &
                       grid%alevsiz, grid%no_src_types,                      &
                       grid%tmn,grid%xland,grid%znt,grid%z0,grid%ust,grid%mol,grid%pblh,grid%tke_pbl,    &
-                      grid%pep_pbl,                             & ! EEPS
                       grid%exch_h,grid%thc,grid%snowc,grid%mavail,grid%hfx,grid%qfx,grid%rainbl, &
                       grid%tslb,grid%zs,grid%dzs,config_flags%num_soil_layers,grid%warm_rain,  &
                       grid%adv_moist_cond, grid%is_CAMMGMP_used,                               &
@@ -1230,6 +1229,7 @@ endif
                       ,grid%xtime1, grid%PBLHAVG, grid%TKEAVG                            &
                       ,grid%ccn_conc                                          & ! RAS
                       ,grid%QKE                                               &!JOE-for mynn
+                      ,grid%pep_pbl                                           & ! EEPS
                       ,grid%landusef,grid%landusef2,grid%mosaic_cat_index                            & ! danli mosaic
                       ,grid%TSK_mosaic,grid%TSLB_mosaic,grid%SMOIS_mosaic,grid%SH2O_mosaic           & ! danli mosaic
                       ,grid%CANWAT_mosaic,grid%SNOW_mosaic,grid%SNOWH_mosaic,grid%SNOWC_mosaic       & ! danli mosaic

--- a/phys/Makefile
+++ b/phys/Makefile
@@ -48,6 +48,7 @@ MODULES = \
 	module_checkerror.o \
 	module_bl_camuwpbl_driver.o \
 	module_bl_mfshconvpbl.o \
+	module_bl_eepsilon.o \
 	module_shcu_camuwshcu_driver.o \
 	module_shcu_camuwshcu.o \
 	module_shcu_deng.o          \

--- a/phys/module_bl_eepsilon.F
+++ b/phys/module_bl_eepsilon.F
@@ -1,0 +1,967 @@
+!WRF:model_layer:physics
+!
+!####################e-epsilon scheme##################################
+!   taken from the IPRC IRAM - Yuqing Wang, university of hawaii
+!   added and improved by Chunxi Zhang and Yuqing Wang to wrf4.2, 2020
+!   refenrences: Langland and Liou (1996, mwr, 124, 905-918)
+!                Zhang et al.      (2020, mwr, 148, 1121-1145)
+!######################################################################
+module module_bl_eeps
+
+   use module_model_constants, only:rgas=>r_d,   &
+   &       t13=>Prandtl,ep1=>EP_1,ep2=>EP_2,grv=>g, &
+   &       akv=>KARMAN,cp,rcp,xlv,xls,xlf,p1000mb
+     
+   real, private, parameter :: cs2=17.67,cs3=273.15,cs4=29.65
+   real, private, parameter :: ci2=22.514,ci3=273.16,ci4=0.0
+   real, private, parameter :: hgfr=233.15,t0=273.15
+   real, private, parameter :: epsl=1.e-20
+   real, private, parameter :: us2min=0.1
+   real, private, parameter :: akvmx = 1600.
+   real, private, parameter :: ricr=0.25,bt=5.0
+   real, private, parameter :: minpek = 1.0e-4
+   real, private, parameter :: minpep = 1.0e-6
+   real, private, parameter :: maxpek = 80.
+   real, private, parameter :: maxpep = 2.0
+   integer,private,parameter:: bl_eeps_tkeadv = 1
+!---------------------------------------------------------------
+! ci--- five constants used in TKE tubrbulence closure scheme
+!---------------------------------------------------------------
+! Detering and Etling (1986); Langland and Liou (1996)
+!   real,parameter :: c1=1.35,c2=0.026,c3=1.13,c4=1.90,c5=0.77
+! Duynkerke and Driedonks (1987); Stubley and Rooney (1986)
+   real,parameter :: c1=1.35,c2=0.09,c3=1.44,c4=1.92,c5=0.77
+! Beljaars et al. (1987)
+!   real,parameter :: c1=1.35,c2=0.032,c3=1.44,c4=1.92,c5=0.54
+!
+contains
+!-------------------------------------------------------------------------------
+!
+   subroutine eeps(u3d,v3d,t3d,qv3d,qc3d,qi3d,qr3d,qs3d,qg3d,p3d,pi3d,    &
+                  rublten,rvblten,rthblten,                               &
+                  rqvblten,rqcblten,rqiblten,                             &
+                  pek,pep,                                                &
+                  dz8w,psfc,qsfc,tsk,ust,rmol,wspd,                       &
+                  xland,hfx,qfx,                                          &
+                  dt,dx,itimestep,exch_h,exch_m,pblh,kpbl,                &
+                  pek_adv,pep_adv,                                        &
+                  ids,ide, jds,jde, kds,kde,                              &
+                  ims,ime, jms,jme, kms,kme,                              &
+                  its,ite, jts,jte, kts,kte                               &
+                                                      )
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!-- u3d         3d u-velocity interpolated to theta points (m/s)
+!-- v3d         3d v-velocity interpolated to theta points (m/s)
+!-- t3d         temperature (k)
+!-- qv3d        3d water vapor mixing ratio (kg/kg)
+!-- qc3d        3d cloud mixing ratio (kg/kg)
+!-- qi3d        3d ice mixing ratio (kg/kg)
+!-- qr3d        3d rain mixing ratio (kg/kg)
+!-- qs3d        3d snow mixing ratio (kg/kg)
+!-- qg3d        3d graupel mixing ratio (kg/kg)
+!               (note: if P_QI<PARAM_FIRST_SCALAR this should be zero filled)
+!-- p3d         3d pressure (pa)
+!-- pi3d        3d exner function (dimensionless)
+!-- rublten     u tendency due to
+!               pbl parameterization (m/s/s)
+!-- rvblten     v tendency due to
+!               pbl parameterization (m/s/s)
+!-- rthblten    theta tendency due to
+!               pbl parameterization (K/s)
+!-- rqvblten    qv tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- rqcblten    qc tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- rqiblten    qi tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- dz8w        dz between full levels (m)
+!-- pek         3d turbulent kinetic energy (TKE, m2/s2)
+!-- pep         3d dissipation rate of TKE 
+!-- psfc        pressure at the surface (pa)
+!-- qsfc        ground saturated mixing ratio
+!-- ust         u* in similarity theory (m/s)
+!-- rmol        inverse (1/L) of Monin-Obukhov length (m)
+!-- xland       land mask (1 for land, 2 for water)
+!-- tsk         surface skin temperature
+!-- hfx         upward heat flux at the surface (w/m^2)
+!-- qfx         upward moisture flux at the surface (kg/m^2/s)
+!-- dt          time step (s)
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!-------------------------------------------------------------------------------
+!
+   integer,  intent(in   )   ::      ids,ide, jds,jde, kds,kde,                &
+                                     ims,ime, jms,jme, kms,kme,                &
+                                     its,ite, jts,jte, kts,kte
+
+   integer,  intent(in   )   ::      itimestep
+
+   real,     intent(in   )   ::      dt, dx
+!
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                          qv3d, &
+                                                                         qc3d, &
+                                                                         qi3d, &
+                                                                          p3d, &
+                                                                         pi3d, &
+                                                                          t3d, &
+                                                                         dz8w, &
+                                                                          u3d, &
+                                                                          v3d
+   
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             optional                                                        , &
+             intent(in   )   ::                                          qr3d, &
+                                                                         qs3d, &
+                                                                         qg3d
+
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(inout)   ::                                       rublten, &
+                                                                      rvblten, &
+                                                                     rthblten, &
+                                                                     rqvblten, &
+                                                                     rqcblten, &
+                                                                     rqiblten
+!
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(in   )   ::                                         xland, &
+                                                                          hfx, &
+                                                                          qfx, &
+                                                                         psfc, &
+                                                                         qsfc, &
+                                                                          tsk, &
+                                                                          ust, &
+                                                                          rmol,&
+                                                                          wspd
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(inout)   ::                                       pek, pep
+
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(inout)   ::                                 pek_adv,pep_adv
+
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(out)   ::                                    exch_h,exch_m
+
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(out   )   ::                                          pblh
+
+   integer,  dimension( ims:ime, jms:jme )                                   , &
+             intent(out   )   ::                                          kpbl
+!
+!local
+      real,     dimension( its:ite, kts:kte+1)::              zi,ghti  
+      real,     dimension( its:ite, kts:kte ) ::              zl                                                   
+      
+      real,     dimension( its:ite, kts:kte ) ::              u1, &
+                                                              v1, &
+                                                              q1, &
+                                                              q2, &
+                                                              q3, &
+                                                              q4, &
+                                                              q5, &
+                                                              q6, &
+                                                              t1, &
+                                                              ghtl, &
+                                                              prsl
+      real,     dimension( its:ite, kts:kte ) ::          pek2d,pep2d
+      real,     dimension( its:ite, kts:kte+1 ) ::        exh2d,exm2d
+      real,     dimension( its:ite) ::               psfc1,ust1,rmol1,  &
+                                                     xland1,qsfc1,hfx1, &
+                                                     qfx1,tsk1,pblh1,wspd1
+      integer,  dimension( its:ite) ::               kpbl1
+
+      real    :: rdelt
+      integer ::  i,j,k,zz,im,kx,pp
+
+      im=ite-its+1
+      kx=kte-kts+1
+      rdelt = 1./dt
+
+      if(itimestep .eq. 1) then
+         pek_adv = pek
+         pep_adv = pep
+      end if
+
+      do j=jts,jte
+! --------------- compute zi and zl -----------------------------------------
+      do i=its,ite
+        zi(i,kts)=0.0
+      enddo
+!
+      do k=kts,kte
+        do i=its,ite
+          zi(i,k+1)=zi(i,k)+dz8w(i,k,j)
+        enddo
+      enddo
+!
+      do k=kts,kte
+        do i=its,ite
+          zl(i,k)=0.5*(zi(i,k)+zi(i,k+1))
+        enddo
+      enddo
+
+! reverse the vertical levels
+      pp = 0
+      do k=kts,kte
+        zz = kte-pp
+        do i=its,ite
+          u1(i,zz)=u3d(i,k,j)
+          v1(i,zz)=v3d(i,k,j)
+          t1(i,zz)=t3d(i,k,j)
+          q1(i,zz)=qv3d(i,k,j)/(1.+qv3d(i,k,j))
+          q2(i,zz)=qc3d(i,k,j)/(1.+qc3d(i,k,j))
+          q3(i,zz)=qi3d(i,k,j)/(1.+qi3d(i,k,j))
+          if(present(qr3d)) then
+            q4(i,zz)=qr3d(i,k,j)/(1.+qr3d(i,k,j))
+          else
+            q4(i,zz)=0.
+          end if
+          if(present(qs3d)) then
+            q5(i,zz)=qs3d(i,k,j)/(1.+qs3d(i,k,j))
+          else
+            q5(i,zz)=0.
+          end if
+          if(present(qg3d)) then
+            q6(i,zz)=qg3d(i,k,j)/(1.+qg3d(i,k,j))
+          else
+            q6(i,zz)=0.
+          end if
+          ghtl(i,zz)=zl(i,k)
+          prsl(i,zz) = p3d(i,k,j)
+          if(bl_eeps_tkeadv==1)then
+            if(k.ne.1) then 
+              pek(i,k,j) = 0.5*(pek_adv(i,k,j)+pek_adv(i,k-1,j))
+              pep(i,k,j) = 0.5*(pep_adv(i,k,j)+pep_adv(i,k-1,j))
+            else
+              pek(i,k,j) = minpek
+              pep(i,k,j) = minpep
+            end if
+          end if
+          pek2d(i,zz)= min(maxpek,max(minpek,pek(i,k,j)))
+          pep2d(i,zz)= min(maxpep,max(minpep,pep(i,k,j)))
+        end do
+        pp = pp + 1
+      end do
+
+       pp = 0
+       do k=kts,kte+1
+        zz = kte+1-pp
+        do i=its,ite
+          ghti(i,zz) = zi(i,k)
+        enddo
+        pp = pp + 1
+      enddo
+
+      do i=its,ite
+        psfc1(i) = psfc(i,j)
+        ust1(i)  = ust(i,j)
+        rmol1(i) = rmol(i,j)
+        wspd1(i) = wspd(i,j)
+        xland1(i)= xland(i,j)
+        qsfc1(i) = qsfc(i,j)
+        hfx1(i)  = hfx(i,j)
+        qfx1(i)  = qfx(i,j)
+        tsk1(i)  = tsk(i,j)
+      end do
+! 
+      call eeps2d(u1,v1,t1,q1,q2,q3,q4,q5,q6,prsl,ghtl,ghti,pek2d,pep2d &
+              ,psfc1,ust1,rmol1,wspd1,xland1,qsfc1,hfx1,qfx1,tsk1       &
+              ,dt,dx,itimestep,exh2d,exm2d,pblh1,kpbl1,im,kx)
+!
+      pp = 0
+      do k=kts,kte
+        zz = kte-pp
+        do i=its,ite
+          rthblten(i,k,j)=(t1(i,zz)-t3d(i,k,j))/pi3d(i,k,j)*rdelt
+          rqvblten(i,k,j)=(q1(i,zz)/(1.-q1(i,zz))-qv3d(i,k,j))*rdelt
+          rqcblten(i,k,j)=(q2(i,zz)/(1.-q2(i,zz))-qc3d(i,k,j))*rdelt
+          rqiblten(i,k,j)=(q3(i,zz)/(1.-q3(i,zz))-qi3d(i,k,j))*rdelt
+          rublten(i,k,j) =(u1(i,zz)-u3d(i,k,j))*rdelt
+          rvblten(i,k,j) =(v1(i,zz)-v3d(i,k,j))*rdelt
+
+          pek(i,k,j)     = pek2d(i,zz)
+          pep(i,k,j)     = pep2d(i,zz)
+        enddo
+        pp = pp + 1
+      enddo
+
+      pp = 0
+      do k=kts,kte+1
+        zz = kte+1-pp
+        do i=its,ite
+          exch_h(i,k,j)  = exh2d(i,zz)
+          exch_m(i,k,j)  = exm2d(i,zz)
+        enddo
+        pp = pp + 1
+      enddo
+
+      do i=its,ite
+        pblh(i,j) = pblh1(i)
+        kpbl(i,j) = kpbl1(i)
+      end do
+
+      if(bl_eeps_tkeadv==1)then
+        do k=kts,kte
+          do i=its,ite
+            if(k.ne.kte) then
+              pek_adv(i,k,j) = 0.5*(pek(i,k,j)+pek(i,k+1,j))
+              pep_adv(i,k,j) = 0.5*(pep(i,k,j)+pep(i,k+1,j))
+            else
+              pek_adv(i,k,j) = 0.5*pek(i,k,j)
+              pep_adv(i,k,j) = 0.5*pep(i,k,j)
+            end if
+          end do
+        end do
+      end if
+!
+   enddo
+
+!
+   end subroutine eeps
+!
+!-------------------------------------------------------------------------------
+!
+   subroutine eeps2d(pu,pv,tz,pqv,pqc,pqi,pqr,pqs,pqg,prs,poz,zz,pek,pep,       &
+                  psfcpa,ust,rmol,wspd,xland,qsfc,hfx,qfx,tsk,                  &
+                  dt,dx,itimestep,k_h,k_m,pblh,kpbl,lq,km)
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!
+   integer,  intent(in   )   ::     itimestep,lq,km
+   real,     intent(in   )   ::     dt, dx
+!
+   real,     dimension( lq )                                            , &
+             intent(in)   ::                                              ust, &
+                                                                        xland, &
+                                                                          hfx, &
+                                                                          qfx, &
+                                                                          rmol,&
+                                                                          wspd,&
+                                                                   psfcpa,qsfc,&
+                                                                           tsk
+!
+   real,     dimension( lq,km ),intent(inout)      ::          pu, &
+                                                               pv, &
+                                                               tz, &
+                                                              pqv, &
+                                                              pqc, &
+                                                              pqi, &
+                                                              pek, &
+                                                              pep
+  
+   real,     dimension( lq,km ),intent(in)      ::            prs, &
+                                                              poz, &
+                                                              pqr, &
+                                                              pqs, &
+                                                              pqg
+   real,     dimension( lq,km+1 ),intent(in)               ::  zz
+
+   real,     dimension( lq,km+1 ),intent(out)              :: k_h,k_m
+   real,     dimension( lq ),intent(out)                   ::  pblh    
+   integer,  dimension( lq ),intent(out)                   ::  kpbl
+
+! Local Vars
+   real,     dimension( lq,km ) :: fac,psp,pt,ztv,szv,disht,up2
+   real,     dimension( lq,km ) :: qvs,st,sh,rich,richb,dum2,dzz,doz
+   real,     dimension( lq,km ) :: am,src,src1,ax,bx,cx,ac,ab,ba,alt
+   real,     dimension( lq,km-1 ) :: ax1,bx1,cx1,yy1,amt
+   real,     dimension( lq,km+1 ) :: akm,akh,pnt
+
+   real,     dimension( lq)    :: tkm,zkm,qkm,us2,us,dens,wstar2,sflux
+   real,     dimension( lq)    :: rm2,sfa,hs,hq
+   real,     dimension( lq)    :: gamat,gamaq
+   real,     dimension( lq,km) :: sgk1,sgk2 
+   integer ::  j,k,mdt,lvl
+   real    ::  dtt,dum,dum0,alh,eqp,qvsw,qvsi,faf,rdz,du,dv,dss
+   real    ::  tk,qvk,alk,af,ag,aks,aco
+   real    ::  duj,alv0,richf,rch,alv,ak,cpm
+   real    ::  govrth,bfx0,wstar3,coef
+   
+   mdt = min(6,max(3,int(dt/10.0+0.1)))
+   dtt = dt/mdt
+
+!  dzz for dz between full levels, doz for dz between half levels
+   do k=1,km
+     do j=1,lq
+       dzz(j,k) = zz(j,k)-zz(j,k+1)
+       alt(j,k) = dt/dzz(j,k)
+       up2(j,k)=grv/max(us2min,pu(j,k)*pu(j,k)+pv(j,k)*pv(j,k))
+     enddo
+   enddo
+
+   do k=1,km-1
+     do j=1,lq
+       doz(j,k)  = poz(j,k)-poz(j,k+1)
+     end do
+   end do
+!
+   do j=1,lq
+     doz(j,km)= 2.0*poz(j,km) ! not used
+!     wstar2(j)= 0.0          ! it will be assigned values later
+   enddo
+!
+   do k=1,km-1
+     do j=1,lq
+       amt(j,k) = dtt/doz(j,k)
+     enddo
+   enddo
+
+   do k=1,km
+     do j=1,lq
+       sgk1(j,k) = 0.1
+       sgk2(j,k) = 0.01
+     end do
+   end do
+!
+   do k=1,km
+   do j=1,lq
+      psp(j,k)=(prs(j,k)/p1000mb)**rcp
+      pt(j,k)=tz(j,k)/psp(j,k)
+      dum=1.0+ep1*pqv(j,k)
+      ztv(j,k)=tz(j,k)*dum
+      szv(j,k)=pt(j,k)*dum
+      fac(j,k) = pqc(j,k) + pqi(j,k) + pqr(j,k) + pqs(j,k) + pqg(j,k)
+      cx(j,k)=1.0+pqv(j,k)+fac(j,k)
+
+      alh=3.1484e6-2.37e3*tz(j,k)
+      eqp=611.2*exp(cs2*(tz(j,k)-cs3)/(tz(j,k)-cs4))
+      eqp=min(0.5*prs(j,k),eqp)
+      qvsw=0.622*eqp/(prs(j,k)-eqp)
+      eqp=611.0*exp(ci2*(tz(j,k)-ci3)/(tz(j,k)-ci4))
+      eqp=min(0.5*prs(j,k),eqp)
+      qvsi=0.622*eqp/(prs(j,k)-eqp)
+      if(tz(j,k).ge.t0) then
+        faf=0.0
+      else if(tz(j,k).le.hgfr) then
+        faf=1.0
+      else
+        if(pqi(j,k).le.epsl) then
+        faf=0.0
+        else if(pqc(j,k).le.epsl) then
+        faf=1.0
+        else
+        faf=pqi(j,k)/(pqc(j,k)+pqi(j,k))
+        endif
+      endif
+      qvs(j,k)=(1.0-faf)*qvsw+faf*qvsi
+      ax(j,k)=(1.0-faf)*alh+faf*xls
+   end do
+   end do
+
+!
+!  to calculate the Richardson number and vertical shear of
+!  the horizontal wind above the surface layer
+!
+      do k=1,km-1
+      do j=1,lq
+        rdz=1.0/(poz(j,k)-poz(j,k+1))
+        du=pu(j,k)-pu(j,k+1)
+        dv=pv(j,k)-pv(j,k+1)
+        sh(j,k)=(du*du+dv*dv)*(rdz*rdz)
+        if((pqv(j,k).lt.qvs(j,k)).or.(pqv(j,k+1).lt.qvs(j,k+1))) then
+          dss=log(szv(j,k)/szv(j,k+1))
+          st(j,k)=grv*dss*rdz
+        else
+          dss=log(pt(j,k)/pt(j,k+1))
+          tk=0.5*(tz(j,k+1)+tz(j,k))
+          qvk=0.5*(pqv(j,k+1)+pqv(j,k))
+          alk=0.5*(ax(j,k+1)+ax(j,k))
+          af=alk*qvk/(rgas*tk)
+          ag=alk/(cp*tk)
+          aks=ep2*af*ag
+          aco=(1.0+af)/(1.0+aks)
+          st(j,k)=(aco*(dss+ag*(pqv(j,k)-pqv(j,k+1))) &
+               -(cx(j,k)-cx(j,k+1)))*grv*rdz
+        endif
+        rich(j,k)=st(j,k)/max(1.0e-7,sh(j,k))
+      end do
+      end do
+
+! calculate first guess pblh
+      do k=1,km
+      do j=1,lq
+        richb(j,k)=poz(j,k)*(szv(j,k)/szv(j,km)-1.0)*up2(j,k)
+      enddo
+      enddo
+!
+      do j=1,lq
+        pblh(j)=poz(j,km)
+        kpbl(j)=1
+        lvl=km
+        do k=km-1,5,-1
+          if(richb(j,k).ge.ricr) then
+            lvl=k
+            exit
+          endif
+        enddo
+
+        if(lvl.lt.km) then
+          dum=(poz(j,lvl)-poz(j,lvl+1))/(richb(j,lvl)-richb(j,lvl+1))
+          pblh(j)=max(poz(j,lvl+1),poz(j,lvl)-(richb(j,lvl)-ricr)*dum)
+          pblh(j)=min(pblh(j),poz(j,lvl))
+        endif
+      end do
+
+!  preparing for tke/ep calculations
+!
+      do j=1,lq
+        tkm(j) = tz(j,km)
+        zkm(j) = poz(j,km)
+        qkm(j) = pqv(j,km)
+        sfa(j) = tsk(j)*(p1000mb/psfcpa(j))**rcp
+        dens(j) = psfcpa(j)/(rgas*tkm(j)*(1.+ep1*qkm(j)))
+        cpm = cp * (1.+0.81*qkm(j))
+
+        rm2(j)=ust(j)*ust(j)/wspd(j)
+        hs(j)=hfx(j)/(dens(j)*cpm)
+        hq(j)=qfx(j)/dens(j)
+!
+        sh(j,km)=0.0
+        st(j,km)=0.0
+        duj=ust(j)*ust(j)
+        pep(j,km)=duj*ust(j)/(akv*zkm(j))
+        pep(j,km) = min(maxpep,max(minpep,pep(j,km)))
+        govrth = grv/pt(j,km)
+        sflux(j) = hfx(j)/dens(j)/cpm + &
+                   qfx(j)/dens(j)*ep1*pt(j,km)
+        bfx0    = max(sflux(j),0.)
+        wstar3  = govrth*bfx0*pblh(j)
+        wstar2(j)  = (wstar3**2)**t13
+
+        rich(j,km) = grv*zkm(j)*  &
+            log(szv(j,km)/(sfa(j)*(1.+ep1*qsfc(j))))/(wspd(j)**2.)
+
+        if(rmol(j).lt.0. .and. sflux(j).gt.0) then
+          pek(j,km)=3.75*duj+0.2*wstar2(j)+duj*((-zkm(j)*rmol(j))**2.)**t13
+        else
+          pek(j,km)=3.75*duj
+        endif
+        pek(j,km) = min(maxpek,max(minpek,pek(j,km)))
+
+      end do
+
+! to recalculate pblh here
+      do j=1,lq
+        if(rmol(j).lt.0. .and. sflux(j).gt.0) then
+          dss=szv(j,km)+min(5.0,bt*sflux(j)/(max(0.1,sqrt(wstar2(j)))))
+          do k=1,km
+            richb(j,k)=poz(j,k)*(szv(j,k)/dss-1.0)*up2(j,k)
+          end do
+
+          pblh(j)=poz(j,km)
+          lvl=km
+          do k=km-1,5,-1
+            if(richb(j,k).ge.ricr) then
+              lvl=k
+              exit
+            end if
+          enddo
+ 
+          if(lvl.lt.km) then
+            dum=(poz(j,lvl)-poz(j,lvl+1))/(richb(j,lvl)-richb(j,lvl+1))
+            pblh(j)=max(poz(j,lvl+1),poz(j,lvl)-(richb(j,lvl)-ricr)*dum)
+            pblh(j)=min(pblh(j),poz(j,lvl))
+            kpbl(j)=km-lvl+1
+          end if
+        end if
+      end do
+
+! to add the countergradient term
+      do j=1,lq
+        if(rmol(j).lt.0.0 .and. sflux(j).gt.0) then
+          du=max(0.1,sqrt(wstar2(j)))
+          gamat(j)=max(bt*hs(j)/(pblh(j)*du),0.)
+          gamaq(j)=max(bt*hq(j)/(pblh(j)*du),0.)
+        else
+          gamat(j)=0.0
+          gamaq(j)=0.0
+        endif
+      end do
+!
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!  time integration of tke and ep equations
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+      do k=1,km
+      do j=1,lq
+        richf=0.1912408
+        if(rich(j,k).lt.0.195) then
+          richf=0.6588*(rich(j,k)+0.1776-sqrt(rich(j,k)*rich(j,k)- &
+              0.3221*rich(j,k)+0.03156))
+          richf=max(-1000.0,min(0.1912408,richf))
+        endif
+        dum2(j,k)=1.122346
+        if(richf.lt.0.16) dum2(j,k)=1.318*(0.2231-richf) &
+              /(0.2341-richf)
+      end do
+      end do
+!
+      lvl=1
+      do while(lvl .le. mdt)
+
+      do k=1,km-1
+        do j=1,lq
+          akm(j,k)=c2*pek(j,k)*pek(j,k)/pep(j,k)
+          akh(j,k)=dum2(j,k)*akm(j,k)
+          akm(j,k)=sgk1(j,k)+akm(j,k)
+          akh(j,k)=sgk2(j,k)+akh(j,k)
+          akm(j,k)=min(akvmx,akm(j,k))
+          akh(j,k)=min(akvmx,akh(j,k))
+          if(zz(j,k).gt.pblh(j))then
+            src(j,k)=akm(j,k)*sh(j,k)-akh(j,k)*st(j,k)
+            src1(j,k)=max(akm(j,k)*sh(j,k),akm(j,k)*sh(j,k)-akh(j,k)*st(j,k))
+          else
+            src(j,k)=akm(j,k)*sh(j,k)-akh(j,k)*(st(j,k) &
+                   -2.0*grv*gamat(j)/(szv(j,k+1)+szv(j,k)))
+            src1(j,k)=max(akm(j,k)*sh(j,k),akm(j,k)*sh(j,k)-akh(j,k)*(st(j,k) &
+                   -2.0*grv*gamat(j)/(szv(j,k+1)+szv(j,k))))
+          end if
+        end do
+      end do
+!
+      do j=1,lq
+        akm(j,km)=c2*pek(j,km)*pek(j,km)/pep(j,km)
+        akh(j,km)=dum2(j,km)*akm(j,km)
+      end do
+!
+!  to calculate the vertical diffusion coefficients at u,v,levels
+!
+      do k=2,km
+      do j=1,lq
+        am(j,k)=0.5*(akm(j,k-1)+akm(j,k))/dzz(j,k)
+      end do
+      end do
+
+      do j=1,lq
+        am(j,1)=0.5*akm(j,1)/dzz(j,1)
+      end do
+!
+!  to calculate the cofficients for the triangle matrix
+!  for tke dissipation and solve the matrix
+!
+      do k=1,km-1
+        do j=1,lq
+          dum=(c3*src1(j,k)-c4*pep(j,k))*dtt/pek(j,k)
+          ax1(j,k)=-c5*amt(j,k)*am(j,k+1)
+          cx1(j,k)=-c5*amt(j,k)*am(j,k)
+          if(dum.le.0.5) then
+            bx1(j,k)=1.0+c5*amt(j,k)*(am(j,k)+am(j,k+1))-dum
+            yy1(j,k)=pep(j,k)
+          else
+            bx1(j,k)=1.0+c5*amt(j,k)*(am(j,k)+am(j,k+1))
+            yy1(j,k)=pep(j,k)+dum*pep(j,k)
+          endif
+        end do
+      end do
+!
+      do j=1,lq
+        cx1(j,1)=0.0
+        ax1(j,km-1)=0.0
+        yy1(j,km-1)=yy1(j,km-1)+c5*amt(j,km-1)*am(j,km)*pep(j,km)
+      end do
+!
+      call tridiag(ax1,bx1,cx1,yy1,lq,km-1)
+!
+!  to calculate the cofficients for the triangle matrix
+!  for tke and solve the matrix
+!
+      do k=1,km-1
+        do j=1,lq
+          pep(j,k)=min(maxpep,max(minpep, yy1(j,k)))
+          dum=(src(j,k)-pep(j,k))*dtt
+          ax1(j,k)=-c1*amt(j,k)*am(j,k+1)
+          bx1(j,k)=1.0+c1*amt(j,k)*(am(j,k)+am(j,k+1))
+          cx1(j,k)=-c1*amt(j,k)*am(j,k)
+          yy1(j,k)=pek(j,k)+dum
+        end do
+      end do
+
+      do j=1,lq
+        cx1(j,1)=0.0
+        ax1(j,km-1)=0.0
+        yy1(j,km-1)=yy1(j,km-1)+c1*amt(j,km-1)*am(j,km)*pek(j,km)
+      end do
+!
+      call tridiag(ax1,bx1,cx1,yy1,lq,km-1)
+!
+      do k=1,km-1
+      do j=1,lq
+        pek(j,k)=min(maxpek,max(minpek, yy1(j,k)))
+      end do
+      end do
+
+      lvl = lvl + 1
+      end do ! end while
+!
+!-------------------------------------------------------------
+!  to calculate the vertical diffusion coeficient for momentum 
+!  heat, moisture
+!-------------------------------------------------------------
+!  note: akm and akh at the first level (km) will not be used 
+      do k=2,km
+        do j=1,lq
+          akm(j,k)=c2*pek(j,k-1)*pek(j,k-1)/pep(j,k-1)
+          akh(j,k)=dum2(j,k)*akm(j,k)
+          akm(j,k)=sgk1(j,k)+akm(j,k)
+          akh(j,k)=sgk2(j,k)+akh(j,k)
+          akm(j,k)=min(akvmx,akm(j,k))
+          akh(j,k)=min(akvmx,akh(j,k))
+          pnt(j,k)=akh(j,k)
+          if(zz(j,k).gt.pblh(j))pnt(j,k)=0.
+          akm(j,k)=akm(j,k)/doz(j,k-1)
+          akh(j,k)=akh(j,k)/doz(j,k-1)
+        end do
+      end do
+!
+      do j=1,lq
+        akm(j,1)=0.0
+        akh(j,1)=0.0
+        pnt(j,1)=0.0
+        akm(j,km+1)=0.0
+        akh(j,km+1)=0.0
+        pnt(j,km+1)=0.0
+      end do
+!
+! Momentum fluxes calculation
+!
+      do k=1,km
+      do j=1,lq
+        ax(j,k)=-alt(j,k)*akm(j,k+1)
+        bx(j,k)=1.0+alt(j,k)*(akm(j,k)+akm(j,k+1))
+        cx(j,k)=-alt(j,k)*akm(j,k)
+        ba(j,k)=ax(j,k)
+        ab(j,k)=bx(j,k)
+        ac(j,k)=cx(j,k)
+      end do
+      end do
+
+      do j=1,lq
+        bx(j,km) = bx(j,km)+alt(j,km)*rm2(j)
+        ab(j,km)=bx(j,km)
+      end do
+
+!
+      call tridiag(ba,ab,ac,pu,lq,km)
+!
+      call tridiag(ax,bx,cx,pv,lq,km)
+!
+! Heat and moisture fluxes calculation
+!
+      do k=1,km
+      do j=1,lq
+        ax(j,k)=-alt(j,k)*akh(j,k+1)
+        bx(j,k)=1.0+alt(j,k)*(akh(j,k)+akh(j,k+1))
+        cx(j,k)=-alt(j,k)*akh(j,k)
+        ba(j,k)=ax(j,k)
+        ab(j,k)=bx(j,k)
+        ac(j,k)=cx(j,k)
+        dum0=0.0       
+        if(k.gt.1) dum0=pep(j,k-1)
+        dum=pep(j,k)
+        if(dum0.le.1.e-6) dum0=0.0
+        if(dum.le.1.e-6) dum=0.0
+        disht(j,k)=0.5*(dum0+dum)/(cp*(1.+.81*pqv(j,k)))
+        pt(j,k)=pt(j,k)+disht(j,k)*dt/psp(j,k)+alt(j,k)* &
+                gamat(j)*(pnt(j,k+1)-pnt(j,k))
+      end do
+      end do
+!
+      do j=1,lq
+        pt(j,km)=pt(j,km)+alt(j,km)*hs(j)
+      end do
+!
+      call tridiag(ba,ab,ac,pt,lq,km)
+!
+      do k=1,km
+      do j=1,lq
+        ba(j,k)=ax(j,k)
+        ab(j,k)=bx(j,k)
+        ac(j,k)=cx(j,k)
+      end do
+      end do
+
+      do k=1,km
+      do j=1,lq
+         pqv(j,k)=pqv(j,k)+alt(j,k)*gamaq(j)* &
+                 (pnt(j,k+1)-pnt(j,k))
+      end do
+      end do
+
+      do j=1,lq
+        pqv(j,km)=pqv(j,km)+alt(j,km)*hq(j)
+      end do
+!
+      call tridiag(ba,ab,ac,pqv,lq,km)
+!
+      do k=1,km
+      do j=1,lq
+        ba(j,k)=ax(j,k)
+        ab(j,k)=bx(j,k)
+        ac(j,k)=cx(j,k)
+      end do
+      end do
+
+      call tridiag(ba,ab,ac,pqc,lq,km)
+!
+      call tridiag(ax,bx,cx,pqi,lq,km)
+!
+      do k=1,km
+      do j=1,lq
+        tz(j,k)=pt(j,k)*psp(j,k)
+        pqv(j,k)=max(epsl,pqv(j,k))
+        pqc(j,k)=max(epsl,pqc(j,k))
+        pqi(j,k)=max(epsl,pqi(j,k))
+!-----------------------------------------------------
+!  immediate melting of cloud ice below freezing level
+!-----------------------------------------------------
+        if(tz(j,k).ge.t0.and.pqi(j,k).gt.epsl) then
+          if(pqc(j,k).le.epsl) then
+            pqc(j,k)=pqi(j,k)
+          else
+            pqc(j,k)=pqc(j,k)+pqi(j,k)
+          endif
+          cpm=cp*(1.0+0.81*pqv(j,k))
+          alh=3.1484e6-2.37e3*tz(j,k)
+          tz(j,k)=tz(j,k)-(xls-alh)*pqi(j,k)/cpm
+          pqi(j,k)=epsl
+        endif
+      end do
+      end do
+
+      do k=2,km
+      do j=1,lq
+        k_h(j,k)=akh(j,k)*doz(j,k-1)
+        k_m(j,k)=akm(j,k)*doz(j,k-1)
+      end do
+      end do
+
+      do j=1,lq
+        k_h(j,1)=0.
+        k_m(j,1)=0.
+        k_m(j,km+1)= 0. !c2*pek(j,km)*pek(j,km)/pep(j,km) ! we don't need it
+        k_h(j,km+1)= 0. !dum2(j,km)*k_m(j,km+1)           ! we don't need it
+      end do
+
+   end subroutine eeps2d
+
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!
+! ==================================================================
+   subroutine tridiag(a,b,c,d,lq,km)
+!! to solve system of linear eqs on tridiagonal matrix n times n
+!! after Peaceman and Rachford, 1955
+!! a,b,c,d - are vectors of order n 
+!! a,b,c - are coefficients on the LHS
+!! d - is initially RHS on the output becomes a solution vector
+
+!-------------------------------------------------------------------
+    implicit none
+    INTEGER, INTENT(in):: lq,km
+    REAL, DIMENSION(lq,km), INTENT(in) :: a,b
+    REAL, DIMENSION(lq,km), INTENT(inout) :: c,d
+
+    INTEGER :: j,k
+    REAL :: p
+    REAL, DIMENSION(lq,km) :: q
+
+    do j=1,lq
+      c(j,1)=0.
+      q(j,km)=-c(j,km)/b(j,km)
+      d(j,km)=d(j,km)/b(j,km)
+    end do
+
+    DO k=km-1,1,-1
+    do j=1,lq
+       p=1./(b(j,k)+a(j,k)*q(j,k+1))
+       q(j,k)=-c(j,k)*p
+       d(j,k)=(d(j,k)-a(j,k)*d(j,k+1))*p
+    end do
+    ENDDO
+
+    DO k=2,km
+    do j=1,lq
+       d(j,k)=d(j,k)+q(j,k)*d(j,k-1)
+    end do
+    ENDDO
+
+   end subroutine tridiag
+
+!-------------------------------------------------------------------------------
+   subroutine eepsinit(rublten,rvblten,rthblten,rqvblten,                       &
+                      rqcblten,rqiblten,p_qi,p_first_scalar,pek,pep,            &
+                      restart, allowed_to_read,                                &
+                      ids, ide, jds, jde, kds, kde,                            &
+                      ims, ime, jms, jme, kms, kme,                            &
+                      its, ite, jts, jte, kts, kte                 )
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!
+   logical , intent(in)          :: restart, allowed_to_read
+   integer , intent(in)          ::  ids, ide, jds, jde, kds, kde,             &
+                                     ims, ime, jms, jme, kms, kme,             &
+                                     its, ite, jts, jte, kts, kte
+   integer , intent(in)          ::  p_qi,p_first_scalar
+   real , dimension( ims:ime , kms:kme , jms:jme ), intent(out) ::             &
+                                                                      rublten, &
+                                                                      rvblten, &
+                                                                     rthblten, &
+                                                                     rqvblten, &
+                                                                     rqcblten, &
+                                                                     rqiblten
+   real, dimension( ims:ime, kms:kme, jms:jme ),intent(out)   ::     pek, pep
+   integer :: i, j, k, itf, jtf, ktf
+!
+   jtf = min0(jte,jde-1)
+   ktf = min0(kte,kde-1)
+   itf = min0(ite,ide-1)
+!
+   if(.not.restart)then
+     do j = jts,jtf
+       do k = kts,ktf
+         do i = its,itf
+            rublten(i,k,j) = 0.
+            rvblten(i,k,j) = 0.
+            rthblten(i,k,j) = 0.
+            rqvblten(i,k,j) = 0.
+            rqcblten(i,k,j) = 0.
+            pek(i,k,j) = minpek
+            pep(i,k,j) = minpep
+         enddo
+       enddo
+     enddo
+   endif
+!
+   if (p_qi .ge. p_first_scalar .and. .not.restart) then
+     do j = jts,jtf
+       do k = kts,ktf
+         do i = its,itf
+           rqiblten(i,k,j) = 0.
+         enddo
+       enddo
+     enddo
+   endif
+!
+   end subroutine eepsinit
+!-------------------------------------------------------------------------------  
+end module module_bl_eeps

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -474,10 +474,10 @@ CONTAINS
                                                       wsedl3d
 
 !For EEPS PBL scheme
-    REAL,       DIMENSION( ims:ime, kms:kme, jms:jme ),            &
+    REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ),            &
                INTENT(INOUT   )    ::                        pep
     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ),        &
-               INTENT(INOUT) :: pek_adv,pep_adv
+               INTENT(INOUT) ::                  pek_adv,pep_adv
 
 !2D Variables required by camuwpbl scheme
     REAL,       DIMENSION( ims:ime , jms:jme ),                   &
@@ -1847,6 +1847,7 @@ CONTAINS
                    PRESENT( qi_curr )                            .AND. &
                    PRESENT( rqvblten ) .AND. PRESENT( rqcblten ) .AND. &
                    PRESENT( rqiblten )                           .AND. &
+                   PRESENT( pep )                                .AND. &
                    PRESENT( pek_adv )  .AND. PRESENT( pep_adv ) ) THEN
 
                 CALL wrf_debug(100,'in EEPSPBL')

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -57,6 +57,8 @@ CONTAINS
                  ,vdfg                                             &
                  ,nupdraft,maxMF,ktop_plume                        &
                  ,spp_pbl,pattern_spp_pbl                          &
+              ! EEPS
+                 ,pep,pek_adv,pep_adv                              &
                  ,restart,cycling                                  &
 #if (NMM_CORE==1)
                  ,DISHEAT                                          &
@@ -144,7 +146,7 @@ CONTAINS
                    QNSEPBLSCHEME,MYNNPBLSCHEME2,MYNNPBLSCHEME3,BOULACSCHEME,&
                    CAMUWPBLSCHEME,BEPSCHEME,BEP_BEMSCHEME,MYJSFCSCHEME, &
                    FITCHSCHEME,SHINHONGSCHEME,                       &
-                   TEMFPBLSCHEME,GBMPBLSCHEME,                       &
+                   TEMFPBLSCHEME,GBMPBLSCHEME,EEPSSCHEME,                  &
                    CAMMGMPSCHEME,p_qi,p_qni,p_qnc,param_first_scalar,& !CAMMGMPSCHEME, p_qni,p_qnc is used for camuwpbl scheme
                    p_qnwfa,p_qnifa
 #if ( WRFPLUS == 1 )
@@ -186,6 +188,7 @@ CONTAINS
    USE module_bl_gbmpbl
 #if (EM_CORE==1)
    USE module_bl_mynn
+   USE module_bl_eeps
    USE module_bl_fogdes
    USE module_wind_fitch
 #endif
@@ -470,6 +473,11 @@ CONTAINS
                                                       rthratenlw, &
                                                       wsedl3d
 
+!For EEPS PBL scheme
+    REAL,       DIMENSION( ims:ime, kms:kme, jms:jme ),            &
+               INTENT(INOUT   )    ::                        pep
+    REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ),        &
+               INTENT(INOUT) :: pek_adv,pep_adv
 
 !2D Variables required by camuwpbl scheme
     REAL,       DIMENSION( ims:ime , jms:jme ),                   &
@@ -1831,6 +1839,51 @@ CONTAINS
                 enddo
                 enddo
               ENDIF
+           ENDIF
+
+        CASE (EEPSSCHEME)
+
+              IF ( PRESENT( qv_curr )  .AND. PRESENT( qc_curr )  .AND. &
+                   PRESENT( qi_curr )                            .AND. &
+                   PRESENT( rqvblten ) .AND. PRESENT( rqcblten ) .AND. &
+                   PRESENT( rqiblten )                           .AND. &
+                   PRESENT( pek_adv )  .AND. PRESENT( pep_adv ) ) THEN
+
+                CALL wrf_debug(100,'in EEPSPBL')
+
+                CALL  eeps(&
+                   U3D=u_phytmp,V3D=v_phytmp,T3D=t_phy                  &
+                  ,QV3D=qv_curr,QC3D=qc_curr,QI3D=qi_curr               &
+                  ,QR3D=qr_curr,QS3D=qs_curr,QG3D=qg_curr               &
+                  ,P3D=p_phy,PI3D=pi_phy,PEK=tke_pbl,PEP=pep            &
+                  ,RUBLTEN=rublten,RVBLTEN=rvblten                      &
+                  ,RTHBLTEN=rthblten,RQVBLTEN=rqvblten                  &
+                  ,RQCBLTEN=rqcblten,RQIBLTEN=rqiblten,KPBL=kpbl        &
+                  ,DZ8W=dz8w,PSFC=psfc,TSK=tsk,QSFC=qsfc,WSPD=wspd      &
+                  ,UST=ust,XLAND=xland,HFX=hfx,QFX=qfx,RMOL=rmol        &
+                  ,DT=dtbl,DX=dx,EXCH_H=exch_h,EXCH_M=exch_m,PBLH=pblh  &
+                  ,ITIMESTEP=itimestep,PEK_ADV=pek_adv,PEP_ADV=pep_adv   &
+                   ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde      &
+                   ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme      &
+                   ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte      &
+                   )
+              ELSE
+               WRITE ( message , FMT = '(A,6(L1,1X))' )             &
+                 'present: '//                                      &
+                 'qv_curr, '//                                      &
+                 'qc_curr, '//                                      &
+                 'qi_curr, '//                                      &
+                 'rqvblten, '//                                     &
+                 'rqcblten, '//                                     &
+                 'rqiblten, ' ,                                     &
+                  PRESENT( qv_curr ) ,                              &
+                  PRESENT( qc_curr ) ,                              &
+                  PRESENT( qi_curr ) ,                              &
+                  PRESENT( rqvblten ) ,                             &
+                  PRESENT( rqcblten ) ,                             &
+                  PRESENT( rqiblten )
+               CALL wrf_debug(0,message)
+               CALL wrf_error_fatal('Lack arguments to call EEPS pbl')
            ENDIF
 
         CASE (BOULACSCHEME)

--- a/phys/module_physics_addtendc.F
+++ b/phys/module_physics_addtendc.F
@@ -732,6 +732,60 @@ SUBROUTINE phy_bl_ten(config_flags,rk_step,n_moist,n_scalar,     &
 
        ENDIF
 
+       CASE (EEPSSCHEME)
+
+           CALL add_a2a(rt_tendf,RTHBLTEN,config_flags,          &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+
+           CALL add_a2c_u(ru_tendf,RUBLTEN,config_flags,         &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+
+           CALL add_a2c_v(rv_tendf,RVBLTEN,config_flags,         &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+
+        if (P_QV .ge. PARAM_FIRST_SCALAR)&
+           CALL add_a2a(moist_tendf(ims,kms,jms,P_QV),RQVBLTEN,  &
+                config_flags,                                    &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+
+        if (P_QC .ge. PARAM_FIRST_SCALAR)&
+           CALL add_a2a(moist_tendf(ims,kms,jms,P_QC),RQCBLTEN,  &
+                config_flags,                                    &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+
+        if (P_QI .ge. PARAM_FIRST_SCALAR)&
+           CALL add_a2a(moist_tendf(ims,kms,jms,P_QI),RQIBLTEN,  &
+                config_flags,                                    &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+       IF(.not. adv_moist_cond)THEN
+
+        if (P_QT .ge. PARAM_FIRST_SCALAR)&
+           CALL add_a2a(scalar_tendf(ims,kms,jms,P_QT),RQCBLTEN,  &
+                config_flags,                                    &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+
+        if (P_QT .ge. PARAM_FIRST_SCALAR)&
+           CALL add_a2a(scalar_tendf(ims,kms,jms,P_QT),RQIBLTEN,  &
+                config_flags,                                    &
+                ids,ide, jds, jde, kds, kde,                     &
+                ims, ime, jms, jme, kms, kme,                    &
+                its, ite, jts, jte, kts, kte                     )
+       ENDIF
+
        CASE (BOULACSCHEME)
 
            CALL add_a2a(rt_tendf,RTHBLTEN,config_flags,          &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -67,7 +67,6 @@ CONTAINS
                          levsiz, n_ozmixm, n_aerosolc, paerlev,  &
                          alevsiz, no_src_types,                  &
                          TMN,XLAND,ZNT,Z0,UST,MOL,PBLH,TKE_PBL,  &
-                         pep,                                    & ! EEPS
                          EXCH_H,THC,SNOWC,MAVAIL,HFX,QFX,RAINBL, &
                          TSLB,ZS,DZS,num_soil_layers,warm_rain,  &
                          adv_moist_cond,is_CAMMGMP_used,         &
@@ -239,6 +238,7 @@ CONTAINS
                          ,xtime1, PBLHAVG, TKEAVG               &
                          ,ccn_conc                             & ! RAS
                          ,QKE                                  & !for MYNN
+                         ,pep                                  & ! EEPS
                          ,landusef,landusef2,mosaic_cat_index                                                 & ! danli mosaic
                          ,TSK_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic                                     & ! danli mosaic
                          ,CANWAT_mosaic,SNOW_mosaic,SNOWH_mosaic,SNOWC_mosaic                                 & ! danli mosaic
@@ -452,8 +452,8 @@ CONTAINS
    REAL,     DIMENSION(1:num_soil_layers),      INTENT(INOUT) :: ZS,DZS
 
   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) ::    & !BSINGH(PNNL)- should be declared inout
-             RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,RQIBLTEN,EXCH_H,TKE_PBL,pep
-  REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT), OPTIONAL :: QKE
+             RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,RQIBLTEN,EXCH_H,TKE_PBL
+  REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT), OPTIONAL :: QKE,pep
 
   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT), OPTIONAL :: &
                                             massflux_EDKF, entr_EDKF, detr_EDKF & 
@@ -2603,9 +2603,9 @@ CONTAINS
                                                           RQVBLTEN, &
                                                           RQCBLTEN, &
                                                           RQIBLTEN, &
-                                                          TKE_PBL,  &
-                                                          pep
-   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT), OPTIONAL :: QKE
+                                                          TKE_PBL
+
+   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT), OPTIONAL :: QKE, pep
 
    REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT), OPTIONAL :: &
                               massflux_EDKF, entr_EDKF, detr_EDKF & 
@@ -3613,13 +3613,12 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
                 CALL wrf_error_fatal ( 'arguments not present for calling TEMF scheme' )
          ENDIF
 
-#endif
-
       CASE (EEPSSCHEME)
            IF(isfc .ne. 1 .and. isfc .ne. 2 .and. isfc .ne. 5 ) CALL wrf_error_fatal &
                 ( 'module_physics_init: use mynnsfc or sfclay or myjsfc schemefor this pbl option')
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
             ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+          IF ( PRESENT( pep ) ) THEN
            CALL eepsinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
                         RQCBLTEN,RQIBLTEN,P_QI,               &
                         PARAM_FIRST_SCALAR,TKE_PBL,pep,       &
@@ -3628,7 +3627,11 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
                         ids, ide, jds, jde, kds, kde,         &
                         ims, ime, jms, jme, kms, kme,         &
                         its, ite, jts, jte, kts, kte          )
+          ELSE
+            CALL wrf_error_fatal ( 'arguments not present for calling EEPS scheme' )
+         ENDIF
 
+#endif
 
       CASE (GBMPBLSCHEME) 
            if(isfc .ne. 1)CALL wrf_error_fatal &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -67,6 +67,7 @@ CONTAINS
                          levsiz, n_ozmixm, n_aerosolc, paerlev,  &
                          alevsiz, no_src_types,                  &
                          TMN,XLAND,ZNT,Z0,UST,MOL,PBLH,TKE_PBL,  &
+                         pep,                                    & ! EEPS
                          EXCH_H,THC,SNOWC,MAVAIL,HFX,QFX,RAINBL, &
                          TSLB,ZS,DZS,num_soil_layers,warm_rain,  &
                          adv_moist_cond,is_CAMMGMP_used,         &
@@ -451,7 +452,7 @@ CONTAINS
    REAL,     DIMENSION(1:num_soil_layers),      INTENT(INOUT) :: ZS,DZS
 
   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) ::    & !BSINGH(PNNL)- should be declared inout
-             RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,RQIBLTEN,EXCH_H,TKE_PBL
+             RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,RQIBLTEN,EXCH_H,TKE_PBL,pep
   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT), OPTIONAL :: QKE
 
   REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT), OPTIONAL :: &
@@ -1320,7 +1321,7 @@ CONTAINS
    CALL bl_init(STEPBL,BLDT,DT,RUBLTEN,RVBLTEN,RTHBLTEN,        &
                 RQVBLTEN,RQCBLTEN,RQIBLTEN,TSK,TMN,             &
                 config_flags,restart,UST,LOWLYR,TSLB,ZS,DZS,    &
-                num_soil_layers,TKE_PBL,mfshconv,               &
+                num_soil_layers,TKE_PBL,mfshconv,pep,           &
                 massflux_EDKF, entr_EDKF, detr_EDKF, & 
                 thl_up, thv_up, rt_up,       &
                 rv_up, rc_up, u_up, v_up,    &
@@ -2330,7 +2331,7 @@ CONTAINS
    SUBROUTINE bl_init(STEPBL,BLDT,DT,RUBLTEN,RVBLTEN,RTHBLTEN,  &
                 RQVBLTEN,RQCBLTEN,RQIBLTEN,TSK,TMN,             &
                 config_flags,restart,UST,LOWLYR,TSLB,ZS,DZS,    &
-                num_soil_layers,TKE_PBL,mfshconv,               &
+                num_soil_layers,TKE_PBL,mfshconv,pep,           &
                 massflux_EDKF, entr_EDKF, detr_EDKF, & 
                 thl_up, thv_up, rt_up,       &
                 rv_up, rc_up, u_up, v_up,    &
@@ -2517,6 +2518,7 @@ CONTAINS
    USE module_bl_gbmpbl
 #if ( EM_CORE == 1 )
    USE module_bl_mynn
+   USE module_bl_eeps
    USE module_bl_temf
 #if ( WRFPLUS == 1 )
    USE module_bl_surface_drag
@@ -2601,7 +2603,8 @@ CONTAINS
                                                           RQVBLTEN, &
                                                           RQCBLTEN, &
                                                           RQIBLTEN, &
-                                                          TKE_PBL
+                                                          TKE_PBL,  &
+                                                          pep
    REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT), OPTIONAL :: QKE
 
    REAL,     DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(OUT), OPTIONAL :: &
@@ -3611,6 +3614,21 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
          ENDIF
 
 #endif
+
+      CASE (EEPSSCHEME)
+           IF(isfc .ne. 1 .and. isfc .ne. 2 .and. isfc .ne. 5 ) CALL wrf_error_fatal &
+                ( 'module_physics_init: use mynnsfc or sfclay or myjsfc schemefor this pbl option')
+           IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
+            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+           CALL eepsinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
+                        RQCBLTEN,RQIBLTEN,P_QI,               &
+                        PARAM_FIRST_SCALAR,TKE_PBL,pep,       &
+                        restart,                              &
+                        allowed_to_read ,                     &
+                        ids, ide, jds, jde, kds, kde,         &
+                        ims, ime, jms, jme, kms, kme,         &
+                        its, ite, jts, jte, kts, kte          )
+
 
       CASE (GBMPBLSCHEME) 
            if(isfc .ne. 1)CALL wrf_error_fatal &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -3614,7 +3614,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
          ENDIF
 
       CASE (EEPSSCHEME)
-           IF(isfc .ne. 1 .and. isfc .ne. 2 .and. isfc .ne. 5 ) CALL wrf_error_fatal &
+           IF(isfc .ne. 1 .and. isfc .ne. 2 .and. isfc .ne. 5 .and. isfc .ne. 91) CALL wrf_error_fatal &
                 ( 'module_physics_init: use mynnsfc or sfclay or myjsfc schemefor this pbl option')
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
             ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -730,6 +730,8 @@ Namelist variables for controlling the adaptive time step option:
                                           sf_sfclay_physics=10
                                      = 11, Shin-Hong 'scale-aware' PBL scheme
                                      = 12, Grenier-Bretherton-McCaa scheme (ARW only)
+                                     = 16, TKE+TKE dissipation rate (epsilon) scheme (ARW only)
+                                           works with surface layer options 1,91,2,5.
                                      = 93, 2015 GFS scheme (NMM only)
                                      = 99, MRF scheme
 


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: E-epsilon, EEPS, TKE, PBL 

SOURCE: Chunxi Zhang: 1: (past) International Pacific Research Center, University of Hawai‘i at Mānoa
                                          2: (past) Center for Analysis and Prediction of Storms, University of Oklahoma
                                          3: (current) I. M. System Group, Inc. (IMSG); NOAA/EMC
                 Yuqing Wang   International Pacific Research Center, and Department of Atmospheric Sciences, University of Hawai‘i at Mānoa

DESCRIPTION OF CHANGES:
1) the file module_bl_eepsilon.F includes the module for this scheme
2) standard procedures for a new scheme in WRF: changed init, addtendc and driver
3) three more variables are declared in registry.EM_COMMON. e.g.,
   pep_pbl (TKE dissipation rate, state)
   pek_adv (TKE advection,        scalar)
   pep_adv (PEP advection,        scalar)
   the files module_first_rd_step_part1.F and start_em.F are revised accordingly
   this scheme is denfied as eepsscheme bl_pbl_physics == 16
4) add module_bl_eepsilon in Makefile

LIST OF MODIFIED FILES:
phys/module_bl_eepsilon.F
phys/module_pbl_driver.F
phys/module_physics_init.F
phys/module_physics_addtendc.F
phys/Makefile
Registry/Registry.EM_COMM
dyn_em/module_first_rk_step_part1.F
dyn_em/start_em.F
run/README.namelist

TESTS CONDUCTED: 
1. Automated jenkins testing is all PASS.
2. The performances of the newly implemented EEPS scheme and the existing Yonsei University (YSU) scheme, the University of Washington (UW) scheme, and Mellor–Yamada–Nakanishi–Niino (MYNN) scheme are evaluated over the stratocumulus dominated southeast Pacific (SEP) and over the Southern Great Plains (SGP) where strong PBL diurnal variation is common. The simulations by these PBL parameterizations are compared with various observations from two field campaigns: the Variability of American Monsoon Systems Project (VAMOS) Ocean–Cloud–Atmosphere–Land Study (VOCALS) in 2008 over the SEP and the Land–Atmosphere Feedback Experiment (LAFE) in 2017 over the SGP. Results show that the EEPS and YSU schemes perform comparably over both regions, while the MYNN scheme performs differently in many aspects, especially over the SEP. The EEPS (MYNN) scheme slightly (significantly) underestimates liquid water path over the SEP. Compared with observations, the UW scheme produces the best PBL height over the SEP. The MYNN produces too high PBL height over the western part of the SEP while both the YSU and EEPS schemes produce too low PBL and cloud-top heights. The differences among the PBL schemes in simulating the PBL features over the SGP are relatively small.
3. See published paper:
Zhang, C., Y. Wang, and M. Xue, 2020: Evaluation of an E–ε and Three Other Boundary Layer Parameterization Schemes in the WRF Model over the Southeast Pacific and the Southern Great Plains. Mon. Wea. Rev., 148, 1121–1145, https://doi.org/10.1175/MWR-D-19-0084.1.

RELEASE NOTE: The turbulence kinetic energy (TKE) and TKE dissipation rate (ε) based 1.5-order closure PBL parameterization (E–ε, EEPS) in the Weather Research and Forecasting (WRF) Model (Zhang et al. 2020, MWR). Works with surface layer options, 1, 91, 2 and 5.
