### PR TITLE
use tke_seed_value only when necessary

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -2160,9 +2160,18 @@ END SUBROUTINE smag2d_km
 ! tke_seed if the drag and flux are off.
 
     c_k = config_flags%c_k
-    tke_seed = tke_seed_value
-    if( (config_flags%tke_drag_coefficient .gt. epsilon) .or.  &
-        (config_flags%tke_heat_flux .gt. epsilon)  ) tke_seed = 0.
+    tke_seed = 0.
+    IF (config_flags%isfflx .eq. 0) THEN
+      IF ((config_flags%diff_opt .eq. 2) .and. (config_flags%bl_pbl_physics .eq. 0)) THEN
+        IF( (config_flags%tke_drag_coefficient .lt. epsilon) .and.  &
+            (config_flags%tke_heat_flux .lt. epsilon)  )  THEN
+          tke_seed = tke_seed_value
+        ENDIF
+      ELSE
+        !tke_drag_coefficient and tke_heat_flux are irrelevant here
+        tke_seed = tke_seed_value
+      ENDIF
+    ENDIF
 
     DO j = j_start, j_end
     DO k = kts+1, ktf-1

--- a/wrftladj/module_diffusion_em_ad.F
+++ b/wrftladj/module_diffusion_em_ad.F
@@ -6711,11 +6711,20 @@ END SUBROUTINE A_SMAG2D_KM
 
 !LPB[12]
        c_k = config_flags%c_k
-       tke_seed = tke_seed_value
+       tke_seed = 0.
 
 !LPB[13]
-    if( (config_flags%tke_drag_coefficient .gt. epsilon) .or.    &
-        (config_flags%tke_heat_flux .gt. epsilon)  ) tke_seed = 0.
+       IF (config_flags%isfflx .eq. 0) THEN
+         IF ((config_flags%diff_opt .eq. 2) .and. (config_flags%bl_pbl_physics .eq. 0)) THEN
+           IF( (config_flags%tke_drag_coefficient .lt. epsilon) .and.  &
+               (config_flags%tke_heat_flux .lt. epsilon)  )  THEN
+             tke_seed = tke_seed_value
+           ENDIF
+         ELSE
+           !tke_drag_coefficient and tke_heat_flux are irrelevant here
+           tke_seed = tke_seed_value
+         ENDIF
+       ENDIF
 
 !LPB[14]
        DO j = j_start, j_end

--- a/wrftladj/module_diffusion_em_tl.F
+++ b/wrftladj/module_diffusion_em_tl.F
@@ -2645,10 +2645,19 @@ END SUBROUTINE G_SMAG2D_KM
  g_c_k =0.0
  c_k =config_flags%c_k
 
- tke_seed =tke_seed_value
+ tke_seed = 0.
 
- if( (config_flags%tke_drag_coefficient .gt. epsilon) .or.    &
-        (config_flags%tke_heat_flux .gt. epsilon)  ) tke_seed =0.
+ IF (config_flags%isfflx .eq. 0) THEN
+   IF ((config_flags%diff_opt .eq. 2) .and. (config_flags%bl_pbl_physics .eq. 0)) THEN
+     IF( (config_flags%tke_drag_coefficient .lt. epsilon) .and.  &
+         (config_flags%tke_heat_flux .lt. epsilon)  )  THEN
+       tke_seed = tke_seed_value
+     ENDIF
+   ELSE
+     !tke_drag_coefficient and tke_heat_flux are irrelevant here
+     tke_seed = tke_seed_value
+   ENDIF
+ ENDIF
 
  DO j =j_start,j_end
  DO k =kts+1,ktf-1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: tke, isfflx, tke_heat_flux, tke_drag_coefficient, tke_seed

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES:
Problem:
The tke seed value is used in the absence of surface drag or a surface heat flux, since there is no way to generate tke without pre-existing tke. So far the usage of the seed value is only tied to the namelist variables tke_drag_coefficient and tke_heat_flux being greater than 0. However, these namelist variables are only applied if no PBL scheme is used, diff_opt=2, and isfflx=0.

If a PBL scheme is used or diff_opt=1, then isfflx=0 is a sufficient condition to get zero fluxes (see also technical notes).

Solution:
Fixed the if statements to enforce a correct setting of the tke seed value that fits to the purpose of the seed.

LIST OF MODIFIED FILES: 
dyn_em/module_diffusion_em.F
wrftladj/module_diffusion_em_ad.F
wrftladj/module_diffusion_em_tl.F

TESTS CONDUCTED:
1. Jenkins testing is all pass.

RELEASE NOTE: corrected the tke seed value to be non-zero if and only if the surface heat and momentum fluxes are zero depending on isfflx, diff_opt, and bl_pbl_physics