### PR TITLE
Removed 'max_rot_angle_gwd' from Registry - no longer used.

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2785,7 +2785,6 @@ rconfig   integer damp_opt                namelist,dynamics	1             3     
 rconfig   integer rad_nudge               namelist,dynamics	1             0       irh    "rad_nudge"             ""      ""
 rconfig   integer gwd_opt                 namelist,dynamics     max_domains   0       irh    "gwd_opt"               ""      ""
 rconfig   integer gwd_diags               namelist,dynamics     1             0       irh    "gwd_diags"             "switch to turn on extra gwd diagnostics if available for given gwd_opt"      ""
-rconfig   real    max_rot_angle_gwd       namelist,dynamics     1             22.5    irh    "max_rot_angle_gwd"    "max projection rotation angle permitted for gravity wave drag"      ""
 rconfig   real    zdamp                   namelist,dynamics	max_domains    5000.   h    "zdamp"         ""      ""
 rconfig   real    dampcoef                namelist,dynamics     max_domains    0.2     h    "dampcoef"              ""      ""
 rconfig   real    khdif                   namelist,dynamics	max_domains    0       h    "khdif"         ""      ""


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: max_rot_angle_gwd, remove, Registry.EM_COMMON, non-applicable

SOURCE: internal 

DESCRIPTION OF CHANGES:
Problem:
The variable 'max_rot_angle_gwd' is no longer used in the code since V4.0, but was still listed in the 
Registry.EM_COMMON file.

Solution:
Removed 'max_rot_angle_gwd' from Registry.EM_COMMON

LIST OF MODIFIED FILES:
M    Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. No impact modification. No testing needed. This variable is not in any other code.
2. Jenkins is OK
