### PR TITLE
bug fix: initialize lat/lon with zeros only for nested fire runs

### DIFF
--- a/dyn_em/module_initialize_fire.F
+++ b/dyn_em/module_initialize_fire.F
@@ -525,11 +525,14 @@ CONTAINS
                 ifms,ifme,jfms,jfme,  &
                 ifts,ifte,jfts,jfte,  &
                 grid%fxlong,grid%fxlat          )
-  call set_ideal_coord( grid%dx,grid%dy, &
-                ids,ide,jds,jde,  &
-                ims,ime,jms,jme,  &
-                its,ite,jts,jte,  &
-                grid%xlong,grid%xlat          )
+! Avoid setting atmospheric coordinates when using nested domains ME
+  if (config_flags%max_dom.eq.1) then
+      call set_ideal_coord( grid%dx,grid%dy, &
+                  ids,ide,jds,jde,  &
+                  ims,ime,jms,jme,  &
+                  its,ite,jts,jte,  &
+                  grid%xlong,grid%xlat          )
+  endif
 
 ! set terrain height
 

--- a/phys/module_fr_fire_util.F
+++ b/phys/module_fr_fire_util.F
@@ -273,6 +273,8 @@ integer, intent(in):: &
 real, intent(out),dimension(ifms:ifme,jfms:jfme)::fxlong,fxlat
 ! local
 integer::i,j
+                ! could we not just as easily get something that
+                ! that looks like a lat/lon 
                 ! set fake  coordinates, in m 
                 do j=jfts,jfte
                     do i=ifts,ifte


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: idealized fire nested domain simulation

SOURCE: Found by Masih Eghdami (NCAR), Pedro Jimenez (NCAR)

DESCRIPTION OF CHANGES:
Problem:
The atmospheric coordinates (lat/lons) are initialized with spatial coordinates, this will create a fatal error when the 
model is run with nested domains. The error is because lat>90 in share/interp_fcn.F:
```
CALL wrf_error_fatal ( 'Nest over the pole, single input domain, longitudes will be wrong' )
```

Solution:
The lat/lon are initialized with zeros similar to LES idealized cases only if the model has 2 domains to prevent the error. If the model is run with 1 domain, the lat/lon are written with spatial coordinates allowing easier post-processing.

ISSUE: This PR addresses the discussion in #1412 with @pedro-jm and @janmandel.

LIST OF MODIFIED FILES: 
module_initialize_fire.F

TESTS CONDUCTED: 
1. Yes, the nested idealized fire case runs without the error described above.
2. They are passing.
