### PR TITLE
Implicit Explicit Vertical Advection (IEVA)

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3166,8 +3166,7 @@ halo      HALO_EM_INIT_4 dyn_em 48:pb,h_diabatic,qv_diabatic,qc_diabatic,msftx,m
 halo      HALO_EM_INIT_5 dyn_em 48:moist,chem,scalar,tracer
 halo      HALO_EM_INIT_6 dyn_em 48:om_tmp,om_s,om_u,om_v,om_depth,om_tini,om_sini,om_lat,om_lon,om_ml
 halo      HALO_EM_VINTERP_UV_1 dyn_em 48:pd_gc,pb,pmaxw,ptrop,pmaxwnn,ptropnn
-#halo      HALO_EM_A dyn_em  8:u_1,u_2,v_1,v_2,ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
-halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
+halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut,rho
 halo      HALO_EM_PHYS_A  dyn_em 4:u_2,v_2
 halo      HALO_EM_PHYS_PBL dyn_em        4:rublten,rvblten
 halo      HALO_EM_PHYS_CU dyn_em         4:rucuten,rvcuten

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3166,7 +3166,8 @@ halo      HALO_EM_INIT_4 dyn_em 48:pb,h_diabatic,qv_diabatic,qc_diabatic,msftx,m
 halo      HALO_EM_INIT_5 dyn_em 48:moist,chem,scalar,tracer
 halo      HALO_EM_INIT_6 dyn_em 48:om_tmp,om_s,om_u,om_v,om_depth,om_tini,om_sini,om_lat,om_lon,om_ml
 halo      HALO_EM_VINTERP_UV_1 dyn_em 48:pd_gc,pb,pmaxw,ptrop,pmaxwnn,ptropnn
-halo      HALO_EM_A dyn_em  8:u_1,u_2,v_1,v_2,ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
+#halo      HALO_EM_A dyn_em  8:u_1,u_2,v_1,v_2,ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
+halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
 halo      HALO_EM_PHYS_A  dyn_em 4:u_2,v_2
 halo      HALO_EM_PHYS_PBL dyn_em        4:rublten,rvblten
 halo      HALO_EM_PHYS_CU dyn_em         4:rucuten,rvcuten

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2620,11 +2620,13 @@ rconfig   integer scm_force_flux          namelist,scm  1       0           rh  
 # dynamics option (see package definitions, below)
 rconfig   integer dyn_opt                 namelist,dynamics	1             2 
 rconfig   integer rk_ord                  namelist,dynamics	1             3       irh   "rk_order"               ""      ""
-rconfig   integer w_damping               namelist,dynamics	1             0       irh    "w_damping"             ""      ""
+rconfig   integer w_damping               namelist,dynamics	1             0       irh   "w_damping"             ""      ""
+rconfig   real    w_crit_cfl              namelist,dynamics 1             1.2     irh   "w_crit_cfl"        "W-CFL where w-damping is on" ""
+rconfig   integer zadvect_implicit        namelist,dynamics 1             0       irh   "zadvect_implicit"  "Turns on IEVA for vertical adv" ""
 # diff_opt 1=old diffusion, 2=new
-rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh    "diff_opt"              ""      ""
+rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh   "diff_opt"              ""      ""
 # diff_opt_dfi is needed for backwards integration in dfi
-rconfig   integer diff_opt_dfi            namelist,dynamics	max_domains   0       irh    "diff_opt_dfi"          ""      ""
+rconfig   integer diff_opt_dfi            namelist,dynamics	max_domains   0       irh   "diff_opt_dfi"          ""      ""
 # km_opt   1=old coefs, 2=tke, 3=Smagorinksy
 rconfig   integer km_opt                  namelist,dynamics	max_domains   -1      irh    "km_opt"                ""      ""
 # km_opt_dfi is needed for backward integration in dfi

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -209,6 +209,8 @@ state    real   w              ikjb     dyn_em      2         Z     \
 state    real   ww             ikj     dyn_em      1         Z      r         "ww"   "mu-coupled eta-dot"    "Pa s-1"
 state    real   rw             ikj     dyn_em      1         Z      -         "rw"   "mu-coupled w"          "Pa m s-1"
 i1       real   ww1            ikj     dyn_em      1         Z                                          
+i1       real   wwE            ikj     dyn_em      1         Z      -         "wwE"  "Explicit vertical velocity" "Pa s-1"
+i1       real   wwI            ikj     dyn_em      1         Z      -         "wwI"  "Implicit vertical velocity" "Pa s-1"
 state    real   ww_m           ikj     dyn_em      1         Z      r         "ww_m"   "time-avg mu-coupled eta-dot"    "Pa s-1"
 i1       real   wwp            ikj     dyn_em      1         Z                                          
 i1       real   rw_tend        ikj     dyn_em      1         Z                                          

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3166,7 +3166,7 @@ halo      HALO_EM_INIT_4 dyn_em 48:pb,h_diabatic,qv_diabatic,qc_diabatic,msftx,m
 halo      HALO_EM_INIT_5 dyn_em 48:moist,chem,scalar,tracer
 halo      HALO_EM_INIT_6 dyn_em 48:om_tmp,om_s,om_u,om_v,om_depth,om_tini,om_sini,om_lat,om_lon,om_ml
 halo      HALO_EM_VINTERP_UV_1 dyn_em 48:pd_gc,pb,pmaxw,ptrop,pmaxwnn,ptropnn
-halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
+halo      HALO_EM_A dyn_em  8:u_1,u_2,v_1,v_2,ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
 halo      HALO_EM_PHYS_A  dyn_em 4:u_2,v_2
 halo      HALO_EM_PHYS_PBL dyn_em        4:rublten,rvblten
 halo      HALO_EM_PHYS_CU dyn_em         4:rucuten,rvcuten

--- a/dyn_em/Makefile
+++ b/dyn_em/Makefile
@@ -7,26 +7,27 @@ RM      =       rm -f
 
 MODULES =                 		\
         module_advect_em.o   		\
-	module_diffusion_em.o  		\
-	module_small_step_em.o 		\
+        module_ieva_em.o            \
+	  module_diffusion_em.o  		\
+	  module_small_step_em.o 		\
         module_big_step_utilities_em.o  \
         module_em.o         		\
         module_solvedebug_em.o    	\
         module_bc_em.o                  \
         module_init_utilities.o         \
         module_wps_io_arw.o             \
-	module_damping_em.o		\
-	module_polarfft.o		\
+	  module_damping_em.o		\
+	  module_polarfft.o		\
         module_force_scm.o              \
         module_first_rk_step_part1.o    \
         module_first_rk_step_part2.o    \
         module_avgflx_em.o              \
-	module_sfs_nba.o		\
+	  module_sfs_nba.o		\
         module_convtrans_prep.o         \
-	module_sfs_driver.o		\
-	module_stoch.o			\
-	module_after_all_rk_steps.o	\
-	$(CASE_MODULE)
+	  module_sfs_driver.o		\
+	  module_stoch.o			\
+	  module_after_all_rk_steps.o	\
+	  $(CASE_MODULE)
 
 # possible CASE_MODULE settings
 #	module_initialize_b_wave.o      \

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -7870,7 +7870,6 @@ END SUBROUTINE advect_scalar_pd
 
 SUBROUTINE advect_scalar_weno ( field, field_old, tendency,     &
                              ru, rv, rom,                   &
-                             c1, c2,                        &
                              mut, time_step, config_flags,  &
                              msfux, msfuy, msfvx, msfvy,    &
                              msftx, msfty,                  &
@@ -10818,7 +10817,7 @@ PROGRAM feeder
    print *,' '
    print *,'Lines to input to gnuplot'
    print *,' '
-   print *,"set term x11"
+   print *,"set terminal x11"
    IF      (config_flags%scalar_adv_opt .EQ. 0 ) THEN
       print *,'set title "Scalar Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 1 ) THEN
@@ -10827,7 +10826,7 @@ PROGRAM feeder
       print *,'set title "Mono Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
       print *,'set title "WENO Advection" font ",20"'
-   ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
+   ELSE IF (config_flags%scalar_adv_opt .EQ. 4 ) THEN
       print *,'set title "WENO PD Advection" font ",20"'
    END IF
    print *,"set yrange[-20:120]"

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -2,7 +2,7 @@
 !WRF:MODEL_LAYER:DYNAMICS
 !
 #if ( defined(ADVECT_KERNEL) )
-! cpp -traditional -cpp -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
+! cpp -traditional-cpp -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
 ! gfortran -ffree-form -ffree-line-length-none advection_kernel.f90
 ! ./a.out
 MODULE advection_kernel
@@ -3028,6 +3028,7 @@ END SUBROUTINE advect_v
 #endif
 SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
                              ru, rv, rom,                   &
+                             c1, c2,                        &
                              mut, time_step, config_flags,  &
                              msfux, msfuy, msfvx, msfvy,    &
                              msftx, msfty,                  &
@@ -3065,7 +3066,9 @@ SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
                                                                   fzp,  &
-                                                                  rdzw
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
 
    REAL ,                                        INTENT(IN   ) :: rdx,  &
                                                                   rdy
@@ -4360,6 +4363,7 @@ END SUBROUTINE advect_scalar
 
 SUBROUTINE advect_w    ( w, w_old, tendency,            &
                          ru, rv, rom,                   &
+                         c1, c2,                        &
                          mut, time_step, config_flags,  &
                          msfux, msfuy, msfvx, msfvy,    &
                          msftx, msfty,                  &
@@ -4397,7 +4401,9 @@ SUBROUTINE advect_w    ( w, w_old, tendency,            &
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
                                                                   fzp,  &
-                                                                  rdzu
+                                                                  rdzu, &
+                                                                  c1,   &
+                                                                  c2
 
    REAL ,                                        INTENT(IN   ) :: rdx,  &
                                                                   rdy
@@ -7864,6 +7870,7 @@ END SUBROUTINE advect_scalar_pd
 
 SUBROUTINE advect_scalar_weno ( field, field_old, tendency,     &
                              ru, rv, rom,                   &
+                             c1, c2,                        &
                              mut, time_step, config_flags,  &
                              msfux, msfuy, msfvx, msfvy,    &
                              msftx, msfty,                  &
@@ -10638,7 +10645,7 @@ PROGRAM feeder
    ru = 90
    rv = 0.
    rom = 0.
-   rom = 0.
+   romI = 0.
    msfux = 1
    msfuy = 1
    msfvx = 1
@@ -10647,8 +10654,6 @@ PROGRAM feeder
    msfty = 1
    rdx = 1/1000.
    rdy = 1/1000.
-   c1  = 1.0
-   c2  = 0.0
    DO k = kts, kte
       znw(k) = 1 - (real(k)-kts)/(real(kte)-kts)
    END DO
@@ -10664,6 +10669,10 @@ PROGRAM feeder
     rdn(k) = 1./dn(k)
     fzp(k) = .5* dnw(k  )/dn(k)
     fzm(k) = .5* dnw(k-1)/dn(k)
+   ENDDO
+   DO k = kts,kte
+      c1(k) = 1. ! This is d(B)/d(eta), so assuming no hyb coord
+      c2(k) = 0. ! This (1 - c1)*(p00 - ptop)
    ENDDO
 
    time_step = 5
@@ -10681,34 +10690,34 @@ PROGRAM feeder
       DO im = 1 , MAX_SCALARS
 
          tendency = 0
-         CALL advect_scalar    ( field(ims,kms,jms,im),          &
-                                 field_old(ims,kms,jms,im),      &
-                                 tendency(ims,kms,jms),          &
-                                 ru, rv, rom,                    &
-                                 mut, time_step/3, config_flags, &
-                                 msfux, msfuy, msfvx, msfvy,     &
-                                 msftx, msfty,                   &
-                                 fzm, fzp,                       &
-                                 rdx, rdy, rdzw,                 &
-                                 ids, ide, jds, jde, kds, kde,   &
-                                 ims, ime, jms, jme, kms, kme,   &
+         CALL advect_scalar    ( field(ims,kms,jms,im), &
+                                 field_old(ims,kms,jms,im), &
+                                 tendency(ims,kms,jms), &
+                                 ru, rv, rom, c1, c2,           &
+                                 mut, time_step/3, config_flags,&
+                                 msfux, msfuy, msfvx, msfvy,    &
+                                 msftx, msfty,                  &
+                                 fzm, fzp,                      &
+                                 rdx, rdy, rdzw,                &
+                                 ids, ide, jds, jde, kds, kde,  &
+                                 ims, ime, jms, jme, kms, kme,  &
                                  its, ite, jts, jte, kts, kte  )
          DO n = 1 , MAX_SCALARS
             field(:,:,:,n) = field_old(:,:,:,n) + dt * tendency(:,:,:) / 3.
          END DO
 
          tendency = 0
-         CALL advect_scalar    ( field(ims,kms,jms,im),          &
-                                 field_old(ims,kms,jms,im),      &
-                                 tendency(ims,kms,jms),          &
-                                 ru, rv, rom,                    &
-                                 mut, time_step/2, config_flags, &
-                                 msfux, msfuy, msfvx, msfvy,     &
-                                 msftx, msfty,                   &
-                                 fzm, fzp,                       &
-                                 rdx, rdy, rdzw,                 &
-                                 ids, ide, jds, jde, kds, kde,   &
-                                 ims, ime, jms, jme, kms, kme,   &
+         CALL advect_scalar    ( field(ims,kms,jms,im), &
+                                 field_old(ims,kms,jms,im), &
+                                 tendency(ims,kms,jms), &
+                                 ru, rv, rom, c1, c2,           &
+                                 mut, time_step/2, config_flags,&
+                                 msfux, msfuy, msfvx, msfvy,    &
+                                 msftx, msfty,                  &
+                                 fzm, fzp,                      &
+                                 rdx, rdy, rdzw,                &
+                                 ids, ide, jds, jde, kds, kde,  &
+                                 ims, ime, jms, jme, kms, kme,  &
                                  its, ite, jts, jte, kts, kte  )
          DO n = 1 , MAX_SCALARS
             field(:,:,:,n) = field_old(:,:,:,n) + dt * tendency(:,:,:) / 2.
@@ -10716,10 +10725,10 @@ PROGRAM feeder
 
          tendency = 0
          IF      (config_flags%scalar_adv_opt .EQ. 0 ) THEN
-            CALL advect_scalar    ( field(ims,kms,jms,im),         &
-                                    field_old(ims,kms,jms,im),     &
-                                    tendency(ims,kms,jms),         &
-                                    ru, rv, rom,                   &
+            CALL advect_scalar    ( field(ims,kms,jms,im), &
+                                    field_old(ims,kms,jms,im), &
+                                    tendency(ims,kms,jms), &
+                                    ru, rv, rom, c1, c2,           &
                                     mut, time_step, config_flags,  &
                                     msfux, msfuy, msfvx, msfvy,    &
                                     msftx, msfty,                  &
@@ -10729,25 +10738,24 @@ PROGRAM feeder
                                     ims, ime, jms, jme, kms, kme,  &
                                     its, ite, jts, jte, kts, kte  )
          ELSE IF (config_flags%scalar_adv_opt .EQ. 1 ) THEN
-            CALL advect_scalar_pd ( field(ims,kms,jms,im),            &
-                                    field_old(ims,kms,jms,im),        &
-                                    tendency(ims,kms,jms),            &
-                                    h_tendency(ims,kms,jms),          &
-                                    z_tendency(ims,kms,jms),          &
-                                    ru, rv, rom,                      &
-                                    c1, c2,                           & 
-                                    mut, mub, mu_old,                 &
+            CALL advect_scalar_pd ( field(ims,kms,jms,im), &
+                                    field_old(ims,kms,jms,im), &
+                                    tendency(ims,kms,jms), &
+                                    h_tendency(ims,kms,jms), &
+                                    z_tendency(ims,kms,jms), &
+                                    ru, rv, rom, c1, c2, &
+                                    mut, mub, mu_old, &
                                     time_step, config_flags, tenddec, &
-                                    msfux, msfuy, msfvx, msfvy,       &
-                                    msftx, msfty, fzm, fzp,           &
-                                    rdx, rdy, rdzw,dt,                &
-                                    ids, ide, jds, jde, kds, kde,     &
-                                    ims, ime, jms, jme, kms, kme,     &
+                                    msfux, msfuy, msfvx, msfvy, &
+                                    msftx, msfty, fzm, fzp, &
+                                    rdx, rdy, rdzw,dt, &
+                                    ids, ide, jds, jde, kds, kde, &
+                                    ims, ime, jms, jme, kms, kme, &
                                     its, ite, jts, jte, kts, kte )
          ELSE IF (config_flags%scalar_adv_opt .EQ. 2 ) THEN
-            CALL advect_scalar_mono ( field(ims,kms,jms,im),   &
+            CALL advect_scalar_mono ( field(ims,kms,jms,im), &
                                     field_old(ims,kms,jms,im), &
-                                    tendency(ims,kms,jms),     &
+                                    tendency(ims,kms,jms), &
                                     h_tendency(ims,kms,jms), &
                                     z_tendency(ims,kms,jms), &
                                     ru, rv, rom, romI,       &

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -7869,16 +7869,16 @@ END SUBROUTINE advect_scalar_pd
 !----------------------------------------------------------------
 
 SUBROUTINE advect_scalar_weno ( field, field_old, tendency,     &
-                             ru, rv, rom,                   &
-                             c1, c2,                        &
-                             mut, time_step, config_flags,  &
-                             msfux, msfuy, msfvx, msfvy,    &
-                             msftx, msfty,                  &
-                             fzm, fzp,                      &
-                             rdx, rdy, rdzw,                &
-                             ids, ide, jds, jde, kds, kde,  &
-                             ims, ime, jms, jme, kms, kme,  &
-                             its, ite, jts, jte, kts, kte  )
+                                ru, rv, rom,                   &
+                                c1, c2,                        &
+                                mut, time_step, config_flags,  &
+                                msfux, msfuy, msfvx, msfvy,    &
+                                msftx, msfty,                  &
+                                fzm, fzp,                      &
+                                rdx, rdy, rdzw,                &
+                                ids, ide, jds, jde, kds, kde,  &
+                                ims, ime, jms, jme, kms, kme,  &
+                                its, ite, jts, jte, kts, kte  )
 !
 ! 5th-order WENO (Weighted Essentially Non-Oscillatory) scheme adapted from COMMAS.  
 ! See Jiang and Shu, 1996, J. Comp. Phys. v. 126, 202-223;

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -1349,8 +1349,8 @@ SUBROUTINE advect_u   ( u, u_old, tendency,            &
 
    IF ( config_flags%open_ys .or. specified ) i_start = MAX(ids+1,its)
    IF ( config_flags%open_ye .or. specified ) i_end   = MIN(ide-1,ite)
-      IF ( config_flags%periodic_x ) i_start = its
-      IF ( config_flags%periodic_x ) i_end = ite
+   IF ( config_flags%periodic_x ) i_start = its
+   IF ( config_flags%periodic_x ) i_end = ite
 
    DO i = i_start, i_end
      vflux(i,kts)=0.
@@ -2818,20 +2818,20 @@ SUBROUTINE advect_v   ( v, v_old, tendency,            &
 !     we can do this using *(my/mx) (see eqn. 45 for example)
 
 
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-      j_start = jts
-      j_end   = jte
+    i_start = its
+    i_end   = MIN(ite,ide-1)
+    j_start = jts
+    j_end   = jte
 
-      DO i = i_start, i_end
-         vflux(i,kts)=0.
-         vflux(i,kte)=0.
-      ENDDO
+    DO i = i_start, i_end
+       vflux(i,kts)=0.
+       vflux(i,kte)=0.
+    ENDDO
 
-      ! Polar boundary conditions are like open or specified
-      ! We don't want to calculate vertical v tendencies at the N or S pole
-      IF ( config_flags%open_ys .or. specified .or. config_flags%polar ) j_start = MAX(jds+1,jts)
-      IF ( config_flags%open_ye .or. specified .or. config_flags%polar ) j_end   = MIN(jde-1,jte)
+    ! Polar boundary conditions are like open or specified
+    ! We don't want to calculate vertical v tendencies at the N or S pole
+    IF ( config_flags%open_ys .or. specified .or. config_flags%polar ) j_start = MAX(jds+1,jts)
+    IF ( config_flags%open_ye .or. specified .or. config_flags%polar ) j_end   = MIN(jde-1,jte)
 
     vert_order_test : IF (vert_order == 6) THEN    
 
@@ -5850,15 +5850,15 @@ ELSE IF (horz_order == 2 ) THEN
 !     Here we have:  - partial d/dz (w*rom) = - partial d/dz (w rho w / my)
 !     Therefore we don't need to make a correction for advect_w
 
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-      j_start = jts
-      j_end   = MIN(jte,jde-1)
+    i_start = its
+    i_end   = MIN(ite,ide-1)
+    j_start = jts
+    j_end   = MIN(jte,jde-1)
 
-      DO i = i_start, i_end
-         vflux(i,kts)=0.
-         vflux(i,kte)=0.
-      ENDDO
+    DO i = i_start, i_end
+       vflux(i,kts)=0.
+       vflux(i,kte)=0.
+    ENDDO
 
     vert_order_test : IF (vert_order == 6) THEN    
 
@@ -11416,8 +11416,8 @@ SUBROUTINE advect_weno_u ( u, u_old, tendency,            &
 
    IF ( config_flags%open_ys .or. specified ) i_start = MAX(ids+1,its)
    IF ( config_flags%open_ye .or. specified ) i_end   = MIN(ide-1,ite)
-      IF ( config_flags%periodic_x ) i_start = its
-      IF ( config_flags%periodic_x ) i_end = ite
+   IF ( config_flags%periodic_x ) i_start = its
+   IF ( config_flags%periodic_x ) i_end = ite
 
    DO i = i_start, i_end
      vflux(i,kts)=0.
@@ -12097,20 +12097,20 @@ SUBROUTINE advect_weno_v   ( v, v_old, tendency,            &
 !     we can do this using *(my/mx) (see eqn. 45 for example)
 
 
-      i_start = its
-      i_end   = MIN(ite,ide-1)
-      j_start = jts
-      j_end   = jte
+    i_start = its
+    i_end   = MIN(ite,ide-1)
+    j_start = jts
+    j_end   = jte
 
-      DO i = i_start, i_end
-         vflux(i,kts)=0.
-         vflux(i,kte)=0.
-      ENDDO
+    DO i = i_start, i_end
+       vflux(i,kts)=0.
+       vflux(i,kte)=0.
+    ENDDO
 
-      ! Polar boundary conditions are like open or specified
-      ! We don't want to calculate vertical v tendencies at the N or S pole
-      IF ( config_flags%open_ys .or. specified .or. config_flags%polar ) j_start = MAX(jds+1,jts)
-      IF ( config_flags%open_ye .or. specified .or. config_flags%polar ) j_end   = MIN(jde-1,jte)
+    ! Polar boundary conditions are like open or specified
+    ! We don't want to calculate vertical v tendencies at the N or S pole
+    IF ( config_flags%open_ys .or. specified .or. config_flags%polar ) j_start = MAX(jds+1,jts)
+    IF ( config_flags%open_ye .or. specified .or. config_flags%polar ) j_end   = MIN(jde-1,jte)
 
 !    vert_order_test : IF (vert_order == 6) THEN    
 

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -2,7 +2,7 @@
 !WRF:MODEL_LAYER:DYNAMICS
 !
 #if ( defined(ADVECT_KERNEL) )
-! cpp -traditional-cpp -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
+! cpp -traditional -C -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
 ! gfortran -ffree-form -ffree-line-length-none advection_kernel.f90
 ! ./a.out
 MODULE advection_kernel
@@ -6106,8 +6106,8 @@ SUBROUTINE advect_scalar_pd   ( field, field_old, tendency,    &
 
    REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
                                                                       field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
+                                                                      ru,        &
+                                                                      rv,        &
                                                                       rom
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut, mub, mu_old
@@ -8553,17 +8553,17 @@ END SUBROUTINE advect_scalar_weno
 !---------------------------------------------------------------------------------
 
 SUBROUTINE advect_scalar_wenopd ( field, field_old, tendency,    &
-                                ru, rv, rom,                   &
-                                c1, c2,                        &
-                                mut, mub, mu_old,              &
-                                time_step, config_flags,       &
-                                msfux, msfuy, msfvx, msfvy,    &
-                                msftx, msfty,                  &
-                                fzm, fzp,                      &
-                                rdx, rdy, rdzw, dt,            &
-                                ids, ide, jds, jde, kds, kde,  &
-                                ims, ime, jms, jme, kms, kme,  &
-                                its, ite, jts, jte, kts, kte  )
+                                  ru, rv, rom,                   &
+                                  c1, c2,                        &
+                                  mut, mub, mu_old,              &
+                                  time_step, config_flags,       &
+                                  msfux, msfuy, msfvx, msfvy,    &
+                                  msftx, msfty,                  &
+                                  fzm, fzp,                      &
+                                  rdx, rdy, rdzw, dt,            &
+                                  ids, ide, jds, jde, kds, kde,  &
+                                  ims, ime, jms, jme, kms, kme,  &
+                                  its, ite, jts, jte, kts, kte  )
 
 !  this is a first cut at a positive definite advection option
 !  for scalars in WRF.  This version is memory intensive ->
@@ -8595,8 +8595,8 @@ SUBROUTINE advect_scalar_wenopd ( field, field_old, tendency,    &
 
    REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
                                                                       field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
+                                                                      ru,        &
+                                                                      rv,        &
                                                                       rom
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut, mub, mu_old
@@ -9476,7 +9476,7 @@ END SUBROUTINE advect_scalar_wenopd
 
 SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                                   h_tendency, z_tendency,        &
-                                  ru, rv, rom,                   &
+                                  ru, rv, rom, romI,             &
                                   c1, c2,                        &
                                   mut, mub, mu_old,              &
                                   config_flags,                  &
@@ -9512,8 +9512,9 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
 
    REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: field,     &
                                                                       field_old, &
-                                                                      ru,    &
-                                                                      rv,    &
+                                                                      ru,        &
+                                                                      rv,        &
+                                                                      romI,      &
                                                                       rom
 
    REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut, mub, mu_old
@@ -9544,7 +9545,7 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
    INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
    INTEGER :: jmin, jmax, jp, jm, imin, imax
 
-   REAL    :: mrdx, mrdy, ub, vb, uw, vw, mu
+   REAL    :: mrdx, mrdy, ub, vb, uw, vw, mu, ieva_corr
    REAL , DIMENSION(its:ite, kts:kte) :: vflux
 
 
@@ -10344,6 +10345,18 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
    DO k=kts, ktf
    DO i=i_start, i_end
 
+! ----------------------------------------------------------------------------------------------
+! IEVA
+! We need to correct for the partial divergence created by the IEVA scheme.
+! If there is no implicit vertical advection, this term == 1.0.  
+! Else, it rescales the qmax & qmin value to reflect the partial divergence present in both the
+! low-order and high-order fluxes because the VV field is partioned.
+! ----------------------------------------------------------------------------------------------
+
+     ieva_corr = (c1(k)*mut(i,j)+c2(k))+dt*msfty(i,j)*rdzw(k)*(romI(i,k+1,j)-romI(i,k,j))
+
+! ----------------------------------------------------------------------------------------------
+
      ph_upwind = ((c1(k)*mub(i,j)+c2(k))+(c1(k)*mu_old(i,j)))*field_old(i,k,j)        &
                    - dt*( msftx(i,j)*msfty(i,j)*(               &
                           rdx*(fqxl(i+1,k,j)-fqxl(i,k,j)) +     &
@@ -10358,7 +10371,8 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                +msfty(i,j)*rdzw(k)*(  max(0.,fqz (i,k+1,j))      &
                                      -min(0.,fqz (i,k  ,j)) )   )
 
-     ph_hi = (c1(k)*mut(i,j)+c2(k))*qmax(i,k,j) - ph_upwind
+     ph_hi = ieva_corr*qmax(i,k,j) - ph_upwind
+
      IF( flux_in .gt. ph_hi ) scale_in(i,k,j) = max(0.,ph_hi/(flux_in+eps))
 
 
@@ -10369,8 +10383,9 @@ SUBROUTINE advect_scalar_mono   ( field, field_old, tendency,    &
                                       -min(0.,fqy (i,k,j  )) ) )  &
                 +msfty(i,j)*rdzw(k)*(  min(0.,fqz (i,k+1,j))      &
                                       -max(0.,fqz (i,k  ,j)) )   )
+ 
+     ph_low = ph_upwind - ieva_corr*qmin(i,k,j)
 
-     ph_low = ph_upwind - (c1(k)*mut(i,j)+c2(k))*qmin(i,k,j)
      IF( flux_out .gt. ph_low ) scale_out(i,k,j) = max(0.,ph_low/(flux_out+eps))
 
    ENDDO
@@ -10558,8 +10573,7 @@ PROGRAM feeder
                                             msfty
    REAL , DIMENSION( : ), ALLOCATABLE :: fzm, &
                                   fzp, &
-                                  rdzw, znw,dnw, rdnw, dn, rdn, &
-                                  c1, c2
+                                  rdzw, znw,dnw, rdnw, dn, rdn
    REAL :: rdx, &
            rdy, &
            dt
@@ -10608,8 +10622,6 @@ PROGRAM feeder
    ALLOCATE (rdnw( kms:kme ) )
    ALLOCATE ( dn ( kms:kme ) )
    ALLOCATE (rdn ( kms:kme ) )
-   ALLOCATE ( c1 ( kms:kme ) )
-   ALLOCATE ( c2 ( kms:kme ) )
    PRINT *,'CALL init'
    CALL init ( config_flags)
    CALL tophat ( field , MAX_SCALARS ,&
@@ -10652,10 +10664,6 @@ PROGRAM feeder
     fzp(k) = .5* dnw(k  )/dn(k)
     fzm(k) = .5* dnw(k-1)/dn(k)
    ENDDO
-   DO k = kts,kte
-      c1(k) = 1. ! This is d(B)/d(eta), so assuming no hyb coord
-      c2(k) = 0. ! This (1 - c1)*(p00 - ptop)
-   ENDDO
 
    time_step = 5
    dt = time_step
@@ -10675,8 +10683,8 @@ PROGRAM feeder
          CALL advect_scalar    ( field(ims,kms,jms,im), &
                                  field_old(ims,kms,jms,im), &
                                  tendency(ims,kms,jms), &
-                                 ru, rv, rom, c1, c2,           &
-                                 mut, time_step/3, config_flags,&
+                                 ru, rv, rom,                   &
+                                 mut, time_step/3, config_flags,  &
                                  msfux, msfuy, msfvx, msfvy,    &
                                  msftx, msfty,                  &
                                  fzm, fzp,                      &
@@ -10692,8 +10700,8 @@ PROGRAM feeder
          CALL advect_scalar    ( field(ims,kms,jms,im), &
                                  field_old(ims,kms,jms,im), &
                                  tendency(ims,kms,jms), &
-                                 ru, rv, rom, c1, c2,           &
-                                 mut, time_step/2, config_flags,&
+                                 ru, rv, rom,                   &
+                                 mut, time_step/2, config_flags,  &
                                  msfux, msfuy, msfvx, msfvy,    &
                                  msftx, msfty,                  &
                                  fzm, fzp,                      &
@@ -10710,7 +10718,7 @@ PROGRAM feeder
             CALL advect_scalar    ( field(ims,kms,jms,im), &
                                     field_old(ims,kms,jms,im), &
                                     tendency(ims,kms,jms), &
-                                    ru, rv, rom, c1, c2,           &
+                                    ru, rv, rom,                   &
                                     mut, time_step, config_flags,  &
                                     msfux, msfuy, msfvx, msfvy,    &
                                     msftx, msfty,                  &
@@ -10725,8 +10733,7 @@ PROGRAM feeder
                                     tendency(ims,kms,jms), &
                                     h_tendency(ims,kms,jms), &
                                     z_tendency(ims,kms,jms), &
-                                    ru, rv, rom, c1, c2, &
-                                    mut, mub, mu_old, &
+                                    ru, rv, rom, mut, mub, mu_old, &
                                     time_step, config_flags, tenddec, &
                                     msfux, msfuy, msfvx, msfvy, &
                                     msftx, msfty, fzm, fzp, &
@@ -10740,8 +10747,7 @@ PROGRAM feeder
                                     tendency(ims,kms,jms), &
                                     h_tendency(ims,kms,jms), &
                                     z_tendency(ims,kms,jms), &
-                                    ru, rv, rom, c1, c2, &
-                                    mut, mub, mu_old, &
+                                    ru, rv, rom, mut, mub, mu_old, &
                                     config_flags, tenddec, &
                                     msfux, msfuy, msfvx, msfvy, &
                                     msftx, msfty, fzm, fzp, &
@@ -10753,7 +10759,7 @@ PROGRAM feeder
             CALL advect_scalar_weno ( field(ims,kms,jms,im), &
                                    field_old(ims,kms,jms,im), &
                                    tendency(ims,kms,jms), &
-                             ru, rv, rom, c1, c2,           &
+                             ru, rv, rom,                   &
                              mut, time_step, config_flags,  &
                              msfux, msfuy, msfvx, msfvy,    &
                              msftx, msfty,                  &
@@ -10766,7 +10772,7 @@ PROGRAM feeder
             CALL advect_scalar_wenopd ( field(ims,kms,jms,im), &
                                         field_old(ims,kms,jms,im), &
                                         tendency(ims,kms,jms), &
-                                ru, rv, rom, c1, c2,           &
+                                ru, rv, rom,                   &
                                 mut, mub, mu_old,              &
                                 time_step, config_flags,       &
                                 msfux, msfuy, msfvx, msfvy,    &
@@ -10812,7 +10818,7 @@ PROGRAM feeder
    print *,' '
    print *,'Lines to input to gnuplot'
    print *,' '
-   print *,"set terminal x11"
+   print *,"set term x11"
    IF      (config_flags%scalar_adv_opt .EQ. 0 ) THEN
       print *,'set title "Scalar Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 1 ) THEN
@@ -10821,7 +10827,7 @@ PROGRAM feeder
       print *,'set title "Mono Advection" font ",20"'
    ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
       print *,'set title "WENO Advection" font ",20"'
-   ELSE IF (config_flags%scalar_adv_opt .EQ. 4 ) THEN
+   ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
       print *,'set title "WENO PD Advection" font ",20"'
    END IF
    print *,"set yrange[-20:120]"

--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -2,7 +2,7 @@
 !WRF:MODEL_LAYER:DYNAMICS
 !
 #if ( defined(ADVECT_KERNEL) )
-! cpp -traditional -C -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
+! cpp -traditional -cpp -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
 ! gfortran -ffree-form -ffree-line-length-none advection_kernel.f90
 ! ./a.out
 MODULE advection_kernel
@@ -3028,7 +3028,6 @@ END SUBROUTINE advect_v
 #endif
 SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
                              ru, rv, rom,                   &
-                             c1, c2,                        &
                              mut, time_step, config_flags,  &
                              msfux, msfuy, msfvx, msfvy,    &
                              msftx, msfty,                  &
@@ -3066,9 +3065,7 @@ SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
                                                                   fzp,  &
-                                                                  rdzw, &
-                                                                  c1,   &
-                                                                  c2
+                                                                  rdzw
 
    REAL ,                                        INTENT(IN   ) :: rdx,  &
                                                                   rdy
@@ -4363,7 +4360,6 @@ END SUBROUTINE advect_scalar
 
 SUBROUTINE advect_w    ( w, w_old, tendency,            &
                          ru, rv, rom,                   &
-                         c1, c2,                        &
                          mut, time_step, config_flags,  &
                          msfux, msfuy, msfvx, msfvy,    &
                          msftx, msfty,                  &
@@ -4401,9 +4397,7 @@ SUBROUTINE advect_w    ( w, w_old, tendency,            &
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
                                                                   fzp,  &
-                                                                  rdzu, &
-                                                                  c1,   &
-                                                                  c2
+                                                                  rdzu
 
    REAL ,                                        INTENT(IN   ) :: rdx,  &
                                                                   rdy
@@ -10556,23 +10550,25 @@ PROGRAM feeder
    INTEGER :: ids, ide, jds, jde, kds, kde, &
               ims, ime, jms, jme, kms, kme, &
               its, ite, jts, jte, kts, kte
-   REAL , DIMENSION( :,:,:,: ) , ALLOCATABLE :: field, &
-                                               field_old
-   REAL , DIMENSION( :,:,: ) , ALLOCATABLE :: ru, &
-                                               rv, &
-                                               rom
+   REAL , DIMENSION( :,:,:,: ) , ALLOCATABLE :: field,    &
+                                                field_old
+   REAL , DIMENSION( :,:,: ) , ALLOCATABLE ::  ru,  &
+                                               rv,  &
+                                               rom, &
+                                               romI
    REAL , DIMENSION( :,: ), ALLOCATABLE :: mut, mub, mu_old
    REAL , DIMENSION( :,:,: ), ALLOCATABLE :: tendency
    REAL , DIMENSION( :,:,: ), ALLOCATABLE :: h_tendency, z_tendency
    REAL , DIMENSION( :,: ), ALLOCATABLE :: msfux, &
-                                            msfuy, &
-                                            msfvx, &
-                                            msfvy, &
-                                            msftx, &
-                                            msfty
+                                           msfuy, &
+                                           msfvx, &
+                                           msfvy, &
+                                           msftx, &
+                                           msfty
    REAL , DIMENSION( : ), ALLOCATABLE :: fzm, &
-                                  fzp, &
-                                  rdzw, znw,dnw, rdnw, dn, rdn
+                                         fzp, &
+                                         c1, c2, &
+                                         rdzw, znw,dnw, rdnw, dn, rdn
    REAL :: rdx, &
            rdy, &
            dt
@@ -10594,6 +10590,7 @@ PROGRAM feeder
    ALLOCATE ( ru(ims:ime , kms:kme , jms:jme ) )
    ALLOCATE ( rv(ims:ime , kms:kme , jms:jme ) )
    ALLOCATE ( rom(ims:ime , kms:kme , jms:jme ) )
+   ALLOCATE ( romI(ims:ime , kms:kme , jms:jme ) )
    PRINT *,'ALLOCATE three 2d MU fields'
    PRINT *,(ime-ims+1)*(jme-jms+1)
    ALLOCATE ( mut(ims:ime , jms:jme) )
@@ -10621,6 +10618,8 @@ PROGRAM feeder
    ALLOCATE (rdnw( kms:kme ) )
    ALLOCATE ( dn ( kms:kme ) )
    ALLOCATE (rdn ( kms:kme ) )
+   ALLOCATE ( c1 ( kms:kme ) )
+   ALLOCATE ( c2 ( kms:kme ) )
    PRINT *,'CALL init'
    CALL init ( config_flags)
    CALL tophat ( field , MAX_SCALARS ,&
@@ -10637,8 +10636,9 @@ PROGRAM feeder
    mut = 1
    mu_old = 0
    ru = 90
-   rv = 0
-   rom = 0
+   rv = 0.
+   rom = 0.
+   rom = 0.
    msfux = 1
    msfuy = 1
    msfvx = 1
@@ -10647,6 +10647,8 @@ PROGRAM feeder
    msfty = 1
    rdx = 1/1000.
    rdy = 1/1000.
+   c1  = 1.0
+   c2  = 0.0
    DO k = kts, kte
       znw(k) = 1 - (real(k)-kts)/(real(kte)-kts)
    END DO
@@ -10679,34 +10681,34 @@ PROGRAM feeder
       DO im = 1 , MAX_SCALARS
 
          tendency = 0
-         CALL advect_scalar    ( field(ims,kms,jms,im), &
-                                 field_old(ims,kms,jms,im), &
-                                 tendency(ims,kms,jms), &
-                                 ru, rv, rom,                   &
-                                 mut, time_step/3, config_flags,  &
-                                 msfux, msfuy, msfvx, msfvy,    &
-                                 msftx, msfty,                  &
-                                 fzm, fzp,                      &
-                                 rdx, rdy, rdzw,                &
-                                 ids, ide, jds, jde, kds, kde,  &
-                                 ims, ime, jms, jme, kms, kme,  &
+         CALL advect_scalar    ( field(ims,kms,jms,im),          &
+                                 field_old(ims,kms,jms,im),      &
+                                 tendency(ims,kms,jms),          &
+                                 ru, rv, rom,                    &
+                                 mut, time_step/3, config_flags, &
+                                 msfux, msfuy, msfvx, msfvy,     &
+                                 msftx, msfty,                   &
+                                 fzm, fzp,                       &
+                                 rdx, rdy, rdzw,                 &
+                                 ids, ide, jds, jde, kds, kde,   &
+                                 ims, ime, jms, jme, kms, kme,   &
                                  its, ite, jts, jte, kts, kte  )
          DO n = 1 , MAX_SCALARS
             field(:,:,:,n) = field_old(:,:,:,n) + dt * tendency(:,:,:) / 3.
          END DO
 
          tendency = 0
-         CALL advect_scalar    ( field(ims,kms,jms,im), &
-                                 field_old(ims,kms,jms,im), &
-                                 tendency(ims,kms,jms), &
-                                 ru, rv, rom,                   &
-                                 mut, time_step/2, config_flags,  &
-                                 msfux, msfuy, msfvx, msfvy,    &
-                                 msftx, msfty,                  &
-                                 fzm, fzp,                      &
-                                 rdx, rdy, rdzw,                &
-                                 ids, ide, jds, jde, kds, kde,  &
-                                 ims, ime, jms, jme, kms, kme,  &
+         CALL advect_scalar    ( field(ims,kms,jms,im),          &
+                                 field_old(ims,kms,jms,im),      &
+                                 tendency(ims,kms,jms),          &
+                                 ru, rv, rom,                    &
+                                 mut, time_step/2, config_flags, &
+                                 msfux, msfuy, msfvx, msfvy,     &
+                                 msftx, msfty,                   &
+                                 fzm, fzp,                       &
+                                 rdx, rdy, rdzw,                 &
+                                 ids, ide, jds, jde, kds, kde,   &
+                                 ims, ime, jms, jme, kms, kme,   &
                                  its, ite, jts, jte, kts, kte  )
          DO n = 1 , MAX_SCALARS
             field(:,:,:,n) = field_old(:,:,:,n) + dt * tendency(:,:,:) / 2.
@@ -10714,9 +10716,9 @@ PROGRAM feeder
 
          tendency = 0
          IF      (config_flags%scalar_adv_opt .EQ. 0 ) THEN
-            CALL advect_scalar    ( field(ims,kms,jms,im), &
-                                    field_old(ims,kms,jms,im), &
-                                    tendency(ims,kms,jms), &
+            CALL advect_scalar    ( field(ims,kms,jms,im),         &
+                                    field_old(ims,kms,jms,im),     &
+                                    tendency(ims,kms,jms),         &
                                     ru, rv, rom,                   &
                                     mut, time_step, config_flags,  &
                                     msfux, msfuy, msfvx, msfvy,    &
@@ -10727,27 +10729,31 @@ PROGRAM feeder
                                     ims, ime, jms, jme, kms, kme,  &
                                     its, ite, jts, jte, kts, kte  )
          ELSE IF (config_flags%scalar_adv_opt .EQ. 1 ) THEN
-            CALL advect_scalar_pd ( field(ims,kms,jms,im), &
-                                    field_old(ims,kms,jms,im), &
-                                    tendency(ims,kms,jms), &
-                                    h_tendency(ims,kms,jms), &
-                                    z_tendency(ims,kms,jms), &
-                                    ru, rv, rom, mut, mub, mu_old, &
+            CALL advect_scalar_pd ( field(ims,kms,jms,im),            &
+                                    field_old(ims,kms,jms,im),        &
+                                    tendency(ims,kms,jms),            &
+                                    h_tendency(ims,kms,jms),          &
+                                    z_tendency(ims,kms,jms),          &
+                                    ru, rv, rom,                      &
+                                    c1, c2,                           & 
+                                    mut, mub, mu_old,                 &
                                     time_step, config_flags, tenddec, &
-                                    msfux, msfuy, msfvx, msfvy, &
-                                    msftx, msfty, fzm, fzp, &
-                                    rdx, rdy, rdzw,dt, &
-                                    ids, ide, jds, jde, kds, kde, &
-                                    ims, ime, jms, jme, kms, kme, &
+                                    msfux, msfuy, msfvx, msfvy,       &
+                                    msftx, msfty, fzm, fzp,           &
+                                    rdx, rdy, rdzw,dt,                &
+                                    ids, ide, jds, jde, kds, kde,     &
+                                    ims, ime, jms, jme, kms, kme,     &
                                     its, ite, jts, jte, kts, kte )
          ELSE IF (config_flags%scalar_adv_opt .EQ. 2 ) THEN
-            CALL advect_scalar_mono ( field(ims,kms,jms,im), &
+            CALL advect_scalar_mono ( field(ims,kms,jms,im),   &
                                     field_old(ims,kms,jms,im), &
-                                    tendency(ims,kms,jms), &
+                                    tendency(ims,kms,jms),     &
                                     h_tendency(ims,kms,jms), &
                                     z_tendency(ims,kms,jms), &
-                                    ru, rv, rom, mut, mub, mu_old, &
-                                    config_flags, tenddec, &
+                                    ru, rv, rom, romI,       &
+                                    c1, c2,                  & 
+                                    mut, mub, mu_old,        &
+                                    config_flags, tenddec,   &
                                     msfux, msfuy, msfvx, msfvy, &
                                     msftx, msfty, fzm, fzp, &
                                     rdx, rdy, rdzw,dt, &
@@ -10756,31 +10762,32 @@ PROGRAM feeder
                                     its, ite, jts, jte, kts, kte )
          ELSE IF (config_flags%scalar_adv_opt .EQ. 3 ) THEN
             CALL advect_scalar_weno ( field(ims,kms,jms,im), &
-                                   field_old(ims,kms,jms,im), &
-                                   tendency(ims,kms,jms), &
-                             ru, rv, rom,                   &
-                             mut, time_step, config_flags,  &
-                             msfux, msfuy, msfvx, msfvy,    &
-                             msftx, msfty,                  &
-                             fzm, fzp,                      &
-                             rdx, rdy, rdzw,                &
-                             ids, ide, jds, jde, kds, kde,  &
-                             ims, ime, jms, jme, kms, kme,  &
-                             its, ite, jts, jte, kts, kte  )
+                                      field_old(ims,kms,jms,im), &
+                                      tendency(ims,kms,jms), &
+                                      ru, rv, rom,                   &
+                                      mut, time_step, config_flags,  &
+                                      msfux, msfuy, msfvx, msfvy,    &
+                                      msftx, msfty,                  &
+                                      fzm, fzp,                      &
+                                      rdx, rdy, rdzw,                &
+                                      ids, ide, jds, jde, kds, kde,  &
+                                      ims, ime, jms, jme, kms, kme,  &
+                                      its, ite, jts, jte, kts, kte  )
          ELSE IF (config_flags%scalar_adv_opt .EQ. 4 ) THEN
-            CALL advect_scalar_wenopd ( field(ims,kms,jms,im), &
-                                        field_old(ims,kms,jms,im), &
-                                        tendency(ims,kms,jms), &
-                                ru, rv, rom,                   &
-                                mut, mub, mu_old,              &
-                                time_step, config_flags,       &
-                                msfux, msfuy, msfvx, msfvy,    &
-                                msftx, msfty,                  &
-                                fzm, fzp,                      &
-                                rdx, rdy, rdzw, dt,            &
-                                ids, ide, jds, jde, kds, kde,  &
-                                ims, ime, jms, jme, kms, kme,  &
-                                its, ite, jts, jte, kts, kte  )
+            CALL advect_scalar_wenopd ( field(ims,kms,jms,im),         &
+                                        field_old(ims,kms,jms,im),     &
+                                        tendency(ims,kms,jms),         &
+                                        ru, rv, rom,                   &
+                                        c1, c2,                        & 
+                                        mut, mub, mu_old,              &
+                                        time_step, config_flags,       &
+                                        msfux, msfuy, msfvx, msfvy,    &
+                                        msftx, msfty,                  &
+                                        fzm, fzp,                      &
+                                        rdx, rdy, rdzw, dt,            &
+                                        ids, ide, jds, jde, kds, kde,  &
+                                        ims, ime, jms, jme, kms, kme,  &
+                                        its, ite, jts, jte, kts, kte  )
          END IF
          DO n = 1 , MAX_SCALARS
             field(:,:,:,n) = field_old(:,:,:,n) + dt * ( tendency(:,:,:) )

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2482,13 +2482,13 @@ END SUBROUTINE pg_buoy_w
 !-------------------------------------------------------------------------------
 
 SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
-                      u, v, ww, w, mut, c1f, c2f, rdnw, &
-                      rdx, rdy, msfux, msfuy,           &
-                      msfvx, msfvy, dt,                 &
-                      config_flags,                     &
-                      ids, ide, jds, jde, kds, kde,     &
-                      ims, ime, jms, jme, kms, kme,     &
-                      its, ite, jts, jte, kts, kte     )
+                   u, v, ww, w, mut, c1f, c2f, rdnw,    &
+                   rdx, rdy, msfux, msfuy,              &
+                   msfvx, msfvy, dt,                    &
+                   config_flags,                        &
+                   ids, ide, jds, jde, kds, kde,        &
+                   ims, ime, jms, jme, kms, kme,        &
+                   its, ite, jts, jte, kts, kte     )
 
    USE module_llxy
    IMPLICIT NONE
@@ -2523,7 +2523,6 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    REAL                :: vert_cfl, cf_n, cf_d, maxdub, maxdeta
 
    INTEGER :: itf, jtf, i, j, k, maxi, maxj, maxk
-   INTEGER :: some
    CHARACTER*512 :: temp
 
    CHARACTER (LEN=256) :: time_str
@@ -2532,9 +2531,18 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    integer :: total
    REAL :: msfuxt , msfxffl
    
+   REAL    :: w_damp_on     = 1.0
+   REAL    :: w_crit_cfl    = 2.0
+   REAL    :: w_flag_cfl    = 1.2
+   LOGICAL :: wflags_differ = .false.
+   LOGICAL :: print_flag    = .true.
+   SAVE    :: print_flag
+   INTEGER :: some1         = 0     ! Now have two catagories of CFL information, hence some1 & some2
+   INTEGER :: some2         = 0
+
 !<DESCRIPTION>
 !
-!  w_damp computes a damping term for the vertical velocity when the
+!  W_damp computes a damping term for the vertical velocity when the
 !  vertical Courant number is too large.  This was found to be preferable to
 !  decreasing the timestep or increasing the diffusion in real-data applications
 !  that produced potentially-unstable large vertical velocities because of
@@ -2545,154 +2553,172 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
 !  horizontal motion.  These values are returned via the max_vert_cfl and
 !  max_horiz_cfl variables.  (Added by T. Hutchinson, WSI, 3/5/2007)
 !
+!-----
+!
+!  W_damp modified to be more flexible with IEVA capability. Two things changed.
+!  First, the value of the W-CFL where damping is turned on can now be set in the namelist
+!  using "w_crit_cfl".  Second, the code has been modified to report two levels of
+!  W-CFL information.  Previously, both damping and W-CFL information was
+!  printed at a W-CFL == 1.2.  This new capability does not need IEVA on to run.
+!
+!  We keep the old level reporting (for consistency), but use "w_flag_cfl" to flag 
+!  and print information from those points.  "w_flag_cfl" is set here in w_damp.  
+!  A second level of print occurs, which is useful for when we run
+!  IEVA, because many points can run with W-CFL > 1.2.  We now print this
+!  second level separately, as these points might make the model blow up.
+!  and where we now want Rayleigh damping turned on.  The default value "w_crit_cfl" 
+!  which replaced "w_beta" in the old code, is set in the namelist/Registery
+!  turn on w_damp at 1.2 consistent with the WRFV3/4 (before this) code.
+!
+!  Summary
+!  -------
+!  W_damp will write out CFL information when the vertical courant number is > w_flag_cfl,
+!  and W_damp will also turn on Rayleigh damping if vertical courant number > w_crit_cfl.
+!
+!  Typical settings for non-IEVA use:  w_crit_cfl = 1.2
+!  Typical settings for     IEVA use:  w_crit_cfl = 2.0
+!
+!  I also commented out a lot of code put in 8-13 years ago for timing assuming that
+!  this is no longer needed....there is some pretty hacky stuff.  HTH.
+!
+!      (Added by L. Wicker, NSSL, 5/4/2020)
+!
 !</DESCRIPTION>
 
    itf=MIN(ite,ide-1)
    jtf=MIN(jte,jde-1)
 
-   some = 0
-   max_vert_cfl = 0.
+   max_vert_cfl  = 0.
    max_horiz_cfl = 0.
    total = 0
+
+   w_crit_cfl = config_flags%w_crit_cfl
+
+   IF( abs(w_crit_cfl - w_flag_cfl) > 0.1 ) THEN
+     wflags_differ = .true.
+   ELSE
+     wflags_differ = .false.
+   ENDIF
+
+   IF( print_flag ) THEN
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 0, wrf_err_message )
+     WRITE(temp,*) 'W-DAMPING  BEGINS AT W-COURANT NUMBER = ',w_crit_cfl
+     CALL wrf_debug ( 0 , TRIM(temp) )
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 0, wrf_err_message )
+     print_flag = .false.
+   ENDIF
 
    IF(config_flags%polar ) then
      msfxffl = 1.0/COS(config_flags%fft_filter_lat*degrad)
    END IF
 
-   IF ( config_flags%w_damping == 1 ) THEN
+! Routine has been reorganized to hopefully reduce redundant code while maintaining efficiency
+
 #ifdef OPTIMIZE_CFL_TEST
 ! 20121025, L. Meadows vector optimization does not include special case for Cassini
-     IF(config_flags%polar ) then
-       CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
-     END IF
+
+   IF(config_flags%polar ) then
+     CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
+   END IF
+
 #endif
 
-     DO j = jts,jtf
+   DO j = jts,jtf
+     DO k = 2,kde-1
+       DO i = its,itf
 
-     DO k = 2, kde-1
-     DO i = its,itf
-#if 1
+         vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
+
 # ifdef OPTIMIZE_CFL_TEST
 ! L. Meadows, Intel, MIC optimization, 20121025
-        msfuxt = msfux(i,j)
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl
-        ENDIF
-# else
-        IF(config_flags%polar ) then
-           msfuxt = MIN(msfux(i,j), msfxffl)
-        ELSE
-           msfuxt = msfux(i,j)
-        END IF
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
 
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
-           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-        ENDIF
+         msfuxt = msfux(i,j)
+
+         IF ( vert_cfl > max_vert_cfl ) THEN
+            max_vert_cfl = vert_cfl
+         ENDIF
+# else
+         IF(config_flags%polar ) THEN
+            msfuxt = MIN(msfux(i,j), msfxffl)
+         ELSE
+            msfuxt = msfux(i,j)
+         ENDIF
+
+         IF ( vert_cfl > max_vert_cfl ) THEN
+            max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
+            maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
+         ENDIF
 # endif
         
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt),                          &
-             abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
-        if (horiz_cfl > max_horiz_cfl) then
-           max_horiz_cfl = horiz_cfl
-        endif
+         horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt     * dt),    &
+                          abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+
+         IF (horiz_cfl > max_horiz_cfl) THEN
+            max_horiz_cfl = horiz_cfl
+         ENDIF
+
+! Dump out more information without affecting performance
         
-        if(vert_cfl .gt. w_beta)then
-#else
-! restructure to get rid of divide
-!
-! This had been used for efficiency, but with the addition of returning the cfl values,
-!   the old version (above) was reinstated.  (T. Hutchinson, 3/5/2007)
-!
-        cf_n = abs(ww(i,k,j)*rdnw(k)*dt)
-        cf_d = abs((c1f(k)*mut(i,j)+c2f(k)))
-        if(cf_n .gt. cf_d*w_beta )then
-#endif
 #ifndef OPTIMIZE_CFL_TEST
 ! This internal write is costly on newer Xeon processors because it breaks
 ! vectorization.  (J. Michalakes for L. Meadows at Intel, 12/13/2012)
-           WRITE(temp,*)i,j,k,' vert_cfl,w,d(eta)=',vert_cfl,w(i,k,j),-1./rdnw(k)
+
+         IF (vert_cfl .gt. w_crit_cfl) THEN
+
+           some1 = some1 + 1
+
+           WRITE(temp,FMT="(3(1x,i5,1x),'W-CRIT_CFL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") &
+                                         i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
            CALL wrf_debug ( 100 , TRIM(temp) )
-#endif
-           if ( vert_cfl > 2. ) some = some + 1
-           rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_beta)*(c1f(k)*mut(i,j)+c2f(k))
-        endif
-     END DO
-     ENDDO
-     ENDDO
-   ELSE
-! just print
-     DO j = jts,jtf
 
-     DO k = 2, kde-1
-     DO i = its,itf
+         ENDIF
 
-#if 1
-# ifdef OPTIMIZE_CFL_TEST
-        msfuxt = msfux(i,j)
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl
-        ENDIF
-# else
-! L. Meadows MIC optimization, 20121025
-        IF(config_flags%polar ) then
-           msfuxt = MIN(msfux(i,j), msfxffl)
-        ELSE
-           msfuxt = msfux(i,j)
-        END IF
-        vert_cfl = abs(ww(i,k,j)/(c1f(k)*mut(i,j)+c2f(k))*rdnw(k)*dt)
-        
-        IF ( vert_cfl > max_vert_cfl ) THEN
-           max_vert_cfl = vert_cfl ; maxi = i ; maxj = j ; maxk = k
-           maxdub = w(i,k,j) ; maxdeta = -1./rdnw(k)
-        ENDIF
-# endif
-        
-        horiz_cfl = max( abs(u(i,k,j) * rdx * msfuxt * dt),                          &
-             abs(v(i,k,j) * rdy * msfvy(i,j) * dt) )
+         IF ((vert_cfl .gt. w_flag_cfl) .and. wflags_differ) THEN
 
-        if (horiz_cfl > max_horiz_cfl) then
-           max_horiz_cfl = horiz_cfl
-        endif
-        
-        if(vert_cfl .gt. w_beta)then
-#else
-! restructure to get rid of divide
-!
-! This had been used for efficiency, but with the addition of returning the cfl values,
-!   the old version (above) was reinstated.  (T. Hutchinson, 3/5/2007)
-!
-        cf_n = abs(ww(i,k,j)*rdnw(k)*dt)
-        cf_d = abs((c1f(k)*mut(i,j)+c2f(k)))
-        if(cf_n .gt. cf_d*w_beta )then
-#endif
-#ifndef OPTIMIZE_CFL_TEST
-           WRITE(temp,*)i,j,k,' vert_cfl,w,d(eta)=',vert_cfl,w(i,k,j),-1./rdnw(k)
+           some2 = some2 + 1
+
+           WRITE(temp,FMT="(3(1x,i5,1x),'W-FLAG_CFL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") &
+                                         i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
            CALL wrf_debug ( 100 , TRIM(temp) )
+
+         ENDIF
 #endif
-           if ( vert_cfl > 2. ) some = some + 1
-        endif
-     END DO
-     ENDDO
-     ENDDO
-   ENDIF
-   IF ( some .GT. 0 ) THEN
+
+         IF ((vert_cfl .gt. w_crit_cfl) .and. (config_flags%w_damping == 1) ) THEN
+
+           rw_tend(i,k,j) = rw_tend(i,k,j)-sign(1.,w(i,k,j))*w_alpha*(vert_cfl-w_crit_cfl)*(c1f(k)*mut(i,j)+c2f(k))
+
+         ENDIF
+
+       ENDDO   ! end i-loop
+     ENDDO   ! end k-loop
+   ENDDO   ! end j-loop
+
+   IF ( some1 .GT. 0 ) THEN
      CALL get_current_time_string( time_str )
      CALL get_current_grid_name( grid_str )
-     WRITE(temp,*)some,                                            &
-            ' points exceeded cfl=2 in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+     WRITE(temp,*) some1,                                            &
+            ' points exceeded W_CRITICAL_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
      CALL wrf_debug ( 0 , TRIM(temp) )
-#ifndef OPTIMIZE_CFL_TEST
-     WRITE(temp,*)'MAX AT i,j,k: ',maxi,maxj,maxk,' vert_cfl,w,d(eta)=',max_vert_cfl, &
-                             maxdub,maxdeta
+     WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'W-CFL: ',f7.2,2x,'dETA: ',f7.2))") &
+                            maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
      CALL wrf_debug ( 0 , TRIM(temp) )
-#endif
+     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'U-CFL: ',f7.2,2x,'V: ',f7.2,2x,'V-CFL: ',f7.2))") &
+           maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
+     CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF
 
-END SUBROUTINE w_damp
+   IF ( some2 .GT. 0 ) THEN   
+     CALL get_current_time_string( time_str )
+     CALL get_current_grid_name( grid_str )
+     WRITE(temp,*) some2,                                            &
+            ' points exceeded W_FLAG_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+     CALL wrf_debug ( 0 , TRIM(temp) )
+   ENDIF
+
+END SUBROUTINE W_DAMP
 
 !-------------------------------------------------------------------------------
 

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2537,8 +2537,8 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
    LOGICAL :: wflags_differ = .false.
    LOGICAL :: print_flag    = .true.
    SAVE    :: print_flag
-   INTEGER :: some1         = 0     ! Now have two catagories of CFL information, hence some1 & some2
-   INTEGER :: some2         = 0
+   INTEGER :: some1       ! Now have two catagories of CFL information, hence some1 & some2
+   INTEGER :: some2        
 
 !<DESCRIPTION>
 !
@@ -2587,6 +2587,9 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
 
    itf=MIN(ite,ide-1)
    jtf=MIN(jte,jde-1)
+
+   some1 = 0
+   some2 = 0
 
    max_vert_cfl  = 0.
    max_horiz_cfl = 0.

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -11,12 +11,14 @@ MODULE module_em
    
    USE module_big_step_utilities_em, only: grid_config_rec_type, calculate_full, couple_momentum, calc_mu_uv, calc_ww_cp, &
         calc_cq, calc_alt, calc_php, set_tend, rhs_ph, &
-    horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
-        horizontal_diffusion_3dmp, vertical_diffusion_u, &
- vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, sixth_order_diffusion, rk_rayleigh_damp, &
-        theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
-
-   USE module_state_description, only: param_first_scalar, p_qr, p_qv, p_qc, p_qg, p_qi, p_qs, tiedtkescheme,ntiedtkescheme, heldsuarez, &
+        horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
+        horizontal_diffusion_3dmp, vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, &
+        sixth_order_diffusion, rk_rayleigh_damp, theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
+  
+  USE module_ieva_em, only: advect_u_implicit, advect_v_implicit, advect_w_implicit, advect_s_implicit, advect_ph_implicit, &
+                            chk_ieva, ww_split, calc_mut_new
+  
+  USE module_state_description, only: param_first_scalar, p_qr, p_qv, p_qc, p_qg, p_qi, p_qs, tiedtkescheme,ntiedtkescheme, heldsuarez, &
         positivedef, gdscheme, g3scheme, gfscheme, kfetascheme, mskfscheme, monotonic, wenopd_scalar, weno_scalar, weno_mom
 
    USE module_damping_em, only: held_suarez_damp
@@ -195,8 +197,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                          u, v, w, t, ph,                                  &
                          u_old, v_old, w_old, t_old, ph_old,              &
                          h_diabatic, phb,t_init,                          &
-                         mu, mut, muu, muv, mub, c1h, c2h, c1f, c2f,      &
-                         al, alt, p, pb, php, cqu, cqv, cqw,              &
+                         mu_old, mu, mut, muu, muv, mub,                  &
+                         c1h, c2h, c1f, c2f,                              &
+                         al, ht, alt, p, pb, php, cqu, cqv, cqw,          &
                          u_base, v_base, t_base, qv_base, z_base,         &
                          msfux, msfuy, msfvx, msfvx_inv,                  &
                          msfvy, msftx, msfty,                             &
@@ -292,11 +295,13 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                                                     e,       &
                                                                     sina,    &
                                                                     cosa,    &
+                                                                    mu_old,  &
                                                                     mu,      &
                                                                     mut,     &
                                                                     mub,     &
                                                                     muu,     &
-                                                                    muv
+                                                                    muv,     &
+                                                                    ht             
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fnm,     &
                                                                   fnp,     &
@@ -314,7 +319,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
    REAL ,                                      INTENT(IN   ) :: rdx,     &
                                                                 rdy,     &
-                                                                dt,      &
+                                                                dt,      &    ! this is the large time step
                                                                 u_frame, &
                                                                 v_frame, &
                                                                 khdif,   &
@@ -333,7 +338,14 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    REAL    :: kdift, khdq, kvdq, cfn, cfn1, cf1, cf2, cf3
    INTEGER :: i,j,k
    INTEGER :: time_step
+   INTEGER :: rk_order
+   REAL    :: dt_step
 
+! IEVA declarations
+   REAL , DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
+   REAL , DIMENSION( ims:ime , jms:jme )         :: mut_old, mut_new                                                              
+   LOGICAL                                       :: ieva
+   
 !<DESCRIPTION>
 !
 !  rk_tendency computes the large-timestep tendency terms in the
@@ -414,109 +426,182 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                     ims, ime, jms, jme, 1, 1, &
                     its, ite, jts, jte, 1, 1 )
 
-   !  advection tendencies
    CALL nl_get_time_step ( 1, time_step )
 
+   rk_order = config_flags%rk_ord
+   dt_step  = dt / (rk_order - rk_step + 1)   ! needed for calculations using sub-rk step
 
-    IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
+! IEVA
+   
+   ieva = CHK_IEVA( config_flags, rk_step ) 
 
-     CALL advect_weno_u ( u, u , ru_tend, ru, rv, ww, &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
+! Need an estimate of the mut at the n time level...
 
-     ELSE
+   CALL calculate_full( mut_old, mub, mu_old,     &
+                        ids, ide, jds, jde, 1, 2, &
+                        ims, ime, jms, jme, 1, 1, &
+                        its, ite, jts, jte, 1, 1 )
+                        
+! Estimate new temporary column mass
+                        
+   CALL calc_mut_new ( u, v, c1h, c2h,                      &
+                       mut_old, muu, muv, mut_new,          &
+                       dt, rdx, rdy, msftx, msfty,          &
+                       msfux, msfuy, msfvx, msfvx_inv,      &
+                       msfvy, rdnw,                         &
+                       ids, ide, jds, jde, kds, kde,        &
+                       ims, ime, jms, jme, kms, kme,        &
+                       its, ite, jts, jte, kts, kte    )
+                         
+! Code for splitting vertical velocity into ex/im parts
+
+   CALL WW_SPLIT(wwE, wwI, ph, phb,                &
+                 u, v, ww, w, mut, rdnw, msfty,    &
+                 c1f, c2f,                         &
+                 rdx, rdy, msfux, msfuy,           &
+                 msfvx, msfvy, dt,                 &
+                 config_flags, rk_step,            &
+                 ids, ide, jds, jde, kds, kde,     &
+                 ims, ime, jms, jme, kms, kme,     &
+                 its, ite, jts, jte, kts, kte )              
+
+! Okay do normal advection now....using the wwE array
+
+   IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+
+     CALL advect_weno_u ( u, u , ru_tend, ru, rv, wwE,  &
+                          c1h, c2h,                     &
+                          mut, time_step, config_flags, &
+                          msfux, msfuy, msfvx, msfvy,   &
+                          msftx, msfty,                 &
+                          fnm, fnp, rdx, rdy, rdnw,     &
+                          ids, ide, jds, jde, kds, kde, &
+                          ims, ime, jms, jme, kms, kme, &
+                          its, ite, jts, jte, kts, kte )
+
+   ELSE
      
-     CALL advect_u ( u, u , ru_tend, ru, rv, ww, &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
-      ENDIF
+     CALL advect_u ( u, u , ru_tend, ru, rv, wwE,  &
+                     c1h, c2h,                     &
+                     mut, time_step, config_flags, &
+                     msfux, msfuy, msfvx, msfvy,   &
+                     msftx, msfty,                 &
+                     fnm, fnp, rdx, rdy, rdnw,     &
+                     ids, ide, jds, jde, kds, kde, &
+                     ims, ime, jms, jme, kms, kme, &
+                     its, ite, jts, jte, kts, kte )
+   ENDIF
 
-     IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
+   IF( ieva ) THEN
 
-     CALL advect_weno_v ( v, v , rv_tend, ru, rv, ww,  &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
+     CALL advect_u_implicit ( u, u_old, ru_tend, ru, rv, wwI,  &
+                              c1h, c2h,                        &
+                              mut_old, mut, mut_new,           &
+                              config_flags,                    &
+                              msfux, msfuy, msfvx, msfvy,      &
+                              msftx, msfty,                    &
+                              fnm, fnp,                        &
+                              dt_step,                         &
+                              rdx, rdy, rdnw,                  &
+                              ids, ide, jds, jde, kds, kde,    &
+                              ims, ime, jms, jme, kms, kme,    &
+                              its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+
+      CALL advect_weno_v ( v, v , rv_tend, ru, rv, wwE,  &
+                           c1h, c2h,                     &
+                           mut, time_step, config_flags, &
+                           msfux, msfuy, msfvx, msfvy,   &
+                           msftx, msfty,                 &
+                           fnm, fnp, rdx, rdy, rdnw,     &
+                           ids, ide, jds, jde, kds, kde, &
+                           ims, ime, jms, jme, kms, kme, &
+                           its, ite, jts, jte, kts, kte )
+
+   ELSE
+     
+    CALL advect_v ( v, v , rv_tend, ru, rv, wwE,  &
+                    c1h, c2h,                     &
+                    mut, time_step, config_flags, &
+                    msfux, msfuy, msfvx, msfvy,   &
+                    msftx, msfty,                 &
+                    fnm, fnp, rdx, rdy, rdnw,     &
+                    ids, ide, jds, jde, kds, kde, &
+                    ims, ime, jms, jme, kms, kme, &
+                    its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF( ieva ) THEN
+     
+     CALL advect_v_implicit ( v, v_old, rv_tend, ru, rv, wwI,  &
+                              c1h, c2h,                        &
+                              mut_old, mut, mut_new,           &
+                              config_flags,                    &
+                              msfux, msfuy, msfvx, msfvy,      &
+                              msftx, msfty,                    &
+                              fnm, fnp,                        &
+                              dt_step,                         &
+                              rdx, rdy, rdnw,                  &
+                              ids, ide, jds, jde, kds, kde,    &
+                              ims, ime, jms, jme, kms, kme,    &
+                              its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF (non_hydrostatic) THEN
+   
+    IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+     
+      CALL advect_weno_w ( w, w, rw_tend, ru, rv, wwE,    &
+                            c1h, c2h,                     &
+                            mut, time_step, config_flags, &
+                            msfux, msfuy, msfvx, msfvy,   &
+                            msftx, msfty,                 &
+                            fnm, fnp, rdx, rdy, rdn,      &
+                            ids, ide, jds, jde, kds, kde, &
+                            ims, ime, jms, jme, kms, kme, &
+                            its, ite, jts, jte, kts, kte )
 
     ELSE
      
-     CALL advect_v ( v, v , rv_tend, ru, rv, ww,  &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
+      CALL advect_w ( w, w, rw_tend, ru, rv, wwE,   &
+                      c1h, c2h,                     &
+                      mut, time_step, config_flags, &
+                      msfux, msfuy, msfvx, msfvy,   &
+                      msftx, msfty,                 &
+                      fnm, fnp, rdx, rdy, rdn,      &
+                      ids, ide, jds, jde, kds, kde, &
+                      ims, ime, jms, jme, kms, kme, &
+                      its, ite, jts, jte, kts, kte )
     ENDIF
-
-
-   IF (non_hydrostatic) THEN
-     IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
-     CALL advect_weno_w ( w, w, rw_tend, ru, rv, ww,    &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdn,      &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
-
-     ELSE
-     
-     CALL advect_w ( w, w, rw_tend, ru, rv, ww,    &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdn,      &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
-     ENDIF
-   ENDIF
+    
+   ENDIF  ! Non-Hydrostatic
+   
 !  theta flux divergence
 
 ! 11/2016 ERM: Use WENO for theta flux on 3rd RK step if using WENO_SCALAR or WENOPD_SCALAR
 ! to be consistent with other scalar fluxes
-      IF(  ( config_flags%scalar_adv_opt == WENO_SCALAR  &
-                 .or. config_flags%scalar_adv_opt == WENOPD_SCALAR    &
-                 .or. config_flags%moist_adv_opt == WENO_SCALAR       &
-                 .or. config_flags%moist_adv_opt == WENOPD_SCALAR     &
-                       )  .and. (rk_step == 3) ) THEN
+   IF(  ( config_flags%scalar_adv_opt == WENO_SCALAR      &
+     .or. config_flags%scalar_adv_opt == WENOPD_SCALAR    &
+     .or. config_flags%moist_adv_opt == WENO_SCALAR       &
+     .or. config_flags%moist_adv_opt == WENOPD_SCALAR )    &
+     .and. (rk_step == rk_order) ) THEN
+     
 ! also use weno for monotonic scalar option so that the h_ and z_tendency arrays are not needed
 
-        CALL advect_scalar_weno ( t, t, t_tend, ru, rv, ww,     &
-                                 c1h, c2h, mut, time_step,      &
-                                 config_flags,                  &
-                                 msfux, msfuy, msfvx, msfvy,    &
-                                 msftx, msfty, fnm, fnp,        &
-                                 rdx, rdy, rdnw,                &
-                                 ids, ide, jds, jde, kds, kde,  &
-                                 ims, ime, jms, jme, kms, kme,  &
-                                 its, ite, jts, jte, kts, kte  )
-     ELSE
+     CALL advect_scalar_weno ( t, t, t_tend, ru, rv, wwE,    &
+                              c1h, c2h, mut, time_step,      &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty, fnm, fnp,        &
+                              rdx, rdy, rdnw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+   ELSE
 
-     CALL advect_scalar ( t, t, t_tend, ru, rv, ww,     &
+     CALL advect_scalar ( t, t, t_tend, ru, rv, wwE,    &
                           c1h, c2h,                     &
                           mut, time_step, config_flags, &
                           msfux, msfuy, msfvx, msfvy,   &
@@ -526,23 +611,40 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           ims, ime, jms, jme, kms, kme, &
                           its, ite, jts, jte, kts, kte )
 
-     ENDIF
-     
-     IF ( config_flags%cu_physics == GDSCHEME  .OR.     &
-          config_flags%cu_physics == GFSCHEME  .OR.     &
-          config_flags%cu_physics == G3SCHEME  .OR.     &
-          config_flags%cu_physics == NTIEDTKESCHEME )  THEN     ! NTiedtke
+   ENDIF
+   
+   IF( ieva ) THEN
+      
+     CALL advect_s_implicit ( t, t_old, t_tend, ru, rv, wwI,  &
+                              c1h, c2h,                       &
+                              mut_old, mut, mut_new,          &
+                              config_flags,                   &
+                              msfux, msfuy, msfvx, msfvy,     &
+                              msftx, msfty,                   &
+                              fnm, fnp,                       &
+                              dt_step,                        &
+                              rdx, rdy, rdnw,                 &
+                              ids, ide, jds, jde, kds, kde,   &
+                              ims, ime, jms, jme, kms, kme,   &
+                              its, ite, jts, jte, kts, kte )
 
-     ! theta advection only:
+   ENDIF
+   
+   IF ( config_flags%cu_physics == GDSCHEME  .OR.     &
+        config_flags%cu_physics == GFSCHEME  .OR.     &
+        config_flags%cu_physics == G3SCHEME  .OR.     &
+        config_flags%cu_physics == NTIEDTKESCHEME )  THEN     ! NTiedtke
 
-         CALL set_tend( RTHFTEN, t_tend, msfty,          &
-                        ids, ide, jds, jde, kds, kde,    &
-                        ims, ime, jms, jme, kms, kme,    &
-                        its, ite, jts, jte, kts, kte     )
+  ! theta advection only:
 
-     END IF
+      CALL set_tend( RTHFTEN, t_tend, msfty,          &
+                     ids, ide, jds, jde, kds, kde,    &
+                     ims, ime, jms, jme, kms, kme,    &
+                     its, ite, jts, jte, kts, kte     )
 
-     CALL rhs_ph( ph_tend, u, v, ww, ph, ph, phb, w, &
+   ENDIF  ! cu_physics scheme
+
+     CALL rhs_ph( ph_tend, u, v, wwE, ph, ph, phb, w, &
                   mut, muu, muv,                     &
                   c1f, c2f,                          &
                   fnm, fnp,                          &
@@ -556,6 +658,41 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                   ims, ime, jms, jme, kms, kme,      &
                   its, ite, jts, jte, kts, kte      )
 
+    IF( ieva ) THEN
+      
+        CALL advect_ph_implicit ( ph, ph_old, ph_tend, phb,       &
+                                  ru, rv, wwE, wwI, w,            & 
+                                  c1f, c2f,                       &
+                                  mut, config_flags,              &
+                                  msfux, msfuy, msfvx, msfvy,     &
+                                  msftx, msfty,                   &
+                                  fnm, fnp,                       &
+                                  dt_step,                        &
+                                  rdx, rdy, rdnw,                 &
+                                  ids, ide, jds, jde, kds, kde,   &
+                                  ims, ime, jms, jme, kms, kme,   &
+                                  its, ite, jts, jte, kts, kte )
+
+     IF (non_hydrostatic) THEN
+      
+       CALL advect_w_implicit ( w, w_old, rw_tend,              &
+                                ru_tend, rv_tend, ht, wwI,      &
+                                ph, ph_old, ph_tend,            &
+                                c1f, c2f, cf1, cf2, cf3,        &
+                                mut_old, mut, mut_new,          &
+                                config_flags,                   &
+                                msfux, msfuy, msfvx, msfvy,     &
+                                msftx, msfty,                   &
+                                fnm, fnp,                       &
+                                dt_step,                        &
+                                rdx, rdy, rdn,                  &
+                                ids, ide, jds, jde, kds, kde,   &
+                                ims, ime, jms, jme, kms, kme,   &
+                                its, ite, jts, jte, kts, kte )
+     ENDIF
+     
+   ENDIF  ! IEVA
+      
      CALL horizontal_pressure_gradient( ru_tend,rv_tend,                 &
                                          ph,alt,p,pb,al,php,cqu,cqv,     &
                                          muu,muv,mu,c1h,c2h,fnm,fnp,rdnw,&
@@ -577,14 +714,14 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           its, ite, jts, jte, kts, kte   )
      ENDIF
 
-     CALL w_damp   ( rw_tend, max_vert_cfl,             &
-                      max_horiz_cfl,                    &
-                      u, v, ww, w, mut, c1f, c2f, rdnw, &
-                      rdx, rdy, msfux, msfuy, msfvx,    &
-                      msfvy, dt, config_flags,          &
-                      ids, ide, jds, jde, kds, kde,     &
-                      ims, ime, jms, jme, kms, kme,     &
-                      its, ite, jts, jte, kts, kte     )
+     CALL w_damp   ( rw_tend, max_vert_cfl,            &
+                     max_horiz_cfl,                    &
+                     u, v, ww, w, mut, c1f, c2f, rdnw, &
+                     rdx, rdy, msfux, msfuy, msfvx,    &
+                     msfvy, dt, config_flags,          &
+                     ids, ide, jds, jde, kds, kde,     &
+                     ims, ime, jms, jme, kms, kme,     &
+                     its, ite, jts, jte, kts, kte     )
 
      IF(config_flags%pert_coriolis) THEN
 
@@ -935,9 +1072,10 @@ END SUBROUTINE rk_addtend_dry
 !-------------------------------------------------------------------------------
 
 SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
-                            tenddec,                        &
-                            rk_step, dt,                     &
-                            ru, rv, ww, mut, mub, mu_old,    &
+                            tenddec,                         &
+                            rk_step, dt_step,                &
+                            ru, rv, ww, u,  v,  w,           &  
+                            mut, mub, mu_old,                &
                             c1h, c2h, alt,                   &
                             scalar_old, scalar,              &
                             scalar_tends, advect_tend,       &
@@ -985,6 +1123,9 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,  &
                                                                       rv,  &
                                                                       ww,  &
+                                                                      u,   &
+                                                                      v,   &
+                                                                      w,   &
                                                                       xkmhd,  &
                                                                       alt,    &
                                                                       phb,    &
@@ -1017,7 +1158,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    INTEGER, INTENT( IN ) :: diff_6th_opt
    REAL,    INTENT( IN ) :: diff_6th_factor
 
-   REAL ,                                        INTENT(IN   ) :: dt
+   REAL,    INTENT(IN   ) :: dt_step    ! This is the local dt for each RK sub-step
 
    INTEGER, INTENT(IN   ) :: adv_opt          
    LOGICAL, INTENT(IN   ) :: mix2_off, mix6_off
@@ -1026,8 +1167,14 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
   
    INTEGER :: im, i,j,k
    INTEGER :: time_step
+   INTEGER :: rk_order
+   REAL    :: dt         ! This is the large time step computed below
 
    REAL    :: khdq, kvdq, tendency
+
+! IEVA variables
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
+   LOGICAL                                      :: ieva
 
 !<DESCRIPTION>
 !
@@ -1036,9 +1183,29 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 !
 !</DESCRIPTION>
 
-
    khdq = khdif/prandtl
    kvdq = kvdif/prandtl
+
+   rk_order = config_flags%rk_ord
+   dt       = dt_step * (rk_order - rk_step + 1)    ! need large time step
+
+! IEVA
+                         
+   ieva = CHK_IEVA( config_flags, rk_step )
+
+   CALL WW_SPLIT(wwE, wwI, ph, phb,                &
+                 u, v, ww, w, mut, rdnw, msfty,    &
+                 c1h, c2h,                         &
+                 rdx, rdy, msfux, msfuy,           &
+                 msfvx, msfvy, dt,                 &
+                 config_flags, rk_step,            & 
+                 ids, ide, jds, jde, kds, kde,     &
+                 ims, ime, jms, jme, kms, kme,     &
+                 its, ite, jts, jte, kts, kte )             
+                 
+! IEVA
+
+   CALL nl_get_time_step ( 1, time_step )
 
    scalar_loop : DO im = scs, sce
 
@@ -1057,48 +1224,47 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                       ims, ime, jms, jme, kms, kme, &
                       its, ite, jts, jte, kts, kte )
 
-     CALL nl_get_time_step ( 1, time_step )
 
-      IF( (rk_step == 3) .and. (adv_opt == POSITIVEDEF) ) THEN
+    IF( (rk_step == rk_order) .and. (adv_opt == POSITIVEDEF) ) THEN
 
         CALL advect_scalar_pd       ( scalar(ims,kms,jms,im),             &
                                       scalar_old(ims,kms,jms,im),         &
                                       advect_tend(ims,kms,jms),           &
                                       h_tendency(ims,kms,jms),            &
                                       z_tendency(ims,kms,jms),            &
-                                      ru, rv, ww, c1h, c2h,               &
+                                      ru, rv, wwE, c1h, c2h,              &
                                       mut, mub, mu_old,                   &
                                       time_step, config_flags, tenddec,   &
                                       msfux, msfuy, msfvx, msfvy,         &
                                       msftx, msfty, fnm, fnp,             &
-                                      rdx, rdy, rdnw,dt,                  &
+                                      rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt here
                                       ids, ide, jds, jde, kds, kde,       &
                                       ims, ime, jms, jme, kms, kme,       &
                                       its, ite, jts, jte, kts, kte     )
 
-      ELSE IF( (rk_step == 3) .and. (adv_opt == MONOTONIC) ) THEN
+      ELSE IF( (rk_step == rk_order) .and. (adv_opt == MONOTONIC) ) THEN
 
         CALL advect_scalar_mono       ( scalar(ims,kms,jms,im),             &
                                         scalar_old(ims,kms,jms,im),         &
                                         advect_tend(ims,kms,jms),           &
                                         h_tendency(ims,kms,jms),            &
                                         z_tendency(ims,kms,jms),            &
-                                        ru, rv, ww, c1h, c2h,               &
+                                        ru, rv, wwE, wwI, c1h, c2h,         &
                                         mut, mub, mu_old,                   &
                                         config_flags, tenddec,              &
                                         msfux, msfuy, msfvx, msfvy,         &
                                         msftx, msfty, fnm, fnp,             &
-                                        rdx, rdy, rdnw,dt,                  &
+                                        rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt here
                                         ids, ide, jds, jde, kds, kde,       &
                                         ims, ime, jms, jme, kms, kme,       &
                                         its, ite, jts, jte, kts, kte     )
 
-      ELSE IF( (rk_step == 3) .and. (adv_opt == WENO_SCALAR) ) THEN
+      ELSE IF( (rk_step == rk_order) .and. (adv_opt == WENO_SCALAR) ) THEN
 
         CALL advect_scalar_weno ( scalar(ims,kms,jms,im),        &
                                  scalar(ims,kms,jms,im),        &
                                  advect_tend(ims,kms,jms),      &
-                                 ru, rv, ww, c1h, c2h,          &
+                                 ru, rv, wwE, c1h, c2h,          &
                                  mut, time_step,                &
                                  config_flags,                  &
                                  msfux, msfuy, msfvx, msfvy,    &
@@ -1108,17 +1274,17 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                  ims, ime, jms, jme, kms, kme,  &
                                  its, ite, jts, jte, kts, kte  )
 
-      ELSEIF( (rk_step == 3) .and. (adv_opt == WENOPD_SCALAR) ) THEN
+      ELSEIF( (rk_step == rk_order) .and. (adv_opt == WENOPD_SCALAR) ) THEN
 
         CALL advect_scalar_wenopd   ( scalar(ims,kms,jms,im),             &
                                       scalar_old(ims,kms,jms,im),         &
                                       advect_tend(ims,kms,jms),           &
-                                      ru, rv, ww, c1h, c2h,               &
+                                      ru, rv, wwE, c1h, c2h,              &
                                       mut, mub, mu_old,                   &
                                       time_step, config_flags,            &
                                       msfux, msfuy, msfvx, msfvy,         &
                                       msftx, msfty, fnm, fnp,             &
-                                      rdx, rdy, rdnw,dt,                  &
+                                      rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt
                                       ids, ide, jds, jde, kds, kde,       &
                                       ims, ime, jms, jme, kms, kme,       &
                                       its, ite, jts, jte, kts, kte     )
@@ -1128,7 +1294,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
         CALL advect_scalar     ( scalar(ims,kms,jms,im),        &
                                  scalar(ims,kms,jms,im),        &
                                  advect_tend(ims,kms,jms),      &
-                                 ru, rv, ww, c1h, c2h,          &
+                                 ru, rv, wwE, c1h, c2h,         &
                                  mut, time_step,                &
                                  config_flags,                  &
                                  msfux, msfuy, msfvx, msfvy,    &
@@ -1140,6 +1306,26 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
       END IF
 
+      IF( ieva ) THEN
+     
+       CALL advect_s_implicit ( scalar(ims,kms,jms,im),         &
+                                scalar_old(ims,kms,jms,im),     &
+                                advect_tend(ims,kms,jms),       &
+                                ru, rv, wwI,                    &
+                                c1h, c2h,                       &
+                                mut, mut, mut,                  &
+                                config_flags,                   &
+                                msfux, msfuy, msfvx, msfvy,     &
+                                msftx, msfty,                   &
+                                fnm, fnp,                       &
+                                dt_step,                        &
+                                rdx, rdy, rdnw,                 &
+                                ids, ide, jds, jde, kds, kde,   &
+                                ims, ime, jms, jme, kms, kme,   &
+                                its, ite, jts, jte, kts, kte )
+                               
+     ENDIF
+    
      IF((config_flags%cu_physics == GDSCHEME .OR. config_flags%cu_physics == G3SCHEME .OR. &
          config_flags%cu_physics == GFSCHEME .OR.    &
          config_flags%cu_physics == KFETASCHEME .OR. config_flags%cu_physics == MSKFSCHEME .OR. &
@@ -1195,10 +1381,12 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
     ENDIF diff_opt1
 
-    IF ( (diff_6th_opt .NE. 0 ) .and. (.not. mix6_off) )              &
+    IF ( (diff_6th_opt .NE. 0) .and. (.not. mix6_off) ) THEN
+
       CALL sixth_order_diffusion( 'm', scalar(ims,kms,jms,im),        &
                                        scalar_tends(ims,kms,jms,im),  &
-                                       mut, dt, config_flags, c1h,c2h,&
+                                       mut, dt_step,                  &
+                                       config_flags, c1h, c2h,        &
                                        diff_6th_opt, diff_6th_factor, &
                                        phb, ph,                       &
                                        rdx, rdy,                      &
@@ -1208,6 +1396,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                        ids, ide, jds, jde, kds, kde,  &
                                        ims, ime, jms, jme, kms, kme,  &
                                        its, ite, jts, jte, kts, kte )
+    ENDIF
 
   ENDIF rk_step_1
 

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -9,8 +9,8 @@ MODULE module_em
    USE module_advect_em, only: advect_u, advect_v, advect_w, advect_scalar, advect_scalar_pd, advect_scalar_mono, &
         advect_weno_u, advect_weno_v, advect_weno_w, advect_scalar_weno,  advect_scalar_wenopd
    
-   USE module_big_step_utilities_em, only: grid_config_rec_type, calculate_full, couple_momentum, calc_mu_uv, calc_ww_cp, &
-        calc_cq, calc_alt, calc_php, set_tend, rhs_ph, horizontal_pressure_gradient, pg_buoy_w, w_damp, &
+   USE module_big_step_utilities_em, only: grid_config_rec_type, calculate_full, couple_momentum, calc_mu_uv, calc_mu_uv_1, &
+        calc_ww_cp, calc_cq, calc_alt, calc_php, set_tend, rhs_ph, horizontal_pressure_gradient, pg_buoy_w, w_damp, &
         perturbation_coriolis, coriolis, curvature, horizontal_diffusion, horizontal_diffusion_3dmp, &
         vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, sixth_order_diffusion, & 
         rk_rayleigh_damp, theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
@@ -343,6 +343,8 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 ! IEVA declarations
    REAL , DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
    REAL , DIMENSION( ims:ime , jms:jme )         :: mut_old, mut_new                                                              
+   REAL , DIMENSION( ims:ime , jms:jme )         :: muu_old, muu_new                                                              
+   REAL , DIMENSION( ims:ime , jms:jme )         :: muv_old, muv_new                                                              
    LOGICAL                                       :: ieva
    
 !<DESCRIPTION>
@@ -430,16 +432,10 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    rk_order = config_flags%rk_ord
    dt_step  = dt / (rk_order - rk_step + 1)   ! needed for calculations using sub-rk step
 
-! Need an estimate of the mut at the n time level...
-
-   CALL calculate_full( mut_old, mub, mu_old,     &
-                        ids, ide, jds, jde, 1, 2, &
-                        ims, ime, jms, jme, 1, 1, &
-                        its, ite, jts, jte, 1, 1 )
                         
 ! Code for splitting vertical velocity into ex/im parts
 
-   CALL WW_SPLIT(wwE, wwI, ph, phb,                &
+   CALL WW_SPLIT(wwE, wwI,                         &
                  u,  v,  ww,                       &
                  mut, rdnw, msfty,                 &
                  c1f, c2f,                         &
@@ -455,6 +451,13 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    ieva = CHK_IEVA( config_flags, rk_step ) 
 
    IF( ieva ) THEN
+   
+! Need an estimate of the mut at the n time level...
+
+   CALL calculate_full( mut_old,  mub, mu_old,     &
+                        ids, ide, jds, jde, 1, 2,  &
+                        ims, ime, jms, jme, 1, 1,  &
+                        its, ite, jts, jte, 1, 1 )
 
 ! Estimate new temporary column mass
                         
@@ -467,6 +470,19 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                        ims, ime, jms, jme, kms, kme,        &
                        its, ite, jts, jte, kts, kte    )
                          
+! Create staggered mass values for u and v points
+
+   CALL calc_mu_uv_1 ( config_flags,                 &
+                       mut_old, muu_old, muv_old,    &
+                       ids, ide, jds, jde, kds, kde, &
+                       ims, ime, jms, jme, kms, kme, &
+                       its, ite, jts, jte, kts, kte )
+                      
+   CALL calc_mu_uv_1 ( config_flags,                 &
+                       mut_new, muu_new, muv_new,    &
+                       ids, ide, jds, jde, kds, kde, &
+                       ims, ime, jms, jme, kms, kme, &
+                       its, ite, jts, jte, kts, kte )
 
    ENDIF
 
@@ -501,7 +517,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
      CALL advect_u_implicit ( u, u_old, ru_tend, ru, rv, wwI,  &
                               c1h, c2h,                        &
-                              mut_old, mut, mut_new,           &
+                              muu_old, muu, muu_new,           &
                               config_flags,                    &
                               msfux, msfuy, msfvx, msfvy,      &
                               msftx, msfty,                    &
@@ -542,7 +558,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
      
      CALL advect_v_implicit ( v, v_old, rv_tend, ru, rv, wwI,  &
                               c1h, c2h,                        &
-                              mut_old, mut, mut_new,           &
+                              muv_old, muv, muv_new,           &
                               config_flags,                    &
                               msfux, msfuy, msfvx, msfvy,      &
                               msftx, msfty,                    &
@@ -1081,7 +1097,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                             tenddec,                         &
                             rk_step, dt_step,                &
                             ru, rv, ww,                      &  
-                            u_old,  v_old,                   &  
+                            u,   v,                          &  
                             mut, mub, mu_old,                &
                             c1h, c2h, c1f, c2f, alt,         &
                             scalar_old, scalar,              &
@@ -1130,8 +1146,8 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,     &
                                                                       rv,     &
                                                                       ww,     &
-                                                                      u_old,  &
-                                                                      v_old,  &
+                                                                      u,      &
+                                                                      v,      &
                                                                       xkmhd,  &
                                                                       alt,    &
                                                                       phb,    &
@@ -1202,8 +1218,8 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
 ! Code for splitting vertical velocity into ex/im parts
 
-   CALL WW_SPLIT(wwE, wwI, ph, phb,                &
-                 u_old, v_old, ww,                 &
+   CALL WW_SPLIT(wwE, wwI,                         &
+                 u,   v,    ww,                    &
                  mut, rdnw, msfty,                 &
                  c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -10,10 +10,10 @@ MODULE module_em
         advect_weno_u, advect_weno_v, advect_weno_w, advect_scalar_weno,  advect_scalar_wenopd
    
    USE module_big_step_utilities_em, only: grid_config_rec_type, calculate_full, couple_momentum, calc_mu_uv, calc_ww_cp, &
-        calc_cq, calc_alt, calc_php, set_tend, rhs_ph, &
-    horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
-        horizontal_diffusion_3dmp, vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, sixth_order_diffusion, rk_rayleigh_damp, &
-        theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
+        calc_cq, calc_alt, calc_php, set_tend, rhs_ph, horizontal_pressure_gradient, pg_buoy_w, w_damp, &
+        perturbation_coriolis, coriolis, curvature, horizontal_diffusion, horizontal_diffusion_3dmp, &
+        vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, sixth_order_diffusion, & 
+        rk_rayleigh_damp, theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
 
   USE module_ieva_em, only: advect_u_implicit, advect_v_implicit, advect_w_implicit, advect_s_implicit, advect_ph_implicit, &
                             chk_ieva, ww_split, calc_mut_new
@@ -485,17 +485,58 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           its, ite, jts, jte, kts, kte )
 
    ELSE
-     
-     CALL advect_v ( v, v , rv_tend, ru, rv, ww,  &
-                   c1h, c2h,                     &
-                   mut, time_step, config_flags, &
-                   msfux, msfuy, msfvx, msfvy,   &
-                   msftx, msfty,                 &
-                   fnm, fnp, rdx, rdy, rdnw,     &
-                   ids, ide, jds, jde, kds, kde, &
-                   ims, ime, jms, jme, kms, kme, &
-                   its, ite, jts, jte, kts, kte )
-  ENDIF
+
+     CALL advect_u ( u, u , ru_tend, ru, rv, wwE,  &
+                     c1h, c2h,                     &
+                     mut, time_step, config_flags, &
+                     msfux, msfuy, msfvx, msfvy,   &
+                     msftx, msfty,                 &
+                     fnm, fnp, rdx, rdy, rdnw,     &
+                     ids, ide, jds, jde, kds, kde, &
+                     ims, ime, jms, jme, kms, kme, &
+                     its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF( ieva ) THEN
+
+     CALL advect_u_implicit ( u, u_old, ru_tend, ru, rv, wwI,  &
+                              c1h, c2h,                        &
+                              mut_old, mut, mut_new,           &
+                              config_flags,                    &
+                              msfux, msfuy, msfvx, msfvy,      &
+                              msftx, msfty,                    &
+                              fnm, fnp,                        &
+                              dt_step,                         &
+                              rdx, rdy, rdnw,                  &
+                              ids, ide, jds, jde, kds, kde,    &
+                              ims, ime, jms, jme, kms, kme,    &
+                              its, ite, jts, jte, kts, kte )
+   ENDIF
+
+   IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+
+      CALL advect_weno_v ( v, v , rv_tend, ru, rv, wwE,  &
+                           c1h, c2h,                     &
+                           mut, time_step, config_flags, &
+                           msfux, msfuy, msfvx, msfvy,   &
+                           msftx, msfty,                 &
+                           fnm, fnp, rdx, rdy, rdnw,     &
+                           ids, ide, jds, jde, kds, kde, &
+                           ims, ime, jms, jme, kms, kme, &
+                           its, ite, jts, jte, kts, kte )
+
+   ELSE
+
+     CALL advect_v ( v, v , rv_tend, ru, rv, wwE,  &
+                     c1h, c2h,                     &
+                     mut, time_step, config_flags, &
+                     msfux, msfuy, msfvx, msfvy,   &
+                     msftx, msfty,                 &
+                     fnm, fnp, rdx, rdy, rdnw,     &
+                     ids, ide, jds, jde, kds, kde, &
+                     ims, ime, jms, jme, kms, kme, &
+                     its, ite, jts, jte, kts, kte )
+   ENDIF
 
    IF( ieva ) THEN
      
@@ -514,30 +555,34 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    ENDIF
 
    IF (non_hydrostatic) THEN
+
      IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
-     CALL advect_weno_w ( w, w, rw_tend, ru, rv, ww,    &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdn,      &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
+
+       CALL advect_weno_w ( w, w, rw_tend, ru, rv, ww,    &
+                            c1h, c2h,                     &
+                            mut, time_step, config_flags, &
+                            msfux, msfuy, msfvx, msfvy,   &
+                            msftx, msfty,                 &
+                            fnm, fnp, rdx, rdy, rdn,      &
+                            ids, ide, jds, jde, kds, kde, &
+                            ims, ime, jms, jme, kms, kme, &
+                            its, ite, jts, jte, kts, kte )
 
      ELSE
      
-     CALL advect_w ( w, w, rw_tend, ru, rv, ww,    &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdn,      &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
+       CALL advect_w ( w, w, rw_tend, ru, rv, ww,    &
+                       c1h, c2h,                     &
+                       mut, time_step, config_flags, &
+                       msfux, msfuy, msfvx, msfvy,   &
+                       msftx, msfty,                 &
+                       fnm, fnp, rdx, rdy, rdn,      &
+                       ids, ide, jds, jde, kds, kde, &
+                       ims, ime, jms, jme, kms, kme, &
+                       its, ite, jts, jte, kts, kte )
      ENDIF
-   ENDIF
+
+   ENDIF  ! non-hydrostatic
+
 !  theta flux divergence
 
 ! 11/2016 ERM: Use WENO for theta flux on 3rd RK step if using WENO_SCALAR or WENOPD_SCALAR
@@ -550,15 +595,15 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
      
 ! also use weno for monotonic scalar option so that the h_ and z_tendency arrays are not needed
 
-       CALL advect_scalar_weno ( t, t, t_tend, ru, rv, ww,      &
-                                 c1h, c2h, mut, time_step,      &
-                                 config_flags,                  &
-                                 msfux, msfuy, msfvx, msfvy,    &
-                                 msftx, msfty, fnm, fnp,        &
-                                 rdx, rdy, rdnw,                &
-                                 ids, ide, jds, jde, kds, kde,  &
-                                 ims, ime, jms, jme, kms, kme,  &
-                                 its, ite, jts, jte, kts, kte  )
+     CALL advect_scalar_weno ( t, t, t_tend, ru, rv, ww,      &
+                               c1h, c2h, mut, time_step,      &
+                               config_flags,                  &
+                               msfux, msfuy, msfvx, msfvy,    &
+                               msftx, msfty, fnm, fnp,        &
+                               rdx, rdy, rdnw,                &
+                               ids, ide, jds, jde, kds, kde,  &
+                               ims, ime, jms, jme, kms, kme,  &
+                               its, ite, jts, jte, kts, kte  )
    ELSE
 
      CALL advect_scalar ( t, t, t_tend, ru, rv, ww,     &
@@ -571,7 +616,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           ims, ime, jms, jme, kms, kme, &
                           its, ite, jts, jte, kts, kte )
 
-     ENDIF
+   ENDIF
 
    IF( ieva ) THEN
       

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -192,7 +192,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                          ru_tendf, rv_tendf, rw_tendf, ph_tendf, t_tendf, &
                          mu_tend, u_save, v_save, w_save, ph_save,        &
                          t_save, mu_save, RTHFTEN,                        &
-                         ru, rv, rw, ww,                                  &
+                         ru, rv, rw, ww, wwE, wwI,                        &
                          u, v, w, t, ph,                                  &
                          u_old, v_old, w_old, t_old, ph_old,              &
                          h_diabatic, phb,t_init,                          &
@@ -1096,7 +1096,7 @@ END SUBROUTINE rk_addtend_dry
 SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                             tenddec,                         &
                             rk_step, dt_step,                &
-                            ru, rv, ww,                      &  
+                            ru, rv, ww, wwE, wwI,            &  
                             u_old, v_old,                    &  
                             mut, mub, mu_old,                &
                             c1h, c2h, c1f, c2f, alt,         &

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -11,13 +11,12 @@ MODULE module_em
    
    USE module_big_step_utilities_em, only: grid_config_rec_type, calculate_full, couple_momentum, calc_mu_uv, calc_ww_cp, &
         calc_cq, calc_alt, calc_php, set_tend, rhs_ph, &
-        horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
-        horizontal_diffusion_3dmp, vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, &
-        sixth_order_diffusion, rk_rayleigh_damp, theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
-  
+    horizontal_pressure_gradient, pg_buoy_w, w_damp, perturbation_coriolis, coriolis, curvature, horizontal_diffusion, &
+        horizontal_diffusion_3dmp, vertical_diffusion_u, vertical_diffusion_v, vertical_diffusion, vertical_diffusion_3dmp, sixth_order_diffusion, rk_rayleigh_damp, &
+        theta_relaxation, vertical_diffusion_mp, zero_tend, zero_tend2d
+
   USE module_ieva_em, only: advect_u_implicit, advect_v_implicit, advect_w_implicit, advect_s_implicit, advect_ph_implicit, &
                             chk_ieva, ww_split, calc_mut_new
-  
   USE module_state_description, only: param_first_scalar, p_qr, p_qv, p_qc, p_qg, p_qi, p_qs, tiedtkescheme,ntiedtkescheme, heldsuarez, &
         positivedef, gdscheme, g3scheme, gfscheme, kfetascheme, mskfscheme, monotonic, wenopd_scalar, weno_scalar, weno_mom
 
@@ -319,7 +318,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
    REAL ,                                      INTENT(IN   ) :: rdx,     &
                                                                 rdy,     &
-                                                                dt,      &    ! this is the large time step
+                                                                dt,      &
                                                                 u_frame, &
                                                                 v_frame, &
                                                                 khdif,   &
@@ -486,57 +485,16 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
    ELSE
      
-     CALL advect_u ( u, u , ru_tend, ru, rv, wwE,  &
-                     c1h, c2h,                     &
-                     mut, time_step, config_flags, &
-                     msfux, msfuy, msfvx, msfvy,   &
-                     msftx, msfty,                 &
-                     fnm, fnp, rdx, rdy, rdnw,     &
-                     ids, ide, jds, jde, kds, kde, &
-                     ims, ime, jms, jme, kms, kme, &
-                     its, ite, jts, jte, kts, kte )
-   ENDIF
-
-   IF( ieva ) THEN
-
-     CALL advect_u_implicit ( u, u_old, ru_tend, ru, rv, wwI,  &
-                              c1h, c2h,                        &
-                              mut_old, mut, mut_new,           &
-                              config_flags,                    &
-                              msfux, msfuy, msfvx, msfvy,      &
-                              msftx, msfty,                    &
-                              fnm, fnp,                        &
-                              dt_step,                         &
-                              rdx, rdy, rdnw,                  &
-                              ids, ide, jds, jde, kds, kde,    &
-                              ims, ime, jms, jme, kms, kme,    &
-                              its, ite, jts, jte, kts, kte )
-   ENDIF
-
-   IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
-
-      CALL advect_weno_v ( v, v , rv_tend, ru, rv, wwE,  &
-                           c1h, c2h,                     &
-                           mut, time_step, config_flags, &
-                           msfux, msfuy, msfvx, msfvy,   &
-                           msftx, msfty,                 &
-                           fnm, fnp, rdx, rdy, rdnw,     &
-                           ids, ide, jds, jde, kds, kde, &
-                           ims, ime, jms, jme, kms, kme, &
-                           its, ite, jts, jte, kts, kte )
-
-   ELSE
-     
-    CALL advect_v ( v, v , rv_tend, ru, rv, wwE,  &
-                    c1h, c2h,                     &
-                    mut, time_step, config_flags, &
-                    msfux, msfuy, msfvx, msfvy,   &
-                    msftx, msfty,                 &
-                    fnm, fnp, rdx, rdy, rdnw,     &
-                    ids, ide, jds, jde, kds, kde, &
-                    ims, ime, jms, jme, kms, kme, &
-                    its, ite, jts, jte, kts, kte )
-   ENDIF
+     CALL advect_v ( v, v , rv_tend, ru, rv, ww,  &
+                   c1h, c2h,                     &
+                   mut, time_step, config_flags, &
+                   msfux, msfuy, msfvx, msfvy,   &
+                   msftx, msfty,                 &
+                   fnm, fnp, rdx, rdy, rdnw,     &
+                   ids, ide, jds, jde, kds, kde, &
+                   ims, ime, jms, jme, kms, kme, &
+                   its, ite, jts, jte, kts, kte )
+  ENDIF
 
    IF( ieva ) THEN
      
@@ -555,34 +513,30 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    ENDIF
 
    IF (non_hydrostatic) THEN
-   
-    IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
-     
-      CALL advect_weno_w ( w, w, rw_tend, ru, rv, wwE,    &
-                            c1h, c2h,                     &
-                            mut, time_step, config_flags, &
-                            msfux, msfuy, msfvx, msfvy,   &
-                            msftx, msfty,                 &
-                            fnm, fnp, rdx, rdy, rdn,      &
-                            ids, ide, jds, jde, kds, kde, &
-                            ims, ime, jms, jme, kms, kme, &
-                            its, ite, jts, jte, kts, kte )
+     IF( (rk_step == rk_order) .and. ( adv_opt == WENO_MOM ) ) THEN
+     CALL advect_weno_w ( w, w, rw_tend, ru, rv, ww,    &
+                     c1h, c2h,                     &
+                     mut, time_step, config_flags, &
+                     msfux, msfuy, msfvx, msfvy,   &
+                     msftx, msfty,                 &
+                     fnm, fnp, rdx, rdy, rdn,      &
+                     ids, ide, jds, jde, kds, kde, &
+                     ims, ime, jms, jme, kms, kme, &
+                     its, ite, jts, jte, kts, kte )
 
-    ELSE
+     ELSE
      
-      CALL advect_w ( w, w, rw_tend, ru, rv, wwE,   &
-                      c1h, c2h,                     &
-                      mut, time_step, config_flags, &
-                      msfux, msfuy, msfvx, msfvy,   &
-                      msftx, msfty,                 &
-                      fnm, fnp, rdx, rdy, rdn,      &
-                      ids, ide, jds, jde, kds, kde, &
-                      ims, ime, jms, jme, kms, kme, &
-                      its, ite, jts, jte, kts, kte )
-    ENDIF
-    
-   ENDIF  ! Non-Hydrostatic
-   
+     CALL advect_w ( w, w, rw_tend, ru, rv, ww,    &
+                     c1h, c2h,                     &
+                     mut, time_step, config_flags, &
+                     msfux, msfuy, msfvx, msfvy,   &
+                     msftx, msfty,                 &
+                     fnm, fnp, rdx, rdy, rdn,      &
+                     ids, ide, jds, jde, kds, kde, &
+                     ims, ime, jms, jme, kms, kme, &
+                     its, ite, jts, jte, kts, kte )
+     ENDIF
+   ENDIF
 !  theta flux divergence
 
 ! 11/2016 ERM: Use WENO for theta flux on 3rd RK step if using WENO_SCALAR or WENOPD_SCALAR
@@ -595,18 +549,18 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
      
 ! also use weno for monotonic scalar option so that the h_ and z_tendency arrays are not needed
 
-     CALL advect_scalar_weno ( t, t, t_tend, ru, rv, wwE,    &
-                              c1h, c2h, mut, time_step,      &
-                              config_flags,                  &
-                              msfux, msfuy, msfvx, msfvy,    &
-                              msftx, msfty, fnm, fnp,        &
-                              rdx, rdy, rdnw,                &
-                              ids, ide, jds, jde, kds, kde,  &
-                              ims, ime, jms, jme, kms, kme,  &
-                              its, ite, jts, jte, kts, kte  )
+       CALL advect_scalar_weno ( t, t, t_tend, ru, rv, ww,      &
+                                 c1h, c2h, mut, time_step,      &
+                                 config_flags,                  &
+                                 msfux, msfuy, msfvx, msfvy,    &
+                                 msftx, msfty, fnm, fnp,        &
+                                 rdx, rdy, rdnw,                &
+                                 ids, ide, jds, jde, kds, kde,  &
+                                 ims, ime, jms, jme, kms, kme,  &
+                                 its, ite, jts, jte, kts, kte  )
    ELSE
 
-     CALL advect_scalar ( t, t, t_tend, ru, rv, wwE,    &
+     CALL advect_scalar ( t, t, t_tend, ru, rv, ww,     &
                           c1h, c2h,                     &
                           mut, time_step, config_flags, &
                           msfux, msfuy, msfvx, msfvy,   &
@@ -616,8 +570,8 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           ims, ime, jms, jme, kms, kme, &
                           its, ite, jts, jte, kts, kte )
 
-   ENDIF
-   
+     ENDIF
+
    IF( ieva ) THEN
       
      CALL advect_s_implicit ( t, t_old, t_tend, ru, rv, wwI,  &
@@ -634,34 +588,34 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                               its, ite, jts, jte, kts, kte )
 
    ENDIF
-   
+     
    IF ( config_flags%cu_physics == GDSCHEME  .OR.     &
         config_flags%cu_physics == GFSCHEME  .OR.     &
         config_flags%cu_physics == G3SCHEME  .OR.     &
         config_flags%cu_physics == NTIEDTKESCHEME )  THEN     ! NTiedtke
 
-  ! theta advection only:
+     ! theta advection only:
 
-      CALL set_tend( RTHFTEN, t_tend, msfty,          &
-                     ids, ide, jds, jde, kds, kde,    &
-                     ims, ime, jms, jme, kms, kme,    &
-                     its, ite, jts, jte, kts, kte     )
+     CALL set_tend( RTHFTEN, t_tend, msfty,          &
+                    ids, ide, jds, jde, kds, kde,    &
+                    ims, ime, jms, jme, kms, kme,    &
+                    its, ite, jts, jte, kts, kte     )
 
-   ENDIF  ! cu_physics scheme
+   END IF
 
-     CALL rhs_ph( ph_tend, u, v, wwE, ph, ph, phb, w, &
-                  mut, muu, muv,                     &
-                  c1f, c2f,                          &
-                  fnm, fnp,                          &
-                  rdnw, cfn, cfn1, rdx, rdy,         &
-                  msfux, msfuy, msfvx,               &
-                  msfvx_inv, msfvy,                  &
-                  msftx, msfty,                      &
-                  non_hydrostatic,                   &
-                  config_flags,                      &
-                  ids, ide, jds, jde, kds, kde,      &
-                  ims, ime, jms, jme, kms, kme,      &
-                  its, ite, jts, jte, kts, kte      )
+   CALL rhs_ph( ph_tend, u, v, ww, ph, ph, phb, w, &
+                mut, muu, muv,                     &
+                c1f, c2f,                          &
+                fnm, fnp,                          &
+                rdnw, cfn, cfn1, rdx, rdy,         &
+                msfux, msfuy, msfvx,               &
+                msfvx_inv, msfvy,                  &
+                msftx, msfty,                      &
+                non_hydrostatic,                   &
+                config_flags,                      &
+                ids, ide, jds, jde, kds, kde,      &
+                ims, ime, jms, jme, kms, kme,      &
+                its, ite, jts, jte, kts, kte      )
 
     IF( ieva ) THEN
       
@@ -697,81 +651,82 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
      ENDIF
      
    ENDIF  ! IEVA
-      
-     CALL horizontal_pressure_gradient( ru_tend,rv_tend,                 &
-                                         ph,alt,p,pb,al,php,cqu,cqv,     &
-                                         muu,muv,mu,c1h,c2h,fnm,fnp,rdnw,&
-                                         cf1,cf2,cf3,cfn,cfn1,           &
-                                         rdx,rdy,msfux,msfuy,            &
-                                         msfvx,msfvy,msftx,msfty,        &
-                                         config_flags, non_hydrostatic,  &
-                                         top_lid,                        &
-                                         ids, ide, jds, jde, kds, kde,   &
-                                         ims, ime, jms, jme, kms, kme,   &
-                                         its, ite, jts, jte, kts, kte   )
 
-     IF (non_hydrostatic) THEN
-          CALL pg_buoy_w( rw_tend, p, cqw, mu, mub,       &
-                          c1f,c2f,                        &
-                          rdnw, rdn, g, msftx, msfty,     &
-                          ids, ide, jds, jde, kds, kde,   &
-                          ims, ime, jms, jme, kms, kme,   &
-                          its, ite, jts, jte, kts, kte   )
-     ENDIF
+   CALL horizontal_pressure_gradient( ru_tend,rv_tend,                 &
+                                       ph,alt,p,pb,al,php,cqu,cqv,     &
+                                       muu,muv,mu,c1h,c2h,fnm,fnp,rdnw,&
+                                       cf1,cf2,cf3,cfn,cfn1,           &
+                                       rdx,rdy,msfux,msfuy,            &
+                                       msfvx,msfvy,msftx,msfty,        &
+                                       config_flags, non_hydrostatic,  &
+                                       top_lid,                        &
+                                       ids, ide, jds, jde, kds, kde,   &
+                                       ims, ime, jms, jme, kms, kme,   &
+                                       its, ite, jts, jte, kts, kte   )
 
-     CALL w_damp   ( rw_tend, max_vert_cfl,            &
-                     max_horiz_cfl,                    &
-                     u, v, ww, w, mut, c1f, c2f, rdnw, &
-                     rdx, rdy, msfux, msfuy, msfvx,    &
-                     msfvy, dt, config_flags,          &
-                     ids, ide, jds, jde, kds, kde,     &
-                     ims, ime, jms, jme, kms, kme,     &
-                     its, ite, jts, jte, kts, kte     )
+   IF (non_hydrostatic) THEN
+        CALL pg_buoy_w( rw_tend, p, cqw, mu, mub,       &
+                        c1f,c2f,                        &
+                        rdnw, rdn, g, msftx, msfty,     &
+                        ids, ide, jds, jde, kds, kde,   &
+                        ims, ime, jms, jme, kms, kme,   &
+                        its, ite, jts, jte, kts, kte   )
+   ENDIF
 
-     IF(config_flags%pert_coriolis) THEN
+   CALL w_damp   ( rw_tend, max_vert_cfl,             &
+                    max_horiz_cfl,                    &
+                    u, v, ww, w, mut, c1f, c2f, rdnw, &
+                    rdx, rdy, msfux, msfuy, msfvx,    &
+                    msfvy, dt, config_flags,          &
+                    ids, ide, jds, jde, kds, kde,     &
+                    ims, ime, jms, jme, kms, kme,     &
+                    its, ite, jts, jte, kts, kte     )
 
-          CALL perturbation_coriolis ( ru, rv, rw,                   &
-                                       ru_tend,  rv_tend,  rw_tend,  &
-                                       config_flags,                 &
-                                       u_base, v_base, z_base,       &
-                                       muu, muv, c1h, c2h, phb, ph,  &
-                                       msftx, msfty, msfux, msfuy,   &
-                                       msfvx, msfvy,                 &
-                                       f, e, sina, cosa, fnm, fnp,   &
-                                       ids, ide, jds, jde, kds, kde, &
-                                       ims, ime, jms, jme, kms, kme, &
-                                       its, ite, jts, jte, kts, kte )
-     ELSE
-          CALL coriolis ( ru, rv, rw,                   &
-                          ru_tend,  rv_tend,  rw_tend,  &
-                          config_flags,                 &
-                          msftx, msfty, msfux, msfuy,   &
-                          msfvx, msfvy,                 &
-                          f, e, sina, cosa, fnm, fnp,   &
-                          ids, ide, jds, jde, kds, kde, &
-                          ims, ime, jms, jme, kms, kme, &
-                          its, ite, jts, jte, kts, kte )
+   IF(config_flags%pert_coriolis) THEN
 
-     END IF
+        CALL perturbation_coriolis ( ru, rv, rw,                   &
+                                     ru_tend,  rv_tend,  rw_tend,  &
+                                     config_flags,                 &
+                                     u_base, v_base, z_base,       &
+                                     muu, muv, c1h, c2h, phb, ph,  &
+                                     msftx, msfty, msfux, msfuy,   &
+                                     msfvx, msfvy,                 &
+                                     f, e, sina, cosa, fnm, fnp,   &
+                                     ids, ide, jds, jde, kds, kde, &
+                                     ims, ime, jms, jme, kms, kme, &
+                                     its, ite, jts, jte, kts, kte )
+   ELSE
+        CALL coriolis ( ru, rv, rw,                   &
+                        ru_tend,  rv_tend,  rw_tend,  &
+                        config_flags,                 &
+                        msftx, msfty, msfux, msfuy,   &
+                        msfvx, msfvy,                 &
+                        f, e, sina, cosa, fnm, fnp,   &
+                        ids, ide, jds, jde, kds, kde, &
+                        ims, ime, jms, jme, kms, kme, &
+                        its, ite, jts, jte, kts, kte )
 
-     CALL curvature ( ru, rv, rw, u, v, w,            &
-                       ru_tend,  rv_tend,  rw_tend,    &
-                       config_flags,                   &
-                       msfux, msfuy, msfvx, msfvy,     &
-                       msftx, msfty,                   &
-                       clat, fnm, fnp, rdx, rdy,       &
-                       ids, ide, jds, jde, kds, kde,   &
-                       ims, ime, jms, jme, kms, kme,   &
-                       its, ite, jts, jte, kts, kte   )
+   END IF
+
+   CALL curvature ( ru, rv, rw, u, v, w,            &
+                     ru_tend,  rv_tend,  rw_tend,    &
+                     config_flags,                   &
+                     msfux, msfuy, msfvx, msfvy,     &
+                     msftx, msfty,                   &
+                     clat, fnm, fnp, rdx, rdy,       &
+                     ids, ide, jds, jde, kds, kde,   &
+                     ims, ime, jms, jme, kms, kme,   &
+                     its, ite, jts, jte, kts, kte   )
 
 ! Damping option added for Held-Suarez test (also uses lw option HELDSUAREZ)
-      IF (config_flags%ra_lw_physics == HELDSUAREZ) THEN
-         CALL held_suarez_damp ( ru_tend, rv_tend,               &   
-                                 ru,rv,p,pb,                     &
-                                 ids, ide, jds, jde, kds, kde,   &
-                                 ims, ime, jms, jme, kms, kme,   &
-                                 its, ite, jts, jte, kts, kte   )
-      END IF
+
+    IF (config_flags%ra_lw_physics == HELDSUAREZ) THEN
+       CALL held_suarez_damp ( ru_tend, rv_tend,               &   
+                               ru,rv,p,pb,                     &
+                               ids, ide, jds, jde, kds, kde,   &
+                               ims, ime, jms, jme, kms, kme,   &
+                               its, ite, jts, jte, kts, kte   )
+    END IF
 
 !**************************************************************
 !
@@ -1079,7 +1034,7 @@ END SUBROUTINE rk_addtend_dry
 SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                             tenddec,                         &
                             rk_step, dt_step,                &
-                            ru, rv, ww, u,  v,  w,           &  
+                            ru, rv, ww,                      &  
                             u_old,  v_old,                   &  
                             mut, mub, mu_old,                &
                             c1h, c2h, c1f, c2f, alt,         &
@@ -1129,9 +1084,6 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,     &
                                                                       rv,     &
                                                                       ww,     &
-                                                                      u,      &
-                                                                      v,      &
-                                                                      w,      &
                                                                       u_old,  &
                                                                       v_old,  &
                                                                       xkmhd,  &
@@ -1213,6 +1165,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                  ids, ide, jds, jde, kds, kde,     &
                  ims, ime, jms, jme, kms, kme,     &
                  its, ite, jts, jte, kts, kte )
+   
    CALL nl_get_time_step ( 1, time_step )
 
    scalar_loop : DO im = scs, sce
@@ -1232,8 +1185,9 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                       ims, ime, jms, jme, kms, kme, &
                       its, ite, jts, jte, kts, kte )
 
+     CALL nl_get_time_step ( 1, time_step )
 
-    IF( (rk_step == rk_order) .and. (adv_opt == POSITIVEDEF) ) THEN
+      IF( (rk_step == rk_order) .and. (adv_opt == POSITIVEDEF) ) THEN
 
         CALL advect_scalar_pd       ( scalar(ims,kms,jms,im),             &
                                       scalar_old(ims,kms,jms,im),         &
@@ -1245,7 +1199,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                       time_step, config_flags, tenddec,   &
                                       msfux, msfuy, msfvx, msfvy,         &
                                       msftx, msfty, fnm, fnp,             &
-                                      rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt here
+                                      rdx, rdy, rdnw, dt_step,            &  
                                       ids, ide, jds, jde, kds, kde,       &
                                       ims, ime, jms, jme, kms, kme,       &
                                       its, ite, jts, jte, kts, kte     )
@@ -1262,17 +1216,17 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                         config_flags, tenddec,              &
                                         msfux, msfuy, msfvx, msfvy,         &
                                         msftx, msfty, fnm, fnp,             &
-                                        rdx, rdy, rdnw, dt_step,            &  ! dt_step == dt here
+                                        rdx, rdy, rdnw, dt_step,            &
                                         ids, ide, jds, jde, kds, kde,       &
                                         ims, ime, jms, jme, kms, kme,       &
                                         its, ite, jts, jte, kts, kte     )
 
       ELSE IF( (rk_step == rk_order) .and. (adv_opt == WENO_SCALAR) ) THEN
 
-        CALL advect_scalar_weno ( scalar(ims,kms,jms,im),        &
+        CALL advect_scalar_weno ( scalar(ims,kms,jms,im),       &
                                  scalar(ims,kms,jms,im),        &
                                  advect_tend(ims,kms,jms),      &
-                                 ru, rv, wwE, c1h, c2h,          &
+                                 ru, rv, wwE,                   &
                                  mut, time_step,                &
                                  config_flags,                  &
                                  msfux, msfuy, msfvx, msfvy,    &
@@ -1350,65 +1304,65 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
        diff_opt1 : IF (config_flags%diff_opt .eq. 1) THEN
 
-       IF (.not. mix2_off)                                                   &
-         CALL horizontal_diffusion ( 'm', scalar(ims,kms,jms,im),            &
-                                          scalar_tends(ims,kms,jms,im), mut, &
-                                          c1h, c2h, config_flags,            &
-                                          msfux, msfuy, msfvx, msfvx_inv,    &
-                                          msfvy, msftx, msfty,               &
-                                          khdq , xkmhd, rdx, rdy,            &
-                                          ids, ide, jds, jde, kds, kde,      &
-                                          ims, ime, jms, jme, kms, kme,      &
-                                          its, ite, jts, jte, kts, kte      )
+         IF (.not. mix2_off)                                                   &
+           CALL horizontal_diffusion ( 'm', scalar(ims,kms,jms,im),            &
+                                            scalar_tends(ims,kms,jms,im), mut, &
+                                            c1h, c2h, config_flags,            &
+                                            msfux, msfuy, msfvx, msfvx_inv,    &
+                                            msfvy, msftx, msfty,               &
+                                            khdq , xkmhd, rdx, rdy,            &
+                                            ids, ide, jds, jde, kds, kde,      &
+                                            ims, ime, jms, jme, kms, kme,      &
+                                            its, ite, jts, jte, kts, kte      )
 
-       pbl_test : IF (config_flags%bl_pbl_physics .eq. 0) THEN
+         pbl_test : IF (config_flags%bl_pbl_physics .eq. 0) THEN
 
-         IF( (moist_step) .and. ( im == P_QV)) THEN
+           IF( (moist_step) .and. ( im == P_QV)) THEN
 
-            CALL vertical_diffusion_mp ( scalar(ims,kms,jms,im),       &
-                                         scalar_tends(ims,kms,jms,im), &
-                                         config_flags, base, c1h, c2h, &
-                                         alt, mut, rdn, rdnw, kvdq ,   &
-                                         ids, ide, jds, jde, kds, kde, &
-                                         ims, ime, jms, jme, kms, kme, &
-                                         its, ite, jts, jte, kts, kte )
+              CALL vertical_diffusion_mp ( scalar(ims,kms,jms,im),       &
+                                           scalar_tends(ims,kms,jms,im), &
+                                           config_flags, base, c1h, c2h, &
+                                           alt, mut, rdn, rdnw, kvdq ,   &
+                                           ids, ide, jds, jde, kds, kde, &
+                                           ims, ime, jms, jme, kms, kme, &
+                                           its, ite, jts, jte, kts, kte )
 
-         ELSE
+           ELSE
 
-            CALL vertical_diffusion (  'm', scalar(ims,kms,jms,im),       &
-                                            scalar_tends(ims,kms,jms,im), &
-                                            config_flags, c1h, c2h,       &
-                                            alt, mut, rdn, rdnw, kvdq,    &
-                                            ids, ide, jds, jde, kds, kde, &
-                                            ims, ime, jms, jme, kms, kme, &
-                                            its, ite, jts, jte, kts, kte )
+              CALL vertical_diffusion (  'm', scalar(ims,kms,jms,im),       &
+                                              scalar_tends(ims,kms,jms,im), &
+                                              config_flags, c1h, c2h,       &
+                                              alt, mut, rdn, rdnw, kvdq,    &
+                                              ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte )
 
-         END IF
+           END IF
 
-      ENDIF pbl_test
+         ENDIF pbl_test
 
-    ENDIF diff_opt1
+       ENDIF diff_opt1
 
-    IF ( (diff_6th_opt .NE. 0) .and. (.not. mix6_off) ) THEN
+       IF ( (diff_6th_opt .NE. 0) .and. (.not. mix6_off) ) THEN
 
-      CALL sixth_order_diffusion( 'm', scalar(ims,kms,jms,im),        &
-                                       scalar_tends(ims,kms,jms,im),  &
-                                       mut, dt_step,                  &
-                                       config_flags, c1h, c2h,        &
-                                       diff_6th_opt, diff_6th_factor, &
-                                       phb, ph,                       &
-                                       rdx, rdy,                      &
-                                       msftx, msfty,                  &
-                                       msfux, msfuy,                  &
-                                       msfvx, msfvy,                  &
-                                       ids, ide, jds, jde, kds, kde,  &
-                                       ims, ime, jms, jme, kms, kme,  &
-                                       its, ite, jts, jte, kts, kte )
-    ENDIF
+         CALL sixth_order_diffusion( 'm', scalar(ims,kms,jms,im),        &
+                                          scalar_tends(ims,kms,jms,im),  &
+                                          mut, dt_step,                  &
+                                          config_flags, c1h, c2h,        &
+                                          diff_6th_opt, diff_6th_factor, &
+                                          phb, ph,                       &
+                                          rdx, rdy,                      &
+                                          msftx, msfty,                  &
+                                          msfux, msfuy,                  &
+                                          msfvx, msfvy,                  &
+                                          ids, ide, jds, jde, kds, kde,  &
+                                          ims, ime, jms, jme, kms, kme,  &
+                                          its, ite, jts, jte, kts, kte )
+       ENDIF
+       
+     ENDIF rk_step_1
 
-  ENDIF rk_step_1
-
- END DO scalar_loop
+   END DO scalar_loop
 
 END SUBROUTINE rk_scalar_tend
 

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -441,7 +441,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 ! Code for splitting vertical velocity into ex/im parts
 
    CALL WW_SPLIT(wwE, wwI, ph, phb,                &
-                 u, v, ww, w, mut, rdnw, msfty,    &
+                 u_old, v_old, ww, w, mut, rdnw, msfty,    &
                  c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &
                  msfvx, msfvy, dt,                 &
@@ -590,7 +590,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    IF(  ( config_flags%scalar_adv_opt == WENO_SCALAR      &
      .or. config_flags%scalar_adv_opt == WENOPD_SCALAR    &
      .or. config_flags%moist_adv_opt == WENO_SCALAR       &
-     .or. config_flags%moist_adv_opt == WENOPD_SCALAR )    &
+     .or. config_flags%moist_adv_opt == WENOPD_SCALAR )   &
      .and. (rk_step == rk_order) ) THEN
      
 ! also use weno for monotonic scalar option so that the h_ and z_tendency arrays are not needed
@@ -1080,8 +1080,9 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                             tenddec,                         &
                             rk_step, dt_step,                &
                             ru, rv, ww, u,  v,  w,           &  
+                            u_old,  v_old,                   &  
                             mut, mub, mu_old,                &
-                            c1h, c2h, alt,                   &
+                            c1h, c2h, c1f, c2f, alt,         &
                             scalar_old, scalar,              &
                             scalar_tends, advect_tend,       &
                             h_tendency, z_tendency,          &
@@ -1125,12 +1126,14 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(OUT  ) :: RQVFTEN
 
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,  &
-                                                                      rv,  &
-                                                                      ww,  &
-                                                                      u,   &
-                                                                      v,   &
-                                                                      w,   &
+   REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,     &
+                                                                      rv,     &
+                                                                      ww,     &
+                                                                      u,      &
+                                                                      v,      &
+                                                                      w,      &
+                                                                      u_old,  &
+                                                                      v_old,  &
                                                                       xkmhd,  &
                                                                       alt,    &
                                                                       phb,    &
@@ -1143,6 +1146,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                                                   base
 
    REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: c1h, c2h
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: c1f, c2f
 
    REAL , DIMENSION( ims:ime , jms:jme ) ,       INTENT(IN   ) :: msfux,    &
                                                                   msfuy,    &
@@ -1198,18 +1202,17 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                          
    ieva = CHK_IEVA( config_flags, rk_step )
 
+! Code for splitting vertical velocity into ex/im parts
+
    CALL WW_SPLIT(wwE, wwI, ph, phb,                &
-                 u, v, ww, w, mut, rdnw, msfty,    &
-                 c1h, c2h,                         &
+                 u_old, v_old, ww, w, mut, rdnw, msfty,    &
+                 c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &
                  msfvx, msfvy, dt,                 &
-                 config_flags, rk_step,            & 
+                 config_flags, rk_step,            &
                  ids, ide, jds, jde, kds, kde,     &
                  ims, ime, jms, jme, kms, kme,     &
-                 its, ite, jts, jte, kts, kte )             
-                 
-! IEVA
-
+                 its, ite, jts, jte, kts, kte )
    CALL nl_get_time_step ( 1, time_step )
 
    scalar_loop : DO im = scs, sce

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -440,7 +440,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 ! Code for splitting vertical velocity into ex/im parts
 
    CALL WW_SPLIT(wwE, wwI, ph, phb,                &
-                 u_old, v_old, ww,                 &
+                 u,  v,  ww,                       &
                  mut, rdnw, msfty,                 &
                  c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -452,7 +452,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
    IF( ieva ) THEN
    
-! Need an estimate of the mut at the n time level...
+! Need an estimate of the mut at the original ('n') time level...
 
    CALL calculate_full( mut_old,  mub, mu_old,     &
                         ids, ide, jds, jde, 1, 2,  &
@@ -1097,7 +1097,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                             tenddec,                         &
                             rk_step, dt_step,                &
                             ru, rv, ww,                      &  
-                            u,   v,                          &  
+                            u_old, v_old,                    &  
                             mut, mub, mu_old,                &
                             c1h, c2h, c1f, c2f, alt,         &
                             scalar_old, scalar,              &
@@ -1146,8 +1146,8 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme  ), INTENT(IN   ) ::     ru,     &
                                                                       rv,     &
                                                                       ww,     &
-                                                                      u,      &
-                                                                      v,      &
+                                                                      u_old,  &
+                                                                      v_old,  &
                                                                       xkmhd,  &
                                                                       alt,    &
                                                                       phb,    &
@@ -1197,6 +1197,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
 ! IEVA variables
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) :: wwE, wwI  
+   REAL, DIMENSION( ims:ime, jms:jme )          :: mut_old  
    LOGICAL                                      :: ieva
 
 !<DESCRIPTION>
@@ -1219,7 +1220,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 ! Code for splitting vertical velocity into ex/im parts
 
    CALL WW_SPLIT(wwE, wwI,                         &
-                 u,   v,    ww,                    &
+                 u_old,   v_old,    ww,            &
                  mut, rdnw, msfty,                 &
                  c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &
@@ -1228,6 +1229,17 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                  ids, ide, jds, jde, kds, kde,     &
                  ims, ime, jms, jme, kms, kme,     &
                  its, ite, jts, jte, kts, kte )
+                 
+                 
+   IF( ieva ) THEN
+   
+! Need an estimate of the mut at the original ('n') time level...
+
+    CALL calculate_full( mut_old,  mub, mu_old,     &
+                         ids, ide, jds, jde, 1, 2,  &
+                         ims, ime, jms, jme, 1, 1,  &
+                         its, ite, jts, jte, 1, 1 )
+   ENDIF
    
    CALL nl_get_time_step ( 1, time_step )
 
@@ -1338,7 +1350,7 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
                                 advect_tend(ims,kms,jms),       &
                                 ru, rv, wwI,                    &
                                 c1h, c2h,                       &
-                                mut, mut, mut,                  &
+                                mut_old, mut, mut,              &
                                 config_flags,                   &
                                 msfux, msfuy, msfvx, msfvy,     &
                                 msftx, msfty,                   &

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -431,10 +431,6 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    rk_order = config_flags%rk_ord
    dt_step  = dt / (rk_order - rk_step + 1)   ! needed for calculations using sub-rk step
 
-! IEVA
-   
-   ieva = CHK_IEVA( config_flags, rk_step ) 
-
 ! Need an estimate of the mut at the n time level...
 
    CALL calculate_full( mut_old, mub, mu_old,     &
@@ -442,17 +438,6 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                         ims, ime, jms, jme, 1, 1, &
                         its, ite, jts, jte, 1, 1 )
                         
-! Estimate new temporary column mass
-                        
-   CALL calc_mut_new ( u, v, c1h, c2h,                      &
-                       mut_old, muu, muv, mut_new,          &
-                       dt, rdx, rdy, msftx, msfty,          &
-                       msfux, msfuy, msfvx, msfvx_inv,      &
-                       msfvy, rdnw,                         &
-                       ids, ide, jds, jde, kds, kde,        &
-                       ims, ime, jms, jme, kms, kme,        &
-                       its, ite, jts, jte, kts, kte    )
-                         
 ! Code for splitting vertical velocity into ex/im parts
 
    CALL WW_SPLIT(wwE, wwI, ph, phb,                &
@@ -464,6 +449,26 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                  ids, ide, jds, jde, kds, kde,     &
                  ims, ime, jms, jme, kms, kme,     &
                  its, ite, jts, jte, kts, kte )              
+
+! IEVA ON/OFF
+   
+   ieva = CHK_IEVA( config_flags, rk_step ) 
+
+   IF( ieva ) THEN
+
+! Estimate new temporary column mass
+                        
+   CALL calc_mut_new ( u, v, c1h, c2h,                      &
+                       mut_old, muu, muv, mut_new,          &
+                       dt, rdx, rdy, msftx, msfty,          &
+                       msfux, msfuy, msfvx, msfvx_inv,      &
+                       msfvy, rdnw,                         &
+                       ids, ide, jds, jde, kds, kde,        &
+                       ims, ime, jms, jme, kms, kme,        &
+                       its, ite, jts, jte, kts, kte    )
+                         
+
+   ENDIF
 
 ! Okay do normal advection now....using the wwE array
 

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -440,7 +440,8 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 ! Code for splitting vertical velocity into ex/im parts
 
    CALL WW_SPLIT(wwE, wwI, ph, phb,                &
-                 u_old, v_old, ww, w, mut, rdnw, msfty,    &
+                 u_old, v_old, ww,                 &
+                 mut, rdnw, msfty,                 &
                  c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &
                  msfvx, msfvy, dt,                 &
@@ -1157,7 +1158,8 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 ! Code for splitting vertical velocity into ex/im parts
 
    CALL WW_SPLIT(wwE, wwI, ph, phb,                &
-                 u_old, v_old, ww, w, mut, rdnw, msfty,    &
+                 u_old, v_old, ww,                 &
+                 mut, rdnw, msfty,                 &
                  c1f, c2f,                         &
                  rdx, rdy, msfux, msfuy,           &
                  msfvx, msfvy, dt,                 &
@@ -1223,18 +1225,18 @@ SUBROUTINE rk_scalar_tend ( scs, sce, config_flags,          &
 
       ELSE IF( (rk_step == rk_order) .and. (adv_opt == WENO_SCALAR) ) THEN
 
-        CALL advect_scalar_weno ( scalar(ims,kms,jms,im),       &
-                                 scalar(ims,kms,jms,im),        &
-                                 advect_tend(ims,kms,jms),      &
-                                 ru, rv, wwE,                   &
-                                 mut, time_step,                &
-                                 config_flags,                  &
-                                 msfux, msfuy, msfvx, msfvy,    &
-                                 msftx, msfty, fnm, fnp,        &
-                                 rdx, rdy, rdnw,                &
-                                 ids, ide, jds, jde, kds, kde,  &
-                                 ims, ime, jms, jme, kms, kme,  &
-                                 its, ite, jts, jte, kts, kte  )
+        CALL advect_scalar_weno ( scalar(ims,kms,jms,im),        &
+                                  scalar(ims,kms,jms,im),        &
+                                  advect_tend(ims,kms,jms),      &
+                                  ru, rv, wwE, c1h, c2h,         &
+                                  mut, time_step,                &
+                                  config_flags,                  &
+                                  msfux, msfuy, msfvx, msfvy,    &
+                                  msftx, msfty, fnm, fnp,        &
+                                  rdx, rdy, rdnw,                &
+                                  ids, ide, jds, jde, kds, kde,  &
+                                  ims, ime, jms, jme, kms, kme,  &
+                                  its, ite, jts, jte, kts, kte  )
 
       ELSEIF( (rk_step == rk_order) .and. (adv_opt == WENOPD_SCALAR) ) THEN
 

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -1,0 +1,1272 @@
+MODULE module_ieva_em
+
+  USE module_bc
+  USE module_model_constants
+  USE module_wrf_error
+  
+  REAL(KIND=8), PARAMETER :: eps        = 1.0d-08
+  REAL,         PARAMETER :: alpha_max  = 1.1
+  REAL,         PARAMETER :: alpha_min  = 0.9
+
+CONTAINS
+
+LOGICAL FUNCTION CHK_IEVA( config_flags, rk_step )
+
+   IMPLICIT NONE
+
+   TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
+   INTEGER,                    INTENT(IN) :: rk_step
+
+   INTEGER :: zadvect_implicit
+   INTEGER :: rk_order
+
+   rk_order         = config_flags%rk_ord
+   zadvect_implicit = config_flags%zadvect_implicit
+
+   CHK_IEVA = .FALSE.
+
+   IF( zadvect_implicit .eq. 3 ) THEN   ! DO IEVA on all sub-steps of RK integrator
+       CHK_IEVA = .TRUE.
+   ENDIF
+
+   IF( zadvect_implicit .eq. 2 .and. rk_step .ge. rk_order-1 ) THEN ! DO IEVA on last two sub-steps of RK integrator
+       CHK_IEVA = .TRUE.
+   ENDIF
+
+   IF( zadvect_implicit .eq. 1 .and. rk_step .eq. rk_order ) THEN  ! DO IEVA on last sub-step of RK integrator
+       CHK_IEVA = .TRUE.
+   ENDIF
+
+RETURN
+END FUNCTION CHK_IEVA
+
+!-------------------------------------------------------------------------------
+! IEVA code for splitting vertical velocity for ex/im based on Shchepetkin (2015)
+
+SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
+                    u, v, ww, w, mut, rdnw, msfty,    &
+                    c1, c2,                           &
+                    rdx, rdy, msfux, msfuy,           &
+                    msfvx, msfvy, dt,                 &
+                    config_flags, rk_step,            &
+                    ids, ide, jds, jde, kds, kde,     &
+                    ims, ime, jms, jme, kms, kme,     &
+                    its, ite, jts, jte, kts, kte )
+                     
+   TYPE( grid_config_rec_type ) ,   INTENT(IN   ) :: config_flags
+
+   INTEGER ,          INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                       ims, ime, jms, jme, kms, kme, &
+                                       its, ite, jts, jte, kts, kte, &
+                                       rk_step
+
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, w, ph, phb
+
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(INOUT) ::  wwE, wwI
+
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   ) :: mut
+
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: rdnw 
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: c1, c2
+
+   REAL, INTENT(IN)    :: dt
+   REAL, INTENT(IN)    :: rdx, rdy
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux, msfuy
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfvx, msfvy, msfty
+
+! Local variables
+
+   REAL(KIND=4)    :: cr, cx, cy, c0, c2d, cw_max2, cw_min, cw, cff, rdz
+   INTEGER         :: i, j, k, ii, jj, i_start, i_end, j_start, j_end
+   LOGICAL         :: print_flag = .true.
+   SAVE            :: print_flag
+   
+! Implicit advection parameters based on Shchepetkin (2015)
+! Moved these to the top of the module.
+
+!  REAL, PARAMETER :: alpha_max  = 1.1
+!  REAL, PARAMETER :: alpha_min  = 0.9
+   REAL, PARAMETER :: cmnx_ratio = alpha_min/alpha_max
+   REAL, PARAMETER :: cutoff     = 2.0 - cmnx_ratio
+   REAL, PARAMETER :: r4cmx      = 1.0/(4.0 - 4.0*cmnx_ratio )
+   REAL, PARAMETER :: Ceps       = 0.9
+
+   LOGICAL         :: ieva
+
+! Debug declarations
+
+   REAL,    PARAMETER :: binfrac = 0.1
+   INTEGER, PARAMETER :: binsize = 11
+   INTEGER            :: count(binsize)
+   real(KIND=4)       :: binavg(binsize), crs(binsize)
+
+! Check to see if IEVA is on for this RK3 substep
+
+   ieva = CHK_IEVA(config_flags, rk_step)
+
+! =========================================================================
+! PRINT OUT IEVA INFO
+
+     IF( print_flag ) THEN
+       write(wrf_err_message,*) '----------------------------------------'
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  ZADVECT_IMPLICT = ', config_flags%zadvect_implicit
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  IEVA = ', ieva
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  dt = ', dt
+       CALL wrf_debug( 0, wrf_err_message )
+       write(wrf_err_message,*) 'WW_SPLIT:  alpha_max/min = ', alpha_max, alpha_min
+       CALL wrf_debug( 0, wrf_err_message )
+       print_flag = .false.     
+      ENDIF
+
+! =========================================================================
+   
+   i_start = its-1
+   i_end   = MIN(ite,ide-1) + 1
+   j_start = jts - 1
+   j_end   = MIN(jte,jde-1) + 1
+   
+   wwE(:,:,:) = 0.0
+   wwI(:,:,:) = 0.0
+
+   IF( ieva ) THEN   ! Implicit adaptive advection
+   
+!=========================================================================
+! DEBUG CODE BLOCK
+!        
+!    binavg(:) = 0.0
+!    crs(:)    = 0.0
+!    count(:)  = 0
+!
+!=========================================================================
+                                                        
+     DO j = j_start, j_end
+       DO k = 2, kde-1
+       
+         IF( k == 2 ) THEN               ! Dont do implicit at lower boundary
+           wwE(i_start:i_end,1,j) = 0.0
+           wwI(i_start:i_end,1,j) = 0.0
+         ENDIF
+         
+         IF( k == kde-1 ) THEN           ! Dont do implicit at upper boundary
+           wwE(i_start:i_end,kde,j) = ww(i_start:i_end,kde,j)
+           wwI(i_start:i_end,kde,j) = 0.0
+         ENDIF
+       
+         DO i = i_start,i_end
+         
+!=========================================================================
+!      
+! Translating Shchepetkin (2015), all the volumes and surface areas cancel out (not obvious unless you read
+! the definitions of U, V, and W right after equation 3.7 (they are u*dy*dz, v*dx*dz, w*dx*dy)...
+! You can write the algorithm using the adjusted maximum vertical courant number (alpha_max - eps*hor_div)
+! versus the actual vertical courant number.  This code is based on the appendix C of Shchepetkin (2015).
+! The CX and CY measure the maximum possible divergence for a zone, e.g., the Lipschlitz number.  If this number ~O(1), 
+! then you want to reduce the maximum allowed vertical courant number for the explicit advection.  Ceps is a fudge
+! factor - so when the 2D Lipschlitz number is larger than O(1), the scheme switches to fully implicit.
+!
+!=========================================================================
+           wfrac = 1.0
+            
+           IF( ww(i,k,j) < 0.0 ) THEN    !! Omega has opposite sign of W
+             cx = msfty(i,j)*rdx*(max(u(i+1,k,j), 0.0) - min(u(i,k,j), 0.0)) 
+             cy = msfty(i,j)*rdy*(max(v(i,k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
+           ELSE
+             cx = msfty(i,j)*rdx*(max(u(i+1,k-1,j), 0.0) - min(u(i,k-1,j), 0.0)) 
+             cy = msfty(i,j)*rdy*(max(v(i,k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
+           ENDIF
+
+           cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
+           cr     = ww(i,k,j) * dt * rdnw(k) / (c1(k)*mut(i,j)+c2(k))      ! vertical courant number
+         
+           IF( cw_max > 0.0 ) THEN
+      
+             cw_max2 = cw_max**2
+             cw_min  = cw_max*cmnx_ratio
+             cw      = abs(cr)
+      
+             if ( cw < cw_min ) then
+               cff = cw_max2
+             elseif ( cw < cutoff*cw_min ) then
+               cff = cw_max2 + r4cmx*(cw-cw_min)**2
+             else
+               cff = cw_max*cw
+             endif
+        
+             wfrac = cw_max2 / cff
+             wfrac = amax1(amin1(wfrac, 1.0), 0.0)
+
+             wwE(i,k,j) = ww(i,k,j) * wfrac
+             wwI(i,k,j) = ww(i,k,j) * (1.0 - wfrac)
+
+!=========================================================================
+! DEBUG CODE BLOCK: compute distribution of wfrac 
+!             
+!            DO mm = 1, binsize
+!              IF( (mm-1)*binfrac / wfrac <= 1.0 .and. &
+!                      mm*binfrac / wfrac  > 1.0 ) THEN   
+!                count(mm)  = count(mm) + 1
+!                binavg(mm) = binavg(mm) + wfrac
+!                crs(mm)    = crs(mm) + cw
+!              ENDIF
+!            ENDDO
+!
+!=========================================================================
+                
+           ELSE
+
+!=========================================================================
+! DEBUG CODE BLOCK:  write out information when fully implicit
+!        
+!            write(wrf_err_message,*) ' MAX VERTICAL CFL ~ 0: i,j,k, cw_max, dt*(cx+cy) ',i,j,k,cw_max,Ceps*dt*(cx+cy)
+!            CALL wrf_debug(0, wrf_err_message )
+!
+!=========================================================================
+             
+             wwE(i,k,j) = 0.0
+             wwI(i,k,j) = ww(i,k,j)
+       
+           ENDIF
+
+         ENDDO
+       ENDDO
+     ENDDO
+     
+   ELSE  ! NOT doing IEVA, pure explicit advection
+
+     DO j = j_start, j_end
+       DO k = kds, kde
+         DO i = i_start,i_end
+           wwE(i,k,j) = ww(i,k,j)
+           wwI(i,k,j) = 0.0
+         ENDDO
+       ENDDO
+     ENDDO
+   
+   ENDIF
+
+!=========================================================================
+! DEBUG - print distribution of wfrac 
+! 
+!  write(wrf_err_message,*) '----------------------------------------'
+!  CALL wrf_debug( 0, wrf_err_message )
+!  DO mm = 1,11 
+!    write(wrf_err_message,FMT='(a, 2(2x,f4.2),2x,i9,2(2x,f6.4))' ) &
+!     'WW_SPLIT: BIN #, count', (mm-1)*binfrac, mm*binfrac, count(mm), binavg(mm)/(count(mm)+1), crs(mm)/(count(mm)+1)
+!    CALL wrf_debug( 0, wrf_err_message )
+!  ENDDO
+!  write(wrf_err_message,*) '----------------------------------------'
+!  CALL wrf_debug( 0, wrf_err_message )
+!
+!=========================================================================
+
+ RETURN
+ END SUBROUTINE WW_SPLIT
+ 
+ 
+ SUBROUTINE TRIDIAG2D(a, b, c, r, bb, is, ie, istart, iend, ks, ke, kstart, kend)
+!--------------------------------------------------------------------------------------------------
+!     Solves for a vector u of length n the tridiagonal linear set      ! from numerical recipes
+!     m u = r, where a, b and c are the three main diagonals of matrix  !
+!     m(n,n), the other terms are 0. r is the right side vector.        !
+!
+!     a(1) and c(n) are not used in the calculation
+!--------------------------------------------------------------------------------------------------
+     
+    integer,                              intent(in)    :: is, ie, ks, ke, istart, iend, kstart, kend
+    real(kind=8), dimension(is:ie,ks:ke), intent(in)    :: a, b, c, r
+    real(kind=8), dimension(is:ie,ks:ke), intent(inout) :: bb
+    
+    !
+    ! Local Variables
+    ! 
+      
+    real(kind=8), dimension(ks:ke) :: gam
+    real(kind=8), dimension(is:ie) :: bet
+    integer                        :: i, k
+
+! Copy into temp storage...
+    
+    DO i = istart, iend   
+     
+      bet(i) = b(i,kstart)  
+           
+    ENDDO
+
+! I did this in this manner so I wont break vectorization
+  
+!   IF ( ANY( bet < 1.0e-15 ) ) THEN      
+!     write(wrf_err_message,*) '----------------------------------------'
+!     CALL wrf_debug( 0, wrf_err_message )
+!     write(wrf_err_message,*) "TriDiag2D Error!!! Min value of diagonal is ", minval(bet)
+!     CALL wrf_debug( 0, wrf_err_message )
+!     write(wrf_err_message,*) '----------------------------------------'
+!     CALL wrf_debug( 0, wrf_err_message )
+!     STOP
+!   ENDIF
+
+    DO i = istart, iend
+        
+       bb(i,kstart) = r(i,kstart)/bet(i)
+    
+       DO k = kstart+1, kend
+       
+         gam(k) = c(i,k-1) / bet(i)
+         bet(i) = b(i,k) - a(i,k) * gam(k)
+      
+         bb(i,k) = ( r(i,k) - a(i,k) * bb(i,k-1) ) / bet(i)
+      
+       ENDDO
+ 
+       DO k = kend-1, kstart, -1
+       
+         bb(i,k) = bb(i,k) - gam(k+1) * bb(i,k+1)
+         
+       ENDDO
+       
+     ENDDO
+ 
+ END SUBROUTINE TRIDIAG2D
+!--------------------------------------------------------------------------------------------------
+ SUBROUTINE TRIDIAG(a, b, c, r, bb, ks, ke, kstart, kend)
+!--------------------------------------------------------------------------------------------------
+!     Solves for a vector u of length n the tridiagonal linear set      ! from numerical recipes
+!     m u = r, where a, b and c are the three main diagonals of matrix  !
+!     m(n,n), the other terms are 0. r is the right side vector.        !
+!
+!     a(1) and c(n) are not used in the calculation
+!--------------------------------------------------------------------------------------------------
+    IMPLICIT NONE
+    
+    integer,                        intent(in)  :: ks, ke, kstart, kend
+    real(kind=4), dimension(ks:ke), intent(in ) :: a, b, c, r
+    real(kind=4), dimension(ks:ke), intent(out) :: bb
+    
+    !
+    ! Local Variables
+    ! 
+      
+    real(kind=4), dimension(size(b,1)) :: gam
+    real(kind=4)                       :: bet
+    integer                            :: k
+    
+    bet = b(kstart)
+     
+    bb(kstart) = r(kstart)/bet
+ 
+    DO k = kstart+1, kend
+       
+      gam(k) = c(k-1) / bet
+      bet    = b(k) - a(k) * gam(k)
+      
+      bb(k) = ( r(k) - a(k) * bb(k-1) ) / bet
+   
+    ENDDO
+
+    DO k = kend-1, kstart, -1
+      bb(k) = bb(k) - gam(k+1) * bb(k+1)
+    ENDDO
+     
+END SUBROUTINE TRIDIAG
+!-------------------------------------------------------------------------------
+!
+
+SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
+                         mut_old, muu, muv, mut_new,         &
+                         dt, rdx, rdy, msftx, msfty,         &
+                         msfux, msfuy, msfvx, msfvx_inv,     &
+                         msfvy, rdnw,                        &
+                         ids, ide, jds, jde, kds, kde,       &
+                         ims, ime, jms, jme, kms, kme,       &
+                         its, ite, jts, jte, kts, kte    )
+
+   IMPLICIT NONE
+
+   ! Input data
+
+
+   INTEGER ,    INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                 ims, ime, jms, jme, kms, kme, &
+                                 its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: u, v
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut_old, muu, muv, &
+                                                            msftx, msfty, &
+                                                            msfux, msfuy, &
+                                                            msfvx, msfvy, &
+                                                            msfvx_inv
+   REAL , DIMENSION( kms:kme ) , INTENT(IN   ) :: rdnw
+   REAL , DIMENSION( kms:kme ) , INTENT(IN   ) :: c1h, c2h
+   
+   REAL , DIMENSION( ims:ime, jms:jme ) , INTENT(OUT  ) :: mut_new
+   REAL , INTENT(IN)  :: dt, rdx, rdy
+   
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   REAL , DIMENSION( its:ite ) :: dmdt
+   REAL , DIMENSION( its:ite, kts:kte ) :: divv
+   REAL :: bigerr
+
+!<DESCRIPTION>
+!
+!  The algorithm integrates the continuity equation through the column
+!  to find a new column mass needed for IEVA calculations
+!
+!</DESCRIPTION>
+
+
+    jtf=MIN(jte,jde-1)
+    ktf=MIN(kte,kde-1)  
+    itf=MIN(ite,ide-1)
+
+
+    DO j=jts,jtf
+
+      DO i=its,ite
+        dmdt(i) = 0.
+      ENDDO
+
+!       Comments on the modifications for map scale factors
+!       ADT eqn 47 / my (putting rho -> 'mu') is:
+!       (1/my) partial d mu/dt = -mx partial d/dx(mu u/my)
+!                                -mx partial d/dy(mu v/mx)
+!                                -partial d/dz(mu w/my)
+!
+!       Using nu instead of z the last term becomes:
+!                                -partial d/dnu((c1(k)*mu(dnu/dt))/my)
+!
+!       Integrating with respect to nu over ALL levels, with dnu/dt=0 at top
+!       and bottom, the last term becomes = 0
+!
+!       Integral|bot->top[(1/my) partial d mu/dt]dnu =
+!       Integral|bot->top[-mx partial d/dx(mu u/my)
+!                         -mx partial d/dy(mu v/mx)]dnu
+!
+!       muu='mu'[on u]/my, muv='mu'[on v]/mx
+!       (1/my) partial d mu/dt is independent of nu
+!         => LHS = Integral|bot->top[con]dnu = conservation*(-1) = -dmdt
+!
+!         => dmdt = mx*Integral|bot->top[partial d/dx(mu u/my) +
+!                                        partial d/dy(mu v/mx)]dnu
+!         => dmdt = sum_bot->top[divv]
+!       where
+!         divv=mx*[partial d/dx(mu u/my) + partial d/dy(mu v/mx)]*delta nu
+
+      DO k=kts,ktf
+       DO i=its,itf
+
+        divv(i,k) = (msftx(i,j) / rdnw(k)) *                                                                        &
+            (rdx*((c1h(k)*muu(i+1,j)+c2h(k))*u(i+1,k,j)/msfuy(i+1,j)-(c1h(k)*muu(i,j)+c2h(k))*u(i,k,j)/msfuy(i,j))  &
+            +rdy*((c1h(k)*muv(i,j+1)+c2h(k))*v(i,k,j+1)*msfvx_inv(i,j+1)-(c1h(k)*muv(i,j)+c2h(k))*v(i,k,j)*msfvx_inv(i,j)) )
+                                  
+        dmdt(i) = dmdt(i) + divv(i,k)
+
+       ENDDO
+      ENDDO
+
+!       Further map scale factor notes:
+!       Now integrate from bottom to top, level by level:
+!       mu dnu/dt/my [k+1] = mu dnu/dt/my [k] + [-(1/my) partial d mu/dt
+!                           -mx partial d/dx(mu u/my)
+!                           -mx partial d/dy(mu v/mx)]*dnu[k->k+1]
+!       ww [k+1] = ww [k] -(1/my) partial d mu/dt * dnu[k->k+1] - divv[k]
+!                = ww [k] -dmdt * dnw[k] - divv[k]
+
+      DO i=its,itf
+
+           mut_new(i,j) = mut_old(i,j) - dt*dmdt(i)
+
+! DEBUG code.           
+!          bigerr = (mut_new(i,j) / mut_old(i,j))
+!     
+!          IF( abs(bigerr) > 2.0 .or. mut_old(i,j) < 0.0 ) THEN    
+!             write(wrf_err_message,*) '------------- CALC_MU_TMP ---------------------------'
+!             CALL wrf_debug( 0, wrf_err_message )
+!             write(wrf_err_message,*) 'MU_ERR: ', bigerr, mut_new(i,j), mut_old(i,j), dt, dt*dmdt(i)
+!             CALL wrf_debug( 0, wrf_err_message )
+!         ENDIF
+
+      ENDDO   ! END I
+    
+    ENDDO     ! END J
+
+
+END SUBROUTINE CALC_MUT_NEW
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_ph_implicit( ph, pho, tendency, phb,        &
+                               ru, rv, wwE, wwI, w,           &
+                               c1, c2,                        &
+                               mut, config_flags,             &
+                               msfux, msfuy, msfvx, msfvy,    &
+                               msftx, msfty,                  &
+                               fzm, fzp,                      &
+                               dt_rk,                         &
+                               rdx, rdy, rdzw,                &
+                               ids, ide, jds, jde, kds, kde,  &
+                               ims, ime, jms, jme, kms, kme,  &
+                               its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: ph,    &
+                                                                      pho,   &
+                                                                      phb,   &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      wwI,   &
+                                                                      wwE,   &
+                                                                      w
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN   ) :: mut
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   REAL    :: wiL, wiR, wiC, weL, weR, dz
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp(ims:ime)
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1, valid_ik
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+   ktf     = kde-1
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+
+! Vertical loop to do implicit advection.....
+! Different from the other schemes - the advection here is not in flux form...
+
+   DO j = j_start, j_end
+ 
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0
+     
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+
+! We are choosing to do the vertical advection here the same as in RHS_PH,
+! e.g., 2nd order box averaging instead of the usual upwinding...
+! Divide my mu(i,j) to make sure the diagnonal term is ~O(1)
+
+! Upwind
+         wiC     = 0.5*wwI(i,k,j)*(rdzw(k-1)+rdzw(k)) * msfty(i,j) / (c1(k)*mut(i,j)+c2(k))
+         at(i,k) = - dt_rk*max(wiC,0.0)
+         ct(i,k) =   dt_rk*min(wiC,0.0)
+         btmp(i) =   - at(i,k) - ct(i,k)
+
+! 2nd order centered for both implicit piece of advection
+!          wiL     = 0.5*(wwI(i,k-1,j)+wwI(i,k,j)) * rdzw(k-1) * msfty(i,j) / mut(i,j) 
+!          wiR     = 0.5*(wwI(i,k+1,j)+wwI(i,k,j)) * rdzw(k)   * msfty(i,j) / mut(i,j)         
+!          at(i,k) = - dt_rk*wiL*fzp(k)
+!          ct(i,k) =   dt_rk*wiR*fzm(k)
+!          btmp(i) =   - at(i,k) - ct(i,k)
+      
+! Diagonal term
+
+         bt(i,k) =   1.0 + btmp(i)
+
+! 2nd order centered for explict piece of advection  (TURNED OFF AND COMPUTED IN RHS_PH)
+!
+!          weL   = -dt_rk*fzp(k)*0.5*(wwE(i,k-1,j)+wwE(i,k,j)) * rdzw(k-1) * msfty(i,j) / mut(i,j)  
+!          weR   =  dt_rk*fzm(k)*0.5*(wwE(i,k+1,j)+wwE(i,k,j)) * rdzw(k)   * msfty(i,j) / mut(i,j)        
+       
+! Eq here is more complicated because the solution to the tridiagonal is in phi', not total
+! phi.  So we retain the vertical advection of phb on RHS.
+
+         rt(i,k) = tendency(i,k,j) * dt_rk * msfty(i,j) / (c1(k)*mut(i,j)+c2(k))        &
+!                  - weL*ph (i,k-1,j)     + (weL + weR)*ph (i,k,j) - weR*ph (i,k+1,j)     &
+!                  - weL*phb(i,k-1,j)     + (weL + weR)*phb(i,k,j) - weR*phb(i,k+1,j)     &            
+                 - at(i,k)*pho(i,k-1,j) -     btmp(i)*pho(i,k,j) - ct(i,k)*pho(i,k+1,j) &
+                 - at(i,k)*phb(i,k-1,j) -     btmp(i)*phb(i,k,j) - ct(i,k)*phb(i,k+1,j)  
+
+! BC's need because tendencies of phi, at kts and kte are not zero, so add them to RHS of Tridiagonal eqs
+! NOT USED!         
+!          IF( k == kts+1 ) THEN
+!             rt(i,k) = rt(i,k) - at(i,k)*(ph(i,k-1,j) - pho(i,k-1,j))       ! lower boundary condition 
+!          ENDIF
+!        
+!          IF( k == ktf ) THEN    ! upper boundary condition
+!           rt(i,k)   = rt(i,k) - ct(i,k) * (ph(i,k+1,j) - pho(i,k+1,j))
+!         ENDIF
+
+       ENDDO
+     ENDDO
+
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts+1, ktf) 
+
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+     
+         tendency(i,k,j) = sngl(bb(i,k)) * (c1(k)*mut(i,j)+c2(k)) / dt_rk / msfty(i,j)
+       
+       ENDDO
+     ENDDO
+   
+   ENDDO
+    
+END SUBROUTINE advect_ph_implicit
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
+                              ru, rv, rom,                   &
+                              c1, c2,                        &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
+
+   INTEGER ,                   INTENT(IN) :: ids, ide, jds, jde, kds, kde, &
+                                             ims, ime, jms, jme, kms, kme, &
+                                             its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN) :: s,     &
+                                                                   s_old, &
+                                                                   ru,    &
+                                                                   rv,    &
+                                                                   rom
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut     ==> current column mass from sub-step
+! mut_old ==> "n" time level column mass
+! mut_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+   
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   INTEGER :: jp1, jp0, jtmp
+
+   INTEGER :: horz_order, vert_order
+
+   REAL    :: mrdx, mrdy, ub, vb, uw, vw, dvm, dvp, wiL, wiR, dz
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb   
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik, skip
+   CHARACTER*512 :: temp
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+   ktf     = MIN(kte,kde-1)
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+   
+! Vertical loop to do implicit advection.....
+
+   DO j = j_start, j_end
+ 
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0
+     
+     DO k = kts, ktf
+       DO i = i_start, i_end
+
+         km1 = k - 1
+         kp1 = k + 1
+         IF( k .eq. ktf ) kp1 = ktf
+         IF( k .eq. kts ) km1 = kts
+
+         ! Redefine mass fluxes with new temporary column mass
+       
+         wiL   = rom(i,k,  j) * rdzw(k) / (c1(k)*mut_new(i,j)+c2(k))
+         wiR   = rom(i,k+1,j) * rdzw(k) / (c1(k)*mut_new(i,j)+c2(k))
+
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0)
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0))
+         bt(i,k) = 1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j)  &
+                   - (c1(k)*mut_old(i,j)+c2(k))*(at(i,k)*s_old(i,km1,j) + btmp(i)*s_old(i,k,j) + ct(i,k)*s_old(i,kp1,j))
+       ENDDO
+     ENDDO
+      
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts, ktf) 
+
+     DO k = kts, ktf
+       DO i = i_start, i_end
+
+         ! Rescale tendency with old column mass for consistency in update step.
+     
+         tendency(i,k,j) = sngl(bb(i,k)) / dt_rk
+       
+       ENDDO
+     ENDDO
+       
+   ENDDO  ! J-LOOP
+
+END SUBROUTINE advect_s_implicit
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
+                              ru, rv, rom,                   &
+                              c1, c2,                        &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: u,     &
+                                                                      u_old, &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      rom
+
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut    ==> current column mass from sub-step
+! mu_old ==> "n" time level column mass
+! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   INTEGER :: jp1, jp0, jtmp
+
+   INTEGER :: horz_order, vert_order
+
+   REAL    :: wiL, wiR, dz
+   
+   REAL , DIMENSION( ims:ime+1 , jms:jme ) :: muu, muu_old, muu_new
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+      
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+!-------------------- vertical advection
+!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
+!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
+!  Since 'my' (map scale factor in y-direction) isn't a function of z,
+!  this is what we need, so leave unchanged in advect_u
+
+   ktf     = MIN(kte,kde-1)
+
+   i_start = its
+   i_end   = ite
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+   
+! Compute column masses for u-staggering...
+
+   DO j = j_start, j_end
+    DO i = its,min(ite+1,ide)
+
+      muu(i,j)     = 0.5*(mut(i,j)    +mut(i-1,j))
+      muu_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i-1,j))
+      muu_new(i,j) = 0.5*(mut_new(i,j)+mut_new(i-1,j))
+      
+    ENDDO
+  ENDDO
+    
+! Vertical loop to do implicit advection.....
+
+   DO j = j_start, j_end
+   
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0    
+     
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+         km1 = k - 1
+         kp1 = k + 1
+         IF( k .eq. ktf ) kp1 = ktf
+         IF( k .eq. kts ) km1 = kts
+
+! SO IMPORTANT to * 1/DZ HERE CAUSE IT CHANGES Wi* SIGN TO BE CORRECT FOR UPWINDING!!!!
+         wiL   = 0.5*(rom(i-1,k,  j)+rom(i,k,  j)) * rdzw(k) * msfuy(i,j) / (c1(k)*muu_new(i,j)+c2(k)) 
+         wiR   = 0.5*(rom(i-1,k+1,j)+rom(i,k+1,j)) * rdzw(k) * msfuy(i,j) / (c1(k)*muu_new(i,j)+c2(k)) 
+       
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0) 
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0)) 
+         bt(i,k) = 1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j)*msfuy(i,j)  &
+                 - (c1(k)*muu_old(i,j)+c2(k))*(at(i,k)*u_old(i,km1,j) + btmp(i)*u_old(i,k,j) + ct(i,k)*u_old(i,kp1,j))
+       
+       ENDDO
+     ENDDO
+   
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts, ktf) 
+
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+         tendency(i,k,j) = sngl(bb(i,k)) / dt_rk / msfuy(i,j)
+                
+       ENDDO
+     ENDDO
+        
+   ENDDO ! J-LOOP
+    
+END SUBROUTINE advect_u_implicit
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
+                              ru, rv, rom,                   &
+                              c1, c2,                        &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzw,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+   ! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: v,     &
+                                                                      v_old, &
+                                                                      ru,    &
+                                                                      rv,    &
+                                                                      rom
+
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut    ==> current column mass from sub-step
+! mu_old ==> "n" time level column mass
+! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzw, &
+                                                                  c1,   &
+                                                                  c2
+
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+   ! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   INTEGER :: jmin, jmax, jp, jm, imin, imax, im, ip
+   INTEGER :: jp1, jp0, jtmp
+
+   INTEGER :: horz_order, vert_order
+
+   REAL    :: mrdx, mrdy, ub, vb, uw, vw, dvm, dvp, wiL, wiR, dz
+
+   REAL,   DIMENSION( ims:ime , jms:jme+1 ) :: muv, muv_old, muv_new
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik
+   
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
+!-------------------- vertical advection
+!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
+!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
+!  Since 'my' (map scale factor in y-direction) isn't a function of z,
+!  this is what we need, so leave unchanged in advect_u
+
+
+   ktf     = MIN(kte,kde-1)
+   
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = jte
+   
+! Compute column masses for u-staggering...
+
+   DO j = jts,min(jte+1,jde)
+    DO i = i_start, i_end
+
+      muv(i,j)     = 0.5*(mut(i,j)    +mut(i,j-1))
+      muv_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i,j-1))
+      muv_new(i,j) = 0.5*(mut_new(i,j)+mut_new(i,j-1))
+      
+    ENDDO
+  ENDDO
+ 
+! Main Loop
+
+   DO j = j_start, j_end
+   
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0 
+     
+      
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+         km1 = k - 1
+         kp1 = k + 1
+         IF( k .eq. ktf ) kp1 = ktf
+         IF( k .eq. kts ) km1 = kts
+
+         wiL   = 0.5*(rom(i,k,  j-1)+rom(i,k,  j)) * rdzw(k) * msfvy(i,j) / (c1(k)*muv_new(i,j)+c2(k)) 
+         wiR   = 0.5*(rom(i,k+1,j-1)+rom(i,k+1,j)) * rdzw(k) * msfvy(i,j) / (c1(k)*muv_new(i,j)+c2(k))
+       
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0)
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0))
+         bt(i,k) = 1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j) * msfvx(i,j) &
+                 - (c1(k)*muv_old(i,j)+c2(k))*(at(i,k)*v_old(i,km1,j) + btmp(i)*v_old(i,k,j) + ct(i,k)*v_old(i,kp1,j))
+       
+       ENDDO
+     ENDDO
+      
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts, ktf) 
+
+     DO k = kts, ktf
+       DO i = i_start, i_end
+     
+       tendency(i,k,j) = sngl(bb(i,k)) / dt_rk / msfvx(i,j)
+       
+       ENDDO     
+     ENDDO
+          
+   ENDDO
+    
+END SUBROUTINE advect_v_implicit
+
+!-------------------------------------------------------------------------------
+! 
+SUBROUTINE advect_w_implicit( w, w_old, tendency,            &
+                              utend, vtend, ht, rom,         &
+                              ph_new, ph_old, ph_tend,       &
+                              c1, c2,                        &
+                              cf1, cf2, cf3,                 &
+                              mut_old, mut, mut_new,         &
+                              config_flags,                  &                              
+                              msfux, msfuy, msfvx, msfvy,    &
+                              msftx, msfty,                  &
+                              fzm, fzp,                      &
+                              dt_rk,                         &
+                              rdx, rdy, rdzu,                &
+                              ids, ide, jds, jde, kds, kde,  &
+                              ims, ime, jms, jme, kms, kme,  &
+                              its, ite, jts, jte, kts, kte  )
+
+   IMPLICIT NONE
+   
+! Input data
+   
+   TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
+
+   INTEGER ,                 INTENT(IN   ) :: ids, ide, jds, jde, kds, kde, &
+                                              ims, ime, jms, jme, kms, kme, &
+                                              its, ite, jts, jte, kts, kte
+
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(IN   ) :: w,     &
+                                                                      w_old, &
+                                                                      utend, &
+                                                                      vtend, &
+                                                                     ph_old, &
+                                                                     ph_new, &
+                                                                    ph_tend, &
+                                                                      rom
+
+!-------------------------------------------------------------------------------
+! LWJ: definitions of various column masses 
+! mut    ==> current column mass from sub-step
+! mu_old ==> "n" time level column mass
+! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
+!            have time-avg column mass.  For scalars (not theta) mut_new == mut
+
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+
+!-------------------------------------------------------------------------------
+   
+   REAL , DIMENSION( ims:ime , kms:kme , jms:jme ) , INTENT(INOUT) :: tendency
+
+   REAL , DIMENSION( ims:ime , jms:jme ) ,         INTENT(IN   ) :: msfux,  &
+                                                                    msfuy,  &
+                                                                    msfvx,  &
+                                                                    msfvy,  &
+                                                                    msftx,  &
+                                                                    msfty,  &
+                                                                    ht
+
+   REAL , DIMENSION( kms:kme ) ,                 INTENT(IN   ) :: fzm,  &
+                                                                  fzp,  &
+                                                                  rdzu, &
+                                                                  c1,   &
+                                                                  c2
+                                                                  
+   REAL ,                                        INTENT(IN   ) :: rdx,  &
+                                                                  rdy,  &
+                                                                  cf1,  &
+                                                                  cf2,  &
+                                                                  cf3
+                                                                  
+   REAL ,                                        INTENT(IN   ) :: dt_rk
+
+! Local data
+   
+   INTEGER :: i, j, k, itf, jtf, ktf
+   INTEGER :: i_start, i_end, j_start, j_end
+   INTEGER :: i_start_f, i_end_f, j_start_f, j_end_f
+   REAL    :: wiL, wiR, dz, dw
+
+   REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
+   REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
+   
+   LOGICAL :: specified
+   INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
+   INTEGER :: valid_ik
+   
+   specified = .false.
+   IF(config_flags%specified .or. config_flags%nested) specified = .true.
+
+!-------------------- vertical advection
+!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
+!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
+!  Since 'my' (map scale factor in y-direction) isn't a function of z,
+!  this is what we need, so leave unchanged in advect_u
+
+   ktf     = MIN(kte,kde-1)
+   i_start = its
+   i_end   = MIN(ite,ide-1)
+   j_start = jts
+   j_end   = MIN(jte,jde-1)
+  
+! Main loop
+
+   DO j = j_start, j_end
+   
+     at(:,:) = 0.0
+     bt(:,:) = 1.0
+     ct(:,:) = 0.0
+     rt(:,:) = 0.0
+     bb(:,:) = 0.0    
+           
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+
+! SO IMPORTANT to * 1/DZ HERE CAUSE IT CHANGES Wi* SIGN TO BE CORRECT FOR UPWINDING!!!!
+         wiL   = 0.5*(rom(i,k-1,j)+rom(i,k,j)) * rdzu(k) * msfty(i,j) / (c1(k)*mut_new(i,j)+c2(k)) 
+         wiR   = 0.5*(rom(i,k+1,j)+rom(i,k,j)) * rdzu(k) * msfty(i,j) / (c1(k)*mut_new(i,j)+c2(k))
+
+         at(i,k) = - dt_rk*max(wiL,0.0)
+         ct(i,k) =   dt_rk*min(wiR,0.0) 
+         btmp(i) =   dt_rk*(max(wiR,0.0) - min(wiL,0.0)) 
+         bt(i,k) =   1.0 + btmp(i)
+         rt(i,k) = dt_rk*tendency(i,k,j) * msfty(i,j)  &
+                 - (c1(k)*mut_old(i,j)+c2(k))*(at(i,k)*w_old(i,k-1,j) + btmp(i)*w_old(i,k,j) + ct(i,k)*w_old(i,k+1,j))
+       
+! BC at lower boundary needed because (W(i,kts,j)  .ne. 0) and value need for RHS of tridiagonal at kts+1
+! Since we already included w_old, just need to compute dw increment from UTEND, VTEND at kts 
+
+        IF( k == kts+1 ) THEN
+         dw =  msfty(i,j)*.5*rdy*(                                       &
+                           (ht(i,j+1)-ht(i,j  ))                         &
+          *(cf1*vtend(i,1,j+1)+cf2*vtend(i,2,j+1)+cf3*vtend(i,3,j+1))    &
+                          +(ht(i,j  )-ht(i,j-1))                         &
+          *(cf1*vtend(i,1,j  )+cf2*vtend(i,2,j  )+cf3*vtend(i,3,j  ))  ) &
+                 +msftx(i,j)*.5*rdx*(                                    &
+                           (ht(i+1,j)-ht(i,j  ))                         &
+          *(cf1*utend(i+1,1,j)+cf2*utend(i+1,2,j)+cf3*utend(i+1,3,j))    &
+                          +(ht(i,j  )-ht(i-1,j))                         &
+          *(cf1*utend(i  ,1,j)+cf2*utend(i  ,2,j)+cf3*utend(i  ,3,j))  )
+
+          rt(i,k) = rt(i,k) - (c1(k)*mut(i,j)+c2(k))*at(i,k)*dt_rk*dw       
+        ENDIF
+
+! W-increment at upper boundary is computed from phi
+       
+        IF( k == ktf ) THEN    ! upper boundary condition
+          dw = msfty(i,j)*(  (ph_new(i,k+1,j)-ph_old(i,k+1,j))/dt_rk     &
+                            - ph_tend(i,k+1,j)/(c1(k)*mut(i,j)+c2(k))/g) 
+
+          rt(i,k)   = rt(i,k) - (c1(k)*mut(i,j)+c2(k))*ct(i,k) * (dw - w_old(i,k+1,j))
+        ENDIF
+
+       ENDDO
+     ENDDO
+
+     CALL tridiag2D(at, bt, ct, rt, bb, ims, ime, i_start, i_end, kts, kte, kts+1, ktf) 
+
+     DO k = kts+1, ktf
+       DO i = i_start, i_end
+     
+         tendency(i,k,j) = sngl(bb(i,k)) / dt_rk / msfty(i,j)
+                         
+       ENDDO
+     ENDDO
+     
+   ENDDO
+    
+END SUBROUTINE advect_w_implicit
+
+END MODULE module_ieva_em
+
+!-----------------------------------

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -100,19 +100,17 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
 
 ! Debug declarations
 
-   REAL,    PARAMETER :: binfrac = 0.1
-   INTEGER, PARAMETER :: binsize = 11
-   INTEGER            :: count(binsize)
-   real(KIND=4)       :: binavg(binsize), crs(binsize)
+!  REAL,    PARAMETER :: binfrac = 0.1
+!  INTEGER, PARAMETER :: binsize = 11
+!  INTEGER            :: count(binsize)
+!  real(KIND=4)       :: binavg(binsize), crs(binsize)
 
 ! Check to see if IEVA is on for this RK3 substep
 
    ieva = CHK_IEVA(config_flags, rk_step)
 
 ! =========================================================================
-! Loop limits
-
-! positive definite filter
+! Loop limits:  need to compute wwE & wwI one halo ring out for staggered variables.
 
    ktf     = kte
    i_start = its-1
@@ -120,57 +118,6 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
    j_start = jts-1
    j_end   = MIN(jte,jde-1)+1
 
-!-- loop bounds for open or specified conditions
-
-!  determine boundary mods for flux operators
-!  We degrade the flux operators from 3rd/4th order
-!   to second order one gridpoint in from the boundaries for
-!   all boundary conditions except periodic and symmetry - these
-!   conditions have boundary zone data fill for correct application
-!   of the higher order flux stencils
-
-   degrade_xs = .true.
-   degrade_xe = .true.
-   degrade_ys = .true.
-   degrade_ye = .true.
-
-   IF( config_flags%periodic_x   .or. &
-       config_flags%symmetric_xs .or. &
-       (its > ids+3)                ) degrade_xs = .false.
-   IF( config_flags%periodic_x   .or. &
-       config_flags%symmetric_xe .or. &
-       (ite < ide-3)                ) degrade_xe = .false.
-   IF( config_flags%periodic_y   .or. &
-       config_flags%symmetric_ys .or. &
-       (jts > jds+3)                ) degrade_ys = .false.
-   IF( config_flags%periodic_y   .or. &
-       config_flags%symmetric_ye .or. &
-       (jte < jde-4)                ) degrade_ye = .false.
-
-   IF(degrade_xs) i_start = MAX(its-1,ids)
-   IF(degrade_xe) i_end   = MIN(ite+1,ide-1)
-   IF(degrade_ys) j_start = MAX(jts-1,jds)
-   IF(degrade_ye) j_end   = MIN(jte+1,jde-1)
-
-   IF(config_flags%specified .or. config_flags%nested) THEN
-     IF (degrade_xs) i_start = MAX(its-1,ids+1)
-     IF (degrade_xe) i_end   = MIN(ite+1,ide-2)
-     IF (degrade_ys) j_start = MAX(jts-1,jds+1)
-     IF (degrade_ye) j_end   = MIN(jte+1,jde-2)
-   END IF
-
-   IF(config_flags%open_xs) THEN
-     IF (degrade_xs) i_start = MAX(its-1,ids+1)
-   END IF
-   IF(config_flags%open_xe) THEN
-     IF (degrade_xe) i_end   = MIN(ite+1,ide-2)
-   END IF
-   IF(config_flags%open_ys) THEN
-     IF (degrade_ys) j_start = MAX(jts-1,jds+1)
-   END IF
-   IF(config_flags%open_ye) THEN
-     IF (degrade_ye) j_end   = MIN(jte+1,jde-2)
-   END IF
 
 ! =========================================================================
 ! PRINT OUT IEVA INFO
@@ -206,12 +153,12 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
    ENDIF
 
    DO j = j_start, j_end
-    DO k = kts, ktf
-     DO i = i_start, i_end
-      wwE(i,k,j) = 0.
-      wwI(i,k,j) = 0.
+     DO k = kts, ktf
+       DO i = i_start, i_end
+         wwE(i,k,j) = 0.
+         wwI(i,k,j) = 0.
+       ENDDO
      ENDDO
-    ENDDO
    ENDDO
 
 ! =========================================================================
@@ -228,7 +175,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
 !
 !=========================================================================
 
-! Set upper and lower boundary values
+! Set upper and lower boundary values to be explicit advection
 
      DO j = j_start, j_end
        DO i = i_start,i_end
@@ -243,14 +190,15 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
      ENDDO
        
      DO j = j_start, j_end
+       
        DO k = 2, ktf-1
 
          DO i = i_start,i_end
          
 !===================================================================================================
 !      
-! Translating Shchepetkin (2015), all the volumes and surface areas cancel out (not obvious unless you read
-! the definitions of U, V, and W right after equation 3.7 (they are u*dy*dz, v*dx*dz, w*dx*dy)...
+! Translating Shchepetkin (2015, hereafter S2015), all the volumes and surface areas cancel out (not obvious 
+! unless you read the definitions of U, V, and W right after equation 3.7; they are u*dy*dz, v*dx*dz, w*dx*dy)...
 ! You can write the algorithm using the adjusted maximum vertical courant number (alpha_max - eps*hor_div)
 ! versus the actual vertical courant number.  This code is based on the appendix C of Shchepetkin (2015).
 ! The CX and CY measure the maximum possible divergence for a zone, e.g., the Lipschlitz number.  If 
@@ -261,8 +209,9 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
 ! region than the integrators used in Shchepetkin (2015).
 !
 !===================================================================================================
-           wfrac = 1.0
-            
+
+! S2015 Lipshlitz courant number.  Sometimes it can be touchy so we use simpler estimate below
+!          
 !          IF( ww(i,k,j) < 0.0 ) THEN    !! Omega has opposite sign of W
 !            cx = rdx*(max(u(i+1,k,j  ), 0.0) - min(u(i,k,j), 0.0)) 
 !            cy = rdy*(max(v(i,  k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
@@ -271,16 +220,20 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
 !            cy = rdy*(max(v(i,  k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
 !          ENDIF
 
+!          cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! S2015 adjusted max vertical courant
+
+! Compute a mean flow courant number to adjust the max vertical courant number
+
            cx = 0.25*rdx*(u(i+1,k,j  ) + u(i,k,j) + u(i+1,k-1,j  ) + u(i,k-1,j)) 
            cy = 0.25*rdy*(v(i,  k,j+1) + v(i,k,j) + v(i  ,k-1,j+1) + v(i,k-1,j)) 
+           
+           cw_max = max(alpha_max - dt*Ceps*sqrt(cx**2 + cy**2),0.0)       ! simpler adjusted max vertical courant
 
-           cw_max = alpha_max                                              ! Using simpler version...
-!          cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
-!          cw_max = max(alpha_max - dt*Ceps*sqrt(cx**2 + cy**2),0.0)       ! adjusted max vertical courant
-
-           cr     = ww(i,k,j) * dt * rdnw(k) / (c1f(k)*mut(i,j)+c2f(k))    ! vertical courant number
+           cr     = ww(i,k,j) * dt * rdnw(k) / (c1f(k)*mut(i,j)+c2f(k))    ! the actual vertical courant number
          
            IF( cw_max > 0.0 ) THEN
+                      
+             wfrac   = 1.0   ! initialize wfrac
       
              cw_max2 = cw_max**2
              cw_min  = cw_max*cmnx_ratio
@@ -314,7 +267,8 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
 !
 !=========================================================================
                 
-           ELSE
+           ELSE   ! If cw_max <= 0 - then the horizontal flow is very fast
+                  ! so do all vertical transport implicitly
 
 !=========================================================================
 ! DEBUG CODE BLOCK:  write out information when fully implicit
@@ -807,7 +761,7 @@ SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
                                                                   rdy
    REAL ,                                        INTENT(IN   ) :: dt_rk
 
-   ! Local data
+! Local data
    
    INTEGER :: i, j, k, itf, jtf, ktf
    INTEGER :: i_start, i_end, j_start, j_end
@@ -824,14 +778,13 @@ SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
    
    INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
    INTEGER :: valid_ik, skip
-   CHARACTER*512 :: temp
 
-   LOGICAL         :: print_flag = .true.
-   SAVE            :: print_flag
-
-!-- loop bounds 
+!
 
    ktf     = MIN(kte,kde-1)
+   
+!-- horizontal loop bounds copied from module_advect_em.F/advect_scalar
+
    i_start = its
    i_end   = MIN(ite,ide-1)
    j_start = jts
@@ -898,7 +851,7 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
 
    IMPLICIT NONE
    
-   ! Input data
+! Input data
    
    TYPE(grid_config_rec_type), INTENT(IN   ) :: config_flags
 
@@ -962,22 +915,37 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
    INTEGER :: valid_ik
 
    ktf     = MIN(kte,kde-1)
+   
+!-- loop bounds copied from module_advect_em.F/advect_u
+
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
    i_start = its
    i_end   = ite
    j_start = jts
-   j_end   = MIN(jte,jde-1)
+   j_end   = min(jte,jde-1)
+
+!  IF ( config_flags%open_xs ) i_start = MAX(ids+1,its)
+!  IF ( config_flags%open_xe ) i_end   = MIN(ide-1,ite)
+
+   IF ( config_flags%open_ys .or. specified ) i_start = MAX(ids+1,its)
+   IF ( config_flags%open_ye .or. specified ) i_end   = MIN(ide-1,ite)
+   IF ( config_flags%periodic_x ) i_start = its
+   IF ( config_flags%periodic_x ) i_end = ite
        
 ! Vertical loop to do implicit advection.....
 
    DO j = j_start, j_end
    
      DO k = kts, ktf
+      
+       km1 = k - 1
+       kp1 = k + 1
+       IF( k .eq. ktf ) kp1 = ktf
+       IF( k .eq. kts ) km1 = kts
+
        DO i = i_start, i_end
-     
-         km1 = k - 1
-         kp1 = k + 1
-         IF( k .eq. ktf ) kp1 = ktf
-         IF( k .eq. kts ) km1 = kts
 
 ! SO IMPORTANT to * 1/DZ HERE CAUSE IT CHANGES Wi* SIGN TO BE CORRECT FOR UPWINDING!!!!
          wiL   = 0.5*(rom(i-1,k,  j)+rom(i,k,  j)) * rdzw(k) * msfuy(i,j) / (c1(k)*muu_new(i,j)+c2(k)) 
@@ -1089,22 +1057,35 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
    INTEGER :: valid_ik
    
    ktf     = MIN(kte,kde-1)
+   
+!-- loop bounds copied from module_advect_em.F/advect_v   
+   
+   specified = .false.
+   if(config_flags%specified .or. config_flags%nested) specified = .true.
+
    i_start = its
    i_end   = MIN(ite,ide-1)
    j_start = jts
    j_end   = jte
+
+! Polar boundary conditions are like open or specified
+! We don't want to calculate vertical v tendencies at the N or S pole
+   IF ( config_flags%open_ys .or. specified .or. config_flags%polar ) j_start = MAX(jds+1,jts)
+   IF ( config_flags%open_ye .or. specified .or. config_flags%polar ) j_end   = MIN(jde-1,jte)
  
 ! Main Loop
 
    DO j = j_start, j_end
    
      DO k = kts, ktf
+     
+       km1 = k - 1
+       kp1 = k + 1
+       IF( k .eq. ktf ) kp1 = ktf
+       IF( k .eq. kts ) km1 = kts
+
        DO i = i_start, i_end
      
-         km1 = k - 1
-         kp1 = k + 1
-         IF( k .eq. ktf ) kp1 = ktf
-         IF( k .eq. kts ) km1 = kts
 
          wiL   = 0.5*(rom(i,k,  j-1)+rom(i,k,  j)) * rdzw(k) * msfvy(i,j) / (c1(k)*muv_new(i,j)+c2(k)) 
          wiR   = 0.5*(rom(i,k+1,j-1)+rom(i,k+1,j)) * rdzw(k) * msfvy(i,j) / (c1(k)*muv_new(i,j)+c2(k))

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -446,9 +446,9 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
    
    ! Local data
    
-   INTEGER :: i, j, k, itf, jtf, ktf
-   REAL , DIMENSION( its:ite ) :: dmdt
-   REAL , DIMENSION( its:ite, kts:kte ) :: divv
+   INTEGER :: i, j, k, ktf, i_start, i_end, j_start, j_end
+   REAL , DIMENSION( its-1:ite ) :: dmdt
+   REAL , DIMENSION( its-1:ite, kts:kte ) :: divv
    REAL :: bigerr
 
 !<DESCRIPTION>
@@ -459,14 +459,17 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
 !</DESCRIPTION>
 
 
-    jtf=MIN(jte,jde-1)
     ktf=MIN(kte,kde-1)  
-    itf=MIN(ite,ide-1)
+
+    i_start = its-1
+    i_end   = MIN(ite,ide-1)
+    j_start = jts-1
+    j_end   = MIN(jte,jde-1)
 
 
-    DO j=jts,jtf
+    DO j = j_start, j_end
 
-      DO i=its,ite
+      DO i = i_start, i_end
         dmdt(i) = 0.
       ENDDO
 
@@ -497,7 +500,7 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
 !         divv=mx*[partial d/dx(mu u/my) + partial d/dy(mu v/mx)]*delta nu
 
       DO k=kts,ktf
-       DO i=its,itf
+        DO i = i_start, i_end
 
         divv(i,k) = (msftx(i,j) / rdnw(k)) *                                                                        &
             (rdx*((c1h(k)*muu(i+1,j)+c2h(k))*u(i+1,k,j)/msfuy(i+1,j)-(c1h(k)*muu(i,j)+c2h(k))*u(i,k,j)/msfuy(i,j))  &
@@ -516,9 +519,10 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
 !       ww [k+1] = ww [k] -(1/my) partial d mu/dt * dnu[k->k+1] - divv[k]
 !                = ww [k] -dmdt * dnw[k] - divv[k]
 
-      DO i=its,itf
 
-           mut_new(i,j) = mut_old(i,j) - dt*dmdt(i)
+      DO i = i_start, i_end
+
+         mut_new(i,j) = mut_old(i,j) - dt*dmdt(i)
 
 ! DEBUG code.           
 !          bigerr = (mut_new(i,j) / mut_old(i,j))
@@ -616,12 +620,6 @@ SUBROUTINE advect_ph_implicit( ph, pho, tendency, phb,        &
 
    DO j = j_start, j_end
  
-     at(:,:) = 0.0
-     bt(:,:) = 1.0
-     ct(:,:) = 0.0
-     rt(:,:) = 0.0
-     bb(:,:) = 0.0
-     
      DO k = kts+1, ktf
        DO i = i_start, i_end
 
@@ -774,21 +772,15 @@ SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
 !-- loop bounds 
 
    ktf     = MIN(kte,kde-1)
-   i_start = its-1
+   i_start = its
    i_end   = MIN(ite,ide-1)
-   j_start = jts-1
+   j_start = jts
    j_end   = MIN(jte,jde-1)
 
 ! J outer loop to do implicit advection.....
 
    DO j = j_start, j_end
      
-     at(:,:) = 0.0
-     bt(:,:) = 1.0
-     ct(:,:) = 0.0
-     rt(:,:) = 0.0
-     bb(:,:) = 0.0    
-           
      DO k = kts, ktf
 
        km1 = k - 1
@@ -933,12 +925,6 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
 
    DO j = j_start, j_end
    
-     at(:,:) = 0.0
-     bt(:,:) = 1.0
-     ct(:,:) = 0.0
-     rt(:,:) = 0.0
-     bb(:,:) = 0.0    
-     
      DO k = kts, ktf
        DO i = i_start, i_end
      
@@ -1080,13 +1066,6 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
 
    DO j = j_start, j_end
    
-     at(:,:) = 0.0
-     bt(:,:) = 1.0
-     ct(:,:) = 0.0
-     rt(:,:) = 0.0
-     bb(:,:) = 0.0 
-     
-      
      DO k = kts, ktf
        DO i = i_start, i_end
      
@@ -1219,12 +1198,6 @@ SUBROUTINE advect_w_implicit( w, w_old, tendency,            &
 
    DO j = j_start, j_end
    
-     at(:,:) = 0.0
-     bt(:,:) = 1.0
-     ct(:,:) = 0.0
-     rt(:,:) = 0.0
-     bb(:,:) = 0.0    
-           
      DO k = kts+1, ktf
        DO i = i_start, i_end
 

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -208,15 +208,16 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !===================================================================================================
            wfrac = 1.0
             
-           IF( ww(i,k,j) < 0.0 ) THEN    !! Omega has opposite sign of W
-             cx = rdx*(max(u(i+1,k,j  ), 0.0) - min(u(i,k,j), 0.0)) 
-             cy = rdy*(max(v(i,  k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
-           ELSE
-             cx = rdx*(max(u(i+1,k-1,j  ), 0.0) - min(u(i,k-1,j), 0.0)) 
-             cy = rdy*(max(v(i,  k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
-           ENDIF
+!          IF( ww(i,k,j) < 0.0 ) THEN    !! Omega has opposite sign of W
+!            cx = rdx*(max(u(i+1,k,j  ), 0.0) - min(u(i,k,j), 0.0)) 
+!            cy = rdy*(max(v(i,  k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
+!          ELSE
+!            cx = rdx*(max(u(i+1,k-1,j  ), 0.0) - min(u(i,k-1,j), 0.0)) 
+!            cy = rdy*(max(v(i,  k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
+!          ENDIF
 
-           cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
+!          cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
+           cw_max = alpha_max                                              ! Using simpler version...
 
            cr     = ww(i,k,j) * dt * rdnw(k) / (c1f(k)*mut(i,j)+c2f(k))    ! vertical courant number
          

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -216,8 +216,12 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !            cy = rdy*(max(v(i,  k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
 !          ENDIF
 
+           cx = 0.25*rdx*(u(i+1,k,j  ) + u(i,k,j) + u(i+1,k-1,j  ) + u(i,k-1,j)) 
+           cy = 0.25*rdy*(v(i,  k,j+1) + v(i,k,j) + v(i  ,k-1,j+1) + v(i,k-1,j)) 
+
+!          cw_max = alpha_max                                              ! Using simpler version...
 !          cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
-           cw_max = alpha_max                                              ! Using simpler version...
+           cw_max = max(alpha_max - dt*Ceps*sqrt(cx**2 + cy**2),0.0)       ! adjusted max vertical courant
 
            cr     = ww(i,k,j) * dt * rdnw(k) / (c1f(k)*mut(i,j)+c2f(k))    ! vertical courant number
          

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -46,7 +46,7 @@ END FUNCTION CHK_IEVA
 ! IEVA code for splitting vertical velocity into pieces for explicit and implicit
 ! advection by the routines based on Shchepetkin (2015)
 
-SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
+SUBROUTINE WW_SPLIT(wwE, wwI,                         &
                     u, v, ww,                         &
                     mut, rdnw, msfty,                 &
                     c1f, c2f,                         &
@@ -64,7 +64,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
                                        its, ite, jts, jte, kts, kte, &
                                        rk_step
 
-   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, ph, phb
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww
 
    REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(INOUT) ::  wwE, wwI
 
@@ -84,6 +84,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    INTEGER         :: i, j, k, ii, jj, i_start, i_end, j_start, j_end, ktf
    LOGICAL         :: print_flag = .true.
    SAVE            :: print_flag
+   LOGICAL         :: degrade_xs, degrade_ys, degrade_xe, degrade_ye
    
 ! Implicit advection parameters based on Shchepetkin (2015)
 ! Moved these to the top of the module.
@@ -111,11 +112,65 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 ! =========================================================================
 ! Loop limits
 
+! positive definite filter
+
    ktf     = kte
-   i_start = its - 1
-   i_end   = MIN(ite+1,ide) 
-   j_start = jts - 1
-   j_end   = MIN(jte+1,jde)
+   i_start = its-1
+   i_end   = MIN(ite,ide-1)+1
+   j_start = jts-1
+   j_end   = MIN(jte,jde-1)+1
+
+!-- loop bounds for open or specified conditions
+
+!  determine boundary mods for flux operators
+!  We degrade the flux operators from 3rd/4th order
+!   to second order one gridpoint in from the boundaries for
+!   all boundary conditions except periodic and symmetry - these
+!   conditions have boundary zone data fill for correct application
+!   of the higher order flux stencils
+
+   degrade_xs = .true.
+   degrade_xe = .true.
+   degrade_ys = .true.
+   degrade_ye = .true.
+
+   IF( config_flags%periodic_x   .or. &
+       config_flags%symmetric_xs .or. &
+       (its > ids+3)                ) degrade_xs = .false.
+   IF( config_flags%periodic_x   .or. &
+       config_flags%symmetric_xe .or. &
+       (ite < ide-3)                ) degrade_xe = .false.
+   IF( config_flags%periodic_y   .or. &
+       config_flags%symmetric_ys .or. &
+       (jts > jds+3)                ) degrade_ys = .false.
+   IF( config_flags%periodic_y   .or. &
+       config_flags%symmetric_ye .or. &
+       (jte < jde-4)                ) degrade_ye = .false.
+
+   IF(degrade_xs) i_start = MAX(its-1,ids)
+   IF(degrade_xe) i_end   = MIN(ite+1,ide-1)
+   IF(degrade_ys) j_start = MAX(jts-1,jds)
+   IF(degrade_ye) j_end   = MIN(jte+1,jde-1)
+
+   IF(config_flags%specified .or. config_flags%nested) THEN
+     IF (degrade_xs) i_start = MAX(its-1,ids+1)
+     IF (degrade_xe) i_end   = MIN(ite+1,ide-2)
+     IF (degrade_ys) j_start = MAX(jts-1,jds+1)
+     IF (degrade_ye) j_end   = MIN(jte+1,jde-2)
+   END IF
+
+   IF(config_flags%open_xs) THEN
+     IF (degrade_xs) i_start = MAX(its-1,ids+1)
+   END IF
+   IF(config_flags%open_xe) THEN
+     IF (degrade_xe) i_end   = MIN(ite+1,ide-2)
+   END IF
+   IF(config_flags%open_ys) THEN
+     IF (degrade_ys) j_start = MAX(jts-1,jds+1)
+   END IF
+   IF(config_flags%open_ye) THEN
+     IF (degrade_ye) j_end   = MIN(jte+1,jde-2)
+   END IF
 
 ! =========================================================================
 ! PRINT OUT IEVA INFO
@@ -150,13 +205,13 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
      print_flag = .false.
    ENDIF
 
-   DO j = jms, jme
-   DO k = kms, kme
-   DO i = ims, ime
-     wwE(i,k,j) = 0.
-     wwI(i,k,j) = 0.
-   ENDDO
-   ENDDO
+   DO j = j_start, j_end
+    DO k = kts, ktf
+     DO i = i_start, i_end
+      wwE(i,k,j) = 0.
+      wwI(i,k,j) = 0.
+     ENDDO
+    ENDDO
    ENDDO
 
 ! =========================================================================
@@ -219,9 +274,9 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
            cx = 0.25*rdx*(u(i+1,k,j  ) + u(i,k,j) + u(i+1,k-1,j  ) + u(i,k-1,j)) 
            cy = 0.25*rdy*(v(i,  k,j+1) + v(i,k,j) + v(i  ,k-1,j+1) + v(i,k-1,j)) 
 
-!          cw_max = alpha_max                                              ! Using simpler version...
+           cw_max = alpha_max                                              ! Using simpler version...
 !          cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
-           cw_max = max(alpha_max - dt*Ceps*sqrt(cx**2 + cy**2),0.0)       ! adjusted max vertical courant
+!          cw_max = max(alpha_max - dt*Ceps*sqrt(cx**2 + cy**2),0.0)       ! adjusted max vertical courant
 
            cr     = ww(i,k,j) * dt * rdnw(k) / (c1f(k)*mut(i,j)+c2f(k))    ! vertical courant number
          
@@ -830,7 +885,7 @@ END SUBROUTINE advect_s_implicit
 SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
                               ru, rv, rom,                   &
                               c1, c2,                        &
-                              mut_old, mut, mut_new,         &
+                              muu_old, muu, muu_new,         &
                               config_flags,                  &
                               msfux, msfuy, msfvx, msfvy,    &
                               msftx, msfty,                  &
@@ -864,7 +919,7 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
 ! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
 !            have time-avg column mass.  For scalars (not theta) mut_new == mut
 
-   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: muu, muu_old, muu_new
 
 !-------------------------------------------------------------------------------
 
@@ -899,8 +954,6 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
 
    REAL    :: wiL, wiR, dz
    
-   REAL , DIMENSION( ims:ime+1 , jms:jme ) :: muu, muu_old, muu_new
-
    REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
    REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
       
@@ -913,19 +966,7 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
    i_end   = ite
    j_start = jts
    j_end   = MIN(jte,jde-1)
-   
-! Compute column masses for u-staggering...
-
-   DO j = j_start, j_end
-    DO i = i_start, i_end
-
-      muu(i,j)     = 0.5*(mut(i,j)    +mut(i-1,j))
-      muu_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i-1,j))
-      muu_new(i,j) = 0.5*(mut_new(i,j)+mut_new(i-1,j))
-      
-    ENDDO
-  ENDDO
-    
+       
 ! Vertical loop to do implicit advection.....
 
    DO j = j_start, j_end
@@ -971,7 +1012,7 @@ END SUBROUTINE advect_u_implicit
 SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
                               ru, rv, rom,                   &
                               c1, c2,                        &
-                              mut_old, mut, mut_new,         &
+                              muv_old, muv, muv_new,         &
                               config_flags,                  &
                               msfux, msfuy, msfvx, msfvy,    &
                               msftx, msfty,                  &
@@ -1005,7 +1046,7 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
 ! mu_new ==> "n+1*" estimated column needed for dynamical variables where we dont
 !            have time-avg column mass.  For scalars (not theta) mut_new == mut
 
-   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: mut, mut_old, mut_new
+   REAL , DIMENSION( ims:ime , jms:jme ) , INTENT(IN) :: muv, muv_old, muv_new
 
 !-------------------------------------------------------------------------------
 
@@ -1040,8 +1081,6 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
 
    REAL    :: mrdx, mrdy, ub, vb, uw, vw, dvm, dvp, wiL, wiR, dz
 
-   REAL,   DIMENSION( ims:ime , jms:jme+1 ) :: muv, muv_old, muv_new
-
    REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb
    REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
    
@@ -1054,18 +1093,6 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
    i_end   = MIN(ite,ide-1)
    j_start = jts
    j_end   = jte
-
-! Compute column masses for v-staggering...
-
-   DO j = j_start,j_end
-    DO i = i_start, i_end
-
-      muv(i,j)     = 0.5*(mut(i,j)    +mut(i,j-1))
-      muv_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i,j-1))
-      muv_new(i,j) = 0.5*(mut_new(i,j)+mut_new(i,j-1))
-      
-    ENDDO
-  ENDDO
  
 ! Main Loop
 

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -6,7 +6,7 @@ MODULE module_ieva_em
   
   REAL(KIND=8), PARAMETER :: eps        = 1.0d-08
   REAL,         PARAMETER :: alpha_max  = 1.1
-  REAL,         PARAMETER :: alpha_min  = 0.9
+  REAL,         PARAMETER :: alpha_min  = 0.8
 
 CONTAINS
 
@@ -25,15 +25,17 @@ LOGICAL FUNCTION CHK_IEVA( config_flags, rk_step )
 
    CHK_IEVA = .FALSE.
 
-   IF( zadvect_implicit .eq. 3 ) THEN   ! DO IEVA on all sub-steps of RK integrator
-       CHK_IEVA = .TRUE.
-   ENDIF
+! These option to run on the sub-steps are off - they dont make much of a difference
 
-   IF( zadvect_implicit .eq. 2 .and. rk_step .ge. rk_order-1 ) THEN ! DO IEVA on last two sub-steps of RK integrator
-       CHK_IEVA = .TRUE.
-   ENDIF
-
-   IF( zadvect_implicit .eq. 1 .and. rk_step .eq. rk_order ) THEN  ! DO IEVA on last sub-step of RK integrator
+!  IF( zadvect_implicit .eq. 3 ) THEN   ! DO IEVA on all sub-steps of RK integrator
+!      CHK_IEVA = .TRUE.
+!  ENDIF
+!
+!  IF( zadvect_implicit .eq. 2 .and. rk_step .ge. rk_order-1 ) THEN ! DO IEVA on last two sub-steps of RK integrator
+!      CHK_IEVA = .TRUE.
+!  ENDIF
+ 
+   IF( zadvect_implicit .gt. 0 .and. rk_step .eq. rk_order ) THEN  ! DO IEVA on last sub-step of RK integrator
        CHK_IEVA = .TRUE.
    ENDIF
 
@@ -41,11 +43,12 @@ RETURN
 END FUNCTION CHK_IEVA
 
 !-------------------------------------------------------------------------------
-! IEVA code for splitting vertical velocity for ex/im based on Shchepetkin (2015)
+! IEVA code for splitting vertical velocity into pieces for explicit and implicit
+! advection by the routines based on Shchepetkin (2015)
 
 SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
                     u, v, ww, w, mut, rdnw, msfty,    &
-                    c1, c2,                           &
+                    c1f, c2f,                         &
                     rdx, rdy, msfux, msfuy,           &
                     msfvx, msfvy, dt,                 &
                     config_flags, rk_step,            &
@@ -67,7 +70,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   ) :: mut
 
    REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: rdnw 
-   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: c1, c2
+   REAL, DIMENSION( kms:kme ), INTENT(IN   ) :: c1f, c2f
 
    REAL, INTENT(IN)    :: dt
    REAL, INTENT(IN)    :: rdx, rdy
@@ -77,7 +80,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 ! Local variables
 
    REAL(KIND=4)    :: cr, cx, cy, c0, c2d, cw_max2, cw_min, cw, cff, rdz
-   INTEGER         :: i, j, k, ii, jj, i_start, i_end, j_start, j_end
+   INTEGER         :: i, j, k, ii, jj, i_start, i_end, j_start, j_end, ktf
    LOGICAL         :: print_flag = .true.
    SAVE            :: print_flag
    
@@ -105,30 +108,59 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    ieva = CHK_IEVA(config_flags, rk_step)
 
 ! =========================================================================
-! PRINT OUT IEVA INFO
+! Loop limits
 
-     IF( print_flag ) THEN
-       write(wrf_err_message,*) '----------------------------------------'
-       CALL wrf_debug( 0, wrf_err_message )
-       write(wrf_err_message,*) 'WW_SPLIT:  ZADVECT_IMPLICT = ', config_flags%zadvect_implicit
-       CALL wrf_debug( 0, wrf_err_message )
-       write(wrf_err_message,*) 'WW_SPLIT:  IEVA = ', ieva
-       CALL wrf_debug( 0, wrf_err_message )
-       write(wrf_err_message,*) 'WW_SPLIT:  dt = ', dt
-       CALL wrf_debug( 0, wrf_err_message )
-       write(wrf_err_message,*) 'WW_SPLIT:  alpha_max/min = ', alpha_max, alpha_min
-       CALL wrf_debug( 0, wrf_err_message )
-       print_flag = .false.     
-      ENDIF
+   ktf     = kte
+   i_start = its - 1
+   i_end   = MIN(ite+1,ide) 
+   j_start = jts - 1
+   j_end   = MIN(jte+1,jde)
 
 ! =========================================================================
-   
-   i_start = its-1
-   i_end   = MIN(ite,ide-1) + 1
-   j_start = jts - 1
-   j_end   = MIN(jte,jde-1) + 1
-   
-  
+! PRINT OUT IEVA INFO
+
+   IF( print_flag ) THEN
+     write(wrf_err_message,*) '-- BEGIN WW_SPLIT INFO ----------------------------------------'
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'RK_STEP ##', rk_step
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'IMS:IME     /  JME:JME     ', ims, ime, jms, jme
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'ISTART:IEND / JSTART:JEND  ', i_start,i_end,j_start,j_end
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'KMS:KME     /   KDS:KDE    KTS:KTE   ', kms,kme,kds,kde,kts,kte
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) '----------------------------------------'
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'WW_SPLIT:  ZADVECT_IMPLICT = ', config_flags%zadvect_implicit
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'WW_SPLIT:  IEVA = ', ieva
+     CALL wrf_debug( 10, wrf_err_message )
+     IF( config_flags%zadvect_implicit > 1 ) THEN
+       write(wrf_err_message,*) 'WW_SPLIT:  WARNING: IEVA IS CONFIG TO ONLY RUN ON LAST RK-substep'
+       CALL wrf_debug( 10, wrf_err_message )
+     ENDIF
+     write(wrf_err_message,*) 'WW_SPLIT:  dt = ', dt
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) 'WW_SPLIT:  alpha_max/min = ', alpha_max, alpha_min
+     CALL wrf_debug( 10, wrf_err_message )
+     write(wrf_err_message,*) '-- END WW_SPLIT INFO ----------------------------------------'
+     CALL wrf_debug( 10, wrf_err_message )
+     print_flag = .false.
+   ENDIF
+
+   DO j = jms, jme
+   DO k = kms, kme
+   DO i = ims, ime
+     wwE(i,k,j) = 0.
+     wwI(i,k,j) = 0.
+   ENDDO
+   ENDDO
+   ENDDO
+
+! =========================================================================
+! Loop limits
+
    IF( ieva ) THEN   ! Implicit adaptive advection
    
 !=========================================================================
@@ -140,46 +172,52 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !
 !=========================================================================
 
+! Set upper and lower boundary values
+
      DO j = j_start, j_end
        DO i = i_start,i_end
        
          wwE(i,1,j) = ww(i,    1,j)
          wwI(i,1,j) = 0.0
          
-         wwE(i,kde,j) = ww(i,kde,j)
-         wwI(i,kde,j) = 0.0
+         wwE(i,ktf,j) = ww(i,ktf,j)
+         wwI(i,ktf,j) = 0.0
 
        ENDDO
      ENDDO
        
      DO j = j_start, j_end
-       DO k = 2, kde-1
+       DO k = 2, ktf-1
 
          DO i = i_start,i_end
          
-!=========================================================================
+!===================================================================================================
 !      
 ! Translating Shchepetkin (2015), all the volumes and surface areas cancel out (not obvious unless you read
 ! the definitions of U, V, and W right after equation 3.7 (they are u*dy*dz, v*dx*dz, w*dx*dy)...
 ! You can write the algorithm using the adjusted maximum vertical courant number (alpha_max - eps*hor_div)
 ! versus the actual vertical courant number.  This code is based on the appendix C of Shchepetkin (2015).
-! The CX and CY measure the maximum possible divergence for a zone, e.g., the Lipschlitz number.  If this number ~O(1), 
-! then you want to reduce the maximum allowed vertical courant number for the explicit advection.  Ceps is a fudge
-! factor - so when the 2D Lipschlitz number is larger than O(1), the scheme switches to fully implicit.
+! The CX and CY measure the maximum possible divergence for a zone, e.g., the Lipschlitz number.  If 
+! this number ~O(1), then the maximum allowed vertical courant number for the explicit advection is close 
+! to zeros, the scheme switches to fully implicit.  Ceps is a fudge factor for when the vertical and 
+! horizontal discretizations are of different order.  It is set to 0.9, which allows the some headroom for 
+! the maximum horizontal Courant number since we are using an RK3 integrator which has a larger stability 
+! region than the integrators used in Shchepetkin (2015).
 !
-!=========================================================================
+!===================================================================================================
            wfrac = 1.0
             
            IF( ww(i,k,j) < 0.0 ) THEN    !! Omega has opposite sign of W
-             cx = msfty(i,j)*rdx*(max(u(i+1,k,j), 0.0) - min(u(i,k,j), 0.0)) 
-             cy = msfty(i,j)*rdy*(max(v(i,k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
+             cx = rdx*(max(u(i+1,k,j  ), 0.0) - min(u(i,k,j), 0.0)) 
+             cy = rdy*(max(v(i,  k,j+1), 0.0) - min(v(i,k,j), 0.0)) 
            ELSE
-             cx = msfty(i,j)*rdx*(max(u(i+1,k-1,j), 0.0) - min(u(i,k-1,j), 0.0)) 
-             cy = msfty(i,j)*rdy*(max(v(i,k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
+             cx = rdx*(max(u(i+1,k-1,j  ), 0.0) - min(u(i,k-1,j), 0.0)) 
+             cy = rdy*(max(v(i,  k-1,j+1), 0.0) - min(v(i,k-1,j), 0.0))
            ENDIF
 
            cw_max = max(alpha_max - dt*Ceps*(cx + cy),0.0)                 ! adjusted max vertical courant
-           cr     = ww(i,k,j) * dt * rdnw(k) / (c1(k)*mut(i,j)+c2(k))      ! vertical courant number
+
+           cr     = ww(i,k,j) * dt * rdnw(k) / (c1f(k)*mut(i,j)+c2f(k))    ! vertical courant number
          
            IF( cw_max > 0.0 ) THEN
       
@@ -220,8 +258,12 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !=========================================================================
 ! DEBUG CODE BLOCK:  write out information when fully implicit
 !        
+!            write(wrf_err_message,*) '-- BEGIN WW_SPLIT ----------------------------------------'
+!            CALL wrf_debug(100, wrf_err_message )
 !            write(wrf_err_message,*) ' MAX VERTICAL CFL ~ 0: i,j,k, cw_max, dt*(cx+cy) ',i,j,k,cw_max,Ceps*dt*(cx+cy)
-!            CALL wrf_debug(0, wrf_err_message )
+!            CALL wrf_debug(100, wrf_err_message )
+!            write(wrf_err_message,*) '-- END WW_SPLIT ----------------------------------------'
+!            CALL wrf_debug( 100, wrf_err_message )
 !
 !=========================================================================
              
@@ -237,7 +279,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    ELSE  ! NOT doing IEVA, pure explicit advection
 
      DO j = j_start, j_end
-       DO k = kds, kde
+       DO k = kts, ktf
          DO i = i_start,i_end
            wwE(i,k,j) = ww(i,k,j)
            wwI(i,k,j) = 0.0
@@ -250,20 +292,20 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !=========================================================================
 ! DEBUG - print distribution of wfrac 
 ! 
-!  write(wrf_err_message,*) '----------------------------------------'
-!  CALL wrf_debug( 0, wrf_err_message )
+!  write(wrf_err_message,*) '-- BEGIN WW_SPLIT ----------------------------------------'
+!  CALL wrf_debug( 100, wrf_err_message )
 !  DO mm = 1,11 
 !    write(wrf_err_message,FMT='(a, 2(2x,f4.2),2x,i9,2(2x,f6.4))' ) &
 !     'WW_SPLIT: BIN #, count', (mm-1)*binfrac, mm*binfrac, count(mm), binavg(mm)/(count(mm)+1), crs(mm)/(count(mm)+1)
-!    CALL wrf_debug( 0, wrf_err_message )
+!    CALL wrf_debug( 100, wrf_err_message )
 !  ENDDO
-!  write(wrf_err_message,*) '----------------------------------------'
-!  CALL wrf_debug( 0, wrf_err_message )
+!  write(wrf_err_message,*) '-- END WW_SPLIT ----------------------------------------'
+!  CALL wrf_debug( 100, wrf_err_message )
 !
 !=========================================================================
 
- RETURN
- END SUBROUTINE WW_SPLIT
+RETURN
+END SUBROUTINE WW_SPLIT
  
  
  SUBROUTINE TRIDIAG2D(a, b, c, r, bb, is, ie, istart, iend, ks, ke, kstart, kend)
@@ -278,25 +320,21 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
     integer,                              intent(in)    :: is, ie, ks, ke, istart, iend, kstart, kend
     real(kind=8), dimension(is:ie,ks:ke), intent(in)    :: a, b, c, r
     real(kind=8), dimension(is:ie,ks:ke), intent(inout) :: bb
-    
-    !
-    ! Local Variables
-    ! 
-      
+!
+! Local Variables
+! 
     real(kind=8), dimension(ks:ke) :: gam
     real(kind=8), dimension(is:ie) :: bet
     integer                        :: i, k
-
+!
 ! Copy into temp storage...
-    
+!   
     DO i = istart, iend   
      
       bet(i) = b(i,kstart)  
            
     ENDDO
 
-! I did this in this manner so I wont break vectorization
-  
 !   IF ( ANY( bet < 1.0e-15 ) ) THEN      
 !     write(wrf_err_message,*) '----------------------------------------'
 !     CALL wrf_debug( 0, wrf_err_message )
@@ -313,8 +351,8 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
     
        DO k = kstart+1, kend
        
-         gam(k) = c(i,k-1) / bet(i)
-         bet(i) = b(i,k) - a(i,k) * gam(k)
+         gam(k)  = c(i,k-1) / bet(i)
+         bet(i)  = b(i,k) - a(i,k) * gam(k)
       
          bb(i,k) = ( r(i,k) - a(i,k) * bb(i,k-1) ) / bet(i)
       
@@ -494,6 +532,7 @@ SUBROUTINE CALC_MUT_NEW( u, v, c1h, c2h,                     &
     ENDDO     ! END J
 
 
+RETURN
 END SUBROUTINE CALC_MUT_NEW
 !-------------------------------------------------------------------------------
 !
@@ -563,10 +602,7 @@ SUBROUTINE advect_ph_implicit( ph, pho, tendency, phb,        &
    LOGICAL :: specified
    INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1, valid_ik
 
-   specified = .false.
-   if(config_flags%specified .or. config_flags%nested) specified = .true.
-
-   ktf     = kde-1
+   ktf     = kte-1
    i_start = its
    i_end   = MIN(ite,ide-1)
    j_start = jts
@@ -646,6 +682,8 @@ SUBROUTINE advect_ph_implicit( ph, pho, tendency, phb,        &
    
    ENDDO
     
+   
+RETURN
 END SUBROUTINE advect_ph_implicit
 !-------------------------------------------------------------------------------
 !
@@ -723,37 +761,39 @@ SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
    REAL(KIND=8), DIMENSION(ims:ime,kts:kte) :: at, bt, ct, rt, bb   
    REAL(KIND=8), DIMENSION(ims:ime)         :: btmp
    
-   LOGICAL :: specified
    INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
    INTEGER :: valid_ik, skip
    CHARACTER*512 :: temp
 
-   specified = .false.
-   if(config_flags%specified .or. config_flags%nested) specified = .true.
+   LOGICAL         :: print_flag = .true.
+   SAVE            :: print_flag
+
+!-- loop bounds 
 
    ktf     = MIN(kte,kde-1)
-   i_start = its
+   i_start = its-1
    i_end   = MIN(ite,ide-1)
-   j_start = jts
+   j_start = jts-1
    j_end   = MIN(jte,jde-1)
-   
-! Vertical loop to do implicit advection.....
+
+! J outer loop to do implicit advection.....
 
    DO j = j_start, j_end
- 
+     
      at(:,:) = 0.0
      bt(:,:) = 1.0
      ct(:,:) = 0.0
      rt(:,:) = 0.0
-     bb(:,:) = 0.0
-     
+     bb(:,:) = 0.0    
+           
      DO k = kts, ktf
-       DO i = i_start, i_end
 
-         km1 = k - 1
-         kp1 = k + 1
-         IF( k .eq. ktf ) kp1 = ktf
-         IF( k .eq. kts ) km1 = kts
+       km1 = k - 1
+       kp1 = k + 1
+       IF( k .eq. ktf ) kp1 = ktf
+       IF( k .eq. kts ) km1 = kts
+
+       DO i = i_start, i_end
 
          ! Redefine mass fluxes with new temporary column mass
        
@@ -783,6 +823,7 @@ SUBROUTINE advect_s_implicit( s, s_old, tendency,            &
        
    ENDDO  ! J-LOOP
 
+RETURN
 END SUBROUTINE advect_s_implicit
 !-------------------------------------------------------------------------------
 !
@@ -867,17 +908,7 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
    INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
    INTEGER :: valid_ik
 
-   specified = .false.
-   if(config_flags%specified .or. config_flags%nested) specified = .true.
-
-!-------------------- vertical advection
-!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
-!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
-!  Since 'my' (map scale factor in y-direction) isn't a function of z,
-!  this is what we need, so leave unchanged in advect_u
-
    ktf     = MIN(kte,kde-1)
-
    i_start = its
    i_end   = ite
    j_start = jts
@@ -886,7 +917,7 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
 ! Compute column masses for u-staggering...
 
    DO j = j_start, j_end
-    DO i = its,min(ite+1,ide)
+    DO i = i_start, i_end
 
       muu(i,j)     = 0.5*(mut(i,j)    +mut(i-1,j))
       muu_old(i,j) = 0.5*(mut_old(i,j)+mut_old(i-1,j))
@@ -939,6 +970,7 @@ SUBROUTINE advect_u_implicit( u, u_old, tendency,            &
         
    ENDDO ! J-LOOP
     
+RETURN
 END SUBROUTINE advect_u_implicit
 !-------------------------------------------------------------------------------
 !
@@ -1023,26 +1055,15 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
    INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
    INTEGER :: valid_ik
    
-   specified = .false.
-   if(config_flags%specified .or. config_flags%nested) specified = .true.
-
-!-------------------- vertical advection
-!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
-!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
-!  Since 'my' (map scale factor in y-direction) isn't a function of z,
-!  this is what we need, so leave unchanged in advect_u
-
-
    ktf     = MIN(kte,kde-1)
-   
    i_start = its
    i_end   = MIN(ite,ide-1)
    j_start = jts
    j_end   = jte
-   
-! Compute column masses for u-staggering...
 
-   DO j = jts,min(jte+1,jde)
+! Compute column masses for v-staggering...
+
+   DO j = j_start,j_end
     DO i = i_start, i_end
 
       muv(i,j)     = 0.5*(mut(i,j)    +mut(i,j-1))
@@ -1096,6 +1117,7 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
           
    ENDDO
     
+RETURN
 END SUBROUTINE advect_v_implicit
 
 !-------------------------------------------------------------------------------
@@ -1184,15 +1206,6 @@ SUBROUTINE advect_w_implicit( w, w_old, tendency,            &
    INTEGER :: iup, jup, kup, idn, jdn, kdn, kp1, km1
    INTEGER :: valid_ik
    
-   specified = .false.
-   IF(config_flags%specified .or. config_flags%nested) specified = .true.
-
-!-------------------- vertical advection
-!  ADT eqn 44 has 3rd term on RHS = -(1/my) partial d/dz (rho u w)
-!  Here we have:  - partial d/dz (u*rom) = - partial d/dz (u rho w / my)
-!  Since 'my' (map scale factor in y-direction) isn't a function of z,
-!  this is what we need, so leave unchanged in advect_u
-
    ktf     = MIN(kte,kde-1)
    i_start = its
    i_end   = MIN(ite,ide-1)
@@ -1265,6 +1278,7 @@ SUBROUTINE advect_w_implicit( w, w_old, tendency,            &
      
    ENDDO
     
+RETURN
 END SUBROUTINE advect_w_implicit
 
 END MODULE module_ieva_em

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -152,15 +152,6 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
      print_flag = .false.
    ENDIF
 
-   DO j = j_start, j_end
-     DO k = kts, ktf
-       DO i = i_start, i_end
-         wwE(i,k,j) = 0.
-         wwI(i,k,j) = 0.
-       ENDDO
-     ENDDO
-   ENDDO
-
 ! =========================================================================
 ! Loop limits
 
@@ -174,6 +165,15 @@ SUBROUTINE WW_SPLIT(wwE, wwI,                         &
 !    count(:)  = 0
 !
 !=========================================================================
+
+     DO j = j_start, j_end
+       DO k = kts+1, ktf-1
+         DO i = i_start, i_end
+           wwE(i,k,j) = 0.
+           wwI(i,k,j) = 0.
+         ENDDO
+       ENDDO
+     ENDDO
 
 ! Set upper and lower boundary values to be explicit advection
 

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -119,33 +119,33 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 ! =========================================================================
 ! PRINT OUT IEVA INFO
 
-   IF( print_flag ) THEN
+   IF( print_flag .and. ieva ) THEN
      write(wrf_err_message,*) '-- BEGIN WW_SPLIT INFO ----------------------------------------'
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'RK_STEP ##', rk_step
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'IMS:IME     /  JME:JME     ', ims, ime, jms, jme
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'ISTART:IEND / JSTART:JEND  ', i_start,i_end,j_start,j_end
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'KMS:KME     /   KDS:KDE    KTS:KTE   ', kms,kme,kds,kde,kts,kte
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) '----------------------------------------'
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'WW_SPLIT:  ZADVECT_IMPLICT = ', config_flags%zadvect_implicit
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'WW_SPLIT:  IEVA = ', ieva
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      IF( config_flags%zadvect_implicit > 1 ) THEN
        write(wrf_err_message,*) 'WW_SPLIT:  WARNING: IEVA IS CONFIG TO ONLY RUN ON LAST RK-substep'
-       CALL wrf_debug( 10, wrf_err_message )
+       CALL wrf_debug( 0, wrf_err_message )
      ENDIF
      write(wrf_err_message,*) 'WW_SPLIT:  dt = ', dt
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) 'WW_SPLIT:  alpha_max/min = ', alpha_max, alpha_min
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      write(wrf_err_message,*) '-- END WW_SPLIT INFO ----------------------------------------'
-     CALL wrf_debug( 10, wrf_err_message )
+     CALL wrf_debug( 0, wrf_err_message )
      print_flag = .false.
    ENDIF
 
@@ -323,6 +323,8 @@ END SUBROUTINE WW_SPLIT
 !
 ! Local Variables
 ! 
+!   real(kind=8), dimension(ks:ke) :: gam
+!   real(kind=8), dimension(is:ie) :: bet
     real(kind=8), dimension(ks:ke) :: gam
     real(kind=8), dimension(is:ie) :: bet
     integer                        :: i, k
@@ -346,26 +348,26 @@ END SUBROUTINE WW_SPLIT
 !   ENDIF
 
     DO i = istart, iend
-        
+
        bb(i,kstart) = r(i,kstart)/bet(i)
-    
+
        DO k = kstart+1, kend
-       
-         gam(k)  = c(i,k-1) / bet(i)
-         bet(i)  = b(i,k) - a(i,k) * gam(k)
-      
+
+         gam(k) = c(i,k-1) / bet(i)
+         bet(i) = b(i,k) - a(i,k) * gam(k)
+
          bb(i,k) = ( r(i,k) - a(i,k) * bb(i,k-1) ) / bet(i)
-      
+
        ENDDO
- 
+
        DO k = kend-1, kstart, -1
-       
+
          bb(i,k) = bb(i,k) - gam(k+1) * bb(i,k+1)
-         
+
        ENDDO
-       
+
      ENDDO
- 
+
  END SUBROUTINE TRIDIAG2D
 !--------------------------------------------------------------------------------------------------
  SUBROUTINE TRIDIAG(a, b, c, r, bb, ks, ke, kstart, kend)
@@ -1034,7 +1036,7 @@ SUBROUTINE advect_v_implicit( v, v_old, tendency,            &
                                                                   rdy
    REAL ,                                        INTENT(IN   ) :: dt_rk
 
-   ! Local data
+! Local data
    
    INTEGER :: i, j, k, itf, jtf, ktf
    INTEGER :: i_start, i_end, j_start, j_end

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -47,7 +47,8 @@ END FUNCTION CHK_IEVA
 ! advection by the routines based on Shchepetkin (2015)
 
 SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
-                    u, v, ww, w, mut, rdnw, msfty,    &
+                    u, v, ww,                         &
+                    mut, rdnw, msfty,                 &
                     c1f, c2f,                         &
                     rdx, rdy, msfux, msfuy,           &
                     msfvx, msfvy, dt,                 &
@@ -63,7 +64,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
                                        its, ite, jts, jte, kts, kte, &
                                        rk_step
 
-   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, w, ph, phb
+   REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(IN   ) ::   u, v, ww, ph, phb
 
    REAL, DIMENSION( ims:ime, kms:kme , jms:jme ), INTENT(INOUT) ::  wwE, wwI
 

--- a/dyn_em/module_ieva_em.F
+++ b/dyn_em/module_ieva_em.F
@@ -128,9 +128,7 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
    j_start = jts - 1
    j_end   = MIN(jte,jde-1) + 1
    
-   wwE(:,:,:) = 0.0
-   wwI(:,:,:) = 0.0
-
+  
    IF( ieva ) THEN   ! Implicit adaptive advection
    
 !=========================================================================
@@ -141,20 +139,22 @@ SUBROUTINE WW_SPLIT(wwE, wwI, ph, phb,                &
 !    count(:)  = 0
 !
 !=========================================================================
-                                                        
+
+     DO j = j_start, j_end
+       DO i = i_start,i_end
+       
+         wwE(i,1,j) = ww(i,    1,j)
+         wwI(i,1,j) = 0.0
+         
+         wwE(i,kde,j) = ww(i,kde,j)
+         wwI(i,kde,j) = 0.0
+
+       ENDDO
+     ENDDO
+       
      DO j = j_start, j_end
        DO k = 2, kde-1
-       
-         IF( k == 2 ) THEN               ! Dont do implicit at lower boundary
-           wwE(i_start:i_end,1,j) = 0.0
-           wwI(i_start:i_end,1,j) = 0.0
-         ENDIF
-         
-         IF( k == kde-1 ) THEN           ! Dont do implicit at upper boundary
-           wwE(i_start:i_end,kde,j) = ww(i_start:i_end,kde,j)
-           wwI(i_start:i_end,kde,j) = 0.0
-         ENDIF
-       
+
          DO i = i_start,i_end
          
 !=========================================================================

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -2139,8 +2139,9 @@ BENCH_START(rk_scalar_tend_tim)
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
                            grid%u_2, grid%v_2,  grid%w_2,                    &  
+                           grid%u_1, grid%v_1,                               &  
                            grid%muts, grid%mub, grid%mu_1,                   &
-                           grid%c1h, grid%c2h,                               &
+                           grid%c1h, grid%c2h,  grid%c1f, grid%c2f,          &
                            grid%alt,                                         &
                            moist_old(ims,kms,jms,im),                        &
                            moist(ims,kms,jms,im),                            &
@@ -2308,8 +2309,9 @@ BENCH_START(tke_adv_tim)
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
                             grid%u_2, grid%v_2,  grid%w_2,                         &  
+                            grid%u_1, grid%v_1,                                    &  
                             grid%muts, grid%mub, grid%mu_1,                        &
-                            grid%c1h, grid%c2h,                                    &
+                            grid%c1h, grid%c2h,  grid%c1f, grid%c2f,               &
                             grid%alt,                                              &
                             grid%tke_1,                                            &
                             grid%tke_2,                                            &
@@ -2401,8 +2403,9 @@ BENCH_START(chem_adv_tim)
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
                               grid%u_2, grid%v_2,  grid%w_2,                     &  
+                              grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
-                              grid%c1h, grid%c2h,                                &
+                              grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
                               grid%alt,                                          &
                               chem_old(ims,kms,jms,ic),                          &
                               chem(ims,kms,jms,ic),                              &
@@ -2563,8 +2566,9 @@ BENCH_START(tracer_adv_tim)
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
                               grid%u_2, grid%v_2,  grid%w_2,                     &  
+                              grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
-                              grid%c1h, grid%c2h,                                &
+                              grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
                               grid%alt,                                          &
                               tracer_old(ims,kms,jms,ic),                        &
                               tracer(ims,kms,jms,ic),                            &
@@ -2705,8 +2709,9 @@ BENCH_END(tracer_adv_tim)
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
                                  grid%u_2, grid%v_2,  grid%w_2,                   &  
+                                 grid%u_1, grid%v_1,                              &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
-                                 grid%c1h, grid%c2h,                              &
+                                 grid%c1h, grid%c2h,  grid%c1f, grid%c2f,         &
                                  grid%alt,                                        &
                                  scalar_old(ims,kms,jms,is),                      &
                                  scalar(ims,kms,jms,is),                          &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -2138,7 +2138,7 @@ BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
-                           grid%u_2, grid%v_2,                               &  
+                           grid%u_1, grid%v_1,                               &  
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,  grid%c1f, grid%c2f,          &
                            grid%alt,                                         &
@@ -2307,7 +2307,7 @@ BENCH_START(tke_adv_tim)
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
-                            grid%u_2, grid%v_2,                                    &  
+                            grid%u_1, grid%v_1,                                    &  
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,  grid%c1f, grid%c2f,               &
                             grid%alt,                                              &
@@ -2400,7 +2400,7 @@ BENCH_START(chem_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_2, grid%v_2,                                &  
+                              grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
                               grid%alt,                                          &
@@ -2562,7 +2562,7 @@ BENCH_START(tracer_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_2, grid%v_2,                                &  
+                              grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
                               grid%alt,                                          &
@@ -2704,7 +2704,7 @@ BENCH_END(tracer_adv_tim)
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
-                                 grid%u_2, grid%v_2,                              &  
+                                 grid%u_1, grid%v_1,                              &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,  grid%c1f, grid%c2f,         &
                                  grid%alt,                                        &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -256,7 +256,7 @@ SUBROUTINE solve_em ( grid , config_flags  &
    f_flux = config_flags%do_avgflx_cugd .EQ. 1
 
 !  Compute these starting and stopping locations for each tile and number of tiles.
-!  See: http://www.mmm.ucar.edu/wrf/WG2/topics/settiles
+!  See: https://www2.mmm.ucar.edu/wrf/WG2/topics/settiles
    CALL set_tiles ( ZONE_SOLVE_EM, grid , ids , ide , jds , jde , ips , ipe , jps , jpe )
 !   CALL set_tiles (  grid , ids , ide , jds , jde , ips , ipe , jps , jpe )
 
@@ -806,7 +806,7 @@ BENCH_START(rk_tend_tim)
                          ,ru_tendf, rv_tendf, rw_tendf, ph_tendf, t_tendf                                      &
                          ,mu_tend, grid%u_save, grid%v_save, w_save, ph_save                                   &
                          ,grid%t_save, mu_save, grid%rthften                                                   &
-                         ,grid%ru, grid%rv, grid%rw, grid%ww                                                   &
+                         ,grid%ru, grid%rv, grid%rw, grid%ww, wwE, wwI                                         &
                          ,grid%u_2, grid%v_2, grid%w_2, grid%t_2, grid%ph_2                                    &
                          ,grid%u_1, grid%v_1, grid%w_1, grid%t_1, grid%ph_1                                    &
                          ,grid%h_diabatic, grid%phb, grid%t_init                                               &
@@ -2137,7 +2137,7 @@ BENCH_END(small_step_finish_tim)
 BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
-                           grid%ru_m, grid%rv_m, grid%ww_m,                  &
+                           grid%ru_m, grid%rv_m, grid%ww_m, wwE, wwI,        &
                            grid%u_1, grid%v_1,                               &  
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,  grid%c1f, grid%c2f,          &
@@ -2306,7 +2306,7 @@ BENCH_START(tke_adv_tim)
            tenddec = .false.
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
-                            grid%ru_m, grid%rv_m, grid%ww_m,                       &
+                            grid%ru_m, grid%rv_m, grid%ww_m, wwE, wwI,             &
                             grid%u_1, grid%v_1,                                    &  
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,  grid%c1f, grid%c2f,               &
@@ -2399,7 +2399,7 @@ BENCH_START(chem_adv_tim)
                         ( adv_ct_indices(ic) >= PARAM_FIRST_SCALAR ))
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
-                              grid%ru_m, grid%rv_m, grid%ww_m,                   &
+                              grid%ru_m, grid%rv_m, grid%ww_m, wwE, wwI,         &
                               grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
@@ -2561,7 +2561,7 @@ BENCH_START(tracer_adv_tim)
              tenddec = .false.
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
-                              grid%ru_m, grid%rv_m, grid%ww_m,                   &
+                              grid%ru_m, grid%rv_m, grid%ww_m, wwE, wwI,         &
                               grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
@@ -2703,7 +2703,7 @@ BENCH_END(tracer_adv_tim)
            tenddec = .false.
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
-                                 grid%ru_m, grid%rv_m, grid%ww_m,                 &
+                                 grid%ru_m, grid%rv_m, grid%ww_m, wwE, wwI,       &
                                  grid%u_1, grid%v_1,                              &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,  grid%c1f, grid%c2f,         &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -810,9 +810,9 @@ BENCH_START(rk_tend_tim)
                          ,grid%u_2, grid%v_2, grid%w_2, grid%t_2, grid%ph_2                                    &
                          ,grid%u_1, grid%v_1, grid%w_1, grid%t_1, grid%ph_1                                    &
                          ,grid%h_diabatic, grid%phb, grid%t_init                                               &
-                         ,grid%mu_2, grid%mut, grid%muu, grid%muv, grid%mub                                    &
+                         ,grid%mu_1, grid%mu_2, grid%mut, grid%muu, grid%muv, grid%mub                         & 
                          ,grid%c1h, grid%c2h, grid%c1f, grid%c2f                                               &
-                         ,grid%al, grid%alt, grid%p, grid%pb, grid%php, cqu, cqv, cqw                          &
+                         ,grid%al, grid%ht, grid%alt, grid%p, grid%pb, grid%php, cqu, cqv, cqw                 & 
                          ,grid%u_base, grid%v_base, grid%t_base, grid%qv_base, grid%z_base                     &
                          ,grid%msfux,grid%msfuy, grid%msfvx, grid%msfvx_inv                                    &
                          ,grid%msfvy, grid%msftx,grid%msfty, grid%clat, grid%f, grid%e, grid%sina, grid%cosa   &
@@ -2138,6 +2138,7 @@ BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
+                           grid%u_2, grid%v_2,  grid%w_2,                    &  
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,                               &
                            grid%alt,                                         &
@@ -2306,6 +2307,7 @@ BENCH_START(tke_adv_tim)
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
+                            grid%u_2, grid%v_2,  grid%w_2,                         &  
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,                                    &
                             grid%alt,                                              &
@@ -2398,6 +2400,7 @@ BENCH_START(chem_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
+                              grid%u_2, grid%v_2,  grid%w_2,                     &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,                                &
                               grid%alt,                                          &
@@ -2559,6 +2562,7 @@ BENCH_START(tracer_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
+                              grid%u_2, grid%v_2,  grid%w_2,                     &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,                                &
                               grid%alt,                                          &
@@ -2700,6 +2704,7 @@ BENCH_END(tracer_adv_tim)
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
+                                 grid%u_2, grid%v_2,  grid%w_2,                   &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,                              &
                                  grid%alt,                                        &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -2138,7 +2138,6 @@ BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
-                           grid%u_2, grid%v_2,  grid%w_2,                    &  
                            grid%u_1, grid%v_1,                               &  
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,  grid%c1f, grid%c2f,          &
@@ -2308,7 +2307,6 @@ BENCH_START(tke_adv_tim)
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
-                            grid%u_2, grid%v_2,  grid%w_2,                         &  
                             grid%u_1, grid%v_1,                                    &  
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,  grid%c1f, grid%c2f,               &
@@ -2402,7 +2400,6 @@ BENCH_START(chem_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_2, grid%v_2,  grid%w_2,                     &  
                               grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
@@ -2565,7 +2562,6 @@ BENCH_START(tracer_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_2, grid%v_2,  grid%w_2,                     &  
                               grid%u_1, grid%v_1,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
@@ -2708,7 +2704,6 @@ BENCH_END(tracer_adv_tim)
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
-                                 grid%u_2, grid%v_2,  grid%w_2,                   &  
                                  grid%u_1, grid%v_1,                              &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,  grid%c1f, grid%c2f,         &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -2138,7 +2138,7 @@ BENCH_START(rk_scalar_tend_tim)
                CALL rk_scalar_tend (  im, im, config_flags, tenddec,         & 
                            rk_step, dt_rk,                                   &
                            grid%ru_m, grid%rv_m, grid%ww_m,                  &
-                           grid%u_1, grid%v_1,                               &  
+                           grid%u_2, grid%v_2,                               &  
                            grid%muts, grid%mub, grid%mu_1,                   &
                            grid%c1h, grid%c2h,  grid%c1f, grid%c2f,          &
                            grid%alt,                                         &
@@ -2307,7 +2307,7 @@ BENCH_START(tke_adv_tim)
            CALL rk_scalar_tend ( 1, 1, config_flags, tenddec,                      & 
                             rk_step, dt_rk,                                        &
                             grid%ru_m, grid%rv_m, grid%ww_m,                       &
-                            grid%u_1, grid%v_1,                                    &  
+                            grid%u_2, grid%v_2,                                    &  
                             grid%muts, grid%mub, grid%mu_1,                        &
                             grid%c1h, grid%c2h,  grid%c1f, grid%c2f,               &
                             grid%alt,                                              &
@@ -2400,7 +2400,7 @@ BENCH_START(chem_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_1, grid%v_1,                                &  
+                              grid%u_2, grid%v_2,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
                               grid%alt,                                          &
@@ -2562,7 +2562,7 @@ BENCH_START(tracer_adv_tim)
              CALL rk_scalar_tend ( ic, ic, config_flags, tenddec,                & 
                               rk_step, dt_rk,                                    &
                               grid%ru_m, grid%rv_m, grid%ww_m,                   &
-                              grid%u_1, grid%v_1,                                &  
+                              grid%u_2, grid%v_2,                                &  
                               grid%muts, grid%mub, grid%mu_1,                    &
                               grid%c1h, grid%c2h,  grid%c1f, grid%c2f,           &
                               grid%alt,                                          &
@@ -2704,7 +2704,7 @@ BENCH_END(tracer_adv_tim)
            CALL rk_scalar_tend ( is, is, config_flags, tenddec,                   & 
                                  rk_step, dt_rk,                                  &
                                  grid%ru_m, grid%rv_m, grid%ww_m,                 &
-                                 grid%u_1, grid%v_1,                              &  
+                                 grid%u_2, grid%v_2,                              &  
                                  grid%muts, grid%mub, grid%mu_1,                  &
                                  grid%c1h, grid%c2h,  grid%c1f, grid%c2f,         &
                                  grid%alt,                                        &

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1424,6 +1424,13 @@ The following are for observation nudging:
  rk_ord                              = 3,	! time-integration scheme option:
                                                   2 = Runge-Kutta 2nd order
                                                   3 = Runge-Kutta 3rd order
+ zadvect_implicit                    = 0,       ! toggle off on [0/1] the IEVA scheme. Default off.
+ w_crit_cfl                          = 1.2      ! default vertical courant number where vertical velocity damping begins (see below).
+                                                !   when zadvect_implicit is on, value can be ~ 2.0
+ zdamp (max_dom)                     = 5000.,	! damping depth (m) from model top
+ w_damping                           = 0,       ! vertical velocity damping flag (for operational use)
+                                                  0 = without damping
+                                                  1 = with    damping
  diff_opt(max_dom)                   = 0,	! turbulence and mixing option:
                                                   0 = no turbulence or explicit
                                                       spatial numerical filters (km_opt IS IGNORED).
@@ -1472,10 +1479,6 @@ The following are for observation nudging:
  diff_6th_slopeopt (max_dom)         = 0        ! if set to =1, turns on 6th-order numerical diffusion - terrain-slope tapering. default is 0=off
  diff_6th_thresh (max_dom)           = 0.10     ! slope threshold (m/m) that turns off 6th order diff in steep terrain
  dampcoef (max_dom)                  = 0.,	! damping coefficient (see above)
- zdamp (max_dom)                     = 5000.,	! damping depth (m) from model top
- w_damping                           = 0,       ! vertical velocity damping flag (for operational use)
-                                                  0 = without damping
-                                                  1 = with    damping
  base_temp                           = 290.,    ! real-data, em ONLY, base sea-level temp (K)
  base_pres                           = 10^5     ! real-data, em ONLY, base sea-level pres (Pa), DO NOT CHANGE
  base_lapse                          = 50.,     ! real-data, em ONLY, lapse rate (K), DO NOT CHANGE

--- a/test/em_real/namelist.input.IEVA.4km
+++ b/test/em_real/namelist.input.IEVA.4km
@@ -1,0 +1,100 @@
+ &time_control
+ run_days                            = 0,
+ run_hours                           = 12,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2001, 2001, 2001,
+ start_month                         = 06,   06,   06,
+ start_day                           = 11,   11,   11,
+ start_hour                          = 12,   12,   12,
+ end_year                            = 2001, 2001, 2001,
+ end_month                           = 06,   06,   06,
+ end_day                             = 12,   12,   12,
+ end_hour                            = 12,   12,   12,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ history_interval                    = 60,   60,   60,
+ frames_per_outfile                  = 1,    1,    1,
+ restart                             = .false.,
+ restart_interval                    = 1440,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ /
+
+ &domains
+ time_step                           = 30,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 1,
+ e_we                                = 225,   112,   94,
+ e_sn                                = 202,   97,    91,
+ e_vert                              = 35,    35,    35,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 32
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 4000,
+ dy                                  = 4000,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     31,    30,
+ j_parent_start                      = 1,     17,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ mp_physics                          = 8,     8,     8,
+ ra_lw_physics                       = 4,     4,     4,
+ ra_sw_physics                       = 4,     4,     4,
+ radt                                = 10,    10,    10,
+ sf_sfclay_physics                   = 1,     1,     1,
+ sf_surface_physics                  = 2,     2,     2,
+ bl_pbl_physics                      = 1,     1,     1,
+ bldt                                = 0,     0,     0,
+ ysu_topdown_pblmix                  = 1,
+ cu_physics                          = 0,     0,     0,
+ cudt                                = 0,     0,     0,
+ icloud                              = 1,
+ num_land_cat                        = 21,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ hybrid_opt                          = 2, 
+ zadvect_implicit                    = 1
+ w_damping                           = 1,
+ w_crit_cfl                          = 2.0,
+ diff_opt                            = 1,      1,      1,
+ km_opt                              = 4,      4,      4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 3,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 2,      2,      2,
+ scalar_adv_opt                      = 2,      2,      2,
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ specified                           = .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: IEVA, vertical advection

SOURCE: Louis Wicker (NOAA/NSSL)

DESCRIPTION OF CHANGES:

For grids with large aspect ratios (dx/dz >> 1) that permit explicit convection, the large time step is limited by the 
strongest updraft that occurs during integration.  This results in time step often 20-30% smaller, or requires the use 
of w-filtering, such as latent-heat tendency limiting.  Regions of large vertical velocities are also often very small 
relative to the domain.  The Implicit-Explicit Vertical Advection (IEVA) scheme has been implemented (see Wicker, L. J., 
and W. C. Skamarock, 2020: An Implicit–Explicit Vertical Transport Scheme for Convection-Allowing Models. Mon. Wea. 
Rev., 148, 3893–3910) and that permits a larger time step by partitioning the vertical transport into an explicit piece, 
which uses the normal vertical schemes present in WRF, and a implicit piece which uses implicit transport (which is 
unconditionally stable).  The combined scheme permits a larger time step than has been previously been used and 
reduced w-filtering.
 
The scheme will be useful for CONUS scale CAM (convection allowing model) simulations (dx ~ 2-3 km) when the 
number of vertical levels > 50.  Time steps can increase to as large as 25 s, depending on the problem.  The Wicker 
and Skamarock paper demonstrates IEVA's advantages on the 27 April 2011 Alabama tornado outbreak by comparing 
it to the operational CAM (the High Resolution Rapid Refresh) configuration.  Results are shown that the HRRR 
simulation is stable up to a dt=20 s and only with latent-heat limiting on.  Using the IEVA scheme the dt can be increased 
to 24 s and no latent-heat limiting is needed.  Overall integration efficiency increases ~ 15%, and the IEVA solutions 
are closer to a benchmark run using smaller dt (12 s) than the HRRR simulation.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/Makefile
M       dyn_em/module_advect_em.F
M       dyn_em/module_big_step_utilities_em.F
M       dyn_em/module_em.F
A       dyn_em/module_ieva_em.F
M       dyn_em/solve_em.F
M       run/README.namelist
A       test/em_real/namelist.input.IEVA.4km 

TESTS CONDUCTED:
1. This pull requested code has been tested repeatedly on 27 April for a 24 hour simulation with the parameters set as in the Wicker and Skamarock (2020) as well as a 10 step difference test with the em_quarter_ss case using a single node and 4 nodes.  The differences in the results ~ 10^-5.

2. Jenkins tests are all pass.

RELEASE NOTES: The Implicit-Explicit Vertical Advection (IEVA) scheme has been implemented (see Wicker, L. J., and W. C. Skamarock, 2020: An Implicit–Explicit Vertical Transport Scheme for Convection-Allowing Models. Mon. Wea. Rev., 148, 3893–3910) and that permits a larger time step by partitioning the vertical transport into an explicit piece, which uses the normal vertical schemes present in WRF, and a implicit piece which uses implicit transport (which is unconditionally stable).  The combined scheme permits a larger time step than has been previously been used and reduced w-filtering. The scheme will be useful for CONUS-scale CAM (convection allowing model) simulations (dx ~ 2-3 km) when the number of vertical levels > 50.  In these cases, time steps can increase to as large as 25 s, depending on the problem. Overall integration efficiency increases ~ 15%, and the IEVA solutions are closer to a benchmark run using smaller time step.