### PR TITLE
fixed boundary issues in rhs_ph

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -1506,7 +1506,7 @@ SUBROUTINE rhs_ph( ph_tend, u, v, ww,               &
    jtf=MIN(jte,jde-1)
 
    IF ( (config_flags%open_ys .or. specified) .and. jts == jds ) j_start = jts+1
-   IF ( (config_flags%open_ye .or. specified) .and. jte == jde ) jtf = jtf-2
+   IF ( (config_flags%open_ye .or. specified) .and. jte == jde ) jtf = jte-2
 
    DO j = j_start, jtf
 
@@ -1539,7 +1539,7 @@ SUBROUTINE rhs_ph( ph_tend, u, v, ww,               &
    jtf=MIN(jte,jde-1)
 
    IF ( (config_flags%open_xs .or. specified) .and. its == ids ) i_start = its+1
-   IF ( (config_flags%open_xe .or. specified) .and. ite == ide ) itf = itf-2
+   IF ( (config_flags%open_xe .or. specified) .and. ite == ide ) itf = ite-2
 
    DO j = j_start, jtf
 
@@ -1574,7 +1574,7 @@ SUBROUTINE rhs_ph( ph_tend, u, v, ww,               &
    jtf=MIN(jte,jde-1)
 
    IF ( (config_flags%open_ys .or. specified) .and. jts == jds ) j_start = jts+2
-   IF ( (config_flags%open_ye .or. specified) .and. jte == jde ) jtf = jtf-3
+   IF ( (config_flags%open_ye .or. specified) .and. jte == jde ) jtf = jte-3
 
    DO j = j_start, jtf
 
@@ -1664,7 +1664,7 @@ SUBROUTINE rhs_ph( ph_tend, u, v, ww,               &
    jtf=MIN(jte,jde-1)
 
    IF ( (config_flags%open_xs) .and. its == ids ) i_start = its+2
-   IF ( (config_flags%open_xe) .and. ite == ide ) itf = itf-3
+   IF ( (config_flags%open_xe) .and. ite == ide ) itf = ite-3
 
    DO j = j_start, jtf
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: geopotential, index, horizontal advection, open, specified

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES:

When using advection order < 5 and open or specified boundary conditions, the upper limits in the horizontal advection loops of geopotential are one too small.

Let's look at the y-advection with advection order = 2, for instance and assume jte=jde. For open and specified BC the 
lower limit is increased by 1 from jds to jds+1, but the upper limit is decreased by 2 from jde-1 to jtf=jde-1-2=jde-3. It should be jtf=jde-2, however. Starting at line 2092 the jde-1 point is set, but the jde-2 point is not handled anywhere.

The issue is analogous for x-advection and advection order = 4 (jtf=jde-4 instead of jtf=jde-3).

For advection order >= 5, the limits are set correctly, because a different notation is used: jtf = min(jtf,jde-4)

LIST OF MODIFIED FILES: 
dyn_em/module_big_step_utilities_em.F

TESTING CONDUCTED: 
I did an LES test case simulation, with periodic y-boundaries and open x-boundaries, mean x-wind of 10 m/s, h_sca_adv_order=3, and north-south oriented cosine ridge in the center of the domain.
Here is the perturbation geopotential after 1 minute integration at k=2:
![ph](https://user-images.githubusercontent.com/17001470/102336394-67d8c780-3f91-11eb-899d-3b05d28c05ab.png)
and here the difference plot:
![ph_diff](https://user-images.githubusercontent.com/17001470/102336506-876ff000-3f91-11eb-9ccf-7615df8adaff.png)

You can clearly see the higher geopotential in the new formulation at i=ide-3. This is the point where the horizontal advection is not carried out by the current algorithm.

After 10 minutes it looks like this:
![ph_600](https://user-images.githubusercontent.com/17001470/102336745-dd449800-3f91-11eb-9b06-94776b70d9c8.png)
![ph_diff_600](https://user-images.githubusercontent.com/17001470/102336749-df0e5b80-3f91-11eb-83ac-1d15a499aae9.png)

RELEASE NOTES: When using advection order < 5, and either open or specified boundary conditions, the upper limit of the indexing in the horizontal advection loops of geopotential was previously incorrect. For horizontal advection order >= 5, the index limits were not incorrect.