### PR TITLE
Farms check a mundo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ all_wrfvar :
 	fi
 	if [ $(BUFR) ] ; then \
 	  (cd var/external/bufr;  \
-	  $(MAKE) $(J) FC="$(SFC)" CC="$(SCC)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" FFLAGS="$(FCOPTIM) $(FORMAT_FIXED)" RANLIB="$(RANLIB)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" ) ; \
+	  $(MAKE) $(J) FC="$(SFC)" CC="$(SCC)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" FFLAGS="$(FCOPTIM) $(FORMAT_FIXED) $(FCCOMPAT)" RANLIB="$(RANLIB)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" ) ; \
 	fi
 ### Use 'make' to avoid '-i -r' above:
 	if [ $(WAVELET) ] ; then \

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -73,8 +73,9 @@ FCDEBUG         =       # -g $(FCNOOPT)  # -fbacktrace -ggdb -fcheck=bounds,do,m
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -785,8 +786,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =     
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1006,8 +1008,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1049,8 +1052,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1772,8 +1776,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1946,8 +1951,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =     
 TRADFLAG        =      -traditional

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -1944,7 +1944,11 @@ ENDIF ghg_block
 !
    drydep_select: SELECT CASE(config_flags%gas_drydep_opt)
      CASE (WESELY)
-       CALL wrf_debug(15,'initializing dry dep (wesely)')
+        IF (numgas .eq. 0) THEN
+            CALL wrf_error_fatal("ERROR: numgas = 0, SELECTED CHEM OPT IS &
+            &NOT COMPATIBLE WITH WESELY DRY DEPOSITION")
+        ENDIF
+        CALL wrf_debug(15,'initializing dry dep (wesely)') 
 
         call dep_init( id, config_flags, numgas, mminlu_loc, &
                       its, ite, jts, jte, ide, jde )

--- a/chem/module_mosaic_addemiss.F
+++ b/chem/module_mosaic_addemiss.F
@@ -601,7 +601,7 @@ size_loop: &
               do i = its, ite
 ! compute mass biomass burning emissions [(ug/m3)*m/s] for each species
 ! using the apportioning fractions
-                aem_so4 = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_sulf)      
+                IF ( p_ebu_sulf .gt. 1) aem_so4 = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_sulf)      
                 aem_oc  = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_oc)    
                 aem_bc  = bburn_mosaic_f(n)*ebu(i,k,j,p_ebu_bc) 
 ! Option to calculate OIN fraction of total PM for fire emissions 

--- a/configure
+++ b/configure
@@ -685,6 +685,25 @@ if [ $os = "Linux" -o $os = "Darwin" ]; then
 
   foo=foo_$$
 
+  grep '^SFC' configure.wrf | grep -i 'gfortran' > /dev/null
+  if [ $? ]
+  then
+
+    cat > ${foo}.F << EOF
+      PROGRAM GFORTRAN_VERSION_CHECK
+        IF (__GNUC__ .GT. 9) CALL EXIT(1)
+      END PROGRAM
+EOF
+
+    gfortran -o ${foo} ${foo}.F > /dev/null 2>&1 && ./${foo}
+    if [ $? -eq 1 ]
+    then
+      sed '/^FCCOMPAT/ s/$/ -fallow-argument-mismatch -fallow-invalid-boz/' configure.wrf > configure.wrf.edit
+      mv configure.wrf.edit configure.wrf
+    fi
+    rm ${foo} ${foo}.F 2> /dev/null
+  fi
+
 cat > ${foo}.c <<EOF 
  int main(int argc, char ** argv)
  {

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1097,8 +1097,8 @@ BENCH_START(pbl_driver_tim)
          ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_CHEM_E_5.inc"
          ELSE
-              WRITE(message,*)'solve_em: invalid h_mom_adv_order = ',&
-              & config_flags%h_mom_adv_order
+              WRITE(message,*)'solve_em: invalid h_sca_adv_order = ',&
+              & config_flags%h_sca_adv_order
         ENDIF
      ENDIF
 #endif
@@ -1421,12 +1421,12 @@ BENCH_START(shcu_driver_tim)
 #ifdef DM_PARALLEL
       IF( config_flags%shcu_physics == CAMUWSHCUSCHEME ) THEN
          CALL wrf_debug ( 200 , ' call HALO CHEM AFTER SHALLOW CUMULUS' )
-         IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+         IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_CHEM_E_3.inc"
-         ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+         ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_CHEM_E_5.inc"
          ELSE
-            WRITE(message,*)'module_first_rk_step_part1: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+            WRITE(message,*)'module_first_rk_step_part1: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
             CALL wrf_error_fatal(TRIM(message))
          ENDIF
       ENDIF

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -689,12 +689,12 @@ ENDIF
 #      include "HALO_EM_PHYS_DIFFUSION.inc"
        ENDIF
 
-       IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+       IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #       include "HALO_EM_TKE_3.inc"
-       ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+       ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #       include "HALO_EM_TKE_5.inc"
        ELSE
-         WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+         WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
          CALL wrf_error_fatal(TRIM(wrf_err_message))
        ENDIF
 #endif

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -1120,10 +1120,10 @@ CONTAINS
 
 !  rebalance hydrostatically
 
-      DO k  = 2,kte
+      DO k = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1165,10 +1165,10 @@ CONTAINS
 
 !  rebalance hydrostatically
 
-      DO k  = 2,kte
+      DO k = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1212,8 +1212,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1245,8 +1245,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
       ENDDO
@@ -1306,8 +1306,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)
@@ -1355,8 +1355,8 @@ CONTAINS
 
       DO k  = 2,kte
         grid%ph_1(i,k,j) = grid%ph_1(i,k-1,j) - (grid%dnw(k-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
+                     ((grid%c1h(k-1)*grid%mub(i,j)+grid%c2h(k-1))+(grid%c1h(k-1)*grid%mu_1(i,j)))*grid%al(i,k-1,j)+ &
+                      (grid%c1h(k-1)*grid%mu_1(i,j))*grid%alb(i,k-1,j)  )
 
         grid%ph_2(i,k,j) = grid%ph_1(i,k,j)
         grid%ph0(i,k,j) = grid%ph_1(i,k,j) + grid%phb(i,k,j)

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -320,7 +320,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
 ! see matching halo calls below for stencils
 !--------------------------------------------------------------
      CALL wrf_debug ( 200 , ' call HALO_RK_CHEM' )
-     IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+     IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_CHEM_E_3.inc"
        IF( config_flags%progn > 0 ) THEN
 #         include "HALO_EM_SCALAR_E_3.inc"
@@ -328,7 +328,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
        IF( config_flags%cu_physics == CAMZMSCHEME ) THEN
 #         include "HALO_EM_SCALAR_E_3.inc"
        ENDIF
-     ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+     ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_CHEM_E_5.inc"
        IF( config_flags%cu_physics == CAMZMSCHEME ) THEN
 #         include "HALO_EM_SCALAR_E_5.inc"
@@ -337,7 +337,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
 #         include "HALO_EM_SCALAR_E_5.inc"
       ENDIF
      ELSE
-       WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+       WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
        CALL wrf_error_fatal(TRIM(wrf_err_message))
      ENDIF
    ENDIF
@@ -346,12 +346,12 @@ SUBROUTINE solve_em ( grid , config_flags  &
 ! see matching halo calls below for stencils
 !--------------------------------------------------------------
      CALL wrf_debug ( 200 , ' call HALO_RK_tracer' )
-     IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+     IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_TRACER_E_3.inc"
-     ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+     ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_TRACER_E_5.inc"
      ELSE
-       WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+       WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
        CALL wrf_error_fatal(TRIM(wrf_err_message))
      ENDIF
    ENDIF
@@ -2288,12 +2288,12 @@ BENCH_END(flow_depbdy_tim)
 BENCH_START(tke_adv_tim)
        TKE_advance: IF (config_flags%km_opt .eq. 2.or.config_flags%km_opt.eq.5) then ! XZ
 #ifdef DM_PARALLEL
-         IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+         IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #       include "HALO_EM_TKE_ADVECT_3.inc"
-         ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+         ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #       include "HALO_EM_TKE_ADVECT_5.inc"
          ELSE
-          WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+          WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
           CALL wrf_error_fatal(TRIM(wrf_err_message))
          ENDIF
 #endif
@@ -3116,12 +3116,13 @@ BENCH_END(calc_p_rho_tim)
 ! scalar                  x
 
 #ifdef DM_PARALLEL
-       IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+       IF      ( config_flags%h_mom_adv_order <= 4 .and. config_flags%h_sca_adv_order <= 4 ) THEN
 #    include "HALO_EM_D2_3.inc"
-       ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+       ELSE IF ( config_flags%h_mom_adv_order <= 6 .and. config_flags%h_sca_adv_order <= 6 ) THEN
 #    include "HALO_EM_D2_5.inc"
        ELSE 
-         WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+         WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order or h_sca_adv_order = ', &
+               config_flags%h_mom_adv_order, config_flags%h_sca_adv_order
          CALL wrf_error_fatal(TRIM(wrf_err_message))
        ENDIF
 #  include "PERIOD_BDY_EM_D.inc"
@@ -3252,13 +3253,13 @@ BENCH_END(bc_end_tim)
 ! moist, chem, scalar, tke      x
 
 
-       IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+       IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
          IF ( (config_flags%tke_adv_opt /= ORIGINAL .and. config_flags%tke_adv_opt /= WENO_SCALAR) .and. (rk_step == rk_order-1) ) THEN
 #         include "HALO_EM_TKE_5.inc"
          ELSE
 #         include "HALO_EM_TKE_3.inc"
          ENDIF
-       ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+       ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
          IF ( (config_flags%tke_adv_opt /= ORIGINAL .and. config_flags%tke_adv_opt /= WENO_SCALAR) .and. (rk_step == rk_order-1) ) THEN
 #         include "HALO_EM_TKE_7.inc"
          ELSE
@@ -4264,12 +4265,13 @@ BENCH_END(moist_phys_end_tim)
 
 
 #ifdef DM_PARALLEL
-   IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+   IF      ( config_flags%h_mom_adv_order <= 4 .and. config_flags%h_sca_adv_order <= 4 ) THEN
 #    include "HALO_EM_D3_3.inc"
-   ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+   ELSE IF ( config_flags%h_mom_adv_order <= 6 .and. config_flags%h_sca_adv_order <= 6 ) THEN
 #    include "HALO_EM_D3_5.inc"
    ELSE 
-      WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+      WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order or h_sca_adv_order = ', &
+               config_flags%h_mom_adv_order, config_flags%h_sca_adv_order
       CALL wrf_error_fatal(TRIM(wrf_err_message))
    ENDIF
 #  include "PERIOD_BDY_EM_D3.inc"
@@ -4609,12 +4611,13 @@ BENCH_END(bc_2d_tim)
 ! see above
 !--------------------------------------------------------------
    CALL wrf_debug ( 200 , ' call HALO_RK_E' )
-   IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+   IF      ( config_flags%h_mom_adv_order <= 4  .and. config_flags%h_sca_adv_order <= 4 ) THEN
 #    include "HALO_EM_E_3.inc"
-   ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+   ELSE IF ( config_flags%h_mom_adv_order <= 6 .and. config_flags%h_sca_adv_order <= 6 ) THEN
 #    include "HALO_EM_E_5.inc"
    ELSE
-     WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+     WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order or h_sca_adv_order = ', &
+               config_flags%h_mom_adv_order, config_flags%h_sca_adv_order
      CALL wrf_error_fatal(TRIM(wrf_err_message))
    ENDIF
 #endif
@@ -4625,12 +4628,12 @@ BENCH_END(bc_2d_tim)
 ! see above
 !--------------------------------------------------------------
      CALL wrf_debug ( 200 , ' call HALO_RK_MOIST' )
-     IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+     IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_MOIST_E_3.inc"
-     ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+     ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_MOIST_E_5.inc"
      ELSE
-       WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+       WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
        CALL wrf_error_fatal(TRIM(wrf_err_message))
      ENDIF
    ENDIF
@@ -4639,12 +4642,12 @@ BENCH_END(bc_2d_tim)
 ! see above
 !--------------------------------------------------------------
      CALL wrf_debug ( 200 , ' call HALO_RK_CHEM' )
-     IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+     IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_CHEM_E_3.inc"
-     ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+     ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_CHEM_E_5.inc"
      ELSE
-       WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+       WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
        CALL wrf_error_fatal(TRIM(wrf_err_message))
      ENDIF
    ENDIF
@@ -4653,12 +4656,12 @@ BENCH_END(bc_2d_tim)
 ! see above
 !--------------------------------------------------------------
      CALL wrf_debug ( 200 , ' call HALO_RK_TRACER' )
-     IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+     IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_TRACER_E_3.inc"
-     ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+     ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_TRACER_E_5.inc"
      ELSE
-       WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+       WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
        CALL wrf_error_fatal(TRIM(wrf_err_message))
      ENDIF
    ENDIF
@@ -4667,12 +4670,12 @@ BENCH_END(bc_2d_tim)
 ! see above
 !--------------------------------------------------------------
      CALL wrf_debug ( 200 , ' call HALO_RK_SCALAR' )
-     IF      ( config_flags%h_mom_adv_order <= 4 ) THEN
+     IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_SCALAR_E_3.inc"
-     ELSE IF ( config_flags%h_mom_adv_order <= 6 ) THEN
+     ELSE IF ( config_flags%h_sca_adv_order <= 6 ) THEN
 #      include "HALO_EM_SCALAR_E_5.inc"
      ELSE
-       WRITE(wrf_err_message,*)'solve_em: invalid h_mom_adv_order = ',config_flags%h_mom_adv_order
+       WRITE(wrf_err_message,*)'solve_em: invalid h_sca_adv_order = ',config_flags%h_sca_adv_order
        CALL wrf_error_fatal(TRIM(wrf_err_message))
      ENDIF
    ENDIF

--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -228,6 +228,9 @@ CONTAINS
       CALL nl_set_nproc_y ( 1, ntasks_y )
       WRITE( wrf_err_message , * )'Ntasks in X ',ntasks_x,', ntasks in Y ',ntasks_y
       CALL wrf_message( wrf_err_message )
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+      CALL MPI_BARRIER( local_communicator, ierr )
+#endif
       RETURN
    END SUBROUTINE wrf_dm_initialize
 

--- a/external/io_int/module_io_int_read.F90
+++ b/external/io_int/module_io_int_read.F90
@@ -87,7 +87,7 @@ end module module_io_int_read
 module module_io_int_read
 
     use module_io_int_idx,           only: io_int_loc, r_info
-    use, intrinsic :: iso_c_binding, only: c_int32_t
+    use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t
 
     implicit none
 
@@ -127,9 +127,9 @@ contains
     integer,                 intent(out) :: dst
     integer,                 intent(out) :: ierr
 
-    integer(kind=mpi_offset_kind)       :: offset
-    integer                             :: count
-    integer                             :: tmp
+    integer(c_int64_t)                   :: offset
+    integer(c_int32_t)                   :: count
+    integer                              :: tmp
 
     call io_int_loc(varname, records, offset, count, ierr)
     if (ierr .ne. 0) then
@@ -161,8 +161,8 @@ contains
     integer,                 intent(inout) :: dst(:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i
     integer                                :: its, ite
@@ -219,8 +219,8 @@ contains
     integer,                 intent(inout) :: dst(:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j
     integer                                :: its, ite, jts, jte
@@ -279,8 +279,8 @@ contains
     integer,                 intent(inout) :: dst(:,:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j, k
     integer                                :: its, ite, jts, jte, kts, kte
@@ -343,8 +343,8 @@ contains
     real,                    intent(out) :: dst
     integer,                 intent(out) :: ierr
 
-    integer(kind=mpi_offset_kind)        :: offset
-    integer                              :: count
+    integer(c_int64_t)                   :: offset
+    integer(c_int32_t)                   :: count
     integer                              :: tmp
 
     call io_int_loc(varname, records, offset, count, ierr)
@@ -377,8 +377,8 @@ contains
     real,                    intent(inout) :: dst(:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i
     integer                                :: its, ite
@@ -435,8 +435,8 @@ contains
     real,                    intent(inout) :: dst(:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j
     integer                                :: its, ite, jts, jte
@@ -495,8 +495,8 @@ contains
     real,                    intent(inout) :: dst(:,:,:)
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i, j, k
     integer                                :: its, ite, jts, jte, kts, kte
@@ -559,8 +559,8 @@ contains
     character(len=*),        intent(inout) :: dst
     integer,                 intent(out)   :: ierr
 
-    integer(kind=mpi_offset_kind)          :: offset
-    integer                                :: count
+    integer(c_int64_t)                     :: offset
+    integer(c_int32_t)                     :: count
     integer                                :: num
     integer                                :: i
     integer, allocatable, dimension(:)     :: tmp

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -49,6 +49,7 @@
 #if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
       USE module_dm, ONLY : wrf_dm_max_real
 #endif
+      USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 
       IMPLICIT NONE
 
@@ -1304,16 +1305,16 @@
 
          IF (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) THEN
           do k = kts, kte
-             re_qc1d(k) = 2.49E-6
-             re_qi1d(k) = 4.99E-6
-             re_qs1d(k) = 9.99E-6
+             re_qc1d(k) = RE_QC_BG
+             re_qi1d(k) = RE_QI_BG
+             re_qs1d(k) = RE_QS_BG
           enddo
           call calc_effectRad (t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d,  &
                       re_qc1d, re_qi1d, re_qs1d, kts, kte)
           do k = kts, kte
-             re_cloud(i,k,j) = MAX(2.49E-6, MIN(re_qc1d(k), 50.E-6))
-             re_ice(i,k,j)   = MAX(4.99E-6, MIN(re_qi1d(k), 125.E-6))
-             re_snow(i,k,j)  = MAX(9.99E-6, MIN(re_qs1d(k), 999.E-6))
+             re_cloud(i,k,j) = MAX(RE_QC_BG, MIN(re_qc1d(k), 50.E-6))
+             re_ice(i,k,j)   = MAX(RE_QI_BG, MIN(re_qi1d(k), 125.E-6))
+             re_snow(i,k,j)  = MAX(RE_QS_BG, MIN(re_qs1d(k), 999.E-6))
           enddo
          ENDIF
 
@@ -5065,7 +5066,7 @@
 
       if (has_qc) then
       do k = kts, kte
-         re_qc1d(k) = 2.49E-6
+         re_qc1d(k) = RE_QC_BG
          if (rc(k).le.R1 .or. nc(k).le.R2) CYCLE
          if (nc(k).lt.100) then
             inu_c = 15
@@ -5081,16 +5082,16 @@
 
       if (has_qi) then
       do k = kts, kte
-         re_qi1d(k) = 2.49E-6
+         re_qi1d(k) = RE_QI_BG
          if (ri(k).le.R1 .or. ni(k).le.R2) CYCLE
          lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
-         re_qi1d(k) = MAX(2.51E-6, MIN(SNGL(0.5D0 * DBLE(3.+mu_i)/lami), 125.E-6))
+         re_qi1d(k) = MAX(5.01E-6, MIN(SNGL(0.5D0 * DBLE(3.+mu_i)/lami), 125.E-6))
       enddo
       endif
 
       if (has_qs) then
       do k = kts, kte
-         re_qs1d(k) = 4.99E-6
+         re_qs1d(k) = RE_QS_BG
          if (rs(k).le.R1) CYCLE
          tc0 = MIN(-0.1, t1d(k)-273.15)
          smob = rs(k)*oams
@@ -5125,7 +5126,7 @@
      &        + sb(7)*tc0*tc0*cse(1) + sb(8)*tc0*cse(1)*cse(1) &
      &        + sb(9)*tc0*tc0*tc0 + sb(10)*cse(1)*cse(1)*cse(1)
          smoc = a_ * smo2**b_
-         re_qs1d(k) = MAX(5.01E-6, MIN(0.5*(smoc/smob), 999.E-6))
+         re_qs1d(k) = MAX(10.01E-6, MIN(0.5*(smoc/smob), 999.E-6))
       enddo
       endif
 

--- a/phys/module_mp_wdm5.F
+++ b/phys/module_mp_wdm5.F
@@ -10,6 +10,7 @@
 MODULE module_mp_wdm5
 !
    USE module_mp_radar
+   USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops
    REAL, PARAMETER, PRIVATE :: n0r = 8.e6         ! intercept parameter rain
@@ -289,9 +290,9 @@ CONTAINS
         if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
           do i = its, ite
             do k = kts, kte
-              re_qc(k) = 2.51E-6
-              re_qi(k) = 10.01E-6
-              re_qs(k) = 25.E-6
+              re_qc(k) = RE_QC_BG
+              re_qi(k) = RE_QI_BG
+              re_qs(k) = RE_QS_BG
 
               t1d(k)  = th(i,k,j)*pii(i,k,j)
               den1d(k)= den(i,k,j)
@@ -304,9 +305,9 @@ CONTAINS
                                 qmin, t0c, re_qc, re_qi, re_qs,         &
                                 kts, kte, i, j)
             do k = kts, kte
-              re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
-              re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
-              re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
+              re_cloud(i,k,j) = MAX(RE_QC_BG, MIN(re_qc(k),  50.E-6))
+              re_ice(i,k,j)   = MAX(RE_QI_BG, MIN(re_qi(k), 125.E-6))
+              re_snow(i,k,j)  = MAX(RE_QS_BG, MIN(re_qs(k), 999.E-6))
             enddo ! k loop
           enddo   ! i loop
         endif     ! has_reqc, etc...

--- a/phys/module_mp_wdm6.F
+++ b/phys/module_mp_wdm6.F
@@ -10,6 +10,7 @@
 !-------------------------------------------------------------------------------
 !
    use module_mp_radar
+   use module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
 !
 !-------------------------------------------------------------------------------
@@ -301,9 +302,9 @@
      if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
        do i = its,ite
          do k = kts,kte
-           re_qc(k) = 2.51e-6
-           re_qi(k) = 10.01e-6
-           re_qs(k) = 25.e-6
+           re_qc(k) = RE_QC_BG
+           re_qi(k) = RE_QI_BG
+           re_qs(k) = RE_QS_BG
 !
            t1d(k)  = th(i,k,j)*pii(i,k,j)
            den1d(k)= den(i,k,j)
@@ -318,9 +319,9 @@
                              kts, kte, i, j)
 !
          do k = kts,kte
-           re_cloud(i,k,j) = max(2.51e-6,  min(re_qc(k),  50.e-6))
-           re_ice(i,k,j)   = max(10.01e-6, min(re_qi(k), 125.e-6))
-           re_snow(i,k,j)  = max(25.e-6,   min(re_qs(k), 999.e-6))
+           re_cloud(i,k,j) = max(RE_QC_BG, min(re_qc(k),  50.e-6))
+           re_ice(i,k,j)   = max(RE_QI_BG, min(re_qi(k), 125.e-6))
+           re_snow(i,k,j)  = max(RE_QS_BG, min(re_qs(k), 999.e-6))
          enddo
        enddo
      endif

--- a/phys/module_mp_wdm7.F
+++ b/phys/module_mp_wdm7.F
@@ -9,6 +9,7 @@ MODULE module_mp_wdm7
 !
 !
    USE module_mp_radar
+   USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops
    REAL, PARAMETER, PRIVATE :: n0r = 8.e6         ! intercept parameter rain
@@ -334,9 +335,9 @@ CONTAINS
          IF (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) THEN
            DO i=its,ite
              DO k=kts,kte
-               re_qc(k) = 2.51E-6
-               re_qi(k) = 10.01E-6
-               re_qs(k) = 25.E-6
+               re_qc(k) = RE_QC_BG
+               re_qi(k) = RE_QI_BG
+               re_qs(k) = RE_QS_BG
 
                t1d(k)  = th(i,k,j)*pii(i,k,j)
                den1d(k)= den(i,k,j)
@@ -349,9 +350,9 @@ CONTAINS
                                  qmin, t0c, re_qc, re_qi, re_qs,       &
                                  kts, kte, i, j)
              DO k=kts,kte
-               re_cloud(i,k,j) = max(2.51E-6,  min(re_qc(k),  50.E-6))
-               re_ice(i,k,j)   = max(10.01E-6, min(re_qi(k), 125.E-6))
-               re_snow(i,k,j)  = max(25.E-6,   min(re_qs(k), 999.E-6))
+               re_cloud(i,k,j) = max(RE_QC_BG, min(re_qc(k),  50.E-6))
+               re_ice(i,k,j)   = max(RE_QI_BG, min(re_qi(k), 125.E-6))
+               re_snow(i,k,j)  = max(RE_QS_BG, min(re_qs(k), 999.E-6))
              ENDDO
            ENDDO
          ENDIF

--- a/phys/module_mp_wsm3.F
+++ b/phys/module_mp_wsm3.F
@@ -11,6 +11,7 @@
 
 MODULE module_mp_wsm3
 !
+   USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops
    REAL, PARAMETER, PRIVATE :: n0r = 8.e6         ! intercept parameter rain
@@ -162,9 +163,9 @@ CONTAINS
         if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
           do i=its,ite
             do k=kts,kte
-              re_qc(k) = 2.51E-6
-              re_qi(k) = 10.01E-6
-              re_qs(k) = 25.E-6
+              re_qc(k) = RE_QC_BG
+              re_qi(k) = RE_QI_BG
+              re_qs(k) = RE_QS_BG
 
               t1d(k)  = th(i,k,j)*pii(i,k,j)
               den1d(k)= den(i,k,j)
@@ -182,9 +183,9 @@ CONTAINS
                                 qmin, t0c, re_qc, re_qi, re_qs,         &
                                 kts, kte, i, j)
             do k=kts,kte
-              re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
-              re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
-              re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
+              re_cloud(i,k,j) = MAX(RE_QC_BG, MIN(re_qc(k),  50.E-6))
+              re_ice(i,k,j)   = MAX(RE_QI_BG, MIN(re_qi(k), 125.E-6))
+              re_snow(i,k,j)  = MAX(RE_QS_BG, MIN(re_qs(k), 999.E-6))
             enddo
           enddo
         endif     ! has_reqc, etc...

--- a/phys/module_mp_wsm5.F
+++ b/phys/module_mp_wsm5.F
@@ -13,6 +13,7 @@
 MODULE module_mp_wsm5
 !
    USE module_mp_radar
+   USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops
    REAL, PARAMETER, PRIVATE :: n0r = 8.e6         ! intercept parameter rain
@@ -218,9 +219,9 @@ CONTAINS
          if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
            do i=its,ite
              do k=kts,kte
-               re_qc(k) = 2.51E-6
-               re_qi(k) = 10.01E-6
-               re_qs(k) = 25.E-6
+               re_qc(k) = RE_QC_BG
+               re_qi(k) = RE_QI_BG 
+               re_qs(k) = RE_QS_BG
 
                t1d(k)  = th(i,k,j)*pii(i,k,j)
                den1d(k)= den(i,k,j)
@@ -232,9 +233,9 @@ CONTAINS
                                  qmin, t0c, re_qc, re_qi, re_qs,               &
                                  kts, kte, i, j)
              do k=kts,kte
-               re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
-               re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
-               re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
+               re_cloud(i,k,j) = MAX(RE_QC_BG, MIN(re_qc(k),  50.E-6))
+               re_ice(i,k,j)   = MAX(RE_QI_BG, MIN(re_qi(k), 125.E-6))
+               re_snow(i,k,j)  = MAX(RE_QS_BG, MIN(re_qs(k), 999.E-6))
              enddo
            enddo
          endif     ! has_reqc, etc...

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -9,6 +9,7 @@
 MODULE module_mp_wsm6
 !
    USE module_mp_radar
+   USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops
    REAL, PARAMETER, PRIVATE :: n0r = 8.e6         ! intercept parameter rain
@@ -237,9 +238,9 @@ CONTAINS
         if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
           do i=its,ite
             do k=kts,kte
-              re_qc(k) = 2.51E-6
-              re_qi(k) = 10.01E-6
-              re_qs(k) = 25.E-6
+              re_qc(k) = RE_QC_BG
+              re_qi(k) = RE_QI_BG
+              re_qs(k) = RE_QS_BG
 
               t1d(k)  = th(i,k,j)*pii(i,k,j)
               den1d(k)= den(i,k,j)
@@ -251,9 +252,9 @@ CONTAINS
                                 qmin, t0c, re_qc, re_qi, re_qs,         &
                                 kts, kte, i, j)
             do k=kts,kte
-              re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
-              re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
-              re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
+              re_cloud(i,k,j) = MAX(RE_QC_BG, MIN(re_qc(k),  50.E-6))
+              re_ice(i,k,j)   = MAX(RE_QI_BG, MIN(re_qi(k), 125.E-6))
+              re_snow(i,k,j)  = MAX(RE_QS_BG, MIN(re_qs(k), 999.E-6))
             enddo 
           enddo   
         endif     ! has_reqc, etc...

--- a/phys/module_mp_wsm7.F
+++ b/phys/module_mp_wsm7.F
@@ -9,6 +9,7 @@
 MODULE module_mp_wsm7
 !
    USE module_mp_radar
+   USE module_model_constants, only : RE_QC_BG, RE_QI_BG, RE_QS_BG
 !
    REAL, PARAMETER, PRIVATE :: dtcldcr     = 120. ! maximum time step for minor loops
    REAL, PARAMETER, PRIVATE :: n0r = 8.e6         ! intercept parameter rain
@@ -245,9 +246,9 @@ CONTAINS
         if (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) then
           do i=its,ite
             do k=kts,kte
-              re_qc(k) = 2.51E-6
-              re_qi(k) = 10.01E-6
-              re_qs(k) = 25.E-6
+              re_qc(k) = RE_QC_BG
+              re_qi(k) = RE_QI_BG
+              re_qs(k) = RE_QS_BG
 !
               t1d(k)  = th(i,k,j)*pii(i,k,j)
               den1d(k)= den(i,k,j)
@@ -261,9 +262,9 @@ CONTAINS
                                 kts, kte, i, j)
 !
             do k=kts,kte
-              re_cloud(i,k,j) = MAX(2.51E-6,  MIN(re_qc(k),  50.E-6))
-              re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi(k), 125.E-6))
-              re_snow(i,k,j)  = MAX(25.E-6,   MIN(re_qs(k), 999.E-6))
+              re_cloud(i,k,j) = MAX(RE_QC_BG, MIN(re_qc(k),  50.E-6))
+              re_ice(i,k,j)   = MAX(RE_QI_BG, MIN(re_qi(k), 125.E-6))
+              re_snow(i,k,j)  = MAX(RE_QS_BG, MIN(re_qs(k), 999.E-6))
             enddo 
           enddo   
         endif     ! if has_reqc ne 0 end

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -942,15 +942,22 @@ CONTAINS
 ! for cloud, ice, and snow.
 
    IF ( config_flags%swint_opt .eq. 2 ) THEN
-      IF ( ( has_reqc .EQ. 1 ) .AND. &
-           ( has_reqi .EQ. 1 ) .AND. &
-           ( has_reqs .EQ. 1 ) .AND. &
+      IF ((   config_flags%mp_physics == THOMPSON .OR.        &
+              config_flags%mp_physics == THOMPSONAERO .OR.    &
+              config_flags%mp_physics == WSM3SCHEME .OR.    &
+              config_flags%mp_physics == WSM5SCHEME .OR.    &
+              config_flags%mp_physics == WSM6SCHEME .OR.    &
+              config_flags%mp_physics == WSM7SCHEME .OR.    &
+              config_flags%mp_physics == WDM5SCHEME .OR.    &
+              config_flags%mp_physics == WDM6SCHEME .OR.    &
+              config_flags%mp_physics == WDM7SCHEME ).OR.     &
+          (( has_reqc .EQ. 0 .AND. has_reqi .EQ. 0 .and. has_reqs .EQ. 0 ) .AND. &
            ( f_qc            ) .AND. &
            ( f_qi            ) .AND. &
-           ( f_qs            ) ) THEN
+           ( f_qs            ))) THEN
          !  everything is A-OK for FARMS
       ELSE
-         CALL wrf_error_fatal ('--- ERROR: FARMS (swint_opt==2) requires a different MP scheme')
+         CALL wrf_error_fatal ('--- ERROR: FARMS (swint_opt==2) requires a different MP scheme (Please see the module_physics_init')
       END IF
    END IF
 
@@ -1163,13 +1170,13 @@ CONTAINS
     end do
 
 !..Fill initial starting values of radiative effective radii for
-!.. cloud water (2.51 microns), cloud ice (5.01 microns), and
-!.. snow (10.01 microns).
+!.. cloud water (2.49 microns), cloud ice (4.99 microns), and
+!.. snow (9.99 microns).
     if (has_reqc.ne.0) then
        do j=jts,jtf
           do k=kts,ktf
           do i=its,itf
-             re_cloud(i,k,j) = 2.51E-6
+             re_cloud(i,k,j) = RE_QC_BG
           end do
           end do
        end do
@@ -1178,7 +1185,7 @@ CONTAINS
        do j=jts,jtf
           do k=kts,ktf
           do i=its,itf
-             re_ice(i,k,j) = 5.01E-6
+             re_ice(i,k,j) = RE_QI_BG
           end do
           end do
        end do
@@ -1187,7 +1194,7 @@ CONTAINS
        do j=jts,jtf
           do k=kts,ktf
           do i=its,itf
-             re_snow(i,k,j) = 10.01E-6
+             re_snow(i,k,j) = RE_QS_BG
           end do
           end do
        end do

--- a/phys/module_ra_farms.F
+++ b/phys/module_ra_farms.F
@@ -27,26 +27,29 @@
     real, parameter :: DE_CLOUD_MIN = 5.0, DE_CLOUD_MAX = 120.0
     real, parameter :: TAU_MIN = 0.0001, TAU_MAX = 300.0
     real, parameter :: AOD550_VAL = 0.12, ANGEXP_VAL = 1.3, AERSSA_VAL = 0.85, AERASY_VAL = 0.9
+    real, parameter :: RE_CLOUD_CLIM = 8.E-6, RE_ICE_CLIM = 24.E-6, RE_SNOW_CLIM = 24.E-6
 
   contains
 
     subroutine Farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte,  &
            p8w, rho, dz8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
            coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-           julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+           julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2, &
+           has_reqc, has_reqi, has_reqs, cldfra)
 
       implicit None
 
       integer, intent(in) :: ims, ime, jms, jme, its, ite, jts, jte, kms, kme, &
           kts, kte
 
-      integer, intent(in) :: aer_opt
+      integer, intent(in) :: aer_opt, has_reqc, has_reqi, has_reqs
       real,    intent(in) :: julian
 
       real, dimension(ims:ime, jms:jme), intent(in) :: albedo, coszen_loc
 
       real, dimension(ims:ime, kms:kme, jms:jme ), intent(in) :: qv, qi, qs, qc, &
-          p8w, rho, dz8w, re_cloud, re_ice, re_snow 
+          p8w, rho, dz8w, cldfra
+      real, dimension(ims:ime, kms:kme, jms:jme ), intent(in) :: re_cloud, re_ice, re_snow
 
       real, dimension(ims:ime, jms:jme), intent(inout) :: aerssa2d, aerasy2d, aod5502d, angexp2d
       real, dimension(ims:ime,jms:jme), intent(inout) :: swddir2, swdown2, &
@@ -54,10 +57,10 @@
                                                          swdownc2, swddnic2
 
         ! Local
-      integer :: i, j
+      integer :: i, j, k
       real    :: tau_qv, tau_qi, tau_qs, pmw, swp, iwp, lwp, beta
-      real    :: re_cloud_path, re_ice_path, re_snow_path, q_aux
-      real, dimension(kms:kme) :: rhodz
+      real    :: re_cloud_path, re_ice_path, re_snow_path, q_aux, cldfra_h
+      real, dimension(kms:kme) :: rhodz, re_cloud_k, re_ice_k, re_snow_k
 
 
       j_loop: do j = jts, jte
@@ -71,6 +74,34 @@
              swddnic2(i, j) = 0.0
            else
              rhodz(:) = rho(i, :, j) * dz8w(i, :, j) / (1. + qv(i, :, j))
+             re_cloud_k(:) = re_cloud(i, :, j)
+             re_ice_k(:) = re_ice(i, :, j)
+             re_snow_k(:) = re_snow(i, :, j)
+
+             if (has_reqc == 1) then
+               do k = kts, kte
+                 if (CLDFRA (i, k, j) > 0.0 .and. re_cloud_k(k) < 2.5E-6) re_cloud_k(k) = RE_CLOUD_CLIM
+               end do
+             else
+               re_cloud_k(:) = RE_CLOUD_CLIM
+             end if
+
+             if (has_reqi == 1) then
+               do k = kts, kte
+                 if (cldfra(i, k, j) > 0.0 .and. re_ice_k(k) < 5.0E-6) re_ice_k(k) = RE_ICE_CLIM
+               end do
+             else
+               re_ice_k(:) = RE_ICE_CLIM
+             end if
+
+             if (has_reqs == 1) then
+               do k = kts, kte
+                 if (cldfra(i, k, j) > 0.0 .and. re_snow_k(k) < 10.0E-6) re_snow_k(k) = RE_SNOW_CLIM
+               end do
+             else
+               re_snow_k(:) = RE_SNOW_CLIM
+             end if
+
                ! PMW
              pmw = integrate_1var (rhodz, qv(i, :, j), kms, kme, kts, kte)
 
@@ -80,7 +111,7 @@
 
              if (q_aux > 0.0) then
                re_cloud_path = integrate_2var (rhodz, qc(i, :, j), &
-                   re_cloud(i, :, j), kms, kme, kts, kte)
+                   re_cloud_k, kms, kme, kts, kte)
                re_cloud_path = re_cloud_path / q_aux
              else
                re_cloud_path = 0.0
@@ -92,7 +123,7 @@
 
              if (q_aux > 0.0) then
                re_ice_path = integrate_2var (rhodz, qi(i, :, j), &
-                   re_ice(i, :, j), kms, kme, kts, kte)
+                   re_ice_k, kms, kme, kts, kte)
                re_ice_path = re_ice_path / q_aux
              else
                re_ice_path = 0.0
@@ -104,10 +135,20 @@
 
              if (q_aux > 0.0) then
                re_snow_path = integrate_2var (rhodz, qs(i, :, j), &
-                   re_snow(i, :, j), kms, kme, kts, kte)
+                   re_snow_k, kms, kme, kts, kte)
                re_snow_path = re_snow_path / q_aux
              else
                re_snow_path = 0.0
+             end if
+
+             ! Calculate horizontal cloud fraction 
+             q_aux = integrate_1var (rhodz, qc(i, :, j) + qi(i, :, j) + qs(i, :, j), kms, kme, kts, kte)
+             if (q_aux > 0.0) then
+               cldfra_h = integrate_2var (rhodz, qc(i, :, j) + qi(i, :, j) + qs(i, :, j), &
+                   cldfra(i, :, j), kms, kme, kts, kte)
+               cldfra_h = cldfra_h / q_aux
+             else
+               cldfra_h = 0.0
              end if
 
                ! optical thickness  water
@@ -154,11 +195,11 @@
              end if
 
              beta = aod5502d(i, j) * (1000.0/ 550.0) ** (- angexp2d(i, j))
-              
-             Call Farms (p8w(i, 1, j), albedo(i, j), aerssa2d(i, j), &
-                 aerasy2d(i, j), coszen_loc(i, j), beta,   &
-                 angexp2d(i, j), pmw, tau_qv, tau_qi, tau_qs,        &
-                 re_cloud_path, re_ice_path, re_snow_path, int(julian),   &
+
+             Call Farms (p8w(i, 1, j), albedo(i, j), aerssa2d(i, j),         &
+                 aerasy2d(i, j), coszen_loc(i, j), beta,                     &
+                 angexp2d(i, j), pmw, tau_qv, tau_qi, tau_qs, cldfra_h,      &
+                 re_cloud_path, re_ice_path, re_snow_path, int(julian),      &
                  swdown2(i, j), swddni2(i, j), swddif2(i, j), swddir2(i, j), &
                  swdownc2(i, j), swddnic2(i, j))
 
@@ -210,7 +251,7 @@
 
 
     subroutine FARMS (p_pa, albdo, ssa, g, solarangle, beta, alpha, w_mm, &
-        tau_qv, tau_qi, tau_qs, re_cloud_path_m, re_ice_path_m, re_snow_path_m, &
+        tau_qv, tau_qi, tau_qs, cldfra_h, re_cloud_path_m, re_ice_path_m, re_snow_path_m, &
         juday, ghi, dni, dif, dir, ghi_clear, dni_clear)
 
         !!!!!! This Fast All-sky Radiation Model for Solar applications (FARMS) was developed by
@@ -248,7 +289,7 @@
       implicit none
   
       real, intent(in) :: p_pa, albdo, ssa, g, solarangle, beta, alpha, w_mm, &
-          tau_qv, tau_qi, tau_qs, re_cloud_path_m, re_ice_path_m, re_snow_path_m
+          tau_qv, tau_qi, tau_qs, re_cloud_path_m, re_ice_path_m, re_snow_path_m, cldfra_h
       integer, intent(in) :: juday
       real, intent(out) :: ghi, dni, dir, dif, ghi_clear, dni_clear
 
@@ -354,6 +395,9 @@
       Ftotal = F1/(1.0-albdo*(Ruuclr + Ruucld*Tuuclr*Tuuclr))
       ghi = Ftotal
       ghi_clear =  solarangle * F0 * ((Tddclr + Tduclr) / (1.0 - albdo * Ruuclr))
+
+      ghi = cldfra_h * ghi + (1.0 - cldfra_h) * ghi_clear
+      dni = cldfra_h * dni + (1.0 - cldfra_h) * dni_clear
 
       dif = ghi - dir
 

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2797,8 +2797,9 @@ CONTAINS
          jte = j_end(ij)
          call farms_driver (ims, ime, jms, jme, its, ite, jts, jte, kms, kme, kts, kte, &
               p8w, rho, dz8w, albedo, aer_opt, aerssa2d, aerasy2d, aod5502d, angexp2d,  &
-              coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,    &
-              julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2)
+              coszen_loc, qv, qi, qs, qc, re_cloud, re_ice, re_snow,                    &
+              julian, swdown2, swddir2, swddni2, swddif2, swdownc2, swddnic2,           &
+              has_reqc, has_reqi, has_reqs, CLDFRA)
        enddo
        !$OMP END PARALLEL DO
     end if

--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -1161,6 +1161,17 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
    parameters%GDDS3     =     GDDS3_TABLE(CROPTYPE)    ! GDD from seeding to post vegetative 
    parameters%GDDS4     =     GDDS4_TABLE(CROPTYPE)    ! GDD from seeding to intial reproductive
    parameters%GDDS5     =     GDDS5_TABLE(CROPTYPE)    ! GDD from seeding to pysical maturity 
+   parameters%C3PSN     =     C3PSNI_TABLE(CROPTYPE)   ! parameters from stomata ! Zhe Zhang 2020-07-13
+   parameters%KC25      =      KC25I_TABLE(CROPTYPE)
+   parameters%AKC       =       AKCI_TABLE(CROPTYPE)
+   parameters%KO25      =      KO25I_TABLE(CROPTYPE)
+   parameters%AKO       =       AKOI_TABLE(CROPTYPE)
+   parameters%AVCMX     =     AVCMXI_TABLE(CROPTYPE)
+   parameters%VCMX25    =    VCMX25I_TABLE(CROPTYPE)
+   parameters%BP        =        BPI_TABLE(CROPTYPE)
+   parameters%MP        =        MPI_TABLE(CROPTYPE)
+   parameters%FOLNMX    =    FOLNMXI_TABLE(CROPTYPE)
+   parameters%QE25      =      QE25I_TABLE(CROPTYPE)   ! ends here
    parameters%C3C4      =      C3C4_TABLE(CROPTYPE)    ! photosynthetic pathway:  1. = c3 2. = c4
    parameters%AREF      =      AREF_TABLE(CROPTYPE)    ! reference maximum CO2 assimulation rate 
    parameters%PSNRF     =     PSNRF_TABLE(CROPTYPE)    ! CO2 assimulation reduction factor(0-1) (caused by non-modeling part,e.g.pest,weeds)
@@ -1187,6 +1198,9 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
    parameters%STPT      =      STPT_TABLE(CROPTYPE,:)  ! fraction of carbohydrate flux to stem
    parameters%RTPT      =      RTPT_TABLE(CROPTYPE,:)  ! fraction of carbohydrate flux to root
    parameters%GRAINPT   =   GRAINPT_TABLE(CROPTYPE,:)  ! fraction of carbohydrate flux to grain
+   parameters%LFCT      =      LFCT_TABLE(CROPTYPE,:)  ! fraction of translocation to grain ! Zhe Zhang 2020-07-13
+   parameters%STCT      =      STCT_TABLE(CROPTYPE,:)  ! fraction of translocation to grain
+   parameters%RTCT      =      RTCT_TABLE(CROPTYPE,:)  ! fraction of translocation to grain
    parameters%BIO2LAI   =   BIO2LAI_TABLE(CROPTYPE)    ! leaf are per living leaf biomass [m^2/kg]
   END IF
 
@@ -1728,7 +1742,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 		        croptype(i,1,j) > croptype(i,4,j) ) then   ! choose corn
 
 		   cropcat (i,j) = 1
-                   lfmassxy(i,j) =    lai(i,j)/0.035
+                   lfmassxy(i,j) =    lai(i,j)/0.015               ! Initialize lfmass Zhe Zhang 2020-07-13
                    stmassxy(i,j) = xsaixy(i,j)/0.003
 
 	         elseif(croptype(i,2,j) > croptype(i,1,j) .and. &
@@ -1736,7 +1750,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 		        croptype(i,2,j) > croptype(i,4,j) ) then   ! choose soybean
 
 		   cropcat (i,j) = 2
-                   lfmassxy(i,j) =    lai(i,j)/0.015
+                   lfmassxy(i,j) =    lai(i,j)/0.030               ! Initialize lfmass Zhe Zhang 2020-07-13
                    stmassxy(i,j) = xsaixy(i,j)/0.003
 
 	         else

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -346,6 +346,9 @@ MODULE MODULE_SF_NOAHMPLSM
      REAL :: LFPT(NSTAGE)     ! fraction of carbohydrate flux to leaf
      REAL :: STPT(NSTAGE)     ! fraction of carbohydrate flux to stem
      REAL :: RTPT(NSTAGE)     ! fraction of carbohydrate flux to root
+     REAL :: LFCT(NSTAGE)     ! fraction of carbohydrate flux transallocate from leaf to grain ! Zhe Zhang 2020-07-13
+     REAL :: STCT(NSTAGE)     ! fraction of carbohydrate flux transallocate from stem to grain
+     REAL :: RTCT(NSTAGE)     ! fraction of carbohydrate flux transallocate from root to grain
      REAL :: GRAINPT(NSTAGE)  ! fraction of carbohydrate flux to grain
      REAL :: BIO2LAI          ! leaf are per living leaf biomass [m^2/kg]
 
@@ -8589,6 +8592,7 @@ END  SUBROUTINE SHALLOWWATERTABLE
   REAL                   :: STMSMN
   REAL                   :: SAPM     !stem area per unit mass (m2/g)
   REAL                   :: DIEST
+  REAL                   :: LFCONVERT   !leaf to grain conversion ! Zhe Zhang 2020-07-13
   REAL                   :: STCONVERT   !stem to grain conversion [g/m2/s]
   REAL                   :: RTCONVERT   !root to grain conversion [g/m2/s]
 ! -------------------------- constants -------------------------------
@@ -8691,15 +8695,23 @@ END  SUBROUTINE SHALLOWWATERTABLE
 
      GPP = CBHYDRAFX* 0.4 !!g/m2/s C  0.4=12/30, CH20 to C
 
+     LFCONVERT = 0.0 ! Zhe Zhang 2020-07-13
      STCONVERT = 0.0
      RTCONVERT = 0.0
-     IF(PGS==6) THEN
-       STCONVERT = STMASS*(0.00005*DT/3600.0)
-       STMASS = STMASS - STCONVERT
-       RTCONVERT = RTMASS*(0.0005*DT/3600.0)
-       RTMASS = RTMASS - RTCONVERT
-       GRAIN  = GRAIN + STCONVERT + RTCONVERT
-     END IF
+     LFCONVERT = LFMASS*(parameters%LFCT(PGS)*DT/3600.0)
+     STCONVERT = STMASS*(parameters%STCT(PGS)*DT/3600.0)
+     RTCONVERT = RTMASS*(parameters%RTCT(PGS)*DT/3600.0)
+     LFMASS = LFMASS - LFCONVERT
+     STMASS = STMASS - STCONVERT
+     RTMASS = RTMASS - RTCONVERT
+     GRAIN  = GRAIN + STCONVERT + RTCONVERT + LFCONVERT
+     !IF(PGS==6) THEN
+     !  STCONVERT = STMASS*(0.00005*DT/3600.0)
+     !  STMASS = STMASS - STCONVERT
+     !  RTCONVERT = RTMASS*(0.0005*DT/3600.0)
+     !  RTMASS = RTMASS - RTCONVERT
+     !  GRAIN  = GRAIN + STCONVERT + RTCONVERT
+     !END IF
     
      IF(RTMASS.LT.0.0) THEN
        RTTOVR = NPPR
@@ -9300,6 +9312,18 @@ MODULE NOAHMP_TABLES
     REAL :: GDDS4_TABLE(NCROP)          ! GDD from seeding to intial reproductive
     REAL :: GDDS5_TABLE(NCROP)          ! GDD from seeding to pysical maturity 
 
+    REAL :: C3PSNI_TABLE(NCROP)       !photosynthetic pathway: 0. = c4, 1. = c3 ! Zhe Zhang 2020-07-03
+    REAL :: KC25I_TABLE(NCROP)        !co2 michaelis-menten constant at 25c (pa)
+    REAL :: AKCI_TABLE(NCROP)         !q10 for kc25
+    REAL :: KO25I_TABLE(NCROP)        !o2 michaelis-menten constant at 25c (pa)
+    REAL :: AKOI_TABLE(NCROP)         !q10 for ko25
+    REAL :: VCMX25I_TABLE(NCROP)      !maximum rate of carboxylation at 25c (umol co2/m**2/s)
+    REAL :: AVCMXI_TABLE(NCROP)       !q10 for vcmx25
+    REAL :: BPI_TABLE(NCROP)          !minimum leaf conductance (umol/m**2/s)
+    REAL :: MPI_TABLE(NCROP)          !slope of conductance-to-photosynthesis relationship
+    REAL :: QE25I_TABLE(NCROP)        !quantum efficiency at 25c (umol co2 / umol photon)
+    REAL :: FOLNMXI_TABLE(NCROP)      !foliage nitrogen concentration when
+
  INTEGER :: C3C4_TABLE(NCROP)           ! photosynthetic pathway:  1. = c3 2. = c4
     REAL :: AREF_TABLE(NCROP)           ! reference maximum CO2 assimulation rate 
     REAL :: PSNRF_TABLE(NCROP)          ! CO2 assimulation reduction factor(0-1) (caused by non-modeling part,e.g.pest,weeds)
@@ -9330,6 +9354,9 @@ MODULE NOAHMP_TABLES
     REAL :: STPT_TABLE(NCROP,NSTAGE)    ! fraction of carbohydrate flux to stem
     REAL :: RTPT_TABLE(NCROP,NSTAGE)    ! fraction of carbohydrate flux to root
     REAL :: GRAINPT_TABLE(NCROP,NSTAGE) ! fraction of carbohydrate flux to grain
+    REAL :: LFCT_TABLE(NCROP,NSTAGE)    ! fraction of carbohydrate translocation from leaf to grain ! Zhe Zhang 2020-07-13 
+    REAL :: STCT_TABLE(NCROP,NSTAGE)    !                                             stem to grain
+    REAL :: RTCT_TABLE(NCROP,NSTAGE)    !                                             root to grain
     REAL :: BIO2LAI_TABLE(NCROP)        ! leaf are per living leaf biomass [m^2/kg]
 
 ! MPTABLE.TBL optional parameters
@@ -9868,6 +9895,17 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
     REAL, DIMENSION(NCROP) :: GDDS3
     REAL, DIMENSION(NCROP) :: GDDS4
     REAL, DIMENSION(NCROP) :: GDDS5
+    REAL, DIMENSION(NCROP) :: C3PSN   ! this session copied from stomata parameters Zhe Zhang 2020-07-13
+    REAL, DIMENSION(NCROP) :: KC25
+    REAL, DIMENSION(NCROP) :: AKC
+    REAL, DIMENSION(NCROP) :: KO25
+    REAL, DIMENSION(NCROP) :: AKO
+    REAL, DIMENSION(NCROP) :: AVCMX
+    REAL, DIMENSION(NCROP) :: VCMX25
+    REAL, DIMENSION(NCROP) :: BP
+    REAL, DIMENSION(NCROP) :: MP
+    REAL, DIMENSION(NCROP) :: FOLNMX
+    REAL, DIMENSION(NCROP) :: QE25    ! until here
  INTEGER, DIMENSION(NCROP) :: C3C4
     REAL, DIMENSION(NCROP) :: AREF
     REAL, DIMENSION(NCROP) :: PSNRF
@@ -9894,12 +9932,20 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
     REAL, DIMENSION(NCROP) :: STPT_S1,STPT_S2,STPT_S3,STPT_S4,STPT_S5,STPT_S6,STPT_S7,STPT_S8
     REAL, DIMENSION(NCROP) :: RTPT_S1,RTPT_S2,RTPT_S3,RTPT_S4,RTPT_S5,RTPT_S6,RTPT_S7,RTPT_S8
     REAL, DIMENSION(NCROP) :: GRAINPT_S1,GRAINPT_S2,GRAINPT_S3,GRAINPT_S4,GRAINPT_S5,GRAINPT_S6,GRAINPT_S7,GRAINPT_S8
+    REAL, DIMENSION(NCROP) :: LFCT_S1,LFCT_S2,LFCT_S3,LFCT_S4,LFCT_S5,LFCT_S6,LFCT_S7,LFCT_S8
+    REAL, DIMENSION(NCROP) :: STCT_S1,STCT_S2,STCT_S3,STCT_S4,STCT_S5,STCT_S6,STCT_S7,STCT_S8
+    REAL, DIMENSION(NCROP) :: RTCT_S1,RTCT_S2,RTCT_S3,RTCT_S4,RTCT_S5,RTCT_S6,RTCT_S7,RTCT_S8
     REAL, DIMENSION(NCROP) :: BIO2LAI
 
 
-    NAMELIST / noahmp_crop_parameters /DEFAULT_CROP,   PLTDAY,     HSDAY,  PLANTPOP,      IRRI,  GDDTBASE,   GDDTCUT,     GDDS1,     GDDS2, &
-                                             GDDS3,     GDDS4,     GDDS5,      C3C4,      AREF,     PSNRF,     I2PAR,   TASSIM0, &
-                                           TASSIM1,   TASSIM2,         K,      EPSI,     Q10MR,   FOLN_MX,   LEFREEZ,            &
+!    NAMELIST / noahmp_crop_parameters /DEFAULT_CROP,   PLTDAY,     HSDAY,  PLANTPOP,      IRRI,  GDDTBASE,   GDDTCUT,     GDDS1,     GDDS2, &
+!                                             GDDS3,     GDDS4,     GDDS5,      C3C4,      AREF,     PSNRF,     I2PAR,   TASSIM0, &
+!                                           TASSIM1,   TASSIM2,         K,      EPSI,     Q10MR,   FOLN_MX,   LEFREEZ,            &
+! Zhe Zhang 2020-07-13
+    NAMELIST / noahmp_crop_parameters /DEFAULT_CROP,   PLTDAY,     HSDAY,  PLANTPOP,      IRRI,  GDDTBASE,   GDDTCUT,     GDDS1,  GDDS2,  GDDS3,     GDDS4,     GDDS5, & !
+                                              C3PSN,     KC25,       AKC,      KO25,       AKO,     AVCMX,    VCMX25,        BP,     MP, FOLNMX,      QE25, &  ! parameters added from stomata
+                                               C3C4,     AREF,     PSNRF,     I2PAR,   TASSIM0,                                               &
+                                        TASSIM1,   TASSIM2,         K,      EPSI,     Q10MR,   FOLN_MX,   LEFREEZ,               & 
                                         DILE_FC_S1,DILE_FC_S2,DILE_FC_S3,DILE_FC_S4,DILE_FC_S5,DILE_FC_S6,DILE_FC_S7,DILE_FC_S8, &
                                         DILE_FW_S1,DILE_FW_S2,DILE_FW_S3,DILE_FW_S4,DILE_FW_S5,DILE_FW_S6,DILE_FW_S7,DILE_FW_S8, &
                                             FRA_GR,                                                                              &
@@ -9911,6 +9957,9 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
                                            STPT_S1,   STPT_S2,   STPT_S3,   STPT_S4,   STPT_S5,   STPT_S6,   STPT_S7,   STPT_S8, &
                                            RTPT_S1,   RTPT_S2,   RTPT_S3,   RTPT_S4,   RTPT_S5,   RTPT_S6,   RTPT_S7,   RTPT_S8, &
                                         GRAINPT_S1,GRAINPT_S2,GRAINPT_S3,GRAINPT_S4,GRAINPT_S5,GRAINPT_S6,GRAINPT_S7,GRAINPT_S8, &
+                                           LFCT_S1,LFCT_S2,LFCT_S3,LFCT_S4,LFCT_S5,LFCT_S6,LFCT_S7,LFCT_S8,                      &
+                                           STCT_S1,STCT_S2,STCT_S3,STCT_S4,STCT_S5,STCT_S6,STCT_S7,STCT_S8,                      &
+                                           RTCT_S1,RTCT_S2,RTCT_S3,RTCT_S4,RTCT_S5,RTCT_S6,RTCT_S7,RTCT_S8,                      &
                                            BIO2LAI
 
 
@@ -9927,6 +9976,17 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
         GDDS3_TABLE     = -1.E36
         GDDS4_TABLE     = -1.E36
         GDDS5_TABLE     = -1.E36
+       C3PSNI_TABLE     = -1.E36 ! parameter from PSN copied from stomata ! Zhe Zhang 2020-07-13
+        KC25I_TABLE     = -1.E36
+         AKCI_TABLE     = -1.E36
+        KO25I_TABLE     = -1.E36
+         AKOI_TABLE     = -1.E36
+       AVCMXI_TABLE     = -1.E36
+      VCMX25I_TABLE     = -1.E36
+          BPI_TABLE     = -1.E36
+          MPI_TABLE     = -1.E36
+      FOLNMXI_TABLE     = -1.E36
+        QE25I_TABLE     = -1.E36 ! ends here
          C3C4_TABLE     = -99999
          AREF_TABLE     = -1.E36
         PSNRF_TABLE     = -1.E36
@@ -9953,6 +10013,9 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
          STPT_TABLE     = -1.E36
          RTPT_TABLE     = -1.E36
       GRAINPT_TABLE     = -1.E36
+         LFCT_TABLE     = -1.E36 ! convert start
+         STCT_TABLE     = -1.E36
+         RTCT_TABLE     = -1.E36 ! convert end
       BIO2LAI_TABLE     = -1.E36
 
 
@@ -9983,6 +10046,17 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
         GDDS3_TABLE      = GDDS3
         GDDS4_TABLE      = GDDS4
         GDDS5_TABLE      = GDDS5
+       C3PSNI_TABLE(1:5) = C3PSN(1:5)  ! parameters from stomata ! Zhe Zhang 2020-07-13
+        KC25I_TABLE(1:5) = KC25(1:5)
+         AKCI_TABLE(1:5) = AKC(1:5)
+        KO25I_TABLE(1:5) = KO25(1:5)
+         AKOI_TABLE(1:5) = AKO(1:5)
+       AVCMXI_TABLE(1:5) = AVCMX(1:5)
+      VCMX25I_TABLE(1:5) = VCMX25(1:5)
+          BPI_TABLE(1:5) = BP(1:5)
+          MPI_TABLE(1:5) = MP(1:5)
+      FOLNMXI_TABLE(1:5) = FOLNMX(1:5)
+        QE25I_TABLE(1:5) = QE25(1:5)   ! ends here
          C3C4_TABLE      = C3C4
          AREF_TABLE      = AREF
         PSNRF_TABLE      = PSNRF
@@ -10072,6 +10146,30 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
       GRAINPT_TABLE(:,6) = GRAINPT_S6
       GRAINPT_TABLE(:,7) = GRAINPT_S7
       GRAINPT_TABLE(:,8) = GRAINPT_S8
+         LFCT_TABLE(:,1) = LFCT_S1
+         LFCT_TABLE(:,2) = LFCT_S2
+         LFCT_TABLE(:,3) = LFCT_S3
+         LFCT_TABLE(:,4) = LFCT_S4
+         LFCT_TABLE(:,5) = LFCT_S5
+         LFCT_TABLE(:,6) = LFCT_S6
+         LFCT_TABLE(:,7) = LFCT_S7
+         LFCT_TABLE(:,8) = LFCT_S8
+         STCT_TABLE(:,1) = STCT_S1
+         STCT_TABLE(:,2) = STCT_S2
+         STCT_TABLE(:,3) = STCT_S3
+         STCT_TABLE(:,4) = STCT_S4
+         STCT_TABLE(:,5) = STCT_S5
+         STCT_TABLE(:,6) = STCT_S6
+         STCT_TABLE(:,7) = STCT_S7
+         STCT_TABLE(:,8) = STCT_S8
+         RTCT_TABLE(:,1) = RTCT_S1
+         RTCT_TABLE(:,2) = RTCT_S2
+         RTCT_TABLE(:,3) = RTCT_S3
+         RTCT_TABLE(:,4) = RTCT_S4
+         RTCT_TABLE(:,5) = RTCT_S5
+         RTCT_TABLE(:,6) = RTCT_S6
+         RTCT_TABLE(:,7) = RTCT_S7
+         RTCT_TABLE(:,8) = RTCT_S8
       BIO2LAI_TABLE      = BIO2LAI
 
   end subroutine read_mp_crop_parameters

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1202,7 +1202,7 @@ CONTAINS
       real    :: rzol
         nzol = int(zolf*100.)
         rzol = zolf*100. - nzol
-        if(nzol+1 .le. 1000)then
+        if(nzol+1 .lt. 1000)then
            psim_stable = psim_stab(nzol) + rzol*(psim_stab(nzol+1)-psim_stab(nzol))
         else
            psim_stable = psim_stable_full(zolf)
@@ -1215,7 +1215,7 @@ CONTAINS
       real    :: rzol
         nzol = int(zolf*100.)
         rzol = zolf*100. - nzol
-        if(nzol+1 .le. 1000)then
+        if(nzol+1 .lt. 1000)then
            psih_stable = psih_stab(nzol) + rzol*(psih_stab(nzol+1)-psih_stab(nzol))
         else
            psih_stable = psih_stable_full(zolf)
@@ -1228,7 +1228,7 @@ CONTAINS
       real    :: rzol
         nzol = int(-zolf*100.)
         rzol = -zolf*100. - nzol
-        if(nzol+1 .le. 1000)then
+        if(nzol+1 .lt. 1000)then
            psim_unstable = psim_unstab(nzol) + rzol*(psim_unstab(nzol+1)-psim_unstab(nzol))
         else
            psim_unstable = psim_unstable_full(zolf)
@@ -1241,7 +1241,7 @@ CONTAINS
       real    :: rzol
         nzol = int(-zolf*100.)
         rzol = -zolf*100. - nzol
-        if(nzol+1 .le. 1000)then
+        if(nzol+1 .lt. 1000)then
            psih_unstable = psih_unstab(nzol) + rzol*(psih_unstab(nzol+1)-psih_unstab(nzol))
         else
            psih_unstable = psih_unstable_full(zolf)

--- a/phys/module_shcu_deng.F
+++ b/phys/module_shcu_deng.F
@@ -255,8 +255,7 @@ CONTAINS
 
      CA_RAD(I,K,J)=(1.0-CLDAREAA(I,K,J))*CS+CLDAREAA(I,K,J)
      CLDFRA_SH(I,K,J)= CA_RAD(I,K,J)
-!    CW_RAD(I,K,J)=CLDLIQA(I,K,J)+QC(I,K,J)
-     CW_RAD(I,K,J)=CLDLIQA(I,K,J)*CLDAREAA(I,K,J) + QC(I,K,J)
+     CW_RAD(I,K,J)=CLDLIQA(I,K,J)*CLDAREAA(I,K,J)
   ENDDO
   ENDDO
   ENDDO
@@ -414,12 +413,9 @@ CONTAINS
       ENDIF
 
       IF(CLDDPTHB(I,J) .LE. 0.0) THEN   ! No active updraft
-        IF( CLDAREAB(I,K,J) .LE. 1.0e-3 .OR. CLDLIQB(I,K,J) .LE. 1.0e-17 ) THEN
-  !        QC(I,K,J)=QC(I,K,J)+CLDAREAB(I,K,J)*CLDLIQB(I,K,J)
           RQCSHTEN(I,K,J)=RQCSHTEN(I,K,J)+CLDAREAB(I,K,J)*CLDLIQB(I,K,J)/DT
           CLDAREAB(I,K,J) = 0.0
           CLDLIQB(I,K,J) = 0.0
-        ENDIF
       ENDIF
     ENDDO
     ENDDO
@@ -679,8 +675,8 @@ CONTAINS
       DCLDTOP(I,J)=0.0
       DCLDBASE(I,J)=0.0
       CLDBMFLX(I,J)=0.0
-      RADIUSC(I,J)=0.0
 #endif
+      RADIUSC(I,J)=0.0
 !
 !...INPUT A VERTICAL SOUNDING ... NOTE THAT MODEL LAYERS ARE NUMBERED FROM THE
 !...BOTTOM-UP IN THE SHALLOW CONVECTION SCHEME...
@@ -2099,6 +2095,7 @@ CONTAINS
 !
       IF(CAPEI(I,J) .LT. 100.0) THEN    ! averaging KF number of clouds
         NT = NINT(15.0*60.0/(0.5*DT))-1 ! for 15 min.
+        NT = MIN(NT, 100)
       ELSE
         NT = 0
       ENDIF
@@ -2799,7 +2796,7 @@ CONTAINS
 !
 ! CALCULATE THE CONVECTIVE RAINFALL
 !
-        RAINSHV(I,J)=.1*.5*DT2*PPTFLX/DXSQ
+        RAINSHV(I,J)=.5*DT2*PPTFLX/DXSQ
 
     IF ( wrf_dm_on_monitor()) THEN
       CALL get_wrf_debug_level( dbg_level )

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1392,8 +1392,8 @@ CONTAINS
    REAL, PARAMETER    :: PI_GRECO=3.14159 
    INTEGER  :: end_hour, irr_start,xt24,irr_day  
    REAL :: constants_irrigation   
-   REAL,DIMENSION( ims:ime, jms:jme ) :: IRRIGATION_CHANNEL      
-   REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN),OPTIONAL::   IRRIGATION
+   REAL, DIMENSION( ims:ime, jms:jme ) :: IRRIGATION_CHANNEL      
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)   , OPTIONAL::   IRRIGATION
    REAL,  INTENT(IN),OPTIONAL::  irr_daily_amount     
    INTEGER :: phase
    INTEGER, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT),OPTIONAL :: irr_rand_field
@@ -1499,6 +1499,7 @@ CONTAINS
          IF ( PRESENT( rainshv ))RAINBL(i,j) = RAINBL(i,j) + RAINSHV(i,j)
          RAINBL(i,j) = MAX (RAINBL(i,j), 0.0)
 #if (EM_CORE==1)
+         IRRIGATION_CHANNEL(i,j) = 0.
          sf_surf_irr: SELECT CASE(sf_surf_irr_scheme)
             CASE(DRIP)
                CALL drip_irrigation(                                     &
@@ -2740,7 +2741,7 @@ CONTAINS
                 dl_u_bep,sf_bep,vl_bep                          & !O multi-layer urban
                 ,sfcheadrt,INFXSRT, soldrain                    & !hydro
                 ,SDA_HFX, SDA_QFX, HFX_BOTH, QFX_BOTH, QNORM, fasdas    & ! fasdas
-                ,RS,XLAIDYN)
+                ,RS,XLAIDYN,IRRIGATION_CHANNEL)
            ELSE
                CALL wrf_error_fatal('Lack arguments to call lsm_mosaic')
            ENDIF
@@ -2860,7 +2861,7 @@ CONTAINS
 !
 !  END FASDAS
 !
-                ,RS,XLAIDYN)
+                ,RS,XLAIDYN,IRRIGATION_CHANNEL)
          ENDIF
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &

--- a/run/MPTABLE.TBL
+++ b/run/MPTABLE.TBL
@@ -360,21 +360,31 @@ DEFAULT_CROP = 0                                      ! The default crop type(1-
 !                1       2       3       4       5
 !----------------------------------------------------------
  
-PLTDAY     =    130,    111,    111,    111,    111,  ! Planting date
-HSDAY      =    280,    300,    300,    300,    300,  ! Harvest date
+PLTDAY     =    111,    131,    111,    111,    111,  ! Planting date
+HSDAY      =    300,    280,    300,    300,    300,  ! Harvest date
 PLANTPOP   =   78.0,   78.0,   78.0,   78.0,   78.0,  ! Plant density [per ha] - used?
 IRRI       =    0.0,    0.0,    0.0,    0.0,    0.0,  ! Irrigation strategy 0= non-irrigation 1=irrigation (no water-stress)
 
 GDDTBASE   =   10.0,   10.0,   10.0,   10.0,   10.0,  ! Base temperature for GDD accumulation [C]
 GDDTCUT    =   30.0,   30.0,   30.0,   30.0,   30.0,  ! Upper temperature for GDD accumulation [C]
-GDDS1      =   60.0,   50.0,   50.0,   50.0,   50.0,  ! GDD from seeding to emergence
-GDDS2      =  675.0,  718.0,  718.0,  718.0,  718.0,  ! GDD from seeding to initial vegetative 
-GDDS3      = 1183.0,  933.0,  933.0,  933.0,  933.0,  ! GDD from seeding to post vegetative 
-GDDS4      = 1253.0, 1103.0, 1103.0, 1103.0, 1103.0,  ! GDD from seeding to intial reproductive
-GDDS5      = 1605.0, 1555.0, 1555.0, 1555.0, 1555.0,  ! GDD from seeding to pysical maturity 
-
+GDDS1      =   50.0,   60.0,   50.0,   50.0,   50.0,  ! GDD from seeding to emergence
+GDDS2      =  625.0,  675.0,  718.0,  718.0,  718.0,  ! GDD from seeding to initial vegetative
+GDDS3      =  933.0, 1183.0,  933.0,  933.0,  933.0,  ! GDD from seeding to post vegetative
+GDDS4      = 1103.0, 1253.0, 1103.0, 1103.0, 1103.0,  ! GDD from seeding to intial reproductive
+GDDS5      = 1555.0, 1605.0, 1555.0, 1555.0, 1555.0,  ! GDD from seeding to pysical maturity
+C3PSN      =    0.0,    1.0,    1.0,    1.0,    1.0,  ! transfer crop-specific photosynthetic parameters
+KC25       =   30.0,   30.0,   30.0,   30.0,   30.0,  ! Zhe Zhang
+AKC        =    2.1,    2.1,    2.1,    2.1,    2.1,  ! 2020-02-05
+KO25       =   3.E4,   3.E4,   3.E4,   3.E4,   3.E4,  !
+AKO        =    1.2,    1.2,    1.2,    1.2,    1.2,  !
+AVCMX      =    2.4,    2.4,    2.4,    2.4,    2.4,  !
+VCMX25     =   60.0,   80.0,   60.0,   60.0,   55.0,  !
+BP         =   4.E4,   1.E4,   2.E3,   2.E3,   2.E3,  !
+MP         =     4.,     9.,     6.,     9.,     9.,  !
+FOLNMX     =    1.5,    1.5,    1.5,    1.5,    1.5,  !
+QE25       =   0.05,   0.06,   0.06,   0.06,   0.06,  !
 C3C4       =      2,      1,      2,      2,      2,  ! photosynthetic pathway:  1. = c3 2. = c4
-Aref       =    7.0,    7.0,    7.0,    7.0,    7.0,  ! reference maximum CO2 assimulation rate 
+Aref       =    7.0,    7.0,    7.0,    7.0,    7.0,  ! reference maximum CO2 assimulation rate
 PSNRF      =   0.85,   0.85,   0.85,   0.85,   0.85,  ! CO2 assimulation reduction factor(0-1) (caused by non-modeling part,e.g.pest,weeds)
 I2PAR      =    0.5,    0.5,    0.5,    0.5,    0.5,  ! Fraction of incoming solar radiation to photosynthetically active radiation
 TASSIM0    =    8.0,    8.0,    8.0,    8.0,    8.0,  ! Minimum temperature for CO2 assimulation [C]
@@ -390,7 +400,7 @@ LEFREEZ    =    268,    268,    268,    268,    268,  ! characteristic T for lea
 DILE_FC_S1 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! coeficient for temperature leaf stress death [1/s]
 DILE_FC_S2 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
 DILE_FC_S3 =    0.0,    0.0,    0.0,    0.0,    0.0,
-DILE_FC_S4 =    0.0,    0.0,    0.0,    0.0,    0.0, 
+DILE_FC_S4 =    0.0,    0.0,    0.0,    0.0,    0.0,
 DILE_FC_S5 =    0.5,    0.5,    0.5,    0.5,    0.5,
 DILE_FC_S6 =    0.5,    0.5,    0.5,    0.5,    0.5,
 DILE_FC_S7 =    0.0,    0.0,    0.0,    0.0,    0.0,
@@ -411,8 +421,8 @@ LF_OVRC_S1 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of leaf turnove
 LF_OVRC_S2 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
 LF_OVRC_S3 =    0.0,    0.0,    0.0,    0.0,    0.0,
 LF_OVRC_S4 =    0.0,    0.0,    0.0,    0.0,    0.0,
-LF_OVRC_S5 =    0.2,   0.48,   0.48,   0.48,   0.48,
-LF_OVRC_S6 =    0.3,   0.48,   0.48,   0.48,   0.48,
+LF_OVRC_S5 =    0.2,    0.2,   0.48,   0.48,   0.48,
+LF_OVRC_S6 =    0.3,    0.3,   0.48,   0.48,   0.48,
 LF_OVRC_S7 =    0.0,    0.0,    0.0,    0.0,    0.0,
 LF_OVRC_S8 =    0.0,    0.0,    0.0,    0.0,    0.0,
 
@@ -420,8 +430,8 @@ ST_OVRC_S1 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of stem turnove
 ST_OVRC_S2 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
 ST_OVRC_S3 =    0.0,    0.0,    0.0,    0.0,    0.0,
 ST_OVRC_S4 =    0.0,    0.0,    0.0,    0.0,    0.0,
-ST_OVRC_S5 =   0.12,   0.12,   0.12,   0.12,   0.12,
-ST_OVRC_S6 =   0.06,   0.06,   0.06,   0.06,   0.06,
+ST_OVRC_S5 =    0.2,   0.12,   0.12,   0.12,   0.12,
+ST_OVRC_S6 =    0.3,   0.06,   0.06,   0.06,   0.06,
 ST_OVRC_S7 =    0.0,    0.0,    0.0,    0.0,    0.0,
 ST_OVRC_S8 =    0.0,    0.0,    0.0,    0.0,    0.0,
 
@@ -429,21 +439,20 @@ RT_OVRC_S1 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of root tunrove
 RT_OVRC_S2 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
 RT_OVRC_S3 =    0.0,    0.0,    0.0,    0.0,    0.0,
 RT_OVRC_S4 =    0.0,    0.0,    0.0,    0.0,    0.0,
-RT_OVRC_S5 =   0.12,   0.12,   0.12,   0.12,   0.12,
-RT_OVRC_S6 =   0.06,   0.06,   0.06,   0.06,   0.06,
+RT_OVRC_S5 =    0.12,   0.12,   0.12,   0.12,   0.12,
+RT_OVRC_S6 =    0.06,   0.06,   0.06,   0.06,   0.06,
 RT_OVRC_S7 =    0.0,    0.0,    0.0,    0.0,    0.0,
 RT_OVRC_S8 =    0.0,    0.0,    0.0,    0.0,    0.0,
 
-             
-LFMR25     =    1.0,    1.0,    1.0,    1.0,    1.0,  !  leaf maintenance respiration at 25C [umol CO2/m**2  /s]
-STMR25     =   0.05,    0.1,    0.1,    0.1,    0.1,  !  stem maintenance respiration at 25C [umol CO2/kg bio/s]
-RTMR25     =   0.05,    0.0,    0.0,    0.0,    0.0,  !  root maintenance respiration at 25C [umol CO2/kg bio/s]
-GRAINMR25  =    0.0,    0.1,    0.1,    0.1,    0.1,  ! grain maintenance respiration at 25C [umol CO2/kg bio/s]
+LFMR25     =    0.8,    1.0,    1.0,    1.0,    1.0,  !  leaf maintenance respiration at 25C [umol CO2/m**2  /s]
+STMR25     =   0.05,    0.05,    0.1,    0.1,    0.1,  !  stem maintenance respiration at 25C [umol CO2/kg bio/s]
+RTMR25     =   0.05,    0.05,    0.0,    0.0,    0.0,  !  root maintenance respiration at 25C [umol CO2/kg bio/s]
+GRAINMR25  =    0.0,    0.0,    0.1,    0.1,    0.1,  ! grain maintenance respiration at 25C [umol CO2/kg bio/s]
 
 LFPT_S1    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of carbohydrate flux to leaf
 LFPT_S2    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
-LFPT_S3    =    0.4,    0.4,    0.4,    0.4,    0.4,
-LFPT_S4    =    0.2,    0.2,    0.2,    0.2,    0.2,
+LFPT_S3    =    0.36,   0.4,    0.4,    0.4,    0.4,
+LFPT_S4    =    0.1,    0.2,    0.2,    0.2,    0.2,
 LFPT_S5    =    0.0,    0.0,    0.0,    0.0,    0.0,
 LFPT_S6    =    0.0,    0.0,    0.0,    0.0,    0.0,
 LFPT_S7    =    0.0,    0.0,    0.0,    0.0,    0.0,
@@ -451,33 +460,60 @@ LFPT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0,
 
 STPT_S1    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of carbohydrate flux to stem
 STPT_S2    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
-STPT_S3    =    0.2,    0.2,    0.2,    0.2,    0.2,
-STPT_S4    =    0.5,    0.5,    0.5,    0.5,    0.5,
-STPT_S5    =    0.0,   0.15,   0.15,   0.15,   0.15,
-STPT_S6    =    0.0,   0.05,   0.05,   0.05,   0.05,
+STPT_S3    =    0.24,   0.2,    0.2,    0.2,    0.2,
+STPT_S4    =    0.6,    0.5,    0.5,    0.5,    0.5,
+STPT_S5    =    0.0,    0.0,   0.15,   0.15,   0.15,
+STPT_S6    =    0.0,    0.0,   0.05,   0.05,   0.05,
 STPT_S7    =    0.0,    0.0,    0.0,    0.0,    0.0,
-STPT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0, 
+STPT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0,
 
 RTPT_S1    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of carbohydrate flux to root
 RTPT_S2    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
-RTPT_S3    =   0.34,    0.4,    0.4,    0.4,    0.4,
+RTPT_S3    =    0.4,    0.4,    0.4,    0.4,    0.4,
 RTPT_S4    =    0.3,    0.3,    0.3,    0.3,    0.3,
-RTPT_S5    =   0.05,   0.05,   0.05,   0.05,   0.05,
-RTPT_S6    =    0.0,   0.05,   0.05,   0.05,   0.05,
+RTPT_S5    =    0.05,   0.05,   0.05,   0.05,   0.05,
+RTPT_S6    =    0.0,    0.0,   0.05,   0.05,   0.05,
 RTPT_S7    =    0.0,    0.0,    0.0,    0.0,    0.0,
 RTPT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0,
-   
+
 GRAINPT_S1 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! fraction of carbohydrate flux to grain
 GRAINPT_S2 =    0.0,    0.0,    0.0,    0.0,    0.0,  ! One row for each of 8 stages
 GRAINPT_S3 =    0.0,    0.0,    0.0,    0.0,    0.0,
 GRAINPT_S4 =    0.0,    0.0,    0.0,    0.0,    0.0,
-GRAINPT_S5 =   0.95,    0.8,    0.8,    0.8,    0.8,
-GRAINPT_S6 =    1.0,    0.9,    0.9,    0.9,    0.9,
+GRAINPT_S5 =    0.95,   0.95,    0.8,    0.8,    0.8,
+GRAINPT_S6 =    1.0,    1.0,    0.9,    0.9,    0.9,
 GRAINPT_S7 =    0.0,    0.0,    0.0,    0.0,    0.0,
 GRAINPT_S8 =    0.0,    0.0,    0.0,    0.0,    0.0,
 
+LFCT_S1    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! carbohydrate translocation
+LFCT_S2    =    0.0,    0.0,    0.0,    0.0,    0.0,
+LFCT_S3    =    0.0,    0.,    0.4,    0.4,    0.4,
+LFCT_S4    =    0.0,    0.,    0.3,    0.3,    0.3,
+LFCT_S5    =    0.0,    0.0,   0.05,   0.05,   0.05,
+LFCT_S6    =    0.0,    0.0,   0.05,   0.05,   0.05,
+LFCT_S7    =    0.0,    0.0,    0.0,    0.0,    0.0,
+LFCT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0,
 
-BIO2LAI   =  0.035,  0.015,  0.015,  0.015,  0.015,  ! leaf are per living leaf biomass [m^2/kg]
+STCT_S1    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! carbohydrate translocation
+STCT_S2    =    0.0,    0.0,    0.0,    0.0,    0.0,
+STCT_S3    =    0.0,    0.,    0.4,    0.4,    0.4,
+STCT_S4    =    0.0,    0.,    0.3,    0.3,    0.3,
+STCT_S5    =    0.0,    0.,   0.05,   0.05,   0.05,
+STCT_S6    =    0.0,    0.0,   0.05,   0.05,   0.05,
+STCT_S7    =    0.0,    0.0,    0.0,    0.0,    0.0,
+STCT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0,
+
+RTCT_S1    =    0.0,    0.0,    0.0,    0.0,    0.0,  ! carbohydrate translocation
+RTCT_S2    =    0.0,    0.0,    0.0,    0.0,    0.0,
+RTCT_S3    =    0.0,    0.,    0.4,    0.4,    0.4,
+RTCT_S4    =    0.0,    0.,    0.3,    0.3,    0.3,
+RTCT_S5    =    0.0,    0.,   0.05,   0.05,   0.05,
+RTCT_S6    =    0.0,    0.0,   0.05,   0.05,   0.05,
+RTCT_S7    =    0.0,    0.0,    0.0,    0.0,    0.0,
+RTCT_S8    =    0.0,    0.0,    0.0,    0.0,    0.0,
+
+BIO2LAI    =  0.015,  0.030,  0.015,  0.015,  0.015,  ! leaf are per living leaf biomass [m^2/kg]
+
 
 /
  

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -576,24 +576,6 @@
          END IF
       ENDDO
 
-!-----------------------------------------------------------------------
-! The FARMS radiation option (swint_opt==2) requires both effective radii
-! and mass for cloud, ice, and snow. A run-time option is available to 
-! disable the use of effective radii in the MP schemes. These two options 
-! may not be used together.
-!-----------------------------------------------------------------------
-      oops = 0
-      IF ( ( model_config_rec%swint_opt .EQ. 2 ) .AND. &
-           ( model_config_rec%use_mp_re .NE. 1 ) ) THEN
-         oops = oops + 1
-      END IF
-
-      IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- ERROR: FARMS (swint_opt=2) requires effective radii (use_mp_re=1)'
-         CALL wrf_message ( wrf_err_message )
-         count_fatal_error = count_fatal_error + 1
-      END IF
-
 #endif
 
 !-----------------------------------------------------------------------

--- a/share/module_model_constants.F
+++ b/share/module_model_constants.F
@@ -63,6 +63,10 @@
    REAL    , PARAMETER :: rhowater     = 1000.       ! density of liquid water at 0^oC (kg m^-3)
    REAL    , PARAMETER :: rhosnow      = 100.        ! density of snow (kg m^-3)
    REAL    , PARAMETER :: rhoair0      = 1.28        ! density of dry air at 0^oC and 1000mb pressure (kg m^-3)
+
+   REAL    , PARAMETER :: RE_QC_BG     = 2.49E-6     ! effective radius of cloud for background (m)
+   REAL    , PARAMETER :: RE_QI_BG     = 4.99E-6     ! effective radius of ice for background (m)
+   REAL    , PARAMETER :: RE_QS_BG     = 9.99E-6     ! effective radius of snow for background (m)
 !
 ! Now namelist-specified parameter: ccn_conc - RAS
 !   REAL    , PARAMETER :: n_ccn0       = 1.0E8

--- a/var/da/da_minimisation/da_get_innov_vector.inc
+++ b/var/da/da_minimisation/da_get_innov_vector.inc
@@ -285,7 +285,7 @@ subroutine da_get_innov_vector (it, num_qcstat_conv, ob, iv, grid, config_flags)
    ! [3] Optionally rescale observation errors:
    !------------------------------------------------------------------------ 
    
-   if (use_obs_errfac) call da_use_obs_errfac( iv)
+   if (use_obs_errfac .and. it == 1) call da_use_obs_errfac(iv)
 
    !------------------------------------------------------------------------  
    ! [4] Optionally add Gaussian noise to O, O-B:

--- a/var/da/da_setup_structures/da_setup_flow_predictors_ep_format2.inc
+++ b/var/da/da_setup_structures/da_setup_flow_predictors_ep_format2.inc
@@ -359,6 +359,7 @@ subroutine da_setup_flow_predictors_ep_format2( ix, jy, kz, ne, ep, its, ite, jt
                read(unit=ep_unit) temp3d_r4(1:ix,1:jy,1:kz)
                temp3d = temp3d_r4
             end if
+            call wrf_dm_bcast_real(temp3d, ijk)
             te = ie + (it-1)*nens
             ep % ci(its:ite,jts:jte,kts:kte,te) = ens_scaling_inv * &
                                                   temp3d(its:ite,jts:jte,kts:kte)
@@ -393,6 +394,7 @@ subroutine da_setup_flow_predictors_ep_format2( ix, jy, kz, ne, ep, its, ite, jt
                read(unit=ep_unit) temp3d_r4(1:ix,1:jy,1:kz)
                temp3d = temp3d_r4
             end if
+            call wrf_dm_bcast_real(temp3d, ijk)
             te = ie + (it-1)*nens
             ep % sn(its:ite,jts:jte,kts:kte,te) = ens_scaling_inv * &
                                                   temp3d(its:ite,jts:jte,kts:kte)
@@ -427,6 +429,7 @@ subroutine da_setup_flow_predictors_ep_format2( ix, jy, kz, ne, ep, its, ite, jt
                read(unit=ep_unit) temp3d_r4(1:ix,1:jy,1:kz)
                temp3d = temp3d_r4
             end if
+            call wrf_dm_bcast_real(temp3d, ijk)
             te = ie + (it-1)*nens
             ep % gr(its:ite,jts:jte,kts:kte,te) = ens_scaling_inv * &
                                                   temp3d(its:ite,jts:jte,kts:kte)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, Microphysics, module_check_a_mundo.F 

SOURCE: Ju Hye Kim and Pedro Jimenez (NCAR/RAL)

DESCRIPTION OF CHANGES: FARMS can work correctly with microphysics schemes that do not provide effective radii of clouds (https://github.com/wrf-model/WRF/pull/1191). But, current WRF model displays an ERROR message and stops when the 'swint_opt is 2' and 'use_mp_re is not 1' condition. So, we remove this constraint from ‘module_check_a_mundo.F’.  

LIST OF MODIFIED FILES: 
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted? Yes, it fixed problem. When FARMS and microphysics scheme that do not provide effective radii of clouds (ex: mp=2) are used together, the model does not stop.
2. Are the Jenkins tests all passing?

RELEASE NOTE: FARMS can be used with microphysics parameterizations that do not provide cloud effective radii. 
