### PR TITLE
Remove UM trajectory initialization from real

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4251,44 +4251,6 @@ endif
           END DO
       END IF
 
-      !  Template for initializing trajectories.  The i, j, and k starting locations
-      !  are specified.  Right now, a small plane in the middle of the domain is
-      !  selected.
-      
-      grid%traj_i    = -9999
-      grid%traj_j    = -9999
-      grid%traj_k    = -9999
-      grid%traj_lat  = -9999
-      grid%traj_long = -9999
-    
-      IF (config_flags%num_traj .gt. 0 .and. config_flags%traj_opt .gt. 0) THEN
-         icount = 1
-         DO j = (jde + jds)/2 - 2, (jde + jds)/2 + 2, 1
-            DO i = (ide + ids)/2 - 2, (ide + ids)/2 + 2, 1
-               IF ( its .LE. i    .and. ite .GE. i   .and.  jts .LE. j    .and. jte .GE. j ) THEN
-                  grid%traj_i   (icount) = i
-                  grid%traj_j   (icount) = j
-                  grid%traj_k   (icount) = 10
-                  grid%traj_lat (icount) = grid%xlat(i,j)
-                  grid%traj_long(icount) = grid%xlong(i,j)
-               END IF
-         
-#ifdef DM_PARALLEL
-               grid%traj_i   (icount) = wrf_dm_max_real ( grid%traj_i   (icount) )
-               grid%traj_j   (icount) = wrf_dm_max_real ( grid%traj_j   (icount) )
-               grid%traj_k   (icount) = wrf_dm_max_real ( grid%traj_k   (icount) )
-               grid%traj_lat (icount) = wrf_dm_max_real ( grid%traj_lat (icount) )
-               grid%traj_long(icount) = wrf_dm_max_real ( grid%traj_long(icount) )
-#endif
-                
-               icount = icount + 1
-               IF (icount .GT. config_flags%num_traj) THEN
-                  EXIT
-               END IF
-            END DO
-         END DO  
-      END IF
-
       !  Simple initialization for 3d ocean.  
 
       IF ( config_flags%sf_ocean_physics .EQ. PWP3DSCHEME ) THEN

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -492,11 +492,9 @@ Price, J. F., T. B. Sanford, and G. Z. Forristal, 1994: Forced stage response to
 
 
 
-
 ** Using the ACOM Forward Lagrangian trajectory calculation:
 
 &domains
-
  num_traj                            = 25,
 
 &physics

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -492,7 +492,7 @@ Price, J. F., T. B. Sanford, and G. Z. Forristal, 1994: Forced stage response to
 
 
 
-** Using U. Miami Forward Lagrangian trajectory calculation 
+** Using NCAR ACOM Forward Lagrangian trajectory calculation 
   (add it in namelist record &physics):
 &domain
  num_traj                            = 25,

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -715,7 +715,7 @@ To overwrite the cu_physics option for a second nest, set
  /
 
 
-** Using the irrigation parameterizations:
+** Using irrigation parameterizations:
 &physics
  sf_surf_irr_scheme                  = 3,
  irr_daily_amount                    = 5.7,

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -750,7 +750,7 @@ To overwrite the cu_physics option for a second nest, set
  /
 
 
-** Using irrigation parameterizations:
+** Using the irrigation parameterizations:
 &physics
  sf_surf_irr_scheme                  = 3,
  irr_daily_amount                    = 5.7,


### PR DESCRIPTION
TYPE: feature removed

KEYWORDS: UM trajectory, NCAR ACOM trajectory

SOURCE: Internal

DESCRIPTION OF CHANGES: 
The UM trajectory option has been replaced by NCAR ACOM trajectory option.  Therefore, the initialization for UM 
trajectory (in the real program) is no longer needed.

LIST OF MODIFIED FILES:
M   dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
(1) A single test case has been conducted to demonstrate that the UM trajectory no longer works. NCAR ACOM trajectory option gives expected results. 
(2) Jenkins test is done successfully.

RELEASE NOTE: Not necessary
