### PR TITLE
bug fix: improper indexing in add aircraft emissions

### DIFF
--- a/chem/module_emissions_anthropogenics.F
+++ b/chem/module_emissions_anthropogenics.F
@@ -241,7 +241,7 @@ is_mozart:if( is_moz_chm ) then
    if (config_flags%aircraft_emiss_opt == 1 ) then
       do j=jts,jte  
         do k=kts,min(config_flags%kemit_aircraft,kte)
-          conv_rho(its:ite)=4.828e-4/rho_phy(i,k,j)*dtstep/(dz8w(i,k,j)*60.)
+          conv_rho(its:ite)=4.828e-4/rho_phy(its:ite,k,j)*dtstep/(dz8w(its:ite,k,j)*60.)
           if( p_no >= param_first_scalar ) then
             chem(its:ite,k,j,p_no)  = chem(its:ite,k,j,p_no)  + emis_aircraft(its:ite,k,j,p_eac_no) *conv_rho(its:ite)
           endif


### PR DESCRIPTION
KEYWORDS: chemistry, emissions, aircraft, indexing

SOURCE: Stacy Walters (formerly NCAR)

DESCRIPTION OF CHANGES:
Problem:
An improper loop indexing that can cause addressing or floating point errors when aircraft emissions are
used.

Solution:
Fix indexing (i - dimension) for the conversion term, from i to its:ite

LIST OF MODIFIED FILES:
M       chem/module_emissions_anthropogenics.F

TESTS CONDUCTED:
1. Jenkins test PASSED

RELEASE NOTE: Improper indexing in a conversion factor when using aircraft emissions for WRF Chem previously caused addressing (seg fault) or floating point errors. This has been corrected by matching the indexing on the LHS with the RHS.