### PR TITLE
bug fix: incorrectly adding sulf biomass burning emissions for MOZART/MOSAIC and biomass_burn_opt = 2)

### DIFF
--- a/chem/module_mosaic_addemiss.F
+++ b/chem/module_mosaic_addemiss.F
@@ -601,7 +601,7 @@ size_loop: &
               do i = its, ite
 ! compute mass biomass burning emissions [(ug/m3)*m/s] for each species
 ! using the apportioning fractions
-                aem_so4 = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_sulf)      
+                IF ( p_ebu_sulf .gt. 1) aem_so4 = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_sulf)      
                 aem_oc  = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_oc)    
                 aem_bc  = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_bc) 
 ! Option to calculate OIN fraction of total PM for fire emissions 


### PR DESCRIPTION
Fix for high sulfate concentrations with  biomass_burn_opt = 2

TYPE: bug fix

KEYWORDS: chem,biomassburn,plumerise,sulfate

SOURCE: Neeldip Barman (IIT Guwahati)

DESCRIPTION OF CHANGES:
Problem:
Namelist option biomass_burn_opt = 2 when used with chem_opt=202 produces very high so4 concentration and so4 plumes reaching near the model top. This further leads to very large optical depths.

Namelist option biomass_burn_opt = 2 does not take sulfate emissions as inputs in registry, but sulfate emission inputs have been defined in module_mosaic_addemiss.F

Solution:
Setting IF ( p_ebu_sulf .gt. 1) aem_so4 = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_sulf) inplace of aem_so4 = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_sulf) 

LIST OF MODIFIED FILES: 
module_mosaic_addemiss.F

TESTS CONDUCTED:
 1. chem_opt = 202 with the code modification 

RELEASE NOTE: sulf emissions are not defined for biomass_burn_opt = 2 (MOZART option) in the registry, but sulf emission inputs have been defined in module_mosaic_addemiss.F, which is used for any MOZART option coupled to MOSAIC
