### PR TITLE
Update vertical interpolation stand-alone, fix vert_interp call

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4930,6 +4930,8 @@ endif
 
 #ifdef VERT_UNIT
 
+!gfortran -DVERT_UNIT -ffree-form -ffree-line-length-none module_initialize_real.F -o vert.exe
+
 !This is a main program for a small unit test for the vertical interpolation.
 
 program vint
@@ -4961,6 +4963,7 @@ program vint
    logical, parameter :: use_surface             = .TRUE. ! .FALSE. ! .TRUE.
    real   , parameter :: zap_close_levels        = 500. ! 100.
    integer, parameter :: force_sfc_in_vinterp    = 6 ! 0 ! 6
+   integer, parameter :: id                      = 1
 
    integer :: k
 
@@ -4975,7 +4978,7 @@ program vint
    print *,'UNIT TEST FOR VERTICAL INTERPOLATION'
    print *,'------------------------------------'
    print *,' '
-   do lagrange_order = 1 , 9 , 8
+   do lagrange_order = 1 , 1
       print *,' '
       print *,'------------------------------------'
       print *,'Lagrange Order = ',lagrange_order
@@ -5006,7 +5009,7 @@ program vint
                          generic , 'T' , &
                          interp_type , lagrange_order , extrap_type , &
                          lowest_lev_from_sfc , use_levels_below_ground , use_surface , &
-                         zap_close_levels , force_sfc_in_vinterp , &
+                         zap_close_levels , force_sfc_in_vinterp , id , &
                          ids , ide , jds , jde , kds , kde , &
                          ims , ime , jms , jme , kms , kme , &
                          its , ite , jts , jte , kts , kte )
@@ -5052,8 +5055,6 @@ subroutine fillitup ( fo , po , fn , pn , &
 
    integer :: i , j , k
 
-   real , parameter :: piov2 = 3.14159265358 / 2.
-
    k = 1
    do j = jts , jte
    do i = its , ite
@@ -5065,6 +5066,7 @@ subroutine fillitup ( fo , po , fn , pn , &
    do j = jts , jte
    do i = its , ite
       po(i,k,j) = ( 5000. * ( 1 - (k-1) ) + 100000. * ( (k-1) - (generic-1) ) ) / (1. - real(generic-1) )
+!     po(i,k,j) = FILL IN YOUR INPUT PRESSURE LEVELS
    end do
    end do
    end do
@@ -5074,7 +5076,7 @@ subroutine fillitup ( fo , po , fn , pn , &
       do j = jts , jte
       do i = its , ite
          fo(i,k,j) = po(i,k,j)
-!        fo(i,k,j) = sin(po(i,k,j) * piov2 / 102000. )
+!        fo(i,k,j) = FILL IN YOUR COLUMN OF PRESS_LEVEL FIELD
       end do
       end do
       end do
@@ -5083,7 +5085,6 @@ subroutine fillitup ( fo , po , fn , pn , &
       do j = jts , jte
       do i = its , ite
          fo(i,k,j) = (((po(i,k,j)-5000.)/102000.)*((102000.-po(i,k,j))/102000.))*102000.
-!        fo(i,k,j) = sin(po(i,k,j) * piov2 / 102000. )
       end do
       end do
       end do
@@ -5095,6 +5096,7 @@ subroutine fillitup ( fo , po , fn , pn , &
    do j = jts , jte
    do i = its , ite
       pn(i,k,j) = ( 5000. * ( 0 - (k-1) ) + 102000. * ( (k-1) - (kte-1) ) ) / (-1. *  real(kte-1) )
+!     pn(i,k,j) = FILL IN A COLUMN OF KNOWN FULL-LEVEL PRESSURES ON ETA SURFACES
    end do
    end do
    end do
@@ -5113,7 +5115,7 @@ subroutine fillitup ( fo , po , fn , pn , &
       do j = jts , jte
       do i = its , ite
          fn(i,k,j) = pn(i,k,j)
-!        fn(i,k,j) = sin(pn(i,k,j) * piov2 / 102000. )
+!        fn(i,k,j) = FILL IN COLUMN OF HALF LEVEL FIELD
       end do
       end do
       end do
@@ -5136,6 +5138,12 @@ function skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_
    logical :: hold_ups
    skip_middle_points_t = .false.
 end function skip_middle_points_t
+
+subroutine wrf_message(level,message)
+   character(len=*), intent(in) :: message
+   integer, intent(in) :: level
+   print *,trim(message)
+end subroutine wrf_message
 
 #endif
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: vertical, interpolation

SOURCE: internal

DESCRIPTION:
The stand-alone vertical interpolation program that is part of the module_initialize_real.F
file allows detailed testing of the existing vertical interpolation process used for ARW
in the real program. It is understood that practically no one except for me ever exercises
this utility.

1. The call to the main vertical interpolation routine, vert_interp, was out of date (missing
the grid id for some diagnostic error prints).

2. A suggestion for a build command is now provided.

3. Locations to use pressure-level or eta-level data are provided.

LIST OF MODIFIED FILES:
M	module_initialize_real.F

TESTS CONDUCTED:
1. The stand-alone code builds and runs properly.
```
 ------------------------------------
 UNIT TEST FOR VERTICAL INTERPOLATION
 ------------------------------------
  
  
 ------------------------------------
 Lagrange Order =            1
 ------------------------------------
  
  
 Level   Pressure     Field
           (Pa)      (generic)
 ------------------------------------
  
 1    102000.000   102000.00    
 2    100000.000   100000.00    
 3     94722.219   94722.219    
 4     89444.445   89444.445    
 5     84166.664   84166.664    
 6     78888.891   78888.891    
 7     73611.109   73611.109    
 8     68333.336   68333.336    
 9     63055.555   63055.555    
10     57777.777   57777.777    
11     52500.000   52500.000    
12     47222.223   47222.223    
13     41944.445   41944.445    
14     36666.668   36666.668    
15     31388.889   31388.889    
16     26111.111   26111.111    
17     20833.334   20833.334    
18     15555.556   15555.556    
19     10277.777   10277.777    
20      5000.000   5000.0000    
  
 Multi-Order Interpolator
 ------------------------------------
  
 Level  Pressure      Field           Field         Field
          (Pa)        Calc            Interp        Diff
 ------------------------------------
  
 1    100327.586    100327.6       100327.6      0.7812500E-02
 2     96982.758    96982.76       96982.76       0.000000    
 3     93637.930    93637.93       93637.93       0.000000    
 4     90293.102    90293.10       90293.10       0.000000    
 5     86948.273    86948.27       86948.27       0.000000    
 6     83603.445    83603.45       83603.45     -0.7812500E-02
 7     80258.617    80258.62       80258.62       0.000000    
 8     76913.797    76913.80       76913.80       0.000000    
 9     73568.969    73568.97       73568.97       0.000000    
10     70224.141    70224.14       70224.14       0.000000    
11     66879.312    66879.31       66879.31       0.000000    
12     63534.484    63534.48       63534.48       0.000000    
13     60189.656    60189.66       60189.66       0.000000    
14     56844.828    56844.83       56844.83       0.000000    
15     53500.000    53500.00       53500.00       0.000000    
16     50155.172    50155.17       50155.17       0.000000    
17     46810.344    46810.34       46810.35     -0.3906250E-02
18     43465.516    43465.52       43465.52       0.000000    
19     40120.688    40120.69       40120.69       0.000000    
20     36775.863    36775.86       36775.87     -0.3906250E-02
21     33431.035    33431.04       33431.04       0.000000    
22     30086.207    30086.21       30086.21       0.000000    
23     26741.379    26741.38       26741.38       0.000000    
24     23396.551    23396.55       23396.55       0.000000    
25     20051.725    20051.72       20051.73     -0.1953125E-02
26     16706.896    16706.90       16706.90       0.000000    
27     13362.068    13362.07       13362.07       0.000000    
28     10017.241    10017.24       10017.24      0.9765625E-03
29      6672.414    6672.414       6672.413      0.4882812E-03
```
2. Due to cpp ifdefs, the modifications have no impact on the traditionally used compilable code.