### PR TITLE
Bug fix: Adding `chem_opt = 202` to `n2o5_hetchem` conditional

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -451,7 +451,7 @@ call wrf_message("**************************************************************
             (config_flags%chem_opt >= 31  .AND. config_flags%chem_opt <= 34)  .OR. &
              config_flags%chem_opt == 170 .OR.  config_flags%chem_opt == 198  .OR. &
              config_flags%chem_opt == 199 .OR.  config_flags%chem_opt == 201  .OR. &
-             config_flags%chem_opt == 203 .OR.                                     &
+             config_flags%chem_opt == 203 .OR.  config_flags%chem_opt == 202  .OR. &
              config_flags%chem_opt == 601 .OR.  config_flags%chem_opt == 611 ) then
             call wrf_debug( 15, 'using N2O5 heterogeneous chemistry without Cl- pathway')
         else

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -451,7 +451,7 @@ call wrf_message("**************************************************************
             (config_flags%chem_opt >= 31  .AND. config_flags%chem_opt <= 34)  .OR. &
              config_flags%chem_opt == 170 .OR.  config_flags%chem_opt == 198  .OR. &
              config_flags%chem_opt == 199 .OR.  config_flags%chem_opt == 201  .OR. &
-             config_flags%chem_opt == 203 .OR.  config_flags%chem_opt == 202  .OR. &
+             config_flags%chem_opt == 202 .OR.  config_flags%chem_opt == 203  .OR. &
              config_flags%chem_opt == 601 .OR.  config_flags%chem_opt == 611 ) then
             call wrf_debug( 15, 'using N2O5 heterogeneous chemistry without Cl- pathway')
         else


### PR DESCRIPTION
**TYPE:** bug fix

**KEYWORDS:** `chem_opt = 202`, `n2o5_hetchem = 1`

**SOURCE:** Luke Conibear (University of Leeds)

**DESCRIPTION OF CHANGES:**
_Problem:_
N2O5 heterogeneous chemistry without the Cl- pathway (`n2o5_hetchem = 1`) already works with default MOSAIC aerosol schemes (e.g. `chem_opt = 201/202/601/611`). However, `chem_opt = 202` was not included in the `config_flags%n2o5_hetchem == 1` conditional within `chemics_init.F`.

_Solution:_
Added `chem_opt = 202` to the `config_flags%n2o5_hetchem == 1` conditional within `chemics_init.F`.

**ISSUE:** None

**LIST OF MODIFIED FILES:**
```bash
M       chem/chemics_init.F
```