### PR TITLE
Fix return type on wrf_dm_max_int (should be an integer)

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -1298,7 +1298,7 @@ CONTAINS
       RETURN
    END FUNCTION getrealmpitype
 
-   REAL FUNCTION wrf_dm_max_int ( inval )
+   INTEGER FUNCTION wrf_dm_max_int ( inval )
       IMPLICIT NONE
 #ifndef STUBMPI
       INTEGER, intent(in) :: inval


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS, real, int, integer, wrf_dm_max_int

SOURCE: internal

DESCRIPTION OF CHANGES:
While looking to see if WRF had a function to return the maximum integer from among the
max values of integers on each of the MPI ranks, it was noticed that the return value for the
existing function was REAL. It should be an INTEGER.

There is only a single use of this function in the entire model, in the file `share/module_trajectory.F`.
```
glb_traj_proc(trj) = wrf_dm_max_int( traj_proc(trj) )
```
In that file, the input to the function, `traj_proc`, and the return value, `glb_traj_proc`, are both declared as integers. Therefore, there is no reason for a function to be given a list of integers, and when finding the max value to actually return that value as a real.
```
   integer :: traj_proc(traj_max), glb_traj_proc(traj_max)
```

LIST OF MODIFIED FILES:
M	external/RSL_LITE/module_dm.F

TESTS CONDUCTED:
1. Jenkins tests OK.
2. A small set of trajectories works as expected.
![Screen Shot 2021-01-06 at 6 01 44 PM](https://user-images.githubusercontent.com/12666234/103838081-5f802380-5049-11eb-87ed-648860b7d203.png)
