### PR TITLE
Add multilayer UCMs to YSU PBL parameterization 

### DIFF
--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -29,6 +29,13 @@ contains
                   uoce,voce,                                                   &
                   rthraten,ysu_topdown_pblmix,                                 &
                   ctopo,ctopo2,                                                &
+                  IDIFF,FLAG_BEP,FRC_URB2D,                                    &
+                  A_U_BEP,A_V_BEP,A_T_BEP,                                     &
+                  A_Q_BEP,                                                     &
+                  A_E_BEP,B_U_BEP,B_V_BEP,                                     &
+                  B_T_BEP,B_Q_BEP,                                             &
+                  B_E_BEP,DLG_BEP,                                             &
+                  DL_U_BEP,SF_BEP,VL_BEP,                                      &
                   ids,ide, jds,jde, kds,kde,                                   &
                   ims,ime, jms,jme, kms,kme,                                   &
                   its,ite, jts,jte, kts,kte,                                   &
@@ -108,6 +115,23 @@ contains
 !-- jte         end index for j in tile
 !-- kts         start index for k in tile
 !-- kte         end index for k in tile
+!-- IDIFF       BEP/BEM+BEM diffusion flag
+!-- FLAG_BEP    FLAG TO USE BEP AND BEP+BEM
+!-- FRC_URB2D   urban fraction (not currently used)
+!-- A_U_BEP     BEP/BEP+BEM implicit component u-mom
+!-- A_V_BEP     BEP/BEP+BEM implicit component v-mom
+!-- A_T_BEP     BEP/BEP+BEM implicit component pot. temp.
+!-- A_Q_BEP     BEP/BEP+BEM implicit component vapor mixing ratio
+!-- A_E_BEP     BEP/BEP+BEM implicit component TKE
+!-- B_U_BEP     BEP/BEP+BEM explicit component u-mom
+!-- B_V_BEP     BEP/BEP+BEM explicit component v-mom
+!-- B_T_BEP     BEP/BEP+BEM explicit component pot.temp.
+!-- B_Q_BEP     BEP/BEP+BEM explicit component vapor mixing ratio
+!-- B_E_BEP     BEP/BEP+BEM explicit component TKE
+!-- DLG_BEP     Height above ground Martilli et al. (2002) Eq. 24
+!-- DL_U_BEP    modified length scale Martilli et al. (2002) Eq. 22
+!-- SF_BEP      fraction of vertical surface not occupied by buildings
+!-- VL_BEP      volume fraction of grid cell not occupied by buildings
 !-------------------------------------------------------------------------------
 !
    integer,parameter ::  ndiff = 3
@@ -180,6 +204,17 @@ contains
    integer,  dimension( ims:ime, jms:jme )                                   , &
              intent(out  )   ::                                        kpbl2d
    logical,  intent(in)      ::                                       flag_qi
+   integer, intent(in) :: IDIFF
+   logical, intent(in) ::     FLAG_BEP
+   real,dimension(ims:ime,kms:kme,jms:jme),intent(in) :: A_U_BEP    &
+                                              ,A_V_BEP,A_T_BEP         &
+                                             ,A_E_BEP,B_U_BEP         &
+                                             ,A_Q_BEP,B_Q_BEP         &
+                                             ,B_V_BEP,B_T_BEP         &
+                                             ,B_E_BEP,DLG_BEP         &
+                                             ,DL_U_BEP                &
+                                             ,VL_BEP,SF_BEP
+   real, dimension(ims:ime,jms:jme),intent(in) :: FRC_URB2D
 !
 !optional
 !
@@ -206,10 +241,29 @@ contains
                                                                         dvsfc, &
                                                                         dtsfc, &
                                                                         dqsfc
-
+   real,dimension(ims:ime,kms:kme,jms:jme) :: A_U,A_V,A_T,A_E,B_U,B_V,B_T,B_E
+   real,dimension(ims:ime,kms:kme,jms:jme) :: A_Q,B_Q,DLG,DL_U,B_E_FACE,DZ_KFLIP
+   real,dimension(ims:ime,kms:kme,jms:jme) :: SFK, VLK
+   real :: bepswitch ! 0 if not using bep or bep+bem, 1 if using
 !
    qv2d(its:ite,:) = 0.0
 !
+   bepswitch = 0.0
+   A_U(:,:,:)=0.0
+   A_V(:,:,:)=0.0
+   A_T(:,:,:)=0.0
+   A_Q(:,:,:)=0.0
+   A_E(:,:,:)=0.0
+   B_U(:,:,:)=0.0
+   B_V(:,:,:)=0.0
+   B_T(:,:,:)=0.0
+   B_Q(:,:,:)=0.0
+   B_E(:,:,:)=0.0
+   SFK(:,:,:)=1.0
+   VLK(:,:,:)=1.0
+   DL_U(:,:,:)=0.0
+   DLG(:,:,:)=0.0
+
    do j = jts,jte
       do k = kts,kte+1
         do i = its,ite
@@ -225,6 +279,28 @@ contains
           if(flag_qi) qv2d(i,k+kte+kte) = qi3d(i,k,j)
         enddo
       enddo
+
+      if(flag_bep) then
+        bepswitch=1.0
+        do k=kts,kte
+          do i=its,ite
+            A_U(i,k,j)=A_U_BEP(i,k,j)
+            A_V(i,k,j)=A_V_BEP(i,k,j)
+            A_T(i,k,j)=A_T_BEP(i,k,j)
+            A_Q(i,k,j)=A_Q_BEP(i,k,j)
+            A_E(i,k,j)=A_E_BEP(i,k,j)
+            B_U(i,k,j)=B_U_BEP(i,k,j)
+            B_V(i,k,j)=B_V_BEP(i,k,j)
+            B_T(i,k,j)=B_T_BEP(i,k,j)
+            B_Q(i,k,j)=B_Q_BEP(i,k,j)
+            B_E(i,k,j)=B_E_BEP(i,k,j)
+            SFK(i,k,j)=SF_BEP(i,k,j)
+            VLK(i,k,j)=VL_BEP(i,k,j)
+            DL_U(i,k,j)=DL_U_BEP(i,k,j)
+            DLG(i,k,j)=DLG_BEP(i,k,j)
+          enddo
+        enddo
+      endif
 !
       call ysu2d(J=j,ux=u3d(ims,kms,j),vx=v3d(ims,kms,j)                       &
               ,tx=t3d(ims,kms,j)                                               &
@@ -254,6 +330,14 @@ contains
               ,rthraten=rthraten(ims,kms,j),p2diORG=p3di(ims,kms,j)            &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo(ims,j),ctopo2=ctopo2(ims,j)                         &
+              ,a_u2d=A_U(ims,kms,j), a_v2d=A_V(ims,kms,j)                      &
+              ,a_t2d=A_T(ims,kms,j), a_q2d=A_Q(ims,kms,j)                      &
+              ,b_u2d=B_U(ims,kms,j), b_v2d=B_V(ims,kms,j)                      &
+              ,b_t2d=B_T(ims,kms,j), b_q2d=B_Q(ims,kms,j)                      &
+              ,b_e2d=B_E(ims,kms,j), a_e2d=A_E(ims,kms,j)                      &
+              ,sfk2d=SFK(ims,kms,j), vlk2d=VLK(ims,kms,j)                      &
+              ,dlu2d=DL_U(ims,kms,j), dlg2d=DLG(ims,kms,j)                     &
+              ,frc_urb1d=FRC_URB2D(ims,j), bepswitch=bepswitch                 &
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
               ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &
               ,its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
@@ -288,6 +372,11 @@ contains
                   rthraten,p2diORG,                                            &
                   ysu_topdown_pblmix,                                          &
                   ctopo,ctopo2,                                                &
+                  a_u2d, a_v2d, a_t2d, a_q2d,                                  &
+                  b_u2d, b_v2d, b_t2d, b_q2d,                                  &
+                  b_e2d, a_e2d, sfk2d, vlk2d,                                  &
+                  dlu2d, dlg2d,                                                &
+                  frc_urb1d, bepswitch,                                        &
                   ids,ide, jds,jde, kds,kde,                                   &
                   ims,ime, jms,jme, kms,kme,                                   &
                   its,ite, jts,jte, kts,kte,                                   &
@@ -344,9 +433,11 @@ contains
 !              ==> kzo = 0.1 for momentum and = 0.01 for mass to account for
 !                  internal wave mixing of large et al. (1994), songyou hong, feb 2016
 !              ==> alleviate superious excessive mixing when delz is large
+!              add multilayer urban canopy models of BEP and BEP+BEM, jan 2021
 !
 !     references:
 !
+!        hendricks, knievel, and wang (2020), j. appl. meteor. clim.
 !        hong (2010) quart. j. roy. met. soc
 !        hong, noh, and dudhia (2006), mon. wea. rev.
 !        hong and pan (1996), mon. wea. rev.
@@ -432,6 +523,25 @@ contains
    real,     dimension( ims:ime )                                            , &
              optional                                                        , &
              intent(inout)   ::                                        regime
+ real,     dimension( ims:ime, kms:kme ),                                    &
+             intent(in)      ::                                         a_u2d, &
+                                                                        a_v2d, &
+                                                                        a_t2d, &
+                                                                        a_q2d, &
+                                                                        b_u2d, &
+                                                                        b_v2d, &
+                                                                        b_t2d, &
+                                                                        b_q2d, &
+                                                                        b_e2d, &
+                                                                        a_e2d, &
+                                                                        sfk2d, &
+                                                                        vlk2d, &
+                                                                        dlu2d, &
+                                                                        dlg2d
+
+  real,     dimension( ims:ime ),                                         &
+             intent(in)      ::                                     frc_urb1d
+  real ::                                                            bepswitch
 !
 ! local vars
 !
@@ -469,7 +579,8 @@ contains
                                                                          xkzq, &
                                                                          zfac, &
                                                                         rhox2, &
-                                                                       hgamt2
+                                                                       hgamt2, &
+                                                                     ad1, adm
 !
 !jdf added exch_hx
 !
@@ -1109,13 +1220,13 @@ contains
 !
    do i = its,ite
      ad(i,1) = 1.
-     f1(i,1) = thx(i,1)-300.+hfx(i)/cont/del(i,1)*dt2
+     f1(i,1) = thx(i,1)-300.+(1.0-bepswitch)*hfx(i)/cont/del(i,1)*dt2
    enddo
 !
    do k = kts,kte-1
      do i = its,ite
-       dtodsd = dt2/del(i,k)
-       dtodsu = dt2/del(i,k+1)
+       dtodsd = sfk2d(i,k)*dt2/del(i,k)
+       dtodsu = sfk2d(i,k)*dt2/del(i,k+1)
        dsig   = p2d(i,k)-p2d(i,k+1)
        rdz    = 1./dza(i,k+1)
        tem1   = dsig*xkzh(i,k)*rdz
@@ -1134,13 +1245,20 @@ contains
        endif
        tem1   = dsig*xkzh(i,k)*rdz
        dsdz2     = tem1*rdz
-       au(i,k)   = -dtodsd*dsdz2
-       al(i,k)   = -dtodsu*dsdz2
+       au(i,k)   = -dtodsd*dsdz2/vlk2d(i,k)
+       al(i,k)   = -dtodsu*dsdz2/vlk2d(i,k)
        ad(i,k)   = ad(i,k)-au(i,k)
        ad(i,k+1) = 1.-al(i,k)
        exch_hx(i,k+1) = xkzh(i,k)
      enddo
    enddo
+   do k = kts,kte
+     do i = its,ite
+      ad(i,k) = ad(i,k) - a_t2d(i,k)*dt2
+      f1(i,k) = f1(i,k) + b_t2d(i,k)*dt2
+     enddo
+   enddo
+
 !
 ! copies here to avoid duplicate input args for tridin
 !
@@ -1183,7 +1301,7 @@ contains
 !
    do i = its,ite
      ad(i,1) = 1.
-     f3(i,1,1) = qx(i,1)+qfx(i)*g/del(i,1)*dt2
+     f3(i,1,1) = qx(i,1)+(1.0-bepswitch)*qfx(i)*g/del(i,1)*dt2
    enddo
 !
    if(ndiff.ge.2) then
@@ -1205,8 +1323,8 @@ contains
 !
    do k = kts,kte-1
      do i = its,ite
-       dtodsd = dt2/del(i,k)
-       dtodsu = dt2/del(i,k+1)
+       dtodsd = sfk2d(i,k)*dt2/del(i,k)
+       dtodsu = sfk2d(i,k)*dt2/del(i,k+1)
        dsig   = p2d(i,k)-p2d(i,k+1)
        rdz    = 1./dza(i,k+1)
        tem1   = dsig*xkzq(i,k)*rdz
@@ -1225,8 +1343,8 @@ contains
        endif
        tem1   = dsig*xkzq(i,k)*rdz
        dsdz2     = tem1*rdz
-       au(i,k)   = -dtodsd*dsdz2
-       al(i,k)   = -dtodsu*dsdz2
+       au(i,k)   = -dtodsd*dsdz2/vlk2d(i,k)
+       al(i,k)   = -dtodsu*dsdz2/vlk2d(i,k)
        ad(i,k)   = ad(i,k)-au(i,k)
        ad(i,k+1) = 1.-al(i,k)
 !      exch_hx(i,k+1) = xkzh(i,k)
@@ -1243,6 +1361,13 @@ contains
        enddo
      enddo
    endif
+   do k = kts,kte
+     do i = its,ite
+      ad(i,k) = ad(i,k) - a_q2d(i,k)*dt2
+      f3(i,k,1) = f3(i,k,1) + b_q2d(i,k)*dt2
+     enddo
+   enddo
+
 !
 ! copies here to avoid duplicate input args for tridin
 !
@@ -1316,7 +1441,7 @@ contains
         rlamdz = 150.0
        endif
        el_ysu(i,k) = zk*rlamdz/(rlamdz+zk)
-       tke_ysu(i,k)=16.6*el_ysu(i,k)*(shear_ysu(i,k)-buoy_ysu(i,k))
+       tke_ysu(i,k)=16.6*el_ysu(i,k)*(shear_ysu(i,k)-buoy_ysu(i,k)+b_e2d(i,k))
  !q2 when q3 positive
        if(tke_ysu(i,k).le.0) then
         tke_ysu(i,k)=0.0
@@ -1348,18 +1473,21 @@ contains
       if(present(ctopo)) then
         vconvnew=0.9*vconvfx(i)+1.5*(max((pblh_ysu(i)-500)/1000.0,0.0))
         vconvlim = min(vconvnew,1.0)
-        ad(i,1) = 1.+fric(i,1)*vconvlim+ctopo(i)*fric(i,1)*(1-vconvlim)
+       ad(i,1) = 1.+(1.0-bepswitch*frc_urb1d(i))* &
+                     (fric(i,1)*vconvlim+ctopo(i)*fric(i,1)*(1-vconvlim)) - &
+                     fric(i,1)*bepswitch*(1-frc_urb1d(i))
       else
-       ad(i,1) = 1.+fric(i,1)
+       ad(i,1) = 1.+(1.0-bepswitch)*fric(i,1)
       endif
      f1(i,1) = ux(i,1)+uox(i)*ust(i)**2*rhox(i)*g/del(i,1)*dt2/wspd1(i)*(wspd1(i)/wspd(i))**2
      f2(i,1) = vx(i,1)+vox(i)*ust(i)**2*rhox(i)*g/del(i,1)*dt2/wspd1(i)*(wspd1(i)/wspd(i))**2
    enddo
+
 !
    do k = kts,kte-1
      do i = its,ite
-       dtodsd = dt2/del(i,k)
-       dtodsu = dt2/del(i,k+1)
+       dtodsd = sfk2d(i,k)*dt2/del(i,k)
+       dtodsu = sfk2d(i,k)*dt2/del(i,k+1)
        dsig   = p2d(i,k)-p2d(i,k+1)
        rdz    = 1./dza(i,k+1)
        tem1   = dsig*xkzm(i,k)*rdz
@@ -1383,13 +1511,26 @@ contains
        endif
        tem1   = dsig*xkzm(i,k)*rdz
        dsdz2     = tem1*rdz
-       au(i,k)   = -dtodsd*dsdz2
-       al(i,k)   = -dtodsu*dsdz2
+       au(i,k)   = -dtodsd*dsdz2/vlk2d(i,k)
+       al(i,k)   = -dtodsu*dsdz2/vlk2d(i,k)
        ad(i,k)   = ad(i,k)-au(i,k)
        ad(i,k+1) = 1.-al(i,k)
        exch_mx(i,k+1) = xkzm(i,k)
      enddo
    enddo
+  do k = kts,kte
+    do i = its,ite
+      ad1(i,k) = ad(i,k)
+    end do
+  end do
+  do k = kts,kte
+    do i = its,ite
+      ad(i,k) = ad(i,k) - a_u2d(i,k)*dt2
+      ad1(i,k) = ad1(i,k) - a_v2d(i,k)*dt2
+      f1(i,k) = f1(i,k) + b_u2d(i,k)*dt2
+      f2(i,k) = f2(i,k) + b_v2d(i,k)*dt2
+    enddo
+  enddo
 !
 ! copies here to avoid duplicate input args for tridin
 !
@@ -1403,7 +1544,7 @@ contains
 !
 !     solve tridiagonal problem for momentum
 !
-   call tridi1n(al,ad,cu,r1,r2,au,f1,f2,its,ite,kts,kte,1)
+    call tridi2n(al,ad,ad1,cu,r1,r2,au,f1,f2,its,ite,kts,kte,1)
 !
 !     recover tendencies of momentum
 !
@@ -1437,7 +1578,7 @@ contains
 !-------------------------------------------------------------------------------
 !
 !-------------------------------------------------------------------------------
-   subroutine tridi1n(cl,cm,cu,r1,r2,au,f1,f2,its,ite,kts,kte,nt)
+   subroutine tridi2n(cl,cm,cm1,cu,r1,r2,au,f1,f2,its,ite,kts,kte,nt)
 !-------------------------------------------------------------------------------
    implicit none
 !-------------------------------------------------------------------------------
@@ -1449,6 +1590,7 @@ contains
 !
    real, dimension( its:ite, kts:kte )                                       , &
          intent(in   )  ::                                                 cm, &
+                                                                          cm1, &
                                                                            r1
    real, dimension( its:ite, kts:kte,nt )                                    , &
          intent(in   )  ::                                                 r2
@@ -1476,11 +1618,11 @@ contains
 !
    do it = 1,nt
      do i = its,l
-       fk = 1./cm(i,1)
+       fk = 1./cm1(i,1)
        f2(i,1,it) = fk*r2(i,1,it)
      enddo
    enddo
-!
+
    do k = kts+1,n-1
      do i = its,l
        fk = 1./(cm(i,k)-cl(i,k)*au(i,k-1))
@@ -1492,7 +1634,7 @@ contains
    do it = 1,nt
      do k = kts+1,n-1
        do i = its,l
-         fk = 1./(cm(i,k)-cl(i,k)*au(i,k-1))
+         fk = 1./(cm1(i,k)-cl(i,k)*au(i,k-1))
          f2(i,k,it) = fk*(r2(i,k,it)-cl(i,k)*f2(i,k-1,it))
        enddo
      enddo
@@ -1505,7 +1647,7 @@ contains
 !
    do it = 1,nt
      do i = its,l
-       fk = 1./(cm(i,n)-cl(i,n)*au(i,n-1))
+       fk = 1./(cm1(i,n)-cl(i,n)*au(i,n-1))
        f2(i,n,it) = fk*(r2(i,n,it)-cl(i,n)*f2(i,n-1,it))
      enddo
    enddo
@@ -1524,7 +1666,7 @@ contains
      enddo
    enddo
 !
-   end subroutine tridi1n
+   end subroutine tridi2n
 !-------------------------------------------------------------------------------
 !
 !-------------------------------------------------------------------------------

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -29,13 +29,13 @@ contains
                   uoce,voce,                                                   &
                   rthraten,ysu_topdown_pblmix,                                 &
                   ctopo,ctopo2,                                                &
-                  IDIFF,FLAG_BEP,FRC_URB2D,                                    &
-                  A_U_BEP,A_V_BEP,A_T_BEP,                                     &
-                  A_Q_BEP,                                                     &
-                  A_E_BEP,B_U_BEP,B_V_BEP,                                     &
-                  B_T_BEP,B_Q_BEP,                                             &
-                  B_E_BEP,DLG_BEP,                                             &
-                  DL_U_BEP,SF_BEP,VL_BEP,                                      &
+                  idiff,flag_bep,frc_urb2d,                                    &
+                  a_u_bep,a_v_bep,a_t_bep,                                     &
+                  a_q_bep,                                                     &
+                  a_e_bep,b_u_bep,b_v_bep,                                     &
+                  b_t_bep,b_q_bep,                                             &
+                  b_e_bep,dlg_bep,                                             &
+                  dl_u_bep,sf_bep,vl_bep,                                      &
                   ids,ide, jds,jde, kds,kde,                                   &
                   ims,ime, jms,jme, kms,kme,                                   &
                   its,ite, jts,jte, kts,kte,                                   &
@@ -115,23 +115,23 @@ contains
 !-- jte         end index for j in tile
 !-- kts         start index for k in tile
 !-- kte         end index for k in tile
-!-- IDIFF       BEP/BEM+BEM diffusion flag
-!-- FLAG_BEP    FLAG TO USE BEP AND BEP+BEM
-!-- FRC_URB2D   urban fraction 
-!-- A_U_BEP     BEP/BEP+BEM implicit component u-mom
-!-- A_V_BEP     BEP/BEP+BEM implicit component v-mom
-!-- A_T_BEP     BEP/BEP+BEM implicit component pot. temp.
-!-- A_Q_BEP     BEP/BEP+BEM implicit component vapor mixing ratio
-!-- A_E_BEP     BEP/BEP+BEM implicit component TKE
-!-- B_U_BEP     BEP/BEP+BEM explicit component u-mom
-!-- B_V_BEP     BEP/BEP+BEM explicit component v-mom
-!-- B_T_BEP     BEP/BEP+BEM explicit component pot.temp.
-!-- B_Q_BEP     BEP/BEP+BEM explicit component vapor mixing ratio
-!-- B_E_BEP     BEP/BEP+BEM explicit component TKE
-!-- DLG_BEP     Height above ground Martilli et al. (2002) Eq. 24
-!-- DL_U_BEP    modified length scale Martilli et al. (2002) Eq. 22
-!-- SF_BEP      fraction of vertical surface not occupied by buildings
-!-- VL_BEP      volume fraction of grid cell not occupied by buildings
+!-- idiff       diff3d BEP/BEM+BEM diffusion flag 
+!-- flag_bep    flag to use BEP/BEP+BEM
+!-- frc_urb2d   urban fraction 
+!-- a_u_bep     BEP/BEP+BEM implicit component u-mom
+!-- a_v_bep     BEP/BEP+BEM implicit component v-mom
+!-- a_t_bep     BEP/BEP+BEM implicit component pot. temp.
+!-- a_q_bep     BEP/BEP+BEM implicit component vapor mixing ratio
+!-- a_e_bep     BEP/BEP+BEM implicit component TKE
+!-- b_u_bep     BEP/BEP+BEM explicit component u-mom
+!-- b_v_bep     BEP/BEP+BEM explicit component v-mom
+!-- b_t_bep     BEP/BEP+BEM explicit component pot.temp.
+!-- b_q_bep     BEP/BEP+BEM explicit component vapor mixing ratio
+!-- b_e_bep     BEP/BEP+BEM explicit component TKE
+!-- dlg_bep     Height above ground Martilli et al. (2002) Eq. 24
+!-- dl_u_bep    modified length scale Martilli et al. (2002) Eq. 22
+!-- sf_bep      fraction of vertical surface not occupied by buildings
+!-- vl_bep      volume fraction of grid cell not occupied by buildings
 !-------------------------------------------------------------------------------
 !
    integer,parameter ::  ndiff = 3
@@ -204,17 +204,17 @@ contains
    integer,  dimension( ims:ime, jms:jme )                                   , &
              intent(out  )   ::                                        kpbl2d
    logical,  intent(in)      ::                                       flag_qi
-   integer, intent(in) :: IDIFF
-   logical, intent(in) ::     FLAG_BEP
-   real,dimension(ims:ime,kms:kme,jms:jme),intent(in) :: A_U_BEP    &
-                                              ,A_V_BEP,A_T_BEP         &
-                                             ,A_E_BEP,B_U_BEP         &
-                                             ,A_Q_BEP,B_Q_BEP         &
-                                             ,B_V_BEP,B_T_BEP         &
-                                             ,B_E_BEP,DLG_BEP         &
-                                             ,DL_U_BEP                &
-                                             ,VL_BEP,SF_BEP
-   real, dimension(ims:ime,jms:jme),intent(in) :: FRC_URB2D
+   integer, intent(in) ::                                               idiff
+   logical, intent(in) ::                                            flag_bep
+   real,dimension(ims:ime,kms:kme,jms:jme),intent(in) ::              a_u_bep, &
+                                                              a_v_bep,a_t_bep, &
+                                                              a_e_bep,b_u_bep, &
+                                                              a_q_bep,b_q_bep, &
+                                                              b_v_bep,b_t_bep, &
+                                                              b_e_bep,dlg_bep, &
+                                                                     dl_u_bep, &
+                                                                vl_bep,sf_bep
+   real, dimension(ims:ime,jms:jme),intent(in) :: frc_urb2d
 !
 !optional
 !
@@ -241,29 +241,29 @@ contains
                                                                         dvsfc, &
                                                                         dtsfc, &
                                                                         dqsfc
-   real,dimension(ims:ime,kms:kme,jms:jme) :: A_U,A_V,A_T,A_E,B_U,B_V,B_T,B_E
-   real,dimension(ims:ime,kms:kme,jms:jme) :: A_Q,B_Q,DLG,DL_U,SFK,VLK
-   real,dimension(ims:ime,jms:jme)         :: FRCURB
+   real,dimension(ims:ime,kms:kme,jms:jme) :: a_u,a_v,a_t,a_e,b_u,b_v,b_t,b_e, &
+                                                     a_q,b_q,dlg,dl_u,sfk,vlk
+   real,dimension(ims:ime,jms:jme)         :: frcurb
    real :: bepswitch ! 0 if not using bep or bep+bem, 1 if using
 !
    qv2d(its:ite,:) = 0.0
 !
    bepswitch = 0.0
-   A_U(:,:,:)=0.0
-   A_V(:,:,:)=0.0
-   A_T(:,:,:)=0.0
-   A_Q(:,:,:)=0.0
-   A_E(:,:,:)=0.0
-   B_U(:,:,:)=0.0
-   B_V(:,:,:)=0.0
-   B_T(:,:,:)=0.0
-   B_Q(:,:,:)=0.0
-   B_E(:,:,:)=0.0
-   SFK(:,:,:)=1.0
-   VLK(:,:,:)=1.0
-   DL_U(:,:,:)=0.0
-   DLG(:,:,:)=0.0
-   FRCURB(:,:)=0.0   
+   a_u(:,:,:)=0.0
+   a_v(:,:,:)=0.0
+   a_t(:,:,:)=0.0
+   a_q(:,:,:)=0.0
+   a_e(:,:,:)=0.0
+   b_u(:,:,:)=0.0
+   b_v(:,:,:)=0.0
+   b_t(:,:,:)=0.0
+   b_q(:,:,:)=0.0
+   b_e(:,:,:)=0.0
+   sfk(:,:,:)=1.0
+   vlk(:,:,:)=1.0
+   dl_u(:,:,:)=0.0
+   dlg(:,:,:)=0.0
+   frcurb(:,:)=0.0   
 
    do j = jts,jte
       do k = kts,kte+1
@@ -285,21 +285,21 @@ contains
         bepswitch=1.0
         do k=kts,kte
           do i=its,ite
-            A_U(i,k,j)=A_U_BEP(i,k,j)
-            A_V(i,k,j)=A_V_BEP(i,k,j)
-            A_T(i,k,j)=A_T_BEP(i,k,j)
-            A_Q(i,k,j)=A_Q_BEP(i,k,j)
-            A_E(i,k,j)=A_E_BEP(i,k,j)
-            B_U(i,k,j)=B_U_BEP(i,k,j)
-            B_V(i,k,j)=B_V_BEP(i,k,j)
-            B_T(i,k,j)=B_T_BEP(i,k,j)
-            B_Q(i,k,j)=B_Q_BEP(i,k,j)
-            B_E(i,k,j)=B_E_BEP(i,k,j)
-            SFK(i,k,j)=SF_BEP(i,k,j)
-            VLK(i,k,j)=VL_BEP(i,k,j)
-            DL_U(i,k,j)=DL_U_BEP(i,k,j)
-            DLG(i,k,j)=DLG_BEP(i,k,j)
-            FRCURB(i,j)=FRC_URB2D(i,j)
+            a_u(i,k,j)=a_u_bep(i,k,j)
+            a_v(i,k,j)=a_v_bep(i,k,j)
+            a_t(i,k,j)=a_t_bep(i,k,j)
+            a_q(i,k,j)=a_q_bep(i,k,j)
+            a_e(i,k,j)=a_e_bep(i,k,j)
+            b_u(i,k,j)=b_u_bep(i,k,j)
+            b_v(i,k,j)=b_v_bep(i,k,j)
+            b_t(i,k,j)=b_t_bep(i,k,j)
+            b_q(i,k,j)=b_q_bep(i,k,j)
+            b_e(i,k,j)=b_e_bep(i,k,j)
+            sfk(i,k,j)=sf_bep(i,k,j)
+            vlk(i,k,j)=vl_bep(i,k,j)
+            dl_u(i,k,j)=dl_u_bep(i,k,j)
+            dlg(i,k,j)=dlg_bep(i,k,j)
+            frcurb(i,j)=frc_urb2d(i,j)
           enddo
         enddo
       endif
@@ -332,13 +332,13 @@ contains
               ,rthraten=rthraten(ims,kms,j),p2diORG=p3di(ims,kms,j)            &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo(ims,j),ctopo2=ctopo2(ims,j)                         &
-              ,a_u2d=A_U(ims,kms,j), a_v2d=A_V(ims,kms,j)                      &
-              ,a_t2d=A_T(ims,kms,j), a_q2d=A_Q(ims,kms,j)                      &
-              ,b_u2d=B_U(ims,kms,j), b_v2d=B_V(ims,kms,j)                      &
-              ,b_t2d=B_T(ims,kms,j), b_q2d=B_Q(ims,kms,j)                      &
-              ,b_e2d=B_E(ims,kms,j), a_e2d=A_E(ims,kms,j)                      &
-              ,sfk2d=SFK(ims,kms,j), vlk2d=VLK(ims,kms,j)                      &
-              ,dlu2d=DL_U(ims,kms,j), dlg2d=DLG(ims,kms,j)                     &
+              ,a_u2d=a_u(ims,kms,j), a_v2d=a_v(ims,kms,j)                      &
+              ,a_t2d=a_t(ims,kms,j), a_q2d=a_q(ims,kms,j)                      &
+              ,b_u2d=b_u(ims,kms,j), b_v2d=b_v(ims,kms,j)                      &
+              ,b_t2d=b_t(ims,kms,j), b_q2d=b_q(ims,kms,j)                      &
+              ,b_e2d=b_e(ims,kms,j), a_e2d=a_e(ims,kms,j)                      &
+              ,sfk2d=sfk(ims,kms,j), vlk2d=vlk(ims,kms,j)                      &
+              ,dlu2d=dl_u(ims,kms,j), dlg2d=dlg(ims,kms,j)                     &
               ,frc_urb1d=FRCURB(ims,j), bepswitch=bepswitch                    &
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
               ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -339,7 +339,7 @@ contains
               ,b_e2d=b_e(ims,kms,j), a_e2d=a_e(ims,kms,j)                      &
               ,sfk2d=sfk(ims,kms,j), vlk2d=vlk(ims,kms,j)                      &
               ,dlu2d=dl_u(ims,kms,j), dlg2d=dlg(ims,kms,j)                     &
-              ,frc_urb1d=FRCURB(ims,j), bepswitch=bepswitch                    &
+              ,frc_urb1d=frcurb(ims,j), bepswitch=bepswitch                    &
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
               ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &
               ,its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
@@ -525,7 +525,7 @@ contains
    real,     dimension( ims:ime )                                            , &
              optional                                                        , &
              intent(inout)   ::                                        regime
- real,     dimension( ims:ime, kms:kme ),                                    &
+ real,     dimension( ims:ime, kms:kme ),                                      &
              intent(in)      ::                                         a_u2d, &
                                                                         a_v2d, &
                                                                         a_t2d, &
@@ -541,8 +541,8 @@ contains
                                                                         dlu2d, &
                                                                         dlg2d
 
-  real,     dimension( ims:ime ),                                         &
-             intent(in)      ::                                     frc_urb1d
+  real,     dimension( ims:ime ),                                              &
+             intent(in)      ::                                      frc_urb1d
   real ::                                                            bepswitch
 !
 ! local vars

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -117,7 +117,7 @@ contains
 !-- kte         end index for k in tile
 !-- IDIFF       BEP/BEM+BEM diffusion flag
 !-- FLAG_BEP    FLAG TO USE BEP AND BEP+BEM
-!-- FRC_URB2D   urban fraction (not currently used)
+!-- FRC_URB2D   urban fraction 
 !-- A_U_BEP     BEP/BEP+BEM implicit component u-mom
 !-- A_V_BEP     BEP/BEP+BEM implicit component v-mom
 !-- A_T_BEP     BEP/BEP+BEM implicit component pot. temp.
@@ -242,8 +242,8 @@ contains
                                                                         dtsfc, &
                                                                         dqsfc
    real,dimension(ims:ime,kms:kme,jms:jme) :: A_U,A_V,A_T,A_E,B_U,B_V,B_T,B_E
-   real,dimension(ims:ime,kms:kme,jms:jme) :: A_Q,B_Q,DLG,DL_U,B_E_FACE,DZ_KFLIP
-   real,dimension(ims:ime,kms:kme,jms:jme) :: SFK, VLK
+   real,dimension(ims:ime,kms:kme,jms:jme) :: A_Q,B_Q,DLG,DL_U,SFK,VLK
+   real,dimension(ims:ime,jms:jme)         :: FRCURB
    real :: bepswitch ! 0 if not using bep or bep+bem, 1 if using
 !
    qv2d(its:ite,:) = 0.0
@@ -263,6 +263,7 @@ contains
    VLK(:,:,:)=1.0
    DL_U(:,:,:)=0.0
    DLG(:,:,:)=0.0
+   FRCURB(:,:)=0.0   
 
    do j = jts,jte
       do k = kts,kte+1
@@ -298,6 +299,7 @@ contains
             VLK(i,k,j)=VL_BEP(i,k,j)
             DL_U(i,k,j)=DL_U_BEP(i,k,j)
             DLG(i,k,j)=DLG_BEP(i,k,j)
+            FRCURB(i,j)=FRC_URB2D(i,j)
           enddo
         enddo
       endif
@@ -337,7 +339,7 @@ contains
               ,b_e2d=B_E(ims,kms,j), a_e2d=A_E(ims,kms,j)                      &
               ,sfk2d=SFK(ims,kms,j), vlk2d=VLK(ims,kms,j)                      &
               ,dlu2d=DL_U(ims,kms,j), dlg2d=DLG(ims,kms,j)                     &
-              ,frc_urb1d=FRC_URB2D(ims,j), bepswitch=bepswitch                 &
+              ,frc_urb1d=FRCURB(ims,j), bepswitch=bepswitch                    &
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
               ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &
               ,its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
@@ -1453,7 +1455,6 @@ contains
  !tke is q2
       CALL GET_PBLH(KTS,KTE,pblh_ysu(i),thvx(i,kts:kte),&
       &    tke_ysu(i,kts:kte),zq(i,kts:kte+1),dzq(i,kts:kte),xland(i))
-
 !--- end of paj tke
 ! compute vconv
 !      Use Beljaars over land
@@ -1482,7 +1483,6 @@ contains
      f1(i,1) = ux(i,1)+uox(i)*ust(i)**2*rhox(i)*g/del(i,1)*dt2/wspd1(i)*(wspd1(i)/wspd(i))**2
      f2(i,1) = vx(i,1)+vox(i)*ust(i)**2*rhox(i)*g/del(i,1)*dt2/wspd1(i)*(wspd1(i)/wspd(i))**2
    enddo
-
 !
    do k = kts,kte-1
      do i = its,ite
@@ -1518,19 +1518,19 @@ contains
        exch_mx(i,k+1) = xkzm(i,k)
      enddo
    enddo
-  do k = kts,kte
-    do i = its,ite
-      ad1(i,k) = ad(i,k)
-    end do
-  end do
-  do k = kts,kte
-    do i = its,ite
-      ad(i,k) = ad(i,k) - a_u2d(i,k)*dt2
-      ad1(i,k) = ad1(i,k) - a_v2d(i,k)*dt2
-      f1(i,k) = f1(i,k) + b_u2d(i,k)*dt2
-      f2(i,k) = f2(i,k) + b_v2d(i,k)*dt2
-    enddo
-  enddo
+   do k = kts,kte
+     do i = its,ite
+       ad1(i,k) = ad(i,k)
+     end do
+   end do
+   do k = kts,kte
+     do i = its,ite
+       ad(i,k) = ad(i,k) - a_u2d(i,k)*dt2
+       ad1(i,k) = ad1(i,k) - a_v2d(i,k)*dt2
+       f1(i,k) = f1(i,k) + b_u2d(i,k)*dt2
+       f2(i,k) = f2(i,k) + b_v2d(i,k)*dt2
+     enddo
+   enddo
 !
 ! copies here to avoid duplicate input args for tridin
 !

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -1254,13 +1254,15 @@ contains
        exch_hx(i,k+1) = xkzh(i,k)
      enddo
    enddo
+!
+! add bep/bep+bem forcing for heat if flag_bep=.true.
+!
    do k = kts,kte
      do i = its,ite
       ad(i,k) = ad(i,k) - a_t2d(i,k)*dt2
       f1(i,k) = f1(i,k) + b_t2d(i,k)*dt2
      enddo
    enddo
-
 !
 ! copies here to avoid duplicate input args for tridin
 !
@@ -1363,13 +1365,15 @@ contains
        enddo
      enddo
    endif
+!
+! add bep/bep+bem forcing for water vapor if flag_bep=.true.
+!
    do k = kts,kte
      do i = its,ite
       ad(i,k) = ad(i,k) - a_q2d(i,k)*dt2
       f3(i,k,1) = f3(i,k,1) + b_q2d(i,k)*dt2
      enddo
    enddo
-
 !
 ! copies here to avoid duplicate input args for tridin
 !
@@ -1518,6 +1522,9 @@ contains
        exch_mx(i,k+1) = xkzm(i,k)
      enddo
    enddo
+!
+! add bep/bep+bem forcing for momentum if flag_bep=.true.
+!
    do k = kts,kte
      do i = its,ite
        ad1(i,k) = ad(i,k)

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -241,9 +241,9 @@ contains
                                                                         dvsfc, &
                                                                         dtsfc, &
                                                                         dqsfc
-   real,dimension(ims:ime,kms:kme,jms:jme) :: a_u,a_v,a_t,a_e,b_u,b_v,b_t,b_e, &
+   real,dimension(its:ite,kts:kte,jts:jte) :: a_u,a_v,a_t,a_e,b_u,b_v,b_t,b_e, &
                                                      a_q,b_q,dlg,dl_u,sfk,vlk
-   real,dimension(ims:ime,jms:jme)         :: frcurb
+   real,dimension(its:ite,jts:jte)         :: frcurb
    real :: bepswitch ! 0 if not using bep or bep+bem, 1 if using
 !
    qv2d(its:ite,:) = 0.0
@@ -332,14 +332,14 @@ contains
               ,rthraten=rthraten(ims,kms,j),p2diORG=p3di(ims,kms,j)            &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo(ims,j),ctopo2=ctopo2(ims,j)                         &
-              ,a_u2d=a_u(ims,kms,j), a_v2d=a_v(ims,kms,j)                      &
-              ,a_t2d=a_t(ims,kms,j), a_q2d=a_q(ims,kms,j)                      &
-              ,b_u2d=b_u(ims,kms,j), b_v2d=b_v(ims,kms,j)                      &
-              ,b_t2d=b_t(ims,kms,j), b_q2d=b_q(ims,kms,j)                      &
-              ,b_e2d=b_e(ims,kms,j), a_e2d=a_e(ims,kms,j)                      &
-              ,sfk2d=sfk(ims,kms,j), vlk2d=vlk(ims,kms,j)                      &
-              ,dlu2d=dl_u(ims,kms,j), dlg2d=dlg(ims,kms,j)                     &
-              ,frc_urb1d=frcurb(ims,j), bepswitch=bepswitch                    &
+              ,a_u2d=a_u(its,kts,j), a_v2d=a_v(its,kts,j)                      &
+              ,a_t2d=a_t(its,kts,j), a_q2d=a_q(its,kts,j)                      &
+              ,b_u2d=b_u(its,kts,j), b_v2d=b_v(its,kts,j)                      &
+              ,b_t2d=b_t(its,kts,j), b_q2d=b_q(its,kts,j)                      &
+              ,b_e2d=b_e(its,kts,j), a_e2d=a_e(its,kts,j)                      &
+              ,sfk2d=sfk(its,kts,j), vlk2d=vlk(its,kts,j)                      &
+              ,dlu2d=dl_u(its,kts,j), dlg2d=dlg(its,kts,j)                     &
+              ,frc_urb1d=frcurb(its,j), bepswitch=bepswitch                    &
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
               ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &
               ,its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
@@ -525,7 +525,10 @@ contains
    real,     dimension( ims:ime )                                            , &
              optional                                                        , &
              intent(inout)   ::                                        regime
- real,     dimension( ims:ime, kms:kme ),                                      &
+! 
+! local vars
+!
+   real,     dimension( its:ite, kts:kte ),                                    &
              intent(in)      ::                                         a_u2d, &
                                                                         a_v2d, &
                                                                         a_t2d, &
@@ -541,12 +544,9 @@ contains
                                                                         dlu2d, &
                                                                         dlg2d
 
-  real,     dimension( ims:ime ),                                              &
+   real,     dimension( its:ite ),                                             &
              intent(in)      ::                                      frc_urb1d
-  real ::                                                            bepswitch
-!
-! local vars
-!
+   real ::                                                           bepswitch
    real,     dimension( its:ite )            ::                           hol
    real,     dimension( its:ite, kts:kte+1 ) ::                            zq
 !

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -1210,12 +1210,20 @@ CONTAINS
               ,EP1=ep_1,EP2=ep_2,KARMAN=karman                      &
               ,EXCH_H=exch_h,EXCH_M=exch_m,REGIME=regime            &
               ,RTHRATEN=RTHRATEN                                    &
+! for multilayer UCM
+              ,IDIFF=idiff,FLAG_BEP=flag_bep,FRC_URB2D=frc_urb2d    &
+              ,A_U_BEP=a_u_bep,A_V_BEP=a_v_bep,A_T_BEP=a_t_bep      &
+              ,A_Q_BEP=a_q_bep                                      &
+              ,A_E_BEP=a_e_bep,B_U_BEP=b_u_bep,B_V_BEP=b_v_bep      &
+              ,B_T_BEP=b_t_bep,B_Q_BEP=b_q_bep                      &
+              ,B_E_BEP=b_e_bep,DLG_BEP=dlg_bep                      &
+              ,DL_U_BEP=dl_u_bep,SF_BEP=sf_bep,VL_BEP=vl_bep        &
 ! for grims shallow convection with ysupbl
               ,WSTAR=wstar,DELTA=delta                              &
               ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde      &
               ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme      &
               ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte      &
-                                                                    )
+                                                                   )
 !
 ! FASDAS
 !

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -3419,8 +3419,6 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
       CASE (YSUSCHEME)
            if(isfc .ne. 1)CALL wrf_error_fatal &
             ( 'module_physics_init: Use sf_sfclay_physics= 1 or 91 for this pbl option' )
-           IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
            CALL ysuinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
                         RQCBLTEN,RQIBLTEN,P_QI,               &
                         PARAM_FIRST_SCALAR,                   &
@@ -3433,7 +3431,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            if(isfc .ne. 1)CALL wrf_error_fatal &
             ( 'module_physics_init: Use sf_sfclay_physics= 1 or 91 for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL shinhonginit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,&
                         RQCBLTEN,RQIBLTEN,TKE_PBL,P_QI,       &
                         PARAM_FIRST_SCALAR,                   &
@@ -3446,7 +3444,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            if(isfc .ne. 1)CALL wrf_error_fatal &
             ( 'module_physics_init: Use sf_sfclay_physics= 1 or 91 for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL mrfinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
                         RQCBLTEN,RQIBLTEN,P_QI,               &
                         PARAM_FIRST_SCALAR,                   &
@@ -3459,7 +3457,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            if(isfc .ne. 1 .and. isfc .ne. 7)CALL wrf_error_fatal &
             ( 'module_physics_init: use sfclay or pxsfc scheme for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL acminit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
                         RQCBLTEN,RQIBLTEN,P_QI,               &
                         PARAM_FIRST_SCALAR,                   &
@@ -3472,7 +3470,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            if(isfc .ne. 2)CALL wrf_error_fatal &
             ( 'module_physics_init: use myjsfc scheme for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL gfsinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
                         RQCBLTEN,RQIBLTEN,P_QI,               &
                         PARAM_FIRST_SCALAR,                   &
@@ -3486,7 +3484,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            if(isfc .ne. 2)CALL wrf_error_fatal &
             ( 'module_physics_init: use myjsfc scheme for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL gfsedmfinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,&
                         RQCBLTEN,RQIBLTEN,P_QI,               &
                         PARAM_FIRST_SCALAR,                   &
@@ -3520,7 +3518,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            if(isfc .ne. 4)CALL wrf_error_fatal &
             ( 'module_physics_init: use qnsesfc scheme for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL qnsepblinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN, &
                         TKE_PBL,EXCH_H,restart,               &
                         allowed_to_read ,                     &
@@ -3552,7 +3550,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
                          its, ite, jts, jte, kts, kte          )
         CASE (CAMUWPBLSCHEME)
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            CALL camuwpblinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,        &
                 restart,TKE_PBL,is_CAMMGMP_used, &
                 ids, ide, jds, jde, kds, kde,                          &
@@ -3568,7 +3566,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            IF(isfc .NE. 5 .AND. isfc .NE. 1 .AND. isfc .NE. 2) CALL wrf_error_fatal &
                 ( 'module_physics_init: use mynnsfc or sfclay or myjsfc scheme for this pbl option')
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
            
            SELECT CASE(config_flags%bl_pbl_physics)
 
@@ -3595,7 +3593,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
            ! if(isfc .ne. 0)CALL wrf_error_fatal &
            !  ( 'module_physics_init: use sfclay scheme = 0 for this pbl option' )
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
-            ( 'module_physics_init: use myj (option 2) or boulac (option 8) with BEP/BEM urban scheme' )
+            ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
          IF ( PRESENT( te_temf ) .AND. PRESENT( cf3d_temf )) THEN
            CALL temfinit(RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,    &
                         RQCBLTEN,RQIBLTEN,P_QI,               &

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -686,9 +686,9 @@ Namelist variables for controlling the adaptive time step option:
                                      = 0: no
                                      = 1: Single-layer, UCM 
                                      = 2: Multi-layer, Building Environment Parameterization (BEP) scheme 
-                                          (works only with MYJ and BouLac PBL)
+                                          (works only with YSU, MYJ and BouLac PBL)
                                      = 3: Multi-layer, Building Environment Model (BEM) scheme 
-                                          (works only with MYJ and BouLac PBL)
+                                          (works only with YSU, MYJ and BouLac PBL)
 
  num_urban_ndm                       = 1! (=  2 if BEP or BEM active) maximum number of street dimensions (ndm in BEP or BEM header)
  num_urban_ng                        = 1! (= 10 if BEP or BEM active) number of grid levels in the ground (ng_u in BEP or BEM header)


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: BEP, BEP+BEM, YSU PBL scheme, vertical diffusion equations

SOURCE: Eric A. Hendricks (NCAR/RAL/NSAP)

DESCRIPTION OF CHANGES:
The multilayer BEP (Building Effects Parameterization) and BEP+BEM (BEP with the integration of a Building Energy Model) urban canopy models (UCMs) are added to the YSU planetary boundary layer (PBL) scheme. The implicit (A) and explicit (B) BEP and BEP+BEM source terms are added as forcing to the YSU implicit/explicit vertical diffusion equation solvers. Forcing is applied for zonal momentum, meridional momentum, potential temperature, and water vapor mixing ratio. The A sources are added to the tridiagonal matrix and the B sources are added to the explicit term vectors. Additionally, the finite differencing is modified using the BEP volume fraction and surface fraction not occupied by buildings. The BEP and BEP+BEM TKE tendency terms are added to the diagnostic TKE in YSU when topographic drag is turned on.

References:
   * Hendricks, E. A., J. C. Knievel, and Y. Wang, 2020: Addition of multilayer urban canopy models to a nonlocal planetary boundary layer parameterization and evaluation using ideal and real cases, J. Appl. Met. Clim., 59, 1369-1392.
   * Martilli et al. (2009), Description of the modifications made in WRF.3.1 and short user's manual of BEP, NCAR technical note. 

Hendricks et al. (2020) demonstrated that the scheme works properly and produces expected behaviors. Results are qualitatively similar to MYJ and BOULAC with BEP and BEP+BEM. Minor differences are due to the different treatment of vertical mixing among the schemes.

Note: This is a new pull request to replace pull request #1196. Pull request #1196 had the changes implemented into a new urban YSU routine (module_bl_ysuurb.F). This pull request adds the changes to the original YSU PBL routine (module_bl_ysu.F) instead of a new urban routine. After discussions with the WRF model and YSU scheme experts, it was determined that it would be best to implement the changes into the original YSU routine.

LIST OF MODIFIED FILES:
phys/module_bl_ysu.F
phys/module_pbl_driver.F
phys/module_physics_init.F
run/README.namelist

TESTS CONDUCTED:
1. Real-case 48-h simulations of Houston urban area were conducted (10/05/2017-10/07/2017) with an innermost nest grid spacing of 1 km. The following test suite was set up:

Baseline tests (version before physics enhancement):
   a. MYJ BEP
   b. MYJ BEP+BEM
   c. SU BULK
   d. SU SLUCM

New code tests (new version with enhancement):
   e. YSU BULK
   f. YSU SLUCM
   g. YSU BEP
   h. YSU BEP+BEM   
   i. MYJ BEP
   j. MYJ BEP+BEM 

   * Tests (e) and (f) were identical to tests (c) and (d), demonstrating that the new code did not affect the BULK and SLUCM existing code with the YSU PBL parameterization. 
   * Tests (g) and (h) were shown to produce the same behaviors as Hendricks et al. (2020).
   * Tests (i) and (j) were identical to tests (a) and (b), demonstrating that the new code did not affect any existing BEP and BEP+BEM code with the MYJ PBL parameterization. 

2. The real-case example test of the NMM dynamical core was also run for the YSU scheme without BEP and BEP+BEM prior to code modifications, and after the code modifications. The output was examined and shown to be the same. Therefore, the new YSU scheme with BEP and BEP+BEM functions properly in the NMM dynamical core when BEP and BEP+BEM are not active (note that the NMM dynamical core does not support BEP and BEP+BEM).

3. Since YSU is now functional with BEP and BEP+BEM, this line was added to replace the old lines in module_physics_init.F for all other PBL routines:
```
IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
            ( 'module_physics_init: use ysu (option 1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
```
This printout was shown to occur when attempting to run with PBL schemes that do not support the BEP and BEP+BEM functionality.

4. The restart capability was demonstrated to function properly with the new YSU BEP and YSU BEP+BEM code. 
5. Jenkins testing is all PASS. 

RELEASE NOTE: The multilayer BEP (Building Effects Parameterization) and BEP+BEM (BEP with the Building Energy Model) urban canopy models (UCMs) are added to the Yonsei University (YSU) planetary boundary layer parameterization. Reference: Hendricks, E. A., J. C. Knievel, and Y. Wang, 2020: Addition of multilayer urban canopy models to a nonlocal planetary boundary layer parameterization and evaluation using ideal and real cases, J. Appl. Met. Clim., 59, 1369-1392.