### PR TITLE
Alter graupel Y-intercept parameter diagnosis (replacement of PR#1324)

### DIFF
--- a/phys/module_diag_nwp.F
+++ b/phys/module_diag_nwp.F
@@ -606,8 +606,8 @@ CONTAINS
        DO i=i_start(ij),i_end(ij)
         DO k=kme-1, kms, -1
          if (temp_qg(i,k,j) .LT. 1.E-6) CYCLE
-         zans1 = (3.5 + 2./7. * (ALOG10(temp_qg(i,k,j))+7.))
-         zans1 = MAX(2., MIN(zans1, 7.))
+         zans1 = (3.0 + 2./7. * (ALOG10(temp_qg(i,k,j))+8.))
+         zans1 = MAX(2., MIN(zans1, 6.))
          N0exp = 10.**zans1
          lam_exp = (N0exp*xam_g*cgg(1)/temp_qg(i,k,j))**(1./cge(1))
          lamg = lam_exp * (cgg(3)/cgg(2)/cgg(1))**(1./xbm_g)

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -108,8 +108,8 @@
 !.. mixing ratio.  Also, when mu_g is non-zero, these become equiv
 !.. y-intercept for an exponential distrib and proper values are
 !.. computed based on same mixing ratio and total number concentration.
-      REAL, PARAMETER, PRIVATE:: gonv_min = 1.E3
-      REAL, PARAMETER, PRIVATE:: gonv_max = 9.E6
+      REAL, PARAMETER, PRIVATE:: gonv_min = 1.E2
+      REAL, PARAMETER, PRIVATE:: gonv_max = 1.E6
 
 !..Mass power law relations:  mass = am*D**bm
 !.. Snow from Field et al. (2005), others assume spherical form.
@@ -289,11 +289,11 @@
 
 !..Lookup tables for graupel y-intercept parameter (/m**4).
       REAL, DIMENSION(ntb_g1), PARAMETER, PRIVATE:: &
-      N0g_exp = (/1.e3,2.e3,3.e3,4.e3,5.e3,6.e3,7.e3,8.e3,9.e3, &
+      N0g_exp = (/1.e2,2.e2,3.e2,4.e2,5.e2,6.e2,7.e2,8.e2,9.e2, &
+                  1.e3,2.e3,3.e3,4.e3,5.e3,6.e3,7.e3,8.e3,9.e3, &
                   1.e4,2.e4,3.e4,4.e4,5.e4,6.e4,7.e4,8.e4,9.e4, &
                   1.e5,2.e5,3.e5,4.e5,5.e5,6.e5,7.e5,8.e5,9.e5, &
-                  1.e6,2.e6,3.e6,4.e6,5.e6,6.e6,7.e6,8.e6,9.e6, &
-                  1.e7/)
+                  1.e6/)
 
 !..Lookup tables for ice number concentration (/m**3).
       REAL, DIMENSION(ntb_i1), PARAMETER, PRIVATE:: &
@@ -1578,7 +1578,7 @@
       enddo
 #endif
 
-!..Bug fix (2016Jun15), prevent use of uninitialized value(s) of snow moments.
+!..Bug fix (2016Jun15), prevent use of uninitialized value(s).
       do k = kts, kte
          smo0(k) = 0.
          smo1(k) = 0.
@@ -1588,6 +1588,8 @@
          smod(k) = 0.
          smoe(k) = 0.
          smof(k) = 0.
+         mvd_r(k) = 0.
+         mvd_c(k) = 0.
       enddo
 
 !+---+-----------------------------------------------------------------+
@@ -1849,8 +1851,8 @@
 
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = (3.5 + 2./7. * (ygra1+7.))
-         zans1 = MAX(2., MIN(zans1, 7.))
+         zans1 = 3.0 + 2./7.*(ygra1+8.)
+         zans1 = MAX(2., MIN(zans1, 6.))
          N0_exp = 10.**(zans1)
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
          lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg
@@ -2910,8 +2912,8 @@
 
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = (3.5 + 2./7. * (ygra1+7.))
-         zans1 = MAX(2., MIN(zans1, 7.))
+         zans1 = 3.0 + 2./7.*(ygra1+8.)
+         zans1 = MAX(2., MIN(zans1, 6.))
          N0_exp = 10.**(zans1)
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
          lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg
@@ -3579,10 +3581,10 @@
 
       good = 0
       IF ( wrf_dm_on_monitor() ) THEN
-        INQUIRE(FILE="qr_acr_qgV2.dat",EXIST=lexist)
+        INQUIRE(FILE="qr_acr_qgV3.dat",EXIST=lexist)
         IF ( lexist ) THEN
-          CALL wrf_message("ThompMP: read qr_acr_qgV2.dat instead of computing")
-          OPEN(63,file="qr_acr_qgV2.dat",form="unformatted",err=1234)
+          CALL wrf_message("ThompMP: read qr_acr_qgV3.dat instead of computing")
+          OPEN(63,file="qr_acr_qgV3.dat",form="unformatted",err=1234)
           READ(63,err=1234) tcg_racg
           READ(63,err=1234) tmr_racg
           READ(63,err=1234) tcr_gacr
@@ -3595,12 +3597,12 @@
             INQUIRE(63,opened=lopen)
             IF (lopen) THEN
               IF( force_read_thompson ) THEN
-                CALL wrf_error_fatal("Error reading qr_acr_qgV2.dat. Aborting because force_read_thompson is .true.")
+                CALL wrf_error_fatal("Error reading qr_acr_qgV3.dat. Aborting because force_read_thompson is .true.")
               ENDIF
               CLOSE(63)
             ELSE
               IF( force_read_thompson ) THEN
-                CALL wrf_error_fatal("Error opening qr_acr_qgV2.dat. Aborting because force_read_thompson is .true.")
+                CALL wrf_error_fatal("Error opening qr_acr_qgV3.dat. Aborting because force_read_thompson is .true.")
               ENDIF
             ENDIF
           ELSE
@@ -3611,7 +3613,7 @@
           ENDIF
         ELSE
           IF( force_read_thompson ) THEN
-            CALL wrf_error_fatal("Non-existent qr_acr_qgV2.dat. Aborting because force_read_thompson is .true.")
+            CALL wrf_error_fatal("Non-existent qr_acr_qgV3.dat. Aborting because force_read_thompson is .true.")
           ENDIF
         ENDIF
       ENDIF
@@ -3723,7 +3725,7 @@
 #endif
 
         IF ( write_thompson_tables .AND. wrf_dm_on_monitor() ) THEN
-          CALL wrf_message("Writing qr_acr_qgV2.dat in Thompson MP init")
+          CALL wrf_message("Writing qr_acr_qgV3.dat in Thompson MP init")
           OPEN(63,file="qr_acr_qgV2.dat",form="unformatted",err=9234)
           WRITE(63,err=9234) tcg_racg
           WRITE(63,err=9234) tmr_racg
@@ -5295,8 +5297,8 @@
       if (ANY(L_qg .eqv. .true.)) then
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = (3.5 + 2./7. * (ygra1+7.))
-         zans1 = MAX(2., MIN(zans1, 7.))
+         zans1 = 3.0 + 2./7.*(ygra1+8.)
+         zans1 = MAX(2., MIN(zans1, 6.))
          N0_exp = 10.**(zans1)
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
          lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -3726,7 +3726,7 @@
 
         IF ( write_thompson_tables .AND. wrf_dm_on_monitor() ) THEN
           CALL wrf_message("Writing qr_acr_qgV3.dat in Thompson MP init")
-          OPEN(63,file="qr_acr_qgV2.dat",form="unformatted",err=9234)
+          OPEN(63,file="qr_acr_qgV3.dat",form="unformatted",err=9234)
           WRITE(63,err=9234) tcg_racg
           WRITE(63,err=9234) tmr_racg
           WRITE(63,err=9234) tcr_gacr


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: graupel, hail, microphysics, Y-intercept

SOURCE: Greg Thompson (JCSDA)

DESCRIPTION OF CHANGES:
Problem:
Since the prior version of the Thompson MP scheme, where a new relationship was created for Y-intercept parameter of one-moment graupel, the maximum radar reflectivity and max hail size were reduced lower than intended/desired.

Solution:
Minor changes to the diagnosis of the Y-intercept parameter, resulting in a slightly increased highest radar reflectivity and maximum hail size. It is not a very significant increase but fits better with the Paul Field et al. (2019) paper that analyzed T-28 aircraft hail data.

LIST OF MODIFIED FILES:
M phys/module_mp_thompson.F
M phys/module_diag_nwp.F

TESTS CONDUCTED:
1. Numerous simulations run with HRRR-CONUS-like grid.
2. jenkins status is pass

RELEASE NOTE: Relatively small tunings for Thompson MP one-moment graupel Y-intercept parameter diagnosis, creating a better fit to Paul Field et al (2019) analysis of T-28 aircraft hail data.
