### PR TITLE
Thompson MP: reduce fake aerosol emissions by 4x

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -464,7 +464,7 @@
             niCCN3 = -1.0*ALOG(naCCN1/naCCN0)/h_01
             nwfa(i,1,j) = naCCN1+naCCN0*exp(-((hgt(i,2,j)-hgt(i,1,j))/1000.)*niCCN3)
             airmass = 1./orho(i,1,j) * (hgt(i,2,j)-hgt(i,1,j))*dx*dy     ! kg
-            nwfa2d(i,j) = nwfa(i,1,j) * 0.000196 * (airmass*2.E-10)
+            nwfa2d(i,j) = nwfa(i,1,j) * 0.000196 * (airmass*5.E-11)
             do k = 2, kte
                nwfa(i,k,j) = naCCN1+naCCN0*exp(-((hgt(i,k,j)-hgt(i,1,j))/1000.)*niCCN3)
             enddo

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -463,7 +463,7 @@
             endif
             niCCN3 = -1.0*ALOG(naCCN1/naCCN0)/h_01
             nwfa(i,1,j) = naCCN1+naCCN0*exp(-((hgt(i,2,j)-hgt(i,1,j))/1000.)*niCCN3)
-            airmass = 1./orho(i,1,j) * (hgt(i,2,j)-hgt(i,1,j))*dx*dy     ! kg
+            airmass = 1./orho(i,1,j) * (hgt(i,2,j)-hgt(i,1,j))*dx*dy    ! kg
             nwfa2d(i,j) = nwfa(i,1,j) * 0.000196 * (airmass*5.E-11)
             do k = 2, kte
                nwfa(i,k,j) = naCCN1+naCCN0*exp(-((hgt(i,k,j)-hgt(i,1,j))/1000.)*niCCN3)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Thompson, MP, aerosol, constant

SOURCE: Greg Thompson (JCSDA), found by Laura Fowler, Mary Barth (NCAR)

DESCRIPTION OF CHANGES:
A problem with a single constant was discovered a couple months ago, but did not get permanently updated in the 
repository. The fix is to reduce fake surface aerosol emissions by a factor of 4.

LIST OF MODIFIED FILES: 
modified:   phys/module_mp_thompson.F

TESTS CONDUCTED: 
1. Jenkins tests are all PASS.

RELEASE NOTE: For the Thompson MP scheme, a problem with a single constant was discovered that caused approximately 4x too much fake surface aerosol emissions.
