### PR TITLE
Created README.physics_files to describe dependencies with linked files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,6 +587,7 @@ em_real : wrf
 	( cd test/em_real ; /bin/rm -f tc.exe ; ln -s ../../main/tc.exe . )
 	( cd test/em_real ; /bin/rm -f ndown.exe ; ln -s ../../main/ndown.exe . )
 	( cd test/em_real ; /bin/rm -f README.namelist ; ln -s ../../run/README.namelist . )
+	( cd test/em_real ; /bin/rm -f README.physics_files ; ln -s ../../run/README.physics_files . )
 	( cd test/em_real ; /bin/rm -f ETAMPNEW_DATA.expanded_rain ETAMPNEW_DATA RRTM_DATA RRTMG_LW_DATA RRTMG_SW_DATA ;    \
              ln -sf ../../run/ETAMPNEW_DATA . ;                     \
              ln -sf ../../run/ETAMPNEW_DATA.expanded_rain . ;       \

--- a/clean
+++ b/clean
@@ -51,7 +51,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  /bin/cp -f namelist.input namelist.input.backup.`date +%Y-%m-%d_%H_%M_%S` ; \
 	  /bin/rm -f namelist.input ) >& /dev/null
     ( cd test/exp_real ; /bin/rm -f gm* out* fort* real* ) >& /dev/null
-    ( cd test ; rm -f */*.exe */ETAMPNEW_DATA* */GENPARM.TBL */LANDUSE.TBL */README.namelist \
+    ( cd test ; rm -f */*.exe */ETAMPNEW_DATA* */GENPARM.TBL */LANDUSE.TBL */README.namelist */README.physics_files \
 	  */RRTM_DATA */SOILPARM.TBL */VEGPARM.TBL */MPTABLE.TBL */URBPARM.TBL */grib2map.tbl \
 	  */CAM_ABS_DATA */CAM_AEROPT_DATA \
 	  */CCN_ACTIVATE.BIN \

--- a/run/README.physics_files
+++ b/run/README.physics_files
@@ -1,0 +1,159 @@
+This is a list of all the physics options that require additional files.
+Necessary files are listed below each option.
+Those files must be linked to the directory where WRF is run.
+
+Note: the files with DBL at the end are only used when running the model with real*8
+
+----------------------------------------------------------------------------------
+Microphysics
+
+Eta/Ferrier (Option 5):
+	ETAMPNEW_DATA
+	ETAMPNEW_DATA_DBL
+	ETAMPNEW_DATA.expanded_rain
+	ETAMPNEW_DATA.expanded_rain_DBL
+
+Thompson (Option 8):
+	CCN_ACTIVATE.BIN
+
+SBM (Options 30 and 32):
+	bulkdens.asc_s_0_03_0_9
+	bulkradii.asc_s_0_03_0_9
+	capacity.asc
+	coeff_p.asc
+	coeff_q.asc
+	constants.asc
+	kernels.asc_s_0_03_0_9
+	kernels_z.asc
+	masses.asc
+	termvels.asc
+
+P3 (Options 50, 51, and 52)
+	p3_lookup_table_1.dat-v4.1
+	p3_lookup_table_2.dat-v4.1
+
+Jensen (Option 55):
+	ishmael-gamma-tab.bin
+	ishmael-qi-qc.bin
+	ishmael-qi-qr.bin
+
+----------------------------------------------------------------------------------
+Surface
+
+Slab 5-Layer (Option 1):
+	LANDUSE.TBL
+
+Noah (Option 2):
+	LANDUSE.TBL
+	GENPARM.TBL
+	SOILPARM.TBL
+	VEGPARM.TBL
+
+RUC (Option 3):
+	LANDUSE.TBL
+	GENPARM.TBL
+	SOILPARM.TBL
+	VEGPARM.TBL
+
+NoahMP (Option 4):
+	LANDUSE.TBL
+	GENPARTM.TBL
+	MPTABLE.TBL
+	SOILPARM.TBL
+
+CLM (Option 5):
+	LANDUSE.TBL
+	CLM_ALB_ICE_DFS_DATA
+	CLM_ALB_ICE_DRC_DATA
+	CLM_ASM_ICE_DFS_DATA
+	CLM_ASM_ICE_DRC_DATA
+	CLM_DRDSDT0_DATA
+	CLM_EXT_ICE_DFS_DATA
+	CLM_EXT_ICE_DRC_DATA
+	CLM_DRDSDT0_DATA
+	CLM_EXT_ICE_DFS_DATA
+	CLM_EXT_ICE_DRC_DATA
+	CLM_KAPPA_DATA
+	CLM_TAU_DATA
+
+PX (Option 7):
+	LANDUSE.TBL
+	VEGPARM.TBL
+
+SSiB (Option 8):
+	LANDUSE.TBL
+
+Wind-farm SFC Layer (windturbine_spec = 1)
+	wind-turbine-1.tbl
+
+----------------------------------------------------------------------------------
+Radiation
+
+RRTM (ra_lw_physics Option 1): 
+	RRTM_DATA
+	RRTM_DATA_DBL
+        (if compiled with -DCLWRFGHG)
+	        CAMtr_volume_mixing_ratio.A1B
+        	CAMtr_volume_mixing_ratio.A2
+        	CAMtr_volume_mixing_ratio.RCP4.5
+        	CAMtr_volume_mixing_ratio.RCP6
+        	CAMtr_volume_mixing_ratio.RCP8.5
+
+CAM (Option 3):
+        aerosol.formatted
+        aerosol_lat.formatted
+        aerosol_lon.formatted
+        aerosol_plev.formatted
+        CAM_ABS_DATA
+        CAM_AEROPT_DATA
+        (if o3input=2 - default)
+        	ozone.formatted
+        	ozone_lat.formatted
+        	ozone_plev.formatted
+        (if compiled with -DCLWRFGHG)
+        	CAMtr_volume_mixing_ratio.A1B
+        	CAMtr_volume_mixing_ratio.A2
+        	CAMtr_volume_mixing_ratio.RCP4.5
+        	CAMtr_volume_mixing_ratio.RCP6
+        	CAMtr_volume_mixing_ratio.RCP8.5
+
+RRTMG (Option 4,24,14):
+	RRTMG_LW_DATA
+	RRTMG_LW_DATA_DBL
+	RRTMG_SW_DATA
+	RRTMG_SW_DATA_DBL
+        aerosol.formatted
+        aerosol_lat.formatted
+        aerosol_lon.formatted
+        aerosol_plev.formatted
+        (if o3input=2 - default)
+        	ozone.formatted
+        	ozone_lat.formatted
+        	ozone_plev.formatted
+        (if compiled with -DCLWRFGHG)
+        	CAMtr_volume_mixing_ratio.A1B
+        	CAMtr_volume_mixing_ratio.A2
+        	CAMtr_volume_mixing_ratio.RCP4.5
+        	CAMtr_volume_mixing_ratio.RCP6
+        	CAMtr_volume_mixing_ratio.RCP8.5
+
+Goddard (Option 5):
+	BROADBAND_CLOUD_GODDARD.bin
+
+GFDL (Option 99):
+	co2_trans
+	tr49t67
+	tr49t85
+	tr67t85
+
+Eclipse option (ra_sw_eclipse = 1)
+        eclipse_besselian_elements.dat
+
+----------------------------------------------------------------------------------
+Other Options:
+
+Urban Physics (sf_urban_physics = 1, 2, and 3)
+	URBPARM.TBL
+
+Chemistry
+	HLC.TBL


### PR DESCRIPTION
Created README.physics_files to describe dependencies with linked files

TYPE: text only

KEYWORDS: README, README.physics_files, linked, link, physics, schemes

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
There are several files that must reside in (or be linked to) the running directory for many physics schemes. These files 
are in the run/ directory, but are linked to the test/em_real directory during compilation. There is no user documentation 
of which files are mandatory for which schemes.

Solution:
Created a README.physics_files to list all schemes that require additional files, and what those files are. Set the Makefile 
to link this README file to the test/em_real directory upon compilation. Also added this README.physics_files to the clean script.

LIST OF MODIFIED FILES: 
M       Makefile
M       clean
A       run/README.physics_files

TESTS CONDUCTED: 
1. Text only. Verified it compiles and links the new README file to the test/em_real directory.
2. Jenkins tests passed.

RELEASE NOTE: A README.physics_files is now available in the run directory (and is linked to the test/em_real directory during the compile). This file lists all physics options that require additional files for running, and the files necessary for each scheme. These additional files are already in the run/ directory and are linked automatically to the test/em_real directory during compile.