### PR TITLE
Fix for lh_urb2d diagnostics

### DIFF
--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -3207,7 +3207,7 @@ IF((SF_URBAN_PHYSICS == 2).OR.(SF_URBAN_PHYSICS == 3))THEN
     lh(i,j)       = qfx(i,j)*xlv
     hfx(i,j)      = hfx_urb(i,j)                         + (1-frc_urb2d(i,j))*hfx_rural(i,j)      ![W/m/m]
     sh_urb2d(i,j) = hfx_urb(i,j)/frc_urb2d(i,j)
-    lh_urb2d(i,j) = qfx_urb(i,j)*xlv
+    lh_urb2d(i,j) = qfx_urb(i,j)*xlv/frc_urb2d(i,j)
     g_urb2d(i,j)  = grdflx_urb(i,j)
     rn_urb2d(i,j) = rs_abs_urb(i,j)+emiss_urb(i,j)*glw(i,j)-rl_up_urb(i,j)
     ust(i,j)      = (umom**2.+vmom**2.)**.25


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: lh_urb2d, diagnostics, noahmp

SOURCE: internal (reported by Xin-Zhong Liang)

DESCRIPTION OF CHANGES:
Problem:
lh_urb2d was inconsistent with other urban budget arrays sh_urb2d, g_urb2d, and rn_urb2d by being the only one multiplied by the urban fraction making it a grid cell average instead of urban area average. This is only a diagnostic for output with using of an urban option together with NoahMP.

Solution:
Divide lh_urb2d by frc_urb2d. Won't affect model run results apart from this diagnostic. These arrays are not in default history output.

LIST OF MODIFIED FILES: 
phys/module_sf_noahmpdrv.F

TESTS CONDUCTED: 
1. Yes.
2. The Jenkins tests are all passing.

RELEASE NOTE: Fix lh_urb2d diagnostic to be urban area average instead of grid cell average consistent with other urb2d diagnostics associated with NoahMP. No effect on run results.
