### PR TITLE
Bug fix: RRTMG SW solar source function calculation

### DIFF
--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -3290,6 +3290,10 @@
 
 !jm not thread safe      hvrtau = '$Revision: 1.3 $'
 
+! Initialize sfluxzen to 0.0 to prevent junk values when nlayers = laytrop
+
+      sfluxzen(:) = 0.0
+
 ! Calculate gaseous optical depth and planck fractions for each spectral band.
 
       call taumol16


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: RRTMG, shortwave radiation, solar source function

SOURCE: Timothy W. Juliano and Pedro A. Jimenez (NCAR/RAL), Jimy Dudhia (NCAR/MMM)

DESCRIPTION OF CHANGES:
Problem:
In subroutine `setcoef_sw` of `phys/module_ra_rrtmg_sw.F`, which is called within subroutine `rrtmg_sw`, the number 
of vertical levels (`nlayers`) and the tropopause level (`laytrop`) are calculated. If the domain top is sufficiently low, 
then the tropopause level is never "found" by the set pressure threshold, and `laytrop` = `nlayers`. In a typical real 
case, where the tropopause is below the model top, `laytrop < nlayers`. Thus, this scenario is likely to occur only in 
idealized cases.

After `nlayers` and `laytrop` are set, subroutine `taumol_sw` is called within the radiation transfer model. Here, 
the different gas/molecular optical depths over the spectral bands are calculated, and there is a separate subroutine 
for each band (`taumol16`, `taumol17`, etc). One of the purposes of each of these subroutines is to fill the solar source 
function (`sfluxzen`). In each of the subroutines, there are two main loops: a lower atmosphere loop (extending from 
the lowest `k` level to the tropopause layer, `laytrop`) and an upper atmosphere loop (extending from `laytrop+1` 
to `nlayers`). Here is where the issue arises. In some of the `taumol*` subroutines, the indices of `sfluxzen` associated 
with that particular band are filled in the lower atmosphere loop, while in the other subroutines, the relevant indices 
of `sfluxzen` are filled in the upper atmosphere loop. In the subroutines where `sfluxzen` is intended to be filled in 
the upper atmosphere loop, it is never actually filled. This is because `laytrop = nlayers`, and the upper atmosphere 
loop is never executed. Thus, `sfluxzen` is filled with junk values (including `NaN`) for these indices.

This is an issue because after `sfluxzen` is filled, it is then corrected by considering Earth/Sun distance and zenith 
angle and stored in `zincflx` in the `spcvmc_sw` subroutine. The spectral fluxes are then summed over the spectrum 
and stored in `pbbfu` (upwelling) and `pbbfd` (downwelling). The upwelling and downwelling SW fluxes are stored 
in variables `swuflx` and `swdflx` in subroutine `rrtmg_sw` and subsequently used to calculate `GSW` in subroutine 
`RRTMG_SWRAD`. The `NaN` values propagate through all of these variables, and when `SWDOWN` is calculated 
from `GSW` in the radiation driver, it is also `NaN`. The place where the code crashes is in the `diffuse_frac` loop, 
when it checks the value of `swdown(i,j)`.

Solution:
The simple and clean fix is to initialize `sfluxzen` to zero in `taumol_sw` before all of the `taumol*` subroutines are 
called. I implemented this one liner into the code and it integrates through as expected.

LIST OF MODIFIED FILES:
M phys/module_ra_rrtmg_sw.F

TESTS CONDUCTED:
1. I have run an idealized LES at high latitude (setting `xlat` to 75N in `module_initialize_ideal.F`) starting at 06 UTC 
on March 28, 2020 with and without the bug fix. Without the bug fix, the simulation crashes as reported above. With 
the bug fix, the simulation integrates through without an issue. I'll also note that running the simulation at 75N except 
at start times of 12 and 18 UTC leads to failure, while starting at 00 UTC leads to successful integration. So, this issue 
appears to happen during daytime only. Moreover, this issue arises with only RRTMG SW radiation scheme; the code 
integrates properly using every other SW radiation scheme (with the exception of the other RRTMG flavors, which I have 
not tried), suggesting this issue is tied to RRTMG.
2. Jenkins tests are PASS.

RELEASE NOTE: A fix is introduced to the RRTMG SW parameterization. When the model top is relatively low, and the threshold for tropopause pressure is not reached, `laytrop = nlayers`. In this case, some indices in `sfluxzen` can be filled with junk, ultimately leading to NaN value for `SWDOWN` and failure in the radiation driver. The modification is to initialize `sfluxzen` to zero before being filled.