### PR TITLE
Add missing compiler name for Intel HSB/BDW config

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1834,7 +1834,7 @@ RLFLAGS		=
 CC_TOOLS        =      $(SCC) 
 
 ###########################################################
-#ARCH    Linux x86_64 ppc64le i486 i586 i686 #serial smpar dmpar dm+sm
+#ARCH    Linux x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       INTEL ($SFC/$SCC): HSW/BDW
 DMPARALLEL      =       # 1

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1878,7 +1878,7 @@ RLFLAGS		=
 CC_TOOLS        =      $(SCC) 
 
 ###########################################################
-#ARCH    Linux KNL x86_64 ppc64le i486 i586 i686 #serial smpar dmpar dm+sm
+#ARCH    Linux KNL x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       INTEL ($SFC/$SCC): KNL MIC
 DMPARALLEL      =       # 1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: build, hydro

SOURCE: Ryan Cabell (NCAR)

DESCRIPTION OF CHANGES:
Problem:
Building coupled WRF/WRF Hydro models fails when choosing configuration INTEL (ifort/icc): HSW/BDW. 

Solution:
Add missing `ifort compiler with icc` text to ARCH line for the HSW/BDW configuration. For completeness, the KNL MIC
configure stanza was also missing the same information, and has been updated.

Neither of these stanzas are involved in the traditional WRF code build, so there is no impact on users of the default WRF
atmosphere model.

ISSUE: For use when this PR closes an issue.
Fixes #1325 

LIST OF MODIFIED FILES: 
M       arch/configure.defaults

TESTS CONDUCTED: 
1. Modification causes WRF-Hydro build to complete successfully with the `INTEL (ifort/icc): HSW/BDW` configuration
2. Jenkins testing all positive
