### PR TITLE
Remove unused i1 array rho phy

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1788,7 +1788,6 @@ state    real  v_phy           ikj      misc        1         -      r      "V_P
 i1       real  dz8w            ikj      misc        1         Z
 i1       real  p8w             ikj      misc        1         Z
 i1       real  t8w             ikj      misc        1         Z
-i1       real  rho_phy         ikj      misc        1         -
 i1    logical  CU_ACT_FLAG     ij       misc        1         -
 
                                                 

--- a/Registry/registry.wrfplus
+++ b/Registry/registry.wrfplus
@@ -399,7 +399,6 @@ state    real  a_v_phy           ikj      misc        1         -       r      "
 i1       real  a_dz8w            ikj      misc        1         Z
 i1       real  a_p8w             ikj      misc        1         Z
 i1       real  a_t8w             ikj      misc        1         Z
-i1       real  a_rho_phy         ikj      misc        1         -
 
 i1       real  g_th_phy          ikj      misc        1         -
 i1       real  g_pi_phy          ikj      misc        1         -
@@ -410,7 +409,6 @@ state    real  g_v_phy           ikj      misc        1         -       r      "
 i1       real  g_dz8w            ikj      misc        1         Z
 i1       real  g_p8w             ikj      misc        1         Z
 i1       real  g_t8w             ikj      misc        1         Z
-i1       real  g_rho_phy         ikj      misc        1         -
 
 # Additional for gravity wave drag
 state   real   g_DTAUX3D         ikj     misc        1         -     rh        "g_DTAUX3D"               "LOCAL U GWDO STRESS"   "m s-1"

--- a/dyn_em/module_after_all_rk_steps.F
+++ b/dyn_em/module_after_all_rk_steps.F
@@ -13,7 +13,7 @@ CONTAINS
 
    SUBROUTINE after_all_rk_steps ( grid, config_flags,                  &
                                    moist, chem, tracer, scalar,         &
-                                   th_phy, pi_phy, p_phy, rho_phy,      & 
+                                   th_phy, pi_phy, p_phy,               & 
                                    p8w, t8w, dz8w,                      &
                                    curr_secs, curr_secs2,               &
                                    diag_flag,                           &
@@ -92,7 +92,6 @@ CONTAINS
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme)            , INTENT(IN) :: th_phy  , &
                                                                            p_phy   , &
                                                                            pi_phy  , &
-                                                                           rho_phy , &
                                                                            dz8w    , &
                                                                            p8w     , &
                                                                            t8w
@@ -151,7 +150,7 @@ CONTAINS
 
       CALL diagnostics_driver ( grid, config_flags,               &
                                 moist, chem, tracer, scalar,         &
-                                th_phy, pi_phy, p_phy, rho_phy,      & 
+                                th_phy, pi_phy, p_phy,               & 
                                 p8w, t8w, dz8w,                      &
                                 curr_secs, curr_secs2,               &
                                 diag_flag,                           &

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -4602,7 +4602,7 @@ BENCH_END(bc_2d_tim)
 
   CALL after_all_rk_steps ( grid, config_flags,                  &
                             moist, chem, tracer, scalar,         &
-                            th_phy, pi_phy, p_phy, rho_phy,      &   
+                            th_phy, pi_phy, p_phy,               &   
                             p8w, t8w, dz8w,                      &
                             REAL(curr_secs,8), curr_secs2,       &
                             diag_flag,                           &

--- a/phys/module_diag_afwa.F
+++ b/phys/module_diag_afwa.F
@@ -20,7 +20,7 @@ CONTAINS
                              , chem                              &
                              , th_phy , pi_phy , p_phy           &
                              , u_phy , v_phy                     &
-                             , dz8w , p8w , t8w , rho_phy , rho  &
+                             , dz8w , p8w , t8w , rho            &
                              , ids, ide, jds, jde, kds, kde      &
                              , ims, ime, jms, jme, kms, kme      &
                              , ips, ipe, jps, jpe, kps, kpe      &
@@ -65,7 +65,6 @@ CONTAINS
                                               ,           dz8w  &
                                               ,            p8w  &
                                               ,            t8w  &
-                                              ,        rho_phy  &
                                               ,            rho
 
     ! Local

--- a/phys/module_diagnostics_driver.F
+++ b/phys/module_diagnostics_driver.F
@@ -16,7 +16,7 @@ CONTAINS
 
    SUBROUTINE diagnostics_driver ( grid, config_flags,                  &
                                    moist, chem, tracer, scalar,         &
-                                   th_phy, pi_phy, p_phy, rho_phy,      & 
+                                   th_phy, pi_phy, p_phy,               & 
                                    p8w, t8w, dz8w,                      &
                                    curr_secs, curr_secs2,               &
                                    diag_flag,                           &
@@ -117,7 +117,6 @@ CONTAINS
       REAL , DIMENSION(ims:ime,kms:kme,jms:jme)            , INTENT(IN) :: th_phy  , &
                                                                            p_phy   , &
                                                                            pi_phy  , &
-                                                                           rho_phy , &
                                                                            dz8w    , &
                                                                            p8w     , &
                                                                            t8w
@@ -947,7 +946,7 @@ CONTAINS
                          ,chem                                                &
                          ,th_phy , pi_phy , p_phy                             &
                          ,grid%u_phy , grid%v_phy                             &
-                         ,dz8w , p8w , t8w , rho_phy, grid%rho                &
+                         ,dz8w , p8w , t8w , grid%rho                         &
                          ,ids, ide, jds, jde, kds, kde                        &
                          ,ims, ime, jms, jme, kms, kme                        &
                          ,ips, ipe, jps, jpe, kps, kpe                        &

--- a/wrftladj/solve_em_ad.F
+++ b/wrftladj/solve_em_ad.F
@@ -4716,7 +4716,7 @@ BENCH_END(bc_2d_tim)
 
 ! CALL after_all_rk_steps ( grid, config_flags,                  &
 !                           moist, chem, tracer, scalar,         &
-!                           th_phy, pi_phy, p_phy, rho_phy,      &   
+!                           th_phy, pi_phy, p_phy,               &   
 !                           p8w, t8w, dz8w,                      &
 !                           curr_secs,                           &
 !                           diag_flag,                           &

--- a/wrftladj/solve_em_tl.F
+++ b/wrftladj/solve_em_tl.F
@@ -4392,7 +4392,7 @@ BENCH_END(g_bc_2d_tim)
 
   CALL after_all_rk_steps ( grid, config_flags,                  &
                             moist, chem, tracer, scalar,         &
-                            th_phy, pi_phy, p_phy, rho_phy,      &   
+                            th_phy, pi_phy, p_phy,               &   
                             p8w, t8w, dz8w,                      &
                             REAL(curr_secs,8), curr_secs2,       &
                             diag_flag,                           &


### PR DESCRIPTION
TYPE: no impact, clean up

KEYWORDS: un-used 3D array, rho_phy

SOURCE: reported by Xin-Liang Zhong of Univ of Maryland

DESCRIPTION OF CHANGES:
Problem:
There is an un-used 3D array rho_phy.

Solution:
Remove it from the code.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       Registry/registry.wrfplus
M       dyn_em/module_after_all_rk_steps.F
M       dyn_em/solve_em.F
M       phys/module_diag_afwa.F
M       phys/module_diagnostics_driver.F
M       wrftladj/solve_em_ad.F
M       wrftladj/solve_em_tl.F

TESTS CONDUCTED: 
1. No impact.
2. Jenkins tests are all pass.

RELEASE NOTE: Removed an un-used 3D array from the ARW Registry and solver (rho_phy).
