### PR TITLE
Update check_a_mundo to make FARMS work correctly

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -576,24 +576,6 @@
          END IF
       ENDDO
 
-!-----------------------------------------------------------------------
-! The FARMS radiation option (swint_opt==2) requires both effective radii
-! and mass for cloud, ice, and snow. A run-time option is available to 
-! disable the use of effective radii in the MP schemes. These two options 
-! may not be used together.
-!-----------------------------------------------------------------------
-      oops = 0
-      IF ( ( model_config_rec%swint_opt .EQ. 2 ) .AND. &
-           ( model_config_rec%use_mp_re .NE. 1 ) ) THEN
-         oops = oops + 1
-      END IF
-
-      IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- ERROR: FARMS (swint_opt=2) requires effective radii (use_mp_re=1)'
-         CALL wrf_message ( wrf_err_message )
-         count_fatal_error = count_fatal_error + 1
-      END IF
-
 #endif
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, Microphysics, module_check_a_mundo.F

SOURCE: Ju Hye Kim and Pedro Jimenez (NCAR/RAL)

DESCRIPTION OF CHANGES: 

Problem:
FARMS can work correctly with microphysics schemes that do not provide effective radii of clouds. But, current WRF model displays an ERROR message and stops when the 'swint_opt is 2' and 'use_mp_re is not 1'. 

Solution:
We remove this constraint from ‘module_check_a_mundo.F’.

LIST OF MODIFIED FILES: 
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. When FARMS and a microphysics scheme that do not provide effective radii of clouds (ex: mp=2) are used together, the model does not stop anymore.
2. All jenkins tests are passing.

RELEASE NOTE: Fixed an incorrect stop in the model when FARMS radiation is used with microphysics that do not provide effective cloud radii.
