### PR TITLE
Chem: Wet scavenging optional for MP schemes

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -13,8 +13,6 @@ rconfig   integer    io_form_auxinput12  namelist,time_control   1  2
 
 
 state    real    CLDFRA2         ikj    misc        1         -      h        "CLDFRA2"             "CLOUD FRACTION"
-state    real    RAINPROD        ikj    misc        1         -      h        "RAINPROD"            "TOTAL RAIN PRODUCTION RATE"       "s-1"
-state    real    EVAPPROD        ikj    misc        1         -      h        "EVAPPROD"            "RAIN EVAPORATION RATE"            "s-1"
 state    real    QV_B4MP         ikj    misc        1         -      -        "QV_B4MP"             "WATER VAPOR BEFORE MICROPHYSICS"  "kg kg-1"
 state    real    QC_B4MP         ikj    misc        1         -      -        "QC_B4MP"             "CLOUD WATER BEFORE MICROPHYSICS"  "kg kg-1"
 state    real    QI_B4MP         ikj    misc        1         -      -        "QI_B4MP"             "CLOUD ICE BEFORE MICROPHYSICS"    "kg kg-1"
@@ -49,6 +47,12 @@ state   integer last_chem_time_second    -  misc    -         -      r       "la
 #
 state   integer emissframes      -          -          -         -      -       "emissframes"           ""         ""
 state   integer fireemissframes  -        -          -        -        -      "fireemissframes"       ""         ""
+#
+# Rain, evaporation rates
+#
+state    real    -              ikjf     wetscav_frcing        -         -      -        -                     "Rain,evap rates"                  "s-1"
+state    real    RAINPROD       ikjf     wetscav_frcing        1         -      h        "RAINPROD"            "TOTAL RAIN PRODUCTION RATE"       "s-1"
+state    real    EVAPPROD       ikjf     wetscav_frcing        1         -      h        "EVAPPROD"            "RAIN EVAPORATION RATE"            "s-1"
 #
 # Anthropogenic emissions
 #
@@ -4134,6 +4138,9 @@ package   usechemdiag    chemdiag==1         -                conv_ct:conv_co,co
 
 # package for aerosol srf area diagnostic
 package   has_aero_srf_area_diag    aero_srf_area_diag==1         -                aero_srf_area:sulf_srf_area,oc_srf_area,bc_srf_area
+#
+# package for wetscavenging
+package   wetscav_pl                wetscav_onoff==1              -                wetscav_frcing:rainprod,evapprod
 
 # Lightning NOx tracers
 state   real    lnox_total   ikjf    tracer        1         -     i8rhusdf=(bdy_interp:dt)    "lnox_total"      "Total LNOx tracer"          "ppmv"

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -1606,9 +1606,11 @@ if ( cam_mam_aerosols ) &
               rri,t_phy,moist,p8w,t8w,                                                &
               grid%dx, grid%dy,                                                       &
               p_phy,chem,rho,grid%cldfra,grid%cldfra2,                                &
-              grid%rainprod,grid%evapprod,grid%hno3_col_mdel,                         &
+              wetscav_frcing(ims,kms,jms,p_rainprod),                                 &
+              wetscav_frcing(ims,kms,jms,p_evapprod),                                 &
+              grid%hno3_col_mdel,                                                     &                
               grid%qlsink,grid%precr,grid%preci,grid%precs,grid%precg,                &
-              grid%wdflx, &
+              grid%wdflx,                                                             &
               gas_aqfrac, numgas_mam,dz8w,                                            &
               grid%h2oaj,grid%h2oai,grid%nu3,grid%ac3,grid%cor3,                      &
               grid%asulf,grid%ahno3,grid%anh3,grid%cvaro1,grid%cvaro2,                &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -3716,7 +3716,8 @@ BENCH_START(micro_driver_tim)
       &        , QID_CURR=moist(ims,kms,jms,P_QID), F_QID=F_QID               &
       &        , QNDROP_CURR=scalar(ims,kms,jms,P_QNDROP), F_QNDROP=F_QNDROP &
 #if (WRF_CHEM == 1)
-      &        , RAINPROD=grid%rainprod, EVAPPROD=grid%evapprod           &
+      &        , RAINPROD=wetscav_frcing(ims,kms,jms,p_rainprod)          &
+      &        , EVAPPROD=wetscav_frcing(ims,kms,jms,p_evapprod)          &
       &        , QV_B4MP=grid%qv_b4mp,QC_B4MP=grid%qc_b4mp                &
       &        , QI_B4MP=grid%qi_b4mp, QS_B4MP=grid%qs_b4mp               &
 #endif

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -1034,6 +1034,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      GRAUPELNCV=GRAUPELNCV,              &
                      SR=SR,                              &
 #if ( WRF_CHEM == 1 )
+                     WETSCAV_ON=config_flags%wetscav_onoff == 1, &
                      RAINPROD=rainprod,                  &
                      EVAPPROD=evapprod,                  &
 #endif
@@ -1093,6 +1094,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      GRAUPELNCV=GRAUPELNCV,              &
                      SR=SR,                              &
 #if ( WRF_CHEM == 1 )
+                     WETSCAV_ON=config_flags%wetscav_onoff == 1, &
                      RAINPROD=rainprod,                  &
                      EVAPPROD=evapprod,                  &
 #endif
@@ -1338,7 +1340,8 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte &
                  ,QLSINK=qlsink                                     & ! jdf for wrf-chem
 #if ( WRF_CHEM == 1 )
-                 ,EVAPPROD=evapprod,RAINPROD=rainprod               &
+                 ,WETSCAV_ON=config_flags%wetscav_onoff == 1 &
+                 ,EVAPPROD=evapprod,RAINPROD=rainprod          &
 #endif
                  ,PRECR=precr,PRECI=preci,PRECS=precs,PRECG=precg   & ! jdf for wrf-chem
                                                                     )
@@ -1568,7 +1571,8 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  ,CU_UAF=CU_UAF                          & ! TWG add
                  ,QLSINK=qlsink                                     & ! jdf for wrf-chem
 #if ( WRF_CHEM == 1 )
-                 ,EVAPPROD=evapprod,RAINPROD=rainprod               &
+                 ,WETSCAV_ON=config_flags%wetscav_onoff == 1 &
+                 ,EVAPPROD=evapprod,RAINPROD=rainprod          &
 #endif
                  ,PRECR=precr,PRECI=preci,PRECS=precs,PRECG=precg   & ! jdf for wrf-chem
                                                                     )
@@ -1848,6 +1852,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      SR=SR,                              &
                      dbz      = refl_10cm,               &
 #if ( WRF_CHEM == 1 )
+                    WETSCAV_ON = config_flags%wetscav_onoff == 1, &
                     EVAPPROD=evapprod,RAINPROD=rainprod, &
 #endif
                      nssl_progn=nssl_progn,              &
@@ -1924,6 +1929,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      SR=SR,                              &
                      dbz      = refl_10cm,               &
 #if ( WRF_CHEM == 1 )
+                    WETSCAV_ON = config_flags%wetscav_onoff == 1, &
                     EVAPPROD=evapprod,RAINPROD=rainprod, &
 #endif
                      nssl_progn=nssl_progn,              &
@@ -2006,6 +2012,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      SR=SR,                              &
                      dbz      = refl_10cm,               &
 #if ( WRF_CHEM == 1 )
+                     WETSCAV_ON = config_flags%wetscav_onoff == 1, &
                      EVAPPROD=evapprod,RAINPROD=rainprod,&
 #endif
                      nssl_progn=nssl_progn,              &
@@ -2350,7 +2357,8 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
                  ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte &
-#ifdef WRF_CHEM
+#if ( WRF_CHEM == 1 )
+                 ,WETSCAV_ON=config_flags%wetscav_onoff==1          &
                  ,EVAPPROD=evapprod,RAINPROD=rainprod               &
 #endif
                                                                     )

--- a/phys/module_mp_morr_two_moment.F
+++ b/phys/module_mp_morr_two_moment.F
@@ -86,7 +86,7 @@ MODULE MODULE_MP_MORR_TWO_MOMENT
    USE     module_wrf_error
    USE module_mp_radar
 
-! USE WRF PHYSICS CONSTANTS
+!  USE WRF PHYSICS CONSTANTS
   use module_model_constants, ONLY: CP, G, R => r_d, RV => r_v, EP_2
 
 !  USE module_state_description

--- a/phys/module_mp_morr_two_moment.F
+++ b/phys/module_mp_morr_two_moment.F
@@ -570,7 +570,7 @@ SUBROUTINE MP_MORR_TWO_MOMENT(ITIMESTEP,                       &
                ,IMS,IME, JMS,JME, KMS,KME               & ! memory dims
                ,ITS,ITE, JTS,JTE, KTS,KTE               & ! tile   dims            )
 !jdf		   ,C2PREC3D,CSED3D,ISED3D,SSED3D,GSED3D,RSED3D & ! HM ADD, WRF-CHEM
-               ,rainprod, evapprod                      &
+               ,wetscav_on, rainprod, evapprod                      &
 		   ,QLSINK,PRECR,PRECI,PRECS,PRECG &        ! HM ADD, WRF-CHEM
                                             )
  
@@ -671,6 +671,8 @@ SUBROUTINE MP_MORR_TWO_MOMENT(ITIMESTEP,                       &
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) ::       ht
 
+   LOGICAL, optional, INTENT(IN) :: wetscav_on
+
    ! LOCAL VARIABLES
 
    REAL, DIMENSION(its:ite, kts:kte, jts:jte)::                     &
@@ -717,10 +719,18 @@ SUBROUTINE MP_MORR_TWO_MOMENT(ITIMESTEP,                       &
    LOGICAL, OPTIONAL, INTENT(IN) :: diagflag
    INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref
 
+   LOGICAL :: has_wetscav
+
 ! below for wrf-chem
    flag_qndrop = .false.
    IF ( PRESENT ( f_qndrop ) ) flag_qndrop = f_qndrop
 !!!!!!!!!!!!!!!!!!!!!!
+
+   IF( PRESENT( wetscav_on ) ) THEN
+     has_wetscav = wetscav_on
+   ELSE
+     has_wetscav = .false.
+   ENDIF
 
    ! Initialize tendencies (all set to 0) and transfer
    ! array to local variables
@@ -820,7 +830,7 @@ SUBROUTINE MP_MORR_TWO_MOMENT(ITIMESTEP,                       &
                                   QGSTEN,QRSTEN,QISTEN,QNISTEN,QCSTEN, &
                                   nc1d, nc_tend1d, iinum, C2PREC,CSED,ISED,SSED,GSED,RSED & !wrf-chem
 #if (WRF_CHEM == 1)
-                                  ,rainprod1d, evapprod1d & !wrf-chem
+                                  ,has_wetscav,rainprod1d, evapprod1d & !wrf-chem
 #endif
                        )
 
@@ -877,8 +887,10 @@ SUBROUTINE MP_MORR_TWO_MOMENT(ITIMESTEP,                       &
 !          EFFIS(I,K,J)     = MAX(EFFIS(I,K,J),13.)
 
 #if ( WRF_CHEM == 1)
-           IF ( PRESENT( rainprod ) ) rainprod(i,k,j) = rainprod1d(k)
-           IF ( PRESENT( evapprod ) ) evapprod(i,k,j) = evapprod1d(k)
+           IF ( has_wetscav ) THEN
+             IF ( PRESENT( rainprod ) ) rainprod(i,k,j) = rainprod1d(k)
+             IF ( PRESENT( evapprod ) ) evapprod(i,k,j) = evapprod1d(k)
+           ENDIF
 #endif
 
       end do
@@ -924,7 +936,7 @@ END SUBROUTINE MP_MORR_TWO_MOMENT
                         nc3d,nc3dten,iinum, & ! wrf-chem
 				c2prec,CSED,ISED,SSED,GSED,RSED  &  ! hm added, wrf-chem
 #if (WRF_CHEM == 1)
-        ,rainprod, evapprod &
+        ,has_wetscav,rainprod, evapprod &
 #endif
                         )
 
@@ -1021,6 +1033,11 @@ END SUBROUTINE MP_MORR_TWO_MOMENT
 ! MODEL INPUT PARAMETERS (FORMERLY IN COMMON BLOCKS)
 
         REAL DT         ! MODEL TIME STEP (SEC)
+
+#if (WRF_CHEM == 1)
+      LOGICAL, INTENT(IN) :: has_wetscav
+#endif
+
 
 !.....................................................................................................
 ! LOCAL VARIABLES: ALL PARAMETERS BELOW ARE LOCAL TO SCHEME AND DON'T NEED TO COMMUNICATE WITH THE
@@ -2050,8 +2067,10 @@ END SUBROUTINE MP_MORR_TWO_MOMENT
       QC3DTEN(K) = QC3DTEN(K)+PCC(K)
 
 #if (WRF_CHEM == 1)
+      IF( has_wetscav ) THEN
          evapprod(k) = - PRE(K) - EVPMS(K) - EVPMG(K)
          rainprod(k) = PRA(K) + PRC(K) + tqimelt(K)
+      END IF
 #endif
 
 !.......................................................................
@@ -3294,10 +3313,12 @@ END SUBROUTINE MP_MORR_TWO_MOMENT
          NR3DTEN(K) = NR3DTEN(K)+NSUBR(K)
 
 #if (WRF_CHEM == 1)
+      IF( has_wetscav ) THEN
          evapprod(k) = - PRE(K) - EPRDS(K) - EPRDG(K) 
          rainprod(k) = PRA(K) + PRC(K) + PSACWS(K) + PSACWG(K) + PGSACW(K) & 
                        + PRAI(K) + PRCI(K) + PRACI(K) + PRACIS(K)  &
                        + PRDS(K) + PRDG(K)
+      ENDIF
 #endif
 
          END IF !!!!!! TEMPERATURE

--- a/phys/module_mp_morr_two_moment_aero.F
+++ b/phys/module_mp_morr_two_moment_aero.F
@@ -719,7 +719,7 @@ SUBROUTINE MP_MORR_TWO_MOMENT_AERO(ITIMESTEP,                    &
                ,CCN5_GS, CCN6_GS, CCN7_GS, NR_CU        & ! TWG add
                ,QR_CU, NS_CU, QS_CU, CU_UAF             & ! TWG add
 !jdf           ,C2PREC3D,CSED3D,ISED3D,SSED3D,GSED3D,RSED3D & ! HM ADD, WRF-CHEM
-               ,rainprod, evapprod                      &
+               ,wetscav_on, rainprod, evapprod                      &
                ,QLSINK,PRECR,PRECI,PRECS,PRECG          & ! HM ADD, WRF-CHEM
                                            )
  
@@ -830,6 +830,7 @@ SUBROUTINE MP_MORR_TWO_MOMENT_AERO(ITIMESTEP,                    &
                           EFCG, EFIG, EFSG, WACT, CCN1_GS,  &
         CCN2_GS, CCN3_GS, CCN4_GS, CCN5_GS, CCN6_GS, CCN7_GS
 
+   LOGICAL, optional, INTENT(IN) :: wetscav_on
 
    ! LOCAL VARIABLES
 
@@ -891,12 +892,20 @@ SUBROUTINE MP_MORR_TWO_MOMENT_AERO(ITIMESTEP,                    &
   REAL, DIMENSION(kts:kte, no_src_types_cu) :: maerosol, naer
 ! TWG END
 
+  LOGICAL :: has_wetscav
+
 ! below for wrf-chem
    flag_qndrop = .false.
    IF ( PRESENT ( f_qndrop ) ) flag_qndrop = f_qndrop
 !!!!!!!!!!!!!!!!!!!!!!
 
-   ! Initialize tendencies (all set to 0) and transfer
+   IF ( PRESENT ( wetscav_on ) ) THEN
+     has_wetscav = wetscav_on
+   ELSE
+     has_wetscav = .false.
+   ENDIF
+   
+! Initialize tendencies (all set to 0) and transfer
    ! array to local variables
    DT = DT_IN   
 
@@ -1082,7 +1091,7 @@ SUBROUTINE MP_MORR_TWO_MOMENT_AERO(ITIMESTEP,                    &
                                  nc1d, nc_tend1d, iinum, C2PREC,CSED,ISED,SSED,GSED,RSED & !wrf-chem
                                  ,no_src_types_cu,maerosol,naer                          & !TWG add prescribed aerosol
 #if (WRF_CHEM == 1)
-                                 ,rainprod1d, evapprod1d                                 & !wrf-chem
+                                 ,has_wetscav, rainprod1d, evapprod1d                    & !wrf-chem
 #endif
                        )
    !
@@ -1150,8 +1159,10 @@ SUBROUTINE MP_MORR_TWO_MOMENT_AERO(ITIMESTEP,                    &
 !          EFFIS(I,K,J)     = MAX(EFFIS(I,K,J),13.)
 
 #if ( WRF_CHEM == 1)
+         IF ( has_wetscav ) THEN
            IF ( PRESENT( rainprod ) ) rainprod(i,k,j) = rainprod1d(k)
            IF ( PRESENT( evapprod ) ) evapprod(i,k,j) = evapprod1d(k)
+         ENDIF
 #endif
 
       end do
@@ -1209,7 +1220,7 @@ END SUBROUTINE MP_MORR_TWO_MOMENT_AERO
                         ,no_src_types_cu,maerosol,naer & ! TWG add
 
 #if (WRF_CHEM == 1)
-        ,rainprod, evapprod &
+        ,has_wetscav,rainprod, evapprod &
 #endif
                         )
 
@@ -1537,6 +1548,7 @@ END SUBROUTINE MP_MORR_TWO_MOMENT_AERO
 	REAL, DIMENSION(KTS:KTE)::C2PREC,CSED,ISED,SSED,GSED,RSED
 #if (WRF_CHEM == 1)
     REAL, DIMENSION(KTS:KTE), INTENT(INOUT) :: rainprod, evapprod
+    LOGICAL, INTENT(IN)                     :: has_wetscav
 #endif
     REAL, DIMENSION(KTS:KTE)                :: tqimelt ! melting of cloud ice (tendency)
 
@@ -2358,8 +2370,10 @@ END SUBROUTINE MP_MORR_TWO_MOMENT_AERO
       QC3DTEN(K) = QC3DTEN(K)+PCC(K)
 
 #if (WRF_CHEM == 1)
+       IF ( has_wetscav ) THEN
          evapprod(k) = - PRE(K) - EVPMS(K) - EVPMG(K)
          rainprod(k) = PRA(K) + PRC(K) + tqimelt(K)
+       ENDIF
 #endif
 
 !.......................................................................
@@ -4242,10 +4256,12 @@ END SUBROUTINE MP_MORR_TWO_MOMENT_AERO
          NR3DTEN(K) = NR3DTEN(K)+NSUBR(K)
 
 #if (WRF_CHEM == 1)
+       IF ( has_wetscav ) THEN
          evapprod(k) = - PRE(K) - EPRDS(K) - EPRDG(K) 
          rainprod(k) = PRA(K) + PRC(K) + PSACWS(K) + PSACWG(K) + PGSACW(K) & 
                        + PRAI(K) + PRCI(K) + PRACI(K) + PRACIS(K) + &
                        + PRDS(K) + PRDG(K)
+       ENDIF
 #endif
 
          END IF !!!!!! TEMPERATURE

--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -149,7 +149,7 @@ MODULE module_mp_nssl_2mom
   logical, private :: cleardiag = .false.
   PRIVATE
 
-#ifdef WRF_CHEM
+#if ( WRF_CHEM == 1 )
   integer, parameter :: wrfchem_flag = 1
 #else
   integer, parameter :: wrfchem_flag = 0
@@ -1637,7 +1637,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
                               diagflag,ke_diag,                                         &
                               nssl_progn,                                              & ! wrf-chem 
 ! 20130903 acd_mb_washout start
-                              rainprod, evapprod,                                       & ! wrf-chem 
+                              wetscav_on, rainprod, evapprod,                           & ! wrf-chem 
 ! 20130903 acd_mb_washout end
                               cu_used, qrcuten, qscuten, qicuten, qccuten,              & ! hm added
                               ids,ide, jds,jde, kds,kde,                                &  ! domain dims
@@ -1724,7 +1724,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
 ! mu : air mass in column
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme), optional, INTENT(IN):: qrcuten, qscuten, qicuten, qccuten
    INTEGER, optional, intent(in) :: cu_used
-
+   LOGICAL, optional, intent(in) :: wetscav_on
 !
 ! local variables
 !
@@ -1762,7 +1762,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
       double precision :: timevtcalc,timesetvt
       
       logical :: f_cnatmp
-      
+      logical :: has_wetscav
       integer :: kediagloc
 
 
@@ -2075,10 +2075,16 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
 
         ENDDO ! ix
        ENDDO ! kz
-
+    
+         has_wetscav = .false.
          IF ( wrfchem_flag > 0 ) THEN
-           IF ( PRESENT( rainprod ) ) rainprod2d(its:ite,kts:kte) = 0
-           IF ( PRESENT( evapprod ) ) evapprod2d(its:ite,kts:kte) = 0
+           IF ( PRESENT( wetscav_on ) ) THEN
+             has_wetscav = wetscav_on
+             IF ( has_wetscav ) THEN
+               IF ( PRESENT( rainprod ) ) rainprod2d(its:ite,kts:kte) = 0
+               IF ( PRESENT( evapprod ) ) evapprod2d(its:ite,kts:kte) = 0
+             ENDIF
+           ENDIF
          ENDIF
          
 
@@ -2209,7 +2215,7 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
      &   cdx,                              &
      &   xdn0,dbz2d,tke2d,                 &
      &   timevtcalc,axtra2d, makediag        &
-     &   ,rainprod2d, evapprod2d           &
+     &   ,has_wetscav, rainprod2d, evapprod2d  &
      & ,elec2,its,ids,ide,jds,jde          &
      & )
 
@@ -2371,8 +2377,8 @@ SUBROUTINE nssl_2mom_driver(qv, qc, qr, qi, qs, qh, qhl, ccw, crw, cci, csw, chw
          IF ( lvh > 0 )  vhw(ix,kz,jy) = an(ix,1,kz,lvh)
          IF ( lvhl > 0 .and. present( vhl ) ) vhl(ix,kz,jy) = an(ix,1,kz,lvhl)
 
-#ifdef WRF_CHEM
-         IF ( wrfchem_flag > 0 ) THEN
+#if ( WRF_CHEM == 1 )
+         IF ( has_wetscav ) THEN
            IF ( PRESENT( rainprod ) ) rainprod(ix,kz,jy) = rainprod2d(ix,kz)
            IF ( PRESENT( evapprod ) ) evapprod(ix,kz,jy) = evapprod2d(ix,kz)
          ENDIF
@@ -9204,7 +9210,7 @@ END SUBROUTINE nssl_2mom_driver
      &   cdx,                              &
      &   xdn0,tmp3d,tkediss  &
      & ,timevtcalc,axtra,io_flag  &
-     & ,rainprod2d, evapprod2d &
+     & ,has_wetscav, rainprod2d, evapprod2d &
      & ,elec,its,ids,ide,jds,jde &
      & )
 
@@ -9277,6 +9283,7 @@ END SUBROUTINE nssl_2mom_driver
       real dtp,dx,dy,dz
 
       logical, intent(in) :: io_flag
+      logical, intent(in) :: has_wetscav
 
       integer itile,jtile,ktile
       integer ixbeg,jybeg
@@ -17798,7 +17805,7 @@ END SUBROUTINE nssl_2mom_driver
       end if
 
 
-      IF ( wrfchem_flag > 0 ) THEN
+      IF ( has_wetscav ) THEN
         DO mgs = 1,ngscnt
          evapprod2d(igs(mgs),kgs(mgs)) = -(qrcev(mgs) + qssbv(mgs)  + qhsbv(mgs) + qhlsbv(mgs)) 
          rainprod2d(igs(mgs),kgs(mgs)) = qrcnw(mgs) + qracw(mgs) + qsacw(mgs) + qhacw(mgs) + qhlacw(mgs) + &

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -980,7 +980,7 @@
                               SNOWNC, SNOWNCV, &
                               GRAUPELNC, GRAUPELNCV, SR, &
 #if ( WRF_CHEM == 1 )
-                              rainprod, evapprod, &
+                              wetscav_on, rainprod, evapprod, &
 #endif
                               refl_10cm, diagflag, ke_diag, do_radar_ref,      &
                               re_cloud, re_ice, re_snow,              &
@@ -1017,6 +1017,9 @@
                           refl_10cm
       REAL, INTENT(IN):: dt_in
       INTEGER, INTENT(IN):: itimestep
+#if ( WRF_CHEM == 1 )
+      LOGICAL, INTENT(in) :: wetscav_on
+#endif
 
 !..Local variables
       REAL, DIMENSION(kts:kte):: &
@@ -1150,7 +1153,7 @@
                       nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dz1d,  &
                       pptrain, pptsnow, pptgraul, pptice, &
 #if ( WRF_CHEM == 1 )
-                      rainprod1d, evapprod1d, &
+                      wetscav_on, rainprod1d, evapprod1d, &
 #endif
                       kts, kte, dt, i, j)
 
@@ -1198,8 +1201,10 @@
             nr(i,k,j) = nr1d(k)
             th(i,k,j) = t1d(k)/pii(i,k,j)
 #if ( WRF_CHEM == 1 )
+          IF ( wetscav_on ) THEN
             rainprod(i,k,j) = rainprod1d(k)
             evapprod(i,k,j) = evapprod1d(k)
+          ENDIF
 #endif
             if (qc1d(k) .gt. qc_max) then
              imax_qc = i
@@ -1353,7 +1358,7 @@
                           nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dzq, &
                           pptrain, pptsnow, pptgraul, pptice, &
 #if ( WRF_CHEM == 1 )
-                          rainprod, evapprod, &
+                          wetscav_on, rainprod, evapprod, &
 #endif
                           kts, kte, dt, ii, jj)
 
@@ -1370,6 +1375,7 @@
 #if ( WRF_CHEM == 1 )
       REAL, DIMENSION(kts:kte), INTENT(INOUT):: &
                           rainprod, evapprod
+      LOGICAL, INTENT(IN) :: wetscav_on
 #endif
 
 !..Local variables
@@ -1571,10 +1577,12 @@
          pnd_gcd(k) = 0.
       enddo
 #if ( WRF_CHEM == 1 )
+    if ( wetscav_on ) then
       do k = kts, kte
          rainprod(k) = 0.
          evapprod(k) = 0.
       enddo
+    endif
 #endif
 
 !..Bug fix (2016Jun15), prevent use of uninitialized value(s) of snow moments.
@@ -3115,14 +3123,16 @@
          endif
       enddo
 #if ( WRF_CHEM == 1 )
-      do k = kts, kte
-         evapprod(k) = prv_rev(k) - (min(zeroD0,prs_sde(k)) + &
-                                     min(zeroD0,prg_gde(k)))
-         rainprod(k) = prr_wau(k) + prr_rcw(k) + prs_scw(k) + &
-                                    prg_scw(k) + prs_iau(k) + &
-                                    prg_gcw(k) + prs_sci(k) + &
-                                    pri_rci(k)
-      enddo
+      if( wetscav_on ) then
+        do k = kts, kte
+          evapprod(k) = prv_rev(k) - (min(zeroD0,prs_sde(k)) + &
+                                      min(zeroD0,prg_gde(k)))
+          rainprod(k) = prr_wau(k) + prr_rcw(k) + prs_scw(k) + &
+                                     prg_scw(k) + prs_iau(k) + &
+                                     prg_gcw(k) + prs_sci(k) + &
+                                     pri_rci(k)
+        enddo
+      endif
 #endif
 
 !+---+-----------------------------------------------------------------+

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -74,8 +74,8 @@ CONTAINS
                  ,ids,ide, jds,jde, kds,kde                        &
                  ,ims,ime, jms,jme, kms,kme                        &
                  ,its,ite, jts,jte, kts,kte                        &
-#ifdef WRF_CHEM
-                 ,evapprod, rainprod                               &
+#if ( WRF_CHEM == 1)
+                 ,wetscav_on, evapprod, rainprod                               &
 #endif
                                                                    )
 !-------------------------------------------------------------------
@@ -143,10 +143,12 @@ CONTAINS
         INTENT(INOUT) ::                                 graupel, &
                                                       graupelncv
 
-#ifdef WRF_CHEM
+#if ( WRF_CHEM == 1 ) 
   REAL, DIMENSION( ims:ime , kms:kme, jms:jme ), INTENT(INOUT) :: &
                                                       rainprod,   &
                                                       evapprod
+  LOGICAL, INTENT(IN) ::                              wetscav_on
+ 
 ! local variable
   REAL, DIMENSION( its:ite , kts:kte )                 ::         &
                                                       rainprod2d, &
@@ -198,8 +200,8 @@ CONTAINS
                     ,its,ite, jts,jte, kts,kte                     &
                     ,snow,snowncv                                  &
                     ,graupel,graupelncv                            &
-#ifdef WRF_CHEM
-                   ,rainprod2d, evapprod2d                        &
+#if ( WRF_CHEM == 1) 
+                    ,wetscav_on, rainprod2d, evapprod2d            &
 #endif
                                                                    )
          DO K=kts,kte
@@ -258,13 +260,15 @@ CONTAINS
           enddo   
         endif     ! has_reqc, etc...
 !+---+-----------------------------------------------------------------+
-#ifdef WRF_CHEM
-        do i=its,ite
-          do k=kts,kte
-            rainprod(i,k,j) = rainprod2d(i,k)
-            evapprod(i,k,j) = evapprod2d(i,k)
+#if( WRF_CHEM == 1 )
+        if( wetscav_on ) then
+          do i=its,ite
+            do k=kts,kte
+              rainprod(i,k,j) = rainprod2d(i,k)
+              evapprod(i,k,j) = evapprod2d(i,k)
+            enddo
           enddo
-        enddo
+        endif
 #endif
       ENDDO
   END SUBROUTINE wsm6
@@ -284,8 +288,8 @@ CONTAINS
                    ,its,ite, jts,jte, kts,kte                     &
                    ,snow,snowncv                                  &
                    ,graupel,graupelncv                            &
-#ifdef WRF_CHEM
-                   ,rainprod2d, evapprod2d                        &
+#if ( WRF_CHEM == 1 )
+                   ,wetscav_on, rainprod2d, evapprod2d            &
 #endif
                                                                   )
 !-------------------------------------------------------------------
@@ -379,10 +383,11 @@ CONTAINS
         INTENT(INOUT) ::                                 graupel, &
                                                       graupelncv
 
-#ifdef WRF_CHEM
+#if ( WRF_CHEM == 1) 
   REAL, DIMENSION( its:ite , kts:kte ), INTENT(INOUT)  ::         &
                                                       rainprod2d, &
                                                       evapprod2d
+  LOGICAL, INTENT(IN) :: wetscav_on
 #endif
 
 ! LOCAL VAR
@@ -1507,9 +1512,11 @@ CONTAINS
       enddo
       enddo                  ! big loops
 
-#ifdef WRF_CHEM
-      rainprod2d = praut+pracw+praci+psaci+pgaci+psacw+pgacw+paacw+psaut
-      evapprod2d = -(prevp+psevp+pgevp+psdep+pgdep)
+#if( WRF_CHEM == 1 )
+      if( wetscav_on ) then
+        rainprod2d = praut+pracw+praci+psaci+pgaci+psacw+pgacw+paacw+psaut
+        evapprod2d = -(prevp+psevp+pgevp+psdep+pgdep)
+      endif
 #endif
 
   END SUBROUTINE wsm62d

--- a/share/module_trajectory.F
+++ b/share/module_trajectory.F
@@ -315,6 +315,11 @@
 
    dyn_var_lst(1:dyn_max)      = (/ 'p       ', 'T       ', 'z       ', 'u       ', &
                                     'v       ', 'w       ', 'rainprod', 'evapprod' /)
+#if( WRF_CHEM == 1 )
+   if( grid%wetscav_onoff < 1 ) then
+     dyn_var_lst(dyn_max-1:dyn_max) = (/ 'is_blank', 'is_blank' /)
+   endif
+#endif
    dyn_var_unit_att(1:dyn_max) = (/ 'hPa', 'K  ', 'm  ', 'm/s', 'm/s', 'm/s', 's-1', 's-1' /)
    dyn_var_desc_att(1:dyn_max) = (/ 'pressure            ', 'temperature         ', 'height              ', &
                                     'x wind component    ', 'y wind component    ', 'z wind component    ', &
@@ -2055,13 +2060,13 @@ var_loop:      do n = 1,n_vars
        case( 9 )
          do j = jps,jpe
            do k = kps,kpe
-             chem(ips:ipe,k,j,mp1) = grid%rainprod(ips:ipe,k,j)
+             chem(ips:ipe,k,j,mp1) = grid%wetscav_frcing(ips:ipe,k,j,p_rainprod)
            end do
          end do
        case( 10 )
          do j = jps,jpe
            do k = kps,kpe
-             chem(ips:ipe,k,j,mp1) = grid%evapprod(ips:ipe,k,j)
+             chem(ips:ipe,k,j,mp1) = grid%wetscav_frcing(ips:ipe,k,j,p_evapprod)
            end do
          end do
 #endif


### PR DESCRIPTION
KEYWORDS: RAINPROD, EVAPPROD, wetscav

SOURCE: Stacy Walters (NCAR)

Originally submitted as PR #682, but was resubmitted due to conflicts

DESCRIPTION OF CHANGES:

Package the state variables RAINPROD and EVAPPROD into the 4D variable
wetscav_frcing. This allows for a memory footprint reduction when chemistry
is enabled but wet scavenging is disabled.

Add logic to control setting rainprod and evapprod variables only when
the chem group namelist variable wetscav_onoff is set to 1; wetscav_onoff
defaults to 0. This logical "gate" has been added to the following files:

phys/module_mp_morr_two_moment.F
phys/module_mp_morr_two_moment_aero.F
phys/module_mp_nssl_2mom.F
phys/module_mp_thompson.F
phys/module_mp_wsm6.F

This change affects the following microphysics schemes:

MORR_TWO_MOMENT, MORR_TM_AERO
NSSL_2MOM, NSSL_2MOMG, NSSL_2MOMCCN
THOMPSON, THOMPSON_AERO
WSM6SCHEME

LIST OF MODIFIED FILES:

M Registry/registry.chem
M share/module_trajectory.F
M chem/chem_driver.F
M phys/module_microphysics_driver.F
M phys/module_mp_morr_two_moment.F
M phys/module_mp_morr_two_moment_aero.F
M phys/module_mp_nssl_2mom.F
M phys/module_mp_thompson.F
M phys/module_mp_wsm6.F
M dyn_em/em_solve.F

TESTS CONDUCTED:

Stacy Walters compared results from one hour simulations of the modified
and original code. There was bit for bit agreement for the RAINPROD and
EVAPRPOD variables as well as BFB agreement for key washout chemical species
such as H2O2 and HNO3. The comparison was done for the following microphyscis
schemes:

MORR_TWO_MOMENT, NSSL_2MOM, THOMPSON, WSM6SCHEME
