### PR TITLE
Corner points

### DIFF
--- a/share/module_bc.F
+++ b/share/module_bc.F
@@ -680,7 +680,8 @@ CONTAINS
       REAL,  DIMENSION( ims:ime , kms:kme , jms:jme ) :: dat
       TYPE( grid_config_rec_type ) config_flags
 
-      INTEGER  :: i, j, k, istag, jstag, itime, k_end
+      INTEGER  :: i, j, k, istag, jstag, itime, k_end, &
+                  i_start, i_end
 
       LOGICAL  :: debug, open_bc_copy
 
@@ -927,13 +928,27 @@ CONTAINS
 
 !  same procedure in y
 
+!  Set the starting and ending loop indexes in the 'i' direction, so that
+!  halo cells on the edge of the domain are also updated.  Begin with a default
+!  start and end index for inner tiles, and then modify if the tile is on the
+!  edge of the domain.
+
+      i_start = MAX(ids, its-1)
+      i_end = MIN(ite+1, ide+istag)
+      IF ( its .eq. ids) THEN
+        i_start = ims
+      END IF
+      IF ( ite .eq. ide) THEN
+        i_end = ime
+      END IF
+
       periodicity_y:  IF( ( config_flags%periodic_y ) ) THEN
         IF ( ( jds == jps ) .and. ( jde == jpe ) )  THEN      ! test if both north and south on processor
           IF( jts == jds ) then
 
             DO j = 0, -(bdyzone-1), -1
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jds+j-1) = dat(i,k,jde+j-1)
             ENDDO
             ENDDO
@@ -945,7 +960,7 @@ CONTAINS
 
             DO j = -jstag, bdyzone
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jde+j+jstag) = dat(i,k,jds+j+jstag)
             ENDDO
             ENDDO
@@ -964,7 +979,7 @@ CONTAINS
 
             DO j = 1, bdyzone
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jds-j) = dat(i,k,jds+j-1)
             ENDDO                               
             ENDDO
@@ -976,7 +991,7 @@ CONTAINS
 
               DO j = 1, bdyzone
               DO k = kts, k_end
-              DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+              DO i = i_start, i_end
                 dat(i,k,jds-j) = - dat(i,k,jds+j)
               ENDDO              
               ENDDO
@@ -986,7 +1001,7 @@ CONTAINS
 
               DO j = 1, bdyzone
               DO k = kts, k_end
-              DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+              DO i = i_start, i_end
                 dat(i,k,jds-j) = dat(i,k,jds+j)
               ENDDO              
               ENDDO
@@ -1007,7 +1022,7 @@ CONTAINS
 
             DO j = 1, bdyzone
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jde+j-1) = dat(i,k,jde-j)
             ENDDO                               
             ENDDO
@@ -1019,7 +1034,7 @@ CONTAINS
 
               DO j = 1, bdyzone
               DO k = kts, k_end
-              DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+              DO i = i_start, i_end
                 dat(i,k,jde+j) = - dat(i,k,jde-j)
               ENDDO                               
               ENDDO
@@ -1029,7 +1044,7 @@ CONTAINS
 
               DO j = 1, bdyzone
               DO k = kts, k_end
-              DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+              DO i = i_start, i_end
                 dat(i,k,jde+j) = dat(i,k,jde-j)
               ENDDO                               
               ENDDO
@@ -1050,7 +1065,7 @@ CONTAINS
                          ( jts == jds) .and. open_bc_copy )  THEN
 
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jds-1) = dat(i,k,jds)
               dat(i,k,jds-2) = dat(i,k,jds)
               dat(i,k,jds-3) = dat(i,k,jds)
@@ -1070,7 +1085,7 @@ CONTAINS
           IF (variable /= 'v' .and. variable /= 'y' ) THEN
 
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jde  ) = dat(i,k,jde-1)
               dat(i,k,jde+1) = dat(i,k,jde-1)
               dat(i,k,jde+2) = dat(i,k,jde-1)
@@ -1080,7 +1095,7 @@ CONTAINS
           ELSE
 
             DO k = kts, k_end
-            DO i = MAX(ids,its-1), MIN(ite+1,ide+istag)
+            DO i = i_start, i_end
               dat(i,k,jde+1) = dat(i,k,jde)
               dat(i,k,jde+2) = dat(i,k,jde)
               dat(i,k,jde+3) = dat(i,k,jde)
@@ -1105,6 +1120,9 @@ CONTAINS
            DO j = 0, -(bdyzone-1), -1
            DO k = kts, k_end
            DO i = 0, -(bdyzone-1), -1
+             IF (dat(ids+i-1,k,jds+j-1) .ne. dat(ide+i-1,k,jde+j-1)) THEN
+               CALL wrf_debug( 0 , 'lower left corner is wrong' )
+             ENDIF
              dat(ids+i-1,k,jds+j-1) = dat(ide+i-1,k,jde+j-1)
            ENDDO
            ENDDO
@@ -1115,6 +1133,9 @@ CONTAINS
            DO j = 0, -(bdyzone-1), -1
            DO k = kts, k_end
            DO i = 1, bdyzone
+             IF (dat(ide+i+istag,k,jds+j-1) .ne. dat(ids+i+istag,k,jde+j-1)) THEN
+               CALL wrf_debug( 0 , 'lower right corner is wrong' )
+             ENDIF
              dat(ide+i+istag,k,jds+j-1) = dat(ids+i+istag,k,jde+j-1)
            ENDDO
            ENDDO
@@ -1125,6 +1146,9 @@ CONTAINS
            DO j = 1, bdyzone
            DO k = kts, k_end
            DO i = 1, bdyzone
+             IF (dat(ide+i+istag,k,jde+j+jstag) .ne. dat(ids+i+istag,k,jds+j+jstag)) THEN
+               CALL wrf_debug( 0 , 'upper right corner is wrong' )
+             ENDIF
              dat(ide+i+istag,k,jde+j+jstag) = dat(ids+i+istag,k,jds+j+jstag)
            ENDDO
            ENDDO
@@ -1135,6 +1159,9 @@ CONTAINS
            DO j = 1, bdyzone
            DO k = kts, k_end
            DO i = 0, -(bdyzone-1), -1
+             IF (dat(ids+i-1,k,jde+j+jstag) .ne. dat(ide+i-1,k,jds+j+jstag)) THEN
+               CALL wrf_debug( 0 , 'upper left corner is wrong' )
+             ENDIF
              dat(ids+i-1,k,jde+j+jstag) = dat(ide+i-1,k,jds+j+jstag)
            ENDDO
            ENDDO

--- a/share/module_bc.F
+++ b/share/module_bc.F
@@ -1110,66 +1110,6 @@ CONTAINS
 
       END IF periodicity_y
 
-!  fix corners for doubly periodic domains
-
-      IF ( config_flags%periodic_x .and. config_flags%periodic_y &
-           .and. (ids == ips) .and. (ide == ipe)                 &
-           .and. (jds == jps) .and. (jde == jpe)                   ) THEN
-
-         IF ( (its == ids) .and. (jts == jds) ) THEN  ! lower left corner fill
-           DO j = 0, -(bdyzone-1), -1
-           DO k = kts, k_end
-           DO i = 0, -(bdyzone-1), -1
-             IF (dat(ids+i-1,k,jds+j-1) .ne. dat(ide+i-1,k,jde+j-1)) THEN
-               CALL wrf_debug( 0 , 'lower left corner is wrong' )
-             ENDIF
-             dat(ids+i-1,k,jds+j-1) = dat(ide+i-1,k,jde+j-1)
-           ENDDO
-           ENDDO
-           ENDDO
-         END IF
-
-         IF ( (ite == ide) .and. (jts == jds) ) THEN  ! lower right corner fill
-           DO j = 0, -(bdyzone-1), -1
-           DO k = kts, k_end
-           DO i = 1, bdyzone
-             IF (dat(ide+i+istag,k,jds+j-1) .ne. dat(ids+i+istag,k,jde+j-1)) THEN
-               CALL wrf_debug( 0 , 'lower right corner is wrong' )
-             ENDIF
-             dat(ide+i+istag,k,jds+j-1) = dat(ids+i+istag,k,jde+j-1)
-           ENDDO
-           ENDDO
-           ENDDO
-         END IF
-
-         IF ( (ite == ide) .and. (jte == jde) ) THEN  ! upper right corner fill
-           DO j = 1, bdyzone
-           DO k = kts, k_end
-           DO i = 1, bdyzone
-             IF (dat(ide+i+istag,k,jde+j+jstag) .ne. dat(ids+i+istag,k,jds+j+jstag)) THEN
-               CALL wrf_debug( 0 , 'upper right corner is wrong' )
-             ENDIF
-             dat(ide+i+istag,k,jde+j+jstag) = dat(ids+i+istag,k,jds+j+jstag)
-           ENDDO
-           ENDDO
-           ENDDO
-         END IF
-
-         IF ( (its == ids) .and. (jte == jde) ) THEN  ! upper left corner fill
-           DO j = 1, bdyzone
-           DO k = kts, k_end
-           DO i = 0, -(bdyzone-1), -1
-             IF (dat(ids+i-1,k,jde+j+jstag) .ne. dat(ide+i-1,k,jds+j+jstag)) THEN
-               CALL wrf_debug( 0 , 'upper left corner is wrong' )
-             ENDIF
-             dat(ids+i-1,k,jde+j+jstag) = dat(ide+i-1,k,jds+j+jstag)
-           ENDDO
-           ENDDO
-           ENDDO
-         END IF
-
-       END IF
-
    END SUBROUTINE set_physical_bc3d
 
    SUBROUTINE init_module_bc

--- a/share/module_bc.F
+++ b/share/module_bc.F
@@ -780,7 +780,7 @@ CONTAINS
         symmetry_xs: IF( ( config_flags%symmetric_xs ) .and.  &
                          ( its == ids )                  )  THEN
 
-          IF ( (variable /= 'u') .and. (variable /= 'x') ) THEN
+          IF ( istag == -1 ) THEN
 
             DO j = MAX(jds,jts-1), MIN(jte+1,jde+jstag)
             DO k = kts, k_end
@@ -824,7 +824,7 @@ CONTAINS
         symmetry_xe: IF( ( config_flags%symmetric_xe ) .and.  &
                          ( ite == ide )                  )  THEN
 
-          IF ( (variable /= 'u') .and. (variable /= 'x') ) THEN
+          IF ( istag == -1 ) THEN
 
             DO j = MAX(jds,jts-1), MIN(jte+1,jde+jstag)
             DO k = kts, k_end
@@ -975,7 +975,7 @@ CONTAINS
         symmetry_ys: IF( ( config_flags%symmetric_ys ) .and.  &
                          ( jts == jds)                   )  THEN
 
-          IF ( (variable /= 'v') .and. (variable /= 'y') ) THEN
+          IF ( jstag == -1 ) THEN
 
             DO j = 1, bdyzone
             DO k = kts, k_end
@@ -1018,7 +1018,7 @@ CONTAINS
         symmetry_ye: IF( ( config_flags%symmetric_ye ) .and.  &
                          ( jte == jde )                  )  THEN
 
-          IF ( (variable /= 'v') .and. (variable /= 'y') ) THEN
+          IF ( jstag == -1 ) THEN
 
             DO j = 1, bdyzone
             DO k = kts, k_end


### PR DESCRIPTION
Missing corner points are set when setting boundary conditions of 3D variables and all staggered variables are treated equally in symmetric BC. Thereby the periodic BC become cleaner and more consistent with set_physical_bc2d and the symmetric BC are fixed as horizontal deformation is treated now as a staggered variable which leads to correct BC for SGS momentum fluxes at the northern boundaries.

TYPE: bug fix

KEYWORDS: boundary conditions, symmetric, corners

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES:
Problem:
In idealized simulations, the routine `set_physical_bc3d` sets the boundary zone points for periodic, symmetric, and open boundary conditions.
At first, the routine does not set the corner points (e.g., (ids-1,jds-1)): For the y-boundaries, it iterates i only from `MAX(ids,its-1)` to  `MIN(ite+1,ide+istag)` and analogously for the x-boundaries (note that for open BC it actually also tries to set the corner points (see line 896), but not effectively, because the RHS values in lines 903-905 are still 0 there, as the y-BC has not been applied yet).

For doubly-periodic BC, the corner points are set correctly afterward, starting at line 1100. In any other case, however, it seems that the corner points are not assigned and appear as zeros. 

These corner points are later used, e.g. in the SGS UV-flux (titau_21_12) in the diffusion module:
https://github.com/wrf-model/WRF/blob/f311cd5e136631ebf3ebaa02b4b7be3816ed171f/dyn_em/module_diffusion_em.F#L5511-L5517
Thus, because `rho(i_start-1,k,j_start-1)=0` and `xkx(i_start-1,k,j_start-1)=0`, we have `xkxavg(i_start, k, j_start)` much smaller than at the other locations.

This is usually not a problem, since the deformation defor12 and thus also the flux titau_21_12 should be 0 at these corner points when using symmetric boundary conditions on at least one of these boundaries.
I write "should" because that's a theoretical argument. In practice, only the deformation at the ids or jds boundaries is zero. Due to an inconsistency in the symmetric BC for the deformation, the deformation at the ide or jde boundaries is not 0. This problem is described in the following.

The deformation (variable = 'd') is treated like an unstaggered variable: https://github.com/wrf-model/WRF/blob/f311cd5e136631ebf3ebaa02b4b7be3816ed171f/share/module_bc.F#L1003-L1011
Thus, the deformation which was initially zero at the boundary is set to a non-zero value by `dat(i,k,jde) = dat(i,k,jde-1)`.
All staggered variables except the normal velocity (so also the deformation) should be treated equally in the symmetric boundaries since the location of the symmetric boundary is on the staggered grid. Therefore I adjusted the relevant if statement in the second commit.

If open boundary conditions are used on any of the boundaries, only the fluxes on the interior are calculated, so the corner points also don't matter. However, to avoid any current or future side effects due to the missing corner points, corner points are set anyway as it is done in `set_physical_bc2d`.

Solution:

1. commit:
The solution to set the corner points is the same as is already applied in the 2d routine `set_physical_bc2d`.

2. commit:
To treat all variables staggered in a certain direction equally, the variables `jstag` and `istag` are used in the if statement instead of checking the value of `variable`. This was done only for the symmetric BC. For the open BC, it might be necessary, too.

3. commit:
The corner point assignment for doubly-periodic BC is now redundant and was removed.

ISSUE:
Fixes #1311

LIST OF MODIFIED FILES: share/module_bc.F

TESTS CONDUCTED:
With the first commit, I tested, whether the corner points for doubly-periodic BC are set in the same way as in the original code. This test allowed removing this redundant part of the code in commit 3.

To compare the different model versions, I ran an idealized simulation with km_opt=2, diff_opt=2, tke_heat_flux=0.2, U = 5 m/s, periodic in x, symmetric in y.
The following figure shows the titau_21_12 flux at k=kds after 20 minutes for three model versions:
left: original, middle: fixed corners (commit 1), right: fixed corners and fixed symmetric BC for the deformation (commit 1 and 2)
![fuy_sgs](https://user-images.githubusercontent.com/17001470/98154601-505be880-1ed5-11eb-9f0a-6eef1175e730.png)

All versions have titau_21_12=0 at j=jds. In the left and middle panel, the fluxes at jde and jde-1 are almost identical. However, the original version has fluxes with lower magnitudes at the upper left and right corners (as the corners of xkmh and rho are not set as explained above). In the right panel, the flux at j=jde is now also zero as it should be.

The following figure shows a time series of U at the upper left corner:
![u_timeseries](https://user-images.githubusercontent.com/17001470/98154606-52be4280-1ed5-11eb-93d3-563062274e5c.png)

We can see that fixing the symmetric BC to have zero fluxes at j=jde does have a significant effect.
Fixing the corners (commit 1) only has a minor effect, which is maximized at the corner points (j=jde, i=ids, and ide) as can be seen here:
![u_diff](https://user-images.githubusercontent.com/17001470/98154624-55b93300-1ed5-11eb-906d-b8aaef7f1596.png)

RELEASE NOTE: 
Missing corner points are set when setting boundary conditions of 3D variables and all staggered variables are treated equally in symmetric BC. Thereby the periodic BC become cleaner and more consistent with set_physical_bc2d and the symmetric BC are fixed as horizontal deformation is treated now as a staggered variable which leads to correct BC for SGS momentum fluxes at the northern boundaries.
