### PR TITLE
Fix to enable vertical nesting with hybrid vertical coordinate

### DIFF
--- a/external/RSL_LITE/module_dm.F
+++ b/external/RSL_LITE/module_dm.F
@@ -4257,7 +4257,7 @@ endif
             DO i = MAX(ids,ips),MIN(ide-1,ipe)
 
                DO k = 1, kpe-1
-                  grid%pb(i,k,j) = ngrid%c3h(k)*(ngrid%c1h(k)*grid%mub(i,j)+ngrid%c2h(k)) + ngrid%c4h(k) + ngrid%p_top
+                  grid%pb(i,k,j) = ngrid%c3h(k) * grid%mub(i,j) + ngrid%c4h(k) + ngrid%p_top
              
                   !  If this is a real run, recalc t_init.
    

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2418,26 +2418,6 @@
 
 !-----------------------------------------------------------------------
 !  Consistency checks for vertical refinement:
-!  must use the terrain following vertical coordinate
-!-----------------------------------------------------------------------
-      oops = 0 
-      DO i = 2, model_config_rec % max_dom
-        IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-        IF (model_config_rec%vert_refine_method(i) .NE. 0) THEN
-          IF ( model_config_rec%hybrid_opt .NE. 0 ) THEN
-            oops = oops + 1
-          END IF
-        END IF
-      END DO
-
-      IF ( oops .GT. 0 ) THEN
-        wrf_err_message = '--- ERROR: vert_refine_method=2 only works with hybrid_opt = 0 '
-        CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
-        count_fatal_error = count_fatal_error + 1
-      END IF
-
-!-----------------------------------------------------------------------
-!  Consistency checks for vertical refinement:
 !  feedback has to be turned off
 !-----------------------------------------------------------------------
       oops = 0 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: vertical nesting, hybrid vertical coordinate, vert_refine_method, hybrid_opt

SOURCE: Robert Arthur and Katie Lundquist (LLNL)

DESCRIPTION OF CHANGES:
Problem:
When vertical nesting is used with the hybrid vertical coordinate option (hybrid_opt=2), large errors occur in the 
vertically-refined domain.

Solution:
An incorrect calculation of pb (base pressure) was fixed in subroutine force_domain_em_part2 (module_dm.F). The pb 
calculation was changed to match similar code in start_em. This fix is within a block of code that is only called if 
vert_refine_method .ne. 0, in order to rebalance on the "intermediate" nested grid. The error was likely a result of the 
switch to the new hybrid coordinate definition, which was not updated correctly in this particular subroutine.

The check-a-mundo preventing vertical nesting from being used with the hybrid coordinate (see #1154) has also 
been removed.

This PR is related to #901, which addressed vertical nesting with the hybrid coordinate (but did not fully fix the issue), 
as well as #1408, which addressed vertical nesting with use_theta_m=1. 

LIST OF MODIFIED FILES:
external/RSL_LITE/module_dm.F
share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. The tests conducted here are similar to those in #1408. A 4-domain nested case was completed with vertical 
refinement on d04. All domains were initialized from a wrfinput file and eta levels were not provided. Pertinent 
namelist options are:
```
input_from_file = .true., .true., .true., .true.,
e_vert = 45, 45, 45, 55,
vert_refine_method = 0, 0, 0, 2,
rebalance = 1,
hybrid_opt = 0 or 2, depending on the case
use_theta_m = 0
```

Results are summarized in the plot below, which shows U at the first grid point above the surface on d04 at various 
output times.

![U](https://user-images.githubusercontent.com/46732079/111347582-958ae680-863c-11eb-9536-1862a1b650fe.png)

With the original code, vertical nesting works with hybrid_opt=0, but not hybrid_opt=2. With the updated code, results 
look reasonable for hybrid_opt=2 and are roughly the same as for hybrid_opt=0. Similar patterns are also seen for other 
variables, such as V and MU, although they are not shown here.

2. Several similar tests were also conducted, as above but with
   * d04 initialized via interpolation from d03 during runtime, rather than from wrfinput_d04
   * eta levels specified for each domain in the namelist
   * use_theta_m=1

These tests provided qualitatively similar results, showing that the fix works for a range of possible setups.

3. Finally, the tests above were completed with hybrid_opt=0, but using the updated code. These showed bit-for-bit 
identical results (using diffwrf) to the same cases using the original code, confirming that previous vertical nesting 
functionality with hybrid_opt=0 is maintained. This was done for both use_theta_m options, 0 and 1.

4. Jenkins testing is OK

RELEASE NOTE: Vertical nesting now works with the hybrid vertical coordinate.