### PR TITLE
Bug fix to use correct rho value in cal_titau subroutines

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -5478,7 +5478,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg
+    :: xkxavg, rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -5511,10 +5511,11 @@ END SUBROUTINE nonlocal_flux
     DO j = j_start, j_end
     DO k = kts, ktf
     DO i = i_start, i_end
-      xkxavg(i,k,j) = 0.25 * ( xkx(i-1,k,j  ) + xkx(i,k,j  ) +  &
+      rhoavg(i,k,j) = 0.25 * ( rho(i-1,k,j  ) + rho(i,k,j  ) +  &
+                               rho(i-1,k,j-1) + rho(i,k,j-1) )
+      xkxavg(i,k,j) = rhoavg(i,k,j) *                           &
+                      0.25 * ( xkx(i-1,k,j  ) + xkx(i,k,j  ) +  &
                                xkx(i-1,k,j-1) + xkx(i,k,j-1) )
-      xkxavg(i,k,j) = xkxavg(i,k,j) * .25 * ( rho(i-1,k,j  ) + rho(i,k,j  )  +  &
-                                              rho(i-1,k,j-1) + rho(i,k,j-1) )
     END DO
     END DO
     END DO
@@ -5527,7 +5528,7 @@ END SUBROUTINE nonlocal_flux
       DO k = kts, ktf
       DO i = i_start, i_end
 
-        titau(i,k,j) = rho(i,k,j) * mtau(i,k,j)
+        titau(i,k,j) = rhoavg(i,k,j) * mtau(i,k,j)
 
       END DO
       END DO
@@ -5541,7 +5542,7 @@ END SUBROUTINE nonlocal_flux
         DO k = kts, ktf
         DO i = i_start, i_end
           titau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)
-          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rho(i,k,j)
+          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rhoavg(i,k,j)
 
         END DO
         END DO
@@ -5623,7 +5624,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg
+    :: xkxavg, rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -5656,10 +5657,11 @@ END SUBROUTINE nonlocal_flux
     DO j = j_start, j_end
     DO k = kts+1, ktf
     DO i = i_start, i_end
-      xkxavg(i,k,j) = 0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i-1,k  ,j) ) +  &
+      rhoavg(i,k,j) = 0.5 * ( fnm(k) * ( rho(i-1,k  ,j) + rho(i,k  ,j) ) + &
+                              fnp(k) * ( rho(i-1,k-1,j) + rho(i,k-1,j) ) )
+      xkxavg(i,k,j) = rhoavg(i,k,j)  *                                     &
+                      0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i-1,k  ,j) ) + &
                               fnp(k) * ( xkx(i,k-1,j) + xkx(i-1,k-1,j) ) )
-      xkxavg(i,k,j) = xkxavg(i,k,j) * 0.5 * ( fnm(k) * ( rho(i-1,k  ,j) + rho(i,k  ,j) ) + &
-                                              fnp(k) * ( rho(i-1,k-1,j) + rho(i,k-1,j) ) )
     END DO
     END DO
     END DO
@@ -5669,7 +5671,7 @@ END SUBROUTINE nonlocal_flux
       DO j = j_start, j_end
       DO k = kts+1, ktf
       DO i = i_start, i_end
-         titau(i,k,j) = rho(i,k,j) * mtau(i,k,j)
+         titau(i,k,j) = rhoavg(i,k,j) * mtau(i,k,j)
       ENDDO
       ENDDO
       ENDDO
@@ -5683,7 +5685,7 @@ END SUBROUTINE nonlocal_flux
         DO i = i_start, i_end
 
           titau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)
-          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rho(i,k,j)
+          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rhoavg(i,k,j)
 
         ENDDO
         ENDDO
@@ -5772,7 +5774,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg
+    :: xkxavg, rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -5805,10 +5807,11 @@ END SUBROUTINE nonlocal_flux
     DO j = j_start, j_end
     DO k = kts+1, ktf
     DO i = i_start, i_end
-      xkxavg(i,k,j) = 0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i,k  ,j-1) ) +  &
+      rhoavg(i,k,j) = 0.5 * ( fnm(k) * ( rho(i,k  ,j) + rho(i,k  ,j-1) ) + &
+                              fnp(k) * ( rho(i,k-1,j) + rho(i,k-1,j-1) ) )
+      xkxavg(i,k,j) = rhoavg(i,k,j)  *                                     &
+                      0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i,k  ,j-1) ) + &
                               fnp(k) * ( xkx(i,k-1,j) + xkx(i,k-1,j-1) ) )
-      xkxavg(i,k,j) = xkxavg(i,k,j) * 0.5 * ( fnm(k) * ( rho(i,k  ,j) + rho(i,k  ,j-1) ) +  &
-                                              fnp(k) * ( rho(i,k-1,j) + rho(i,k-1,j-1) ) )
     END DO
     END DO
     END DO
@@ -5819,7 +5822,7 @@ END SUBROUTINE nonlocal_flux
       DO k = kts+1, ktf
       DO i = i_start, i_end
 
-        titau(i,k,j) =  rho(i,k,j) * mtau(i,k,j)
+        titau(i,k,j) =  rhoavg(i,k,j) * mtau(i,k,j)
 
       END DO
       END DO
@@ -5834,7 +5837,7 @@ END SUBROUTINE nonlocal_flux
         DO i = i_start, i_end
 
           titau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)
-          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rho(i,k,j)
+          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rhoavg(i,k,j)
 
         END DO
         END DO

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -5478,7 +5478,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg, rhoavg
+    :: xkxavg,rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: rho, sfs_opt, m_opt, cal_titau

SOURCE: Robert Arthur and Jeff Mirocha (LLNL)

DESCRIPTION OF CHANGES:
Problem:
In the cal_titau subroutines in module_diffusion_em, rho was not always interpolated to the correct location on the staggered grid. This issue affected the subgrid stress terms when sfs_opt .gt. 1. Additionally, when sfs_opt .eq. 0 and m_opt .eq. 1, the actual subgrid stresses applied in the code were correct, but the output was wrong.

Solution:
A rhoavg variable was added to cal_titau_12_21, cal_titau_13_31, and cal_titau_23_32 and used instead of the cell-centered rho variable. 

ISSUE: This is a follow-on from issue #1214 by @matzegoebel, which addressed the surface stress output from subroutine vertical_diffusion_2 when sfs_opt .gt. 0 or m_opt .eq. 1, but did not address the cal_titau subroutines.

LIST OF MODIFIED FILES: dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
For this relatively simple fix, no tests were conducted beyond confirming that the code compiles.

RELEASE NOTE: Bug fix to use correct rho value in cal_titau subroutines
