### PR TITLE
Add pH diagnostics for mozart_mosaic_4bin_aq chemistry

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -20,7 +20,6 @@ state    real    QC_B4MP         ikj    misc        1         -      -        "Q
 state    real    QI_B4MP         ikj    misc        1         -      -        "QI_B4MP"             "CLOUD ICE BEFORE MICROPHYSICS"    "kg kg-1"
 state    real    QS_B4MP         ikj    misc        1         -      -        "QS_B4MP"             "SNOW BEFORE MICROPHYSICS"         "kg kg-1"
 
-package  do_mozart_ph_diag    mozart_ph_diag==1         -           state:ph_cw,ph_aer01,ph_aer02,ph_aer03,ph_aer04
 state    real    ph_cw           ikj    misc        1         -      -        "ph_cw"               "pH of cloud water"             "Unitless"
 state    real    ph_aer01        ikj    misc        1         -      -        "ph_aer01"            "H+ of aerosol bin 1"           "mol/kg"
 state    real    ph_aer02        ikj    misc        1         -      -        "ph_aer02"            "H+ of aerosol bin 2"           "mol/kg"
@@ -4075,6 +4074,8 @@ package   biomassb_t1_mozcart   biomass_burn_opt==4          -          state:me
 # GHG biomass burning
 package   biomassb_ghg  biomass_burn_opt==5          -             state::mean_fct_agtf,mean_fct_agef,mean_fct_agsv,mean_fct_aggr,firesize_agtf,firesize_agef,firesize_agsv,firesize_aggr;ebu:ebu_co,ebu_co2,ebu_ch4;ebu_in:ebu_in_co,ebu_in_co2,ebu_in_ch4
 
+# Package for mozart pH diagnostics
+package  do_mozart_ph_diag    mozart_ph_diag==1      -             state:ph_cw,ph_aer01,ph_aer02,ph_aer03,ph_aer04
 
 package   opt_out      opt_pars_out==1             -          ext_coef:extcof3,extcof55,extcof106,extcof3_5,extcof8_12;bscat_coef:bscof3,bscof55,bscof106;asym_par:asympar3,asympar55,asympar106
 

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -21,7 +21,7 @@ state    real    QI_B4MP         ikj    misc        1         -      -        "Q
 state    real    QS_B4MP         ikj    misc        1         -      -        "QS_B4MP"             "SNOW BEFORE MICROPHYSICS"         "kg kg-1"
 
 package  do_mozart_ph_diag    mozart_ph_diag==1         -           state:ph_cw,ph_aer01,ph_aer02,ph_aer03,ph_aer04
-state    real    ph_cw           ikj    misc        1         -      -        "ph_cw"               "pH of cloud water"             "unitless"
+state    real    ph_cw           ikj    misc        1         -      -        "ph_cw"               "pH of cloud water"             "Unitless"
 state    real    ph_aer01        ikj    misc        1         -      -        "ph_aer01"            "H+ of aerosol bin 1"           "mol/kg"
 state    real    ph_aer02        ikj    misc        1         -      -        "ph_aer02"            "H+ of aerosol bin 2"           "mol/kg"
 state    real    ph_aer03        ikj    misc        1         -      -        "ph_aer03"            "H+ of aerosol bin 3"           "mol/kg"

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -20,6 +20,13 @@ state    real    QC_B4MP         ikj    misc        1         -      -        "Q
 state    real    QI_B4MP         ikj    misc        1         -      -        "QI_B4MP"             "CLOUD ICE BEFORE MICROPHYSICS"    "kg kg-1"
 state    real    QS_B4MP         ikj    misc        1         -      -        "QS_B4MP"             "SNOW BEFORE MICROPHYSICS"         "kg kg-1"
 
+package  do_mozart_ph_diag    mozart_ph_diag==1         -           state:ph_cw,ph_aer01,ph_aer02,ph_aer03,ph_aer04
+state    real    ph_cw           ikj    misc        1         -      -        "ph_cw"               "pH of cloud water"             "unitless"
+state    real    ph_aer01        ikj    misc        1         -      -        "ph_aer01"            "H+ of aerosol bin 1"           "mol/kg"
+state    real    ph_aer02        ikj    misc        1         -      -        "ph_aer02"            "H+ of aerosol bin 2"           "mol/kg"
+state    real    ph_aer03        ikj    misc        1         -      -        "ph_aer03"            "H+ of aerosol bin 3"           "mol/kg"
+state    real    ph_aer04        ikj    misc        1         -      -        "ph_aer04"            "H+ of aerosol bin 4"           "mol/kg"
+
 state    real    ccn1            ikj    misc        1         -      r        "ccn1"                "CCN concentration at S=0.02%"  "#/cm3"
 state    real    ccn2            ikj    misc        1         -      r        "ccn2"                "CCN concentration at S=0.05%"  "#/cm3"
 state    real    ccn3            ikj    misc        1         -      r        "ccn3"                "CCN concentration at S=0.1%"   "#/cm3"
@@ -3759,6 +3766,7 @@ rconfig   integer    biomass_emiss_opt     namelist,chem        max_domains    0
 rconfig   integer cam_mam_mode             namelist,chem        1              3       irh     "cam_mam_mode"                   ""    ""
 rconfig   integer cam_mam_nspec            namelist,chem        1              85      irh     "cam_mam_nspec"                   ""    ""
 rconfig   logical CAM_MP_MAM_cpled         namelist,chem        1            .true.    irh     "CAM_MP_MAM_cpled"                   ""    ""
+rconfig   integer mozart_ph_diag           namelist,chem        1              0       rh      "mozart_ph_diag"                  ""    ""
 
 # GHG chemistry namelist options:
 rconfig   character   vprm_opt            namelist,chem        max_domains   "VPRM_param_US"  -       "the file contains VPRM parameters"  ""      ""

--- a/chem/aerosol_driver.F
+++ b/chem/aerosol_driver.F
@@ -16,6 +16,7 @@
                vdrog3, vdrog3_vbs,brch_ratio,dgnum,dgnumwet,wetdens_ap,    &
                del_h2so4_gasprod,dvmrdt_sv13d,dvmrcwdt_sv13d,              &
                is_CAMMGMP_used,                                            &!BSINGH:01/31/2013: Added is_CAMMGMP_used for cam_mam_aerchem_driver
+               ph_aer01, ph_aer02, ph_aer03, ph_aer04,                     &
                ids,ide, jds,jde, kds,kde,                                  &
                ims,ime, jms,jme, kms,kme,                                  &
                its,ite, jts,jte, kts,kte                                   )
@@ -190,6 +191,11 @@
      REAL, dimension (ims:ime,kms:kme-0,jms:jme),                   &
                INTENT(INOUT) ::                                     &
                                vcsulf_old
+
+!  output of aerosol pH from MOSAIC 4-bin
+   REAL,  DIMENSION( ims:ime , kms:kme , jms:jme )         ,        &
+          INTENT(OUT  ) ::                                          &
+                               ph_aer01, ph_aer02, ph_aer03, ph_aer04
 !
 !tendencies:dvmrdt_sv13d,dvmrcwdt_sv13d are the tendencies which are passsed on from the CAM-MAM cloud chemistry
 !           to gasaerexch subroutine
@@ -288,6 +294,7 @@
             id, curr_secs, ktau, dtstep, ktauc, dtstepc, config_flags,  &
             t_phy, rho_phy, p_phy,                                      &
             moist, chem,vbs_nbin,                                       &
+            ph_aer01, ph_aer02, ph_aer03, ph_aer04,                     &
             ids,ide, jds,jde, kds,kde,                                  &
             ims,ime, jms,jme, kms,kme,                                  &
             its,ite, jts,jte, kts,kte                                   )

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -1548,6 +1548,7 @@ if ( cam_mam_aerosols ) &
                grid%f_ice_phy,grid%f_rain_phy,grid%cldfrai, grid%cldfral,             &
                moist, grid%cldfra, grid%cldfra_mp_all, grid%ph_no2,                   &
                chem, gas_aqfrac, numgas_mam,grid%is_CAMMGMP_used,                     &
+               grid%ph_cw,                                                            &
                ids,ide, jds,jde, kds,kde,                                             &
                ims,ime, jms,jme, kms,kme,                                             &
                its,ite, jts,jte, kts,kte                                              )
@@ -1572,6 +1573,7 @@ if ( cam_mam_aerosols ) &
               vdrog3,vdrog3_vbs,grid%br_rto,grid%dgnum4d,grid%dgnumwet4d,wetdens_ap,  &
               del_h2so4_gasprod,grid%dvmrdt_sv13d,grid%dvmrcwdt_sv13d,                &
               grid%is_CAMMGMP_used,                                                   &
+              grid%ph_aer01, grid%ph_aer02, grid%ph_aer03, grid%ph_aer04,             &
               ids,ide, jds,jde, kds,kde,                                              &
               ims,ime, jms,jme, kms,kme,                                              &
               its,ite,jts,jte,kts,kte                                                 )

--- a/chem/cloudchem_driver.F
+++ b/chem/cloudchem_driver.F
@@ -18,6 +18,7 @@
 	       moist, cldfra, cldfra_mp_all, ph_no2,                 &
 	       chem, gas_aqfrac, numgas_aqfrac,                      &
                is_CAMMGMP_used,                                      &!BSINGH:01/31/2013: Added is_CAMMGMP_used for CAM_MAM_cloudchem
+               ph_cw,                                                &
                ids,ide, jds,jde, kds,kde,                            &
                ims,ime, jms,jme, kms,kme,                            &
                its,ite, jts,jte, kts,kte                             )
@@ -169,7 +170,8 @@
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme, numgas_aqfrac ),     &
          INTENT(INOUT ) ::                                gas_aqfrac
 
-
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                    &
+         INTENT(OUT) ::                            ph_cw                ! ph_cw - pH of cloud water
 
 ! LOCAL  VAR
      integer :: ii,jj,kk
@@ -200,7 +202,7 @@
             id, ktau, ktauc, dtstepc, config_flags,   &
             p_phy, t_phy, rho_phy, alt,               &
             cldfra, ph_no2,                           &
-            moist, chem,                              &
+            moist, chem, ph_cw,                       &
             gas_aqfrac, numgas_aqfrac,                &
             ids,ide, jds,jde, kds,kde,                &
             ims,ime, jms,jme, kms,kme,                &

--- a/chem/cloudchem_driver.F
+++ b/chem/cloudchem_driver.F
@@ -171,7 +171,7 @@
          INTENT(INOUT ) ::                                gas_aqfrac
 
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                    &
-         INTENT(OUT) ::                            ph_cw                ! ph_cw - pH of cloud water
+         INTENT(OUT) ::                            ph_cw            ! ph_cw - pH of cloud water
 
 ! LOCAL  VAR
      integer :: ii,jj,kk

--- a/chem/module_chem_cup.F
+++ b/chem/module_chem_cup.F
@@ -3277,7 +3277,7 @@ dndraft_mixratio_k_loop: &
             grid_id, ktau, ktau, dt_aqchem_sp, config_flags,   &
             tmp_p_sp, tmp_t_sp, tmp_rho_sp, tmp_alt_sp,   &
             tmp_cldfra_sp, tmp_ph_no2_sp,   &
-            tmp_moist_sp, tmp_chem_sp, tmp_ph_cw,  &
+            tmp_moist_sp, tmp_chem_sp, tmp_ph_cw,   &
             tmp_gas_aqfrac_sp, num_chem,   &
             1,1,  1,1,  kts,kte,  &
             1,1,  1,1,  kts,kte,  &

--- a/chem/module_chem_cup.F
+++ b/chem/module_chem_cup.F
@@ -3205,6 +3205,7 @@ dndraft_mixratio_k_loop: &
       integer :: l
       real(r8) :: tmpb
       real(r8) :: tmp_chem_up(1:num_chem), tmp_chem_up_old(1:num_chem)
+      real(r4), dimension( 1:1, kts:kte, 1:1 ) ::  tmp_ph_cw
 
 ! single precision variable used for calls to other wrf-chem routines
       real(r4) :: dt_aqchem_sp
@@ -3276,7 +3277,7 @@ dndraft_mixratio_k_loop: &
             grid_id, ktau, ktau, dt_aqchem_sp, config_flags,   &
             tmp_p_sp, tmp_t_sp, tmp_rho_sp, tmp_alt_sp,   &
             tmp_cldfra_sp, tmp_ph_no2_sp,   &
-            tmp_moist_sp, tmp_chem_sp,   &
+            tmp_moist_sp, tmp_chem_sp, tmp_ph_cw,  &
             tmp_gas_aqfrac_sp, num_chem,   &
             1,1,  1,1,  kts,kte,  &
             1,1,  1,1,  kts,kte,  &

--- a/chem/module_mosaic_cloudchem.F
+++ b/chem/module_mosaic_cloudchem.F
@@ -33,7 +33,7 @@
 	    id, ktau, ktauc, dtstepc, config_flags,   &
 	    p_phy, t_phy, rho_phy, alt,   &
 	    cldfra, ph_no2,   &
-	    moist, chem,   &
+	    moist, chem, ph_cw,          &
 	    gas_aqfrac, numgas_aqfrac,   &
 	    ids,ide, jds,jde, kds,kde,   &
 	    ims,ime, jms,jme, kms,kme,   &
@@ -107,6 +107,9 @@
                 gas_aqfrac
 !   gas_aqfrac - fraction (0-1) of gas that is dissolved in cloud water
 
+        real, intent(out),   &
+                dimension( ims:ime, kms:kme, jms:jme ) :: &
+                ph_cw 
 
 !   local variables
 	integer :: it, jt, kt, kpeg, k_pegshift, l, mpeg
@@ -146,6 +149,14 @@
 !   following line turns aqueous radical chem off unconditionally
 	iradical_onoff = 0
 
+!   Initialize pH of CW ph_cw to a FillValue value
+        do jt = jts, jte
+          do kt = kts, kte
+            do it = its, ite
+              ph_cw(it,kt,jt) = -9999.
+            end do
+          end do
+        end do
 
 	do 3920 jt = jts, jte
 	do 3910 it = its, ite
@@ -204,7 +215,7 @@
 		t_phy, p_phy, rho_phy                         )
 
 	gas_aqfrac(it,kt,jt,:) = gas_aqfrac_box(:) 
-
+        ph_cw(it,kt,jt)        = ph_aq_box
 
 3800	continue
 

--- a/chem/module_mosaic_driver.F
+++ b/chem/module_mosaic_driver.F
@@ -135,7 +135,7 @@
 		id, curr_secs, ktau, dtstep, ktauc, dtstepc, config_flags, &
 		t_phy, rho_phy, p_phy,                            &
 		moist, chem, vbs_nbin,                            &
-                ph_aer01, ph_aer02, ph_aer03, ph_aer04,           &
+               ph_aer01, ph_aer02, ph_aer03, ph_aer04,           &
 		ids,ide, jds,jde, kds,kde,                        &
 		ims,ime, jms,jme, kms,kme,                        &
 		its,ite, jts,jte, kts,kte                         )

--- a/chem/module_mosaic_driver.F
+++ b/chem/module_mosaic_driver.F
@@ -135,6 +135,7 @@
 		id, curr_secs, ktau, dtstep, ktauc, dtstepc, config_flags, &
 		t_phy, rho_phy, p_phy,                            &
 		moist, chem, vbs_nbin,                            &
+                ph_aer01, ph_aer02, ph_aer03, ph_aer04,           &
 		ids,ide, jds,jde, kds,kde,                        &
 		ims,ime, jms,jme, kms,kme,                        &
 		its,ite, jts,jte, kts,kte                         )
@@ -234,6 +235,10 @@
 		chem
 !   chem - mixing ratios of trace gase (ppm) and aerosol species
 !	(ug/kg for mass species, #/kg for number species)
+
+        real, intent(out),   &
+                dimension( ims:ime, kms:kme, jms:jme ) :: &
+                ph_aer01, ph_aer02, ph_aer03, ph_aer04
 
 	type(grid_config_rec_type), intent(in) :: config_flags
 !   config_flags - configuration and control parameters
@@ -449,7 +454,9 @@
  	print 93010, 'calling aerchem - it,jt,maerchem =', it, jt, maerchem
 !	print 93010, 'calling aerchem - it,jt,maerchem =', it, jt, maerchem
 	call aerchemistry( it, jt, kclm_calcbgn, kclm_calcend,   &
-                           dtchem, idiagaa_dum, vbs_nbin )
+                           dtchem, idiagaa_dum, vbs_nbin,        &
+                           ph_aer01(it,kms:kme,jt), ph_aer02(it,kms:kme,jt), &
+                           ph_aer03(it,kms:kme,jt), ph_aer04(it,kms:kme,jt), kms,kme  )
 
 !  note units for aerosol is now ug/m3
 

--- a/chem/module_mosaic_therm.F
+++ b/chem/module_mosaic_therm.F
@@ -90,8 +90,9 @@
 ! author: rahul a. zaveri
 ! update: jan 2005
 !-----------------------------------------------------------------------
-      subroutine aerchemistry( iclm, jclm, kclm_calcbgn, kclm_calcend,   &
-                               dtchem_sngl, idiagaa,vbs_nbin )
+      subroutine aerchemistry( iclm, jclm, kclm_calcbgn, kclm_calcend,    &
+                               dtchem_sngl, idiagaa,vbs_nbin,             &
+                               ph_aer1, ph_aer2, ph_aer3, ph_aer4,kms,kme )
 
       use module_data_mosaic_asect
       use module_data_mosaic_other
@@ -105,6 +106,9 @@
 !   subr arguments
       integer iclm, jclm, kclm_calcbgn, kclm_calcend, idiagaa,vbs_nbin(1)
       real dtchem_sngl
+      integer kms, kme
+      real, intent(out), dimension(kms:kme) ::                       &
+            ph_aer1, ph_aer2, ph_aer3, ph_aer4       ! pH of the aerosols
 !   local variables
       real(kind=8) :: dtchem
       integer k, m
@@ -153,6 +157,11 @@
           call specialoutaa( iclm, jclm, k, m, 'befor_movesect' )
           call move_sections( 1, iclm, jclm, k, m)
           call specialoutaa( iclm, jclm, k, m, 'after_movesect' )
+
+          ph_aer1(k) = mc(1,1)
+          ph_aer2(k) = mc(1,2)
+          ph_aer3(k) = mc(1,3)
+          ph_aer4(k) = mc(1,4)
 
 100     continue	! k levels
 


### PR DESCRIPTION
KEYWORDS: pH, cloud water, aerosols, mozart_mosaic_4bin_aq

SOURCE: Mary Barth (ACOM/MMM NCAR) and Stacy Walters (formerly NCAR)

DESCRIPTION OF CHANGES:

Originally submitted as PR #999, but was resubmitted due to inconsistencies

Alter Registry/registry.chem to include diagnostic pH variables ph_cw, ph_aer01, ph_aer02,
ph_aer03, and ph_aer04.
Modify files, listed below, to calculate and set pH diagnostic variables
MOZART is a gas-phase chemistry mechanism (set of reactions) in WRF-Chem

Diagnostics are activated with namelist,chem option mozart_ph_diag=1

MOSAIC is one of the aerosol models in WRF-Chem that represents the size distribution
of the aerosols with 4 size bins (hence "4bin")

The pH is calculated for each of the 4 aerosol size bins. That is why there are 4 variables: pH_aer1,
aer2, aer3, aer4.

pH is a diagnostic variable and is calculated as part of the aerosol model. However what we added
was the ability to write out the field to the history file. It is by default turned off as an output field,
but can be "turned on" using the iofields.txt file.

There is also cloud water pH (pH_CW) which is calculated as part of the cloud chemistry routine.
Same thing as aerosol pH, by default it is not an output field, but can be included in history files
via iofields.txt.

For pretty pictures and a description of what we learned, feel free to look at the report for the
ACOM lab: https://nar.ucar.edu/2019/acom/predicting-acidity-aerosols-and-cloud-water.

LIST OF MODIFIED FILES:
Registry/registry.chem
chem/chem_driver.F
chem/cloudchem_driver.F
chem/module_mosaic_cloudchem.F
chem/aerosol_driver.F
chem/module_mosaic_driver.F
chem/module_mosaic_therm.F
chem/module_chem_cup.F


