### PR TITLE
add HLC.TBL and wind-turbine-1.tbl to clean list

### DIFF
--- a/clean
+++ b/clean
@@ -65,6 +65,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  */constants.asc */p3_lookup_table_1.dat \
 	  */masses.asc */kernels_z.asc */capacity.asc */termvels.asc */coeff_p.asc */coeff_q.asc \
 	  */gribmap.txt */tr??t?? */co2_trans */namelist.output */ishmael-gamma-tab.bin \
+	  */HLC.TBL */wind-turbine-1.tbl \
           */ishmael-qi-qc.bin */ishmael-qi-qr.bin ) >& /dev/null
      ( cd test/em_fire; rm -rf two_fires rain )
   else if ( "$arg" == '-aa' ) then

--- a/clean
+++ b/clean
@@ -65,7 +65,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  */constants.asc */p3_lookup_table_1.dat \
 	  */masses.asc */kernels_z.asc */capacity.asc */termvels.asc */coeff_p.asc */coeff_q.asc \
 	  */gribmap.txt */tr??t?? */co2_trans */namelist.output */ishmael-gamma-tab.bin \
-	  */HLC.TBL */wind-turbine-1.tbl \
+	  */HLC.TBL */wind-turbine-1.tbl */create_p3_lookupTable_1.f90 \
           */ishmael-qi-qc.bin */ishmael-qi-qr.bin ) >& /dev/null
      ( cd test/em_fire; rm -rf two_fires rain )
   else if ( "$arg" == '-aa' ) then

--- a/clean
+++ b/clean
@@ -65,7 +65,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  */constants.asc */p3_lookup_table_1.dat \
 	  */masses.asc */kernels_z.asc */capacity.asc */termvels.asc */coeff_p.asc */coeff_q.asc \
 	  */gribmap.txt */tr??t?? */co2_trans */namelist.output */ishmael-gamma-tab.bin \
-	  */HLC.TBL */wind-turbine-1.tbl */create_p3_lookupTable_1.f90 \
+	  */HLC.TBL */wind-turbine-1.tbl \
           */ishmael-qi-qc.bin */ishmael-qi-qr.bin ) >& /dev/null
      ( cd test/em_fire; rm -rf two_fires rain )
   else if ( "$arg" == '-aa' ) then


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: clean script, HLC.TBL, wind-turbine-1.tbl

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When executing 'clean -a', two files are not removed: HLC.TBL, and wind-turbine-1.tbl

Solution:
Add these two files to the list of files to be removed in the clean script

LIST OF MODIFIED FILES: 
M clean

TESTS CONDUCTED: 
1. It does remove the two files.
2. Jenkins tests are passing.

RELEASE NOTE: The files HLC.TBL, and wind-turbine-1.tbl are now removed from the test/* directories when doing 'clean -a'.