### PR TITLE
Bug fix in FARMS parameterization for ice cloud optical thickness calculation

### DIFF
--- a/phys/module_ra_farms.F
+++ b/phys/module_ra_farms.F
@@ -604,8 +604,8 @@
       endif
       if ( De .gt. 26.0 ) then 
         Ptau =  (2.8355 + (100.0-De)*0.006)*solarangle - 0.00612
-        Ptau = max(Ptau, PTAU_MIN)
       endif
+      Ptau = max(Ptau, PTAU_MIN)
 
       PDHI = 1047.6367*solarangle**1.0883
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: FARMS, radiation, cloud optical thickness

SOURCE: Timothy W. Juliano and Pedro A. Jimenez (NCAR/RAL)

DESCRIPTION OF CHANGES:
Problem:
In the ICEMODEL subroutine, there is an issue with the calculation of `Ptau` (lines 602-608 in the official WRF version). If `De <= 26.0` and `solarangle` (cosine of solar zenith angle) is really small, then `Ptau` (ice cloud optical thickness) can be negative. In my case, `Ptau` goes negative and causes the model to crash since `PPDHI` is later calculated using `log10(Ptau)`. It looks like the original code accounted for a small value of `Ptau` but only when `De > 26.0`.

Solution:
I fixed the issue simply by moving the check on `Ptau` to be located after the conditional statements.

LIST OF MODIFIED FILES:
M phys/module_ra_farms.F

TESTS CONDUCTED: 
1. We have run a 3km CONUS simulation with and without the bug fix. Without the bug fix, the simulation crashes as reported above. With the bug fix, the simulation integrates through without an issue.
2. Jenkins tests are passing.

RELEASE NOTE: A fix is introduced to the FARMS parameterization. When the cosine of solar zenith angle is small, the ice cloud optical thickness can be negative, and the model can crash due to log10 of a negative number. The modification is to limit the value of cloud optical thickness.