### PR TITLE
Bug fix to use correct rho value in cal_titau subroutines

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3165,7 +3165,7 @@ halo      HALO_EM_INIT_4 dyn_em 48:pb,h_diabatic,qv_diabatic,qc_diabatic,msftx,m
 halo      HALO_EM_INIT_5 dyn_em 48:moist,chem,scalar,tracer
 halo      HALO_EM_INIT_6 dyn_em 48:om_tmp,om_s,om_u,om_v,om_depth,om_tini,om_sini,om_lat,om_lon,om_ml
 halo      HALO_EM_VINTERP_UV_1 dyn_em 48:pd_gc,pb,pmaxw,ptrop,pmaxwnn,ptropnn
-halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut
+halo      HALO_EM_A dyn_em  8:ru,rv,rw,ww,php,alt,al,p,muu,muv,mut,rho
 halo      HALO_EM_PHYS_A  dyn_em 4:u_2,v_2
 halo      HALO_EM_PHYS_PBL dyn_em        4:rublten,rvblten
 halo      HALO_EM_PHYS_CU dyn_em         4:rucuten,rvcuten
@@ -3279,7 +3279,7 @@ period    PERIOD_BDY_EM_TKE_OLD dyn_em 4:tke_1
 
 period    PERIOD_BDY_EM_E dyn_em 2:u_2,v_2,ht
 period    PERIOD_EM_HYDRO_UV dyn_em 1:u_2,v_2
-period    PERIOD_BDY_EM_A dyn_em 2:ru,rv,rw,ww,php,alt,p,muu,muv,mut,ph_2,al
+period    PERIOD_BDY_EM_A dyn_em 2:ru,rv,rw,ww,php,alt,p,muu,muv,mut,ph_2,al,rho
 period    PERIOD_BDY_EM_A1  dyn_em 3:rdzw,rdz,z,zx,zy,ustm,ust
 period    PERIOD_BDY_EM_PHY_BC dyn_em 2:rublten,rvblten,rucuten,rvcuten,xkmh,xkmv,xkhh,xkhv,div,defor11,defor22,defor12,defor13,defor23,defor33,tke_2,rho,gamu,gamv,xkmv_meso
 period    PERIOD_BDY_EM_FDDA_BC dyn_em 2:rundgdten,rvndgdten

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -5505,7 +5505,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg
+    :: xkxavg, rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -5538,10 +5538,11 @@ END SUBROUTINE nonlocal_flux
     DO j = j_start, j_end
     DO k = kts, ktf
     DO i = i_start, i_end
-      xkxavg(i,k,j) = 0.25 * ( xkx(i-1,k,j  ) + xkx(i,k,j  ) +  &
+      rhoavg(i,k,j) = 0.25 * ( rho(i-1,k,j  ) + rho(i,k,j  ) +  &
+                               rho(i-1,k,j-1) + rho(i,k,j-1) )
+      xkxavg(i,k,j) = rhoavg(i,k,j) *                           &
+                      0.25 * ( xkx(i-1,k,j  ) + xkx(i,k,j  ) +  &
                                xkx(i-1,k,j-1) + xkx(i,k,j-1) )
-      xkxavg(i,k,j) = xkxavg(i,k,j) * .25 * ( rho(i-1,k,j  ) + rho(i,k,j  )  +  &
-                                              rho(i-1,k,j-1) + rho(i,k,j-1) )
     END DO
     END DO
     END DO
@@ -5554,7 +5555,7 @@ END SUBROUTINE nonlocal_flux
       DO k = kts, ktf
       DO i = i_start, i_end
 
-        titau(i,k,j) = rho(i,k,j) * mtau(i,k,j)
+        titau(i,k,j) = rhoavg(i,k,j) * mtau(i,k,j)
 
       END DO
       END DO
@@ -5568,7 +5569,7 @@ END SUBROUTINE nonlocal_flux
         DO k = kts, ktf
         DO i = i_start, i_end
           titau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)
-          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rho(i,k,j)
+          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rhoavg(i,k,j)
 
         END DO
         END DO
@@ -5650,7 +5651,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg
+    :: xkxavg, rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -5683,10 +5684,11 @@ END SUBROUTINE nonlocal_flux
     DO j = j_start, j_end
     DO k = kts+1, ktf
     DO i = i_start, i_end
-      xkxavg(i,k,j) = 0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i-1,k  ,j) ) +  &
+      rhoavg(i,k,j) = 0.5 * ( fnm(k) * ( rho(i-1,k  ,j) + rho(i,k  ,j) ) + &
+                              fnp(k) * ( rho(i-1,k-1,j) + rho(i,k-1,j) ) )
+      xkxavg(i,k,j) = rhoavg(i,k,j)  *                                     &
+                      0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i-1,k  ,j) ) + &
                               fnp(k) * ( xkx(i,k-1,j) + xkx(i-1,k-1,j) ) )
-      xkxavg(i,k,j) = xkxavg(i,k,j) * 0.5 * ( fnm(k) * ( rho(i-1,k  ,j) + rho(i,k  ,j) ) + &
-                                              fnp(k) * ( rho(i-1,k-1,j) + rho(i,k-1,j) ) )
     END DO
     END DO
     END DO
@@ -5696,7 +5698,7 @@ END SUBROUTINE nonlocal_flux
       DO j = j_start, j_end
       DO k = kts+1, ktf
       DO i = i_start, i_end
-         titau(i,k,j) = rho(i,k,j) * mtau(i,k,j)
+         titau(i,k,j) = rhoavg(i,k,j) * mtau(i,k,j)
       ENDDO
       ENDDO
       ENDDO
@@ -5710,7 +5712,7 @@ END SUBROUTINE nonlocal_flux
         DO i = i_start, i_end
 
           titau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)
-          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rho(i,k,j)
+          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rhoavg(i,k,j)
 
         ENDDO
         ENDDO
@@ -5799,7 +5801,7 @@ END SUBROUTINE nonlocal_flux
     :: i, j, k, ktf, i_start, i_end, j_start, j_end
 
     REAL, DIMENSION( its-1:ite+1, kts:kte, jts-1:jte+1 )  &
-    :: xkxavg
+    :: xkxavg, rhoavg
 
 ! End declarations.
 !-----------------------------------------------------------------------
@@ -5832,10 +5834,11 @@ END SUBROUTINE nonlocal_flux
     DO j = j_start, j_end
     DO k = kts+1, ktf
     DO i = i_start, i_end
-      xkxavg(i,k,j) = 0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i,k  ,j-1) ) +  &
+      rhoavg(i,k,j) = 0.5 * ( fnm(k) * ( rho(i,k  ,j) + rho(i,k  ,j-1) ) + &
+                              fnp(k) * ( rho(i,k-1,j) + rho(i,k-1,j-1) ) )
+      xkxavg(i,k,j) = rhoavg(i,k,j)  *                                     &
+                      0.5 * ( fnm(k) * ( xkx(i,k  ,j) + xkx(i,k  ,j-1) ) + &
                               fnp(k) * ( xkx(i,k-1,j) + xkx(i,k-1,j-1) ) )
-      xkxavg(i,k,j) = xkxavg(i,k,j) * 0.5 * ( fnm(k) * ( rho(i,k  ,j) + rho(i,k  ,j-1) ) +  &
-                                              fnp(k) * ( rho(i,k-1,j) + rho(i,k-1,j-1) ) )
     END DO
     END DO
     END DO
@@ -5846,7 +5849,7 @@ END SUBROUTINE nonlocal_flux
       DO k = kts+1, ktf
       DO i = i_start, i_end
 
-        titau(i,k,j) =  rho(i,k,j) * mtau(i,k,j)
+        titau(i,k,j) =  rhoavg(i,k,j) * mtau(i,k,j)
 
       END DO
       END DO
@@ -5861,7 +5864,7 @@ END SUBROUTINE nonlocal_flux
         DO i = i_start, i_end
 
           titau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)
-          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rho(i,k,j)
+          mtau(i,k,j) = - xkxavg(i,k,j) * defor(i,k,j)  / rhoavg(i,k,j)
 
         END DO
         END DO

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -671,6 +671,13 @@ BENCH_START(set_phys_bc_tim)
                               grid%i_start(ij), grid%i_end(ij),  &
                               grid%j_start(ij), grid%j_end(ij),  &
                               k_start, k_end                )
+       CALL set_physical_bc3d( grid%rho, 'p', config_flags,            &
+                              ids, ide, jds, jde, kds, kde,     &
+                              ims, ime, jms, jme, kms, kme,     &
+                              ips, ipe, jps, jpe, kps, kpe,     &
+                              grid%i_start(ij), grid%i_end(ij), &
+                              grid%j_start(ij), grid%j_end(ij), &
+                              k_start    , k_end               )
        CALL set_physical_bc3d( grid%al, 'p', config_flags,            &
                               ids, ide, jds, jde, kds, kde,     &
                               ims, ime, jms, jme, kms, kme,     &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: rho, sfs_opt, m_opt, cal_titau

SOURCE: Robert Arthur and Jeff Mirocha (LLNL)

DESCRIPTION OF CHANGES:
Problem:
In the cal_titau subroutines in module_diffusion_em, rho was not always interpolated to the correct location on the 
staggered grid. This issue affected the subgrid stress terms when sfs_opt .gt. 1. Additionally, when sfs_opt .eq. 0 and 
m_opt .eq. 1, the actual subgrid stresses applied in the code were correct, but the output was wrong. This is a 
follow-on from issue #1214 by @matzegoebel, which addressed the surface stress output from subroutine 
vertical_diffusion_2 when sfs_opt .gt. 0 or m_opt .eq. 1, but did not address the cal_titau subroutines.

Solution:
A rhoavg variable was added to cal_titau_12_21, cal_titau_13_31, and cal_titau_23_32 and used instead of the 
cell-centered rho variable. Additionally, because cal_titau_12_21 now uses "corner" ghost points for rho, a new 
halo/bc communication was added to solve_em.F to ensure that rho is specified correctly at those points. Correct 
specification of the corner points also requires the updates to subroutine set_physical_bc3d in #1314, included in 
the v4.2.2 release. Without the latter two updates for corner points, bit-for-bit errors occurred in regression tests for 
idealized, doubly-periodic domains.

LIST OF MODIFIED FILES: 
dyn_em/module_diffusion_em.F
dyn_em/solve_em.F
Registry/Registry.EM_COMMON

TESTS CONDUCTED:
1. Idealized, doubly-periodic tests with various processor breakdowns show bit-for-bit identical results.
2. Jenkins is all pass.

RELEASE NOTE: Bug fix to use correct rho value in cal_titau subroutines. In the cal_titau subroutines in module_diffusion_em, rho was not always interpolated to the correct location on the staggered grid. This issue affected the subgrid stress terms when sfs_opt .gt. 1. Additionally, when sfs_opt .eq. 0 and m_opt .eq. 1, the actual subgrid stresses applied in the code were correct, but the output was wrong. A rhoavg variable was added to cal_titau_12_21, cal_titau_13_31, and cal_titau_23_32 and used instead of the cell-centered rho variable.
