### PR TITLE
height-level diagnostic fixes: add p_zl, use ln(p) interp for pressure

### DIFF
--- a/Registry/registry.diags
+++ b/Registry/registry.diags
@@ -69,8 +69,9 @@ state    real   ght_zl i{nz}j   misc    1  Z   h{22}  "GHT_ZL"  "Height level da
 state    real   s_zl   i{nz}j   misc    1  Z   h{22}  "S_ZL"    "Height level data, Speed"                 "m s-1"
 state    real   td_zl  i{nz}j   misc    1  Z   h{22}  "TD_ZL"   "Height level data, Dew point temperature" "K"
 state    real   q_zl   i{nz}j   misc    1  Z   h{22}  "Q_ZL"    "Height level data, Mixing ratio"          "kg/kg"
+state    real   p_zl   i{nz}j   misc    1  Z   h{22}  "P_ZL"    "Height level data, Air Pressure"          "Pa"
 
 #  Package declarations
 
 package   skip_z_diags      z_lev_diags==0     -        -
-package        z_diags      z_lev_diags==1     -        state:z_zl,u_zl,v_zl,t_zl,rh_zl,ght_zl,s_zl,td_zl,q_zl
+package        z_diags      z_lev_diags==1     -        state:z_zl,u_zl,v_zl,t_zl,rh_zl,ght_zl,s_zl,td_zl,q_zl,p_zl

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -2053,6 +2053,7 @@ DEALLOCATE(z_at_q)
                  ,s_zl  = grid%s_zl             &  
                  ,td_zl = grid%td_zl            &
                  ,q_zl = grid%q_zl              &
+                 ,p_zl = grid%p_zl              &
                  !  Dimension arguments
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde    &
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme    &

--- a/phys/module_diag_zld.F
+++ b/phys/module_diag_zld.F
@@ -17,7 +17,7 @@ CONTAINS
                     use_tot_or_hyd_p,extrap_below_grnd,missing,     &  
                     num_z_levels,max_z_levels,z_levels,             &
                     z_zl,u_zl,v_zl,t_zl,rh_zl,ght_zl,s_zl,td_zl,    &
-                    q_zl,                                           &
+                    q_zl,p_zl,                                      &
                     ids,ide, jds,jde, kds,kde,                      &
                     ims,ime, jms,jme, kms,kme,                      &
                     its,ite, jts,jte, kts,kte                       )
@@ -44,7 +44,7 @@ CONTAINS
       !  Output variables
    
       REAL   , INTENT(  OUT) ,  DIMENSION(num_z_levels)                     :: z_zl
-      REAL   , INTENT(  OUT) ,  DIMENSION(ims:ime , num_z_levels , jms:jme) :: u_zl,v_zl,t_zl,rh_zl,ght_zl,s_zl,td_zl,q_zl
+      REAL   , INTENT(  OUT) ,  DIMENSION(ims:ime , num_z_levels , jms:jme) :: u_zl,v_zl,t_zl,rh_zl,ght_zl,s_zl,td_zl,q_zl,p_zl
    
       !  Local variables
    
@@ -82,6 +82,7 @@ CONTAINS
                ght_zl(i,kz,j) = missing
                s_zl  (i,kz,j) = missing
                td_zl (i,kz,j) = missing
+               p_zl  (i,kz,j) = missing
             END DO
          END DO
       END DO
@@ -116,11 +117,16 @@ CONTAINS
 
                      pu = pp(i,ke+1,j)+pb(i,ke+1,j) 
                      pd = pp(i,ke  ,j)+pb(i,ke  ,j)
-                     pm = ( pu * (zm-zd) + pd * (zu-zm) ) / (zu-zd)
+                     !pm = ( pu * (zm-zd) + pd * (zu-zm) ) / (zu-zd)
    
                      !  Found trapping height: up, middle, down.
                      !  We are doing first order interpolation.  
                      !  Now we just put in a list of diagnostics for this level.
+
+                     !  0. Pressure (Pa)
+                     !  Note that it is ln(p) that varies linearly with height, not p itself
+                     pm = exp( ( log(pu) * (zm-zd) + log(pd) * (zu-zm) ) / (zu-zd) )
+                     p_zl(i,kz,j) = pm
    
                      !  1. Temperature (K)
    

--- a/phys/module_diag_zld.F
+++ b/phys/module_diag_zld.F
@@ -117,7 +117,6 @@ CONTAINS
 
                      pu = pp(i,ke+1,j)+pb(i,ke+1,j) 
                      pd = pp(i,ke  ,j)+pb(i,ke  ,j)
-                     !pm = ( pu * (zm-zd) + pd * (zu-zm) ) / (zu-zd)
    
                      !  Found trapping height: up, middle, down.
                      !  We are doing first order interpolation.  
@@ -125,6 +124,7 @@ CONTAINS
 
                      !  0. Pressure (Pa)
                      !  Note that it is ln(p) that varies linearly with height, not p itself
+                     
                      pm = exp( ( log(pu) * (zm-zd) + log(pd) * (zu-zm) ) / (zu-zd) )
                      p_zl(i,kz,j) = pm
    

--- a/phys/module_diagnostics_driver.F
+++ b/phys/module_diagnostics_driver.F
@@ -911,6 +911,7 @@ CONTAINS
                       ,s_zl  = grid%s_zl                                    &
                       ,td_zl = grid%td_zl                                   &
                       ,q_zl = grid%q_zl                                     &
+                      ,p_zl = grid%p_zl                                     &
                !  Dimension arguments
                       ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde    &
                       ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme    &


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: pressure, height level diagnostics, vertical interpolation

SOURCE: Jared A. Lee (NCAR/RAL)

DESCRIPTION OF CHANGES:
Problem:
To compare WRF simulations against observations from above-ground barometers (e.g., mounted on a wind turbine 
nacelle), it is useful to add air pressure to the list of available height-level diagnostics within WRF.

Solution:
Following the definition and development of variables like t_zl, s_zl, and ght_zl, I added a definition for p_zl in the Registry 
file, set an initial value for output, and then added the new variable to the diagnostic call tree. In the height-level 
diagnostic routine, I set the new variable p_zl to be equal to the already computed (but local) height-interpolated 
pressure. The interpolation to compute the pressure was being done linearly in height with respect to pressure, whereas 
the interpolation should actually have been linear in height with respect to ln(pressure). The computed pressure variable 
is used in the relative humidity height-level diagnostic (rh_zl), so this modification creates small changes for the 
diagnosed relative humidity. At height levels in the lowest 1 km AGL, this change results in negligible differences in 
pressure (<0.1 Pa), and also negligible differences in relative humidity (<0.0001%). Higher up in the troposphere, these 
differences may be more noticeable.

LIST OF MODIFIED FILES:
M       Registry/registry.diags
M       dyn_em/start_em.F
M       phys/module_diag_zld.F
M       phys/module_diagnostics_driver.F

TESTS CONDUCTED: 
1. I verified that WRF compiles (opt15: intel/dmpar) on Cheyenne and runs with these modifications. I ran a simulation for 
3 h. The new pressure variable was output successfully to stream 22 at 6 height levels (78, 100, 200, 300, 400, and 
500 m AGL), with expected/sensible values.
2. For the change in how pressure is interpolated vertically for height-level diagnostics, I compared a 3-h simulation 
before/after this modification, using the same 6 heights. I found differences to be negligible for both pressure and 
relative humidity.
3. Jenkins test status is all pass.

RELEASE NOTE: Air pressure was added as a new height-level diagnostic, which is useful for a model validation against barometers mounted above ground (e.g., on a wind turbine nacelle). Also, the vertical interpolation of pressure to height surfaces was switched to linear in ln(p). The resultant pressure and relative humidity changes are negligible in the lowest 1 km AGL.
