### PR TITLE
Fix for instances of dt = 0 when using adaptive time stepping

### DIFF
--- a/dyn_em/adapt_timestep_em.F
+++ b/dyn_em/adapt_timestep_em.F
@@ -101,7 +101,7 @@ RECURSIVE SUBROUTINE adapt_timestep(grid, config_flags)
   !
 
   tmpTimeInterval = domain_get_current_time ( grid ) - &
-                    domain_get_sim_start_time ( grid )
+                    domain_get_start_time ( grid )
 
   !
   ! Calculate current time in seconds since beginning of model run.
@@ -302,7 +302,7 @@ RECURSIVE SUBROUTINE adapt_timestep(grid, config_flags)
           * ( grid%interval_seconds )
      CALL WRFU_TimeIntervalSet(tmpTimeInterval, S=bc_time)
      dtInterval = tmpTimeInterval - &
-          (domain_get_current_time(grid) - domain_get_sim_start_time(grid))
+          (domain_get_current_time(grid) - domain_get_start_time(grid))
      
      use_last2 = .TRUE.
      stepping_to_bc = .true.
@@ -351,7 +351,7 @@ RECURSIVE SUBROUTINE adapt_timestep(grid, config_flags)
              (history_interval_sec) ) * (history_interval_sec)
         CALL WRFU_TimeIntervalSet(tmpTimeInterval, S=output_time)
         dtInterval = tmpTimeInterval - &
-             (domain_get_current_time(grid) - domain_get_sim_start_time(grid))
+             (domain_get_current_time(grid) - domain_get_start_time(grid))
 
         use_last2 = .TRUE.
         grid%stepping_to_time = .TRUE.


### PR DESCRIPTION
Fix for instances of dt = 0 when using adaptive time stepping

TYPE: bug fix

KEYWORDS: adaptive time stepping, time step

SOURCE: internal, reported from two sources

DESCRIPTION OF CHANGES:
Problem:
When using adaptive time stepping, and when option step_to_output_time is used, time step can be zero and cause the model to stop. The problem occurs in part because the function real_time becomes less accurate when feeding a large value of time interval, i.e. time since the simulation start time.

Solution:
This PR fixes the issue by changing the time interval calculation from relative to simulation start time to model start time, i.e. restart time. 

ISSUE: For use when this PR closes an issue.
Fixes #1369

LIST OF MODIFIED FILES: 
M    dyn_em/adapt_timestep_em.F

TESTS CONDUCTED: 
1. Test shows the fix prevents dt=0 from occurring in a case previously failed.

This is some prints from a failed run:
Timing for main (dt=293.68): time 2001-07-07_08:00:52 on domain   1:    0.16209 elapsed seconds
Timing for main (dt=296.62): time 2001-07-07_08:05:48 on domain   1:    0.78269 elapsed seconds
Timing for main (dt=299.59): time 2001-07-07_08:10:48 on domain   1:    0.16217 elapsed seconds
Timing for main (dt=299.59): time 2001-07-07_08:15:48 on domain   1:    0.15795 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:20:48 on domain   1:    0.78560 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:25:48 on domain   1:    0.15789 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:30:48 on domain   1:    0.16164 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:35:48 on domain   1:    0.77986 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:40:48 on domain   1:    0.16140 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:45:48 on domain   1:    0.15741 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:50:48 on domain   1:    0.78672 elapsed seconds
Timing for main (dt=264.00): time 2001-07-07_08:55:12 on domain   1:    0.15702 elapsed seconds
d01 2001-07-07_08:55:12+04/25  L353 dtInterval are  287  21   25  0
Timing for main (dt=287.84): time 2001-07-07_09:00:00 on domain   1:    0.19389 elapsed seconds
Timing for Writing wrfout_d01_2001-07-07_09:00:00 for domain        1:    1.69693 elapsed seconds
d01 2001-07-07_09:00:00  L353 dtInterval are      0        0      25           0

After the fix:
Timing for main (dt=293.77): time 2001-07-07_08:01:12 on domain   1:    0.16144 elapsed seconds
Timing for main (dt=296.71): time 2001-07-07_08:06:09 on domain   1:    0.78215 elapsed seconds
Timing for main (dt=299.68): time 2001-07-07_08:11:08 on domain   1:    0.16142 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:16:08 on domain   1:    0.15739 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:21:08 on domain   1:    0.78563 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:26:08 on domain   1:    0.15712 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:31:08 on domain   1:    0.16140 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:36:08 on domain   1:    0.78050 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:41:08 on domain   1:    0.16107 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:46:08 on domain   1:    0.15700 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_08:51:08 on domain   1:    0.78609 elapsed seconds
Timing for main (dt=265.54): time 2001-07-07_08:55:34 on domain   1:    0.15656 elapsed seconds
d01 2001-07-07_08:55:34+93/**  L353 dtInterval are    265      107     200           0
Timing for main (dt=265.54): time 2001-07-07_09:00:00 on domain   1:    0.19076 elapsed seconds
Timing for Writing wrfout_d01_2001-07-07_09:00:00 for domain        1:    1.70416 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_09:05:00 on domain   1:    2.48374 elapsed seconds
Timing for main (dt=300.00): time 2001-07-07_09:10:00 on domain   1:    0.16118 elapsed seconds

2. Passed all Jenkins tests.

RELEASE NOTE: Fix for reported instances of dt = 0 when using adaptive time stepping together and when step_to_output_time is set to true.