### PR TITLE
Corrections for ntu_init

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -127,7 +127,6 @@
 !..Need to fill special height var for setting up initial condition.  G. Thompson
    REAL, ALLOCATABLE, DIMENSION(:,:,:) :: z_at_q
    REAL, ALLOCATABLE, DIMENSION(:,:,:) :: dz8w   !mchen
-   REAL, ALLOCATABLE, DIMENSION(:,:,:) :: PRES,RHOA       ! ntu3m
 
 !  CCN for MP=18 initializatio
    REAL :: ccn_max_val
@@ -152,8 +151,6 @@
 #endif
    ALLOCATE(dz8w(IMS:IME,KMS:KME,JMS:JME),STAT=I)  ; dz8w = 0.
    ALLOCATE(z_at_q(IMS:IME,KMS:KME,JMS:JME),STAT=I)  ; z_at_q = 0.
-   ALLOCATE(PRES(IMS:IME,KMS:KME,JMS:JME),STAT=I)  ; PRES = 0.   ! ntu3m
-   ALLOCATE(RHOA(IMS:IME,KMS:KME,JMS:JME),STAT=I)  ; RHOA = 0.   ! ntu3m
    CALL model_to_grid_config_rec ( grid%id , model_config_rec , config_flags )
 
    IF ( ( MOD (ide-ids,config_flags%parent_grid_ratio) .NE. 0 ) .OR. &
@@ -873,8 +870,6 @@
       DO k = kts,kte
          DO i = its, min(ite,ide-1)
             z_at_q(i,k,j)=(grid%ph_2(i,k,j)+grid%phb(i,k,j))/g
-            PRES(i,k,j) = grid%p(i,k,j)+grid%pb(i,k,j)              ! ntu3m
-            RHOA(i,k,j) = 1./grid%alt(i,k,j)*(1.+moist(i,k,j,P_QV)) ! ntu3m
          ENDDO
       ENDDO
    ENDDO
@@ -1041,9 +1036,11 @@ endif
                       z_at_q, grid%alt, grid%qnwfa2d, scalar(ims,kms,jms,1), num_scalar,         & ! G. Thompson
                       grid%re_cloud, grid%re_ice, grid%re_snow,         & ! G. Thompson
                       grid%has_reqc, grid%has_reqi, grid%has_reqs,      & ! G. Thompson
-                      PRES,RHOA,config_flags%CCNTY,scalar(:,:,:,P_QDCN),& ! for ntu3m
-                      scalar(:,:,:,P_QTCN),scalar(:,:,:,P_QCCN),        & ! for ntu3m
-                      scalar(:,:,:,P_QRCN),scalar(:,:,:,P_QNIN),        & ! for ntu3m
+                      grid%phb,grid%ph_2,grid%p,grid%pb,                & ! for ntu3m
+                      moist(:,:,:,P_QV),config_flags%CCNTY,             & ! for ntu3m
+                      scalar(:,:,:,P_QDCN),scalar(:,:,:,P_QTCN),        & ! for ntu3m
+                      scalar(:,:,:,P_QCCN),scalar(:,:,:,P_QRCN),        & ! for ntu3m
+                      scalar(:,:,:,P_QNIN),                             & ! for ntu3m
                       grid%re_cloud_gsfc, grid%re_ice_gsfc,             & ! Goddard
                       grid%re_snow_gsfc, grid%re_graupel_gsfc,          & ! Goddard
                       grid%re_hail_gsfc, grid%re_rain_gsfc,             & ! Goddard
@@ -2002,8 +1999,6 @@ endif
 #endif
 
 DEALLOCATE(z_at_q)
-DEALLOCATE(PRES)       ! ntu3m
-DEALLOCATE(RHOA)       ! ntu3m
 
    IF (config_flags%p_lev_diags == PRESS_DIAGS ) THEN
     CALL wrf_debug ( 200 , ' PLD: pressure level diags' )

--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -253,7 +253,7 @@
 
       CONTAINS
 !======================================================================
-      SUBROUTINE NTU_INIT(PRES,z_at_q,RHOA,QDCN,QTCN,QCCN,QRCN,QNIN,   &
+      SUBROUTINE NTU_INIT(PHB,PH,P,PB,ALT,QV,QDCN,QTCN,QCCN,QRCN,QNIN, &
                  XLAND,CCNTY,RESTART,IDS,IDE,JDS,JDE,KDS,KDE,IMS,IME,  &
                  JMS,JME,KMS,KME,ITS,ITE,JTS,JTE,KTS,KTE)
 !======================================================================
@@ -262,12 +262,11 @@
       INTEGER, INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,IMS,IME,JMS,JME,  &
                              KMS,KME,ITS,ITE,JTS,JTE,KTS,KTE,CCNTY
       REAL, INTENT(IN), DIMENSION(IMS:IME,JMS:JME) :: XLAND             ! 1:land ; 2:ocean
-      REAL, INTENT(IN), DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: PRES,    &
-                        z_at_q,RHOA
+      REAL, INTENT(IN), DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: PHB,PH,P,&
+                        PB,ALT,QV
       REAL, INTENT(INOUT), DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: QDCN, &
                            QTCN,QCCN,QRCN,QNIN
-      REAL, DIMENSION(ITS:ITE,KTS:KTE,JTS:JTE) :: ZATQ1,RHOA1,PRES1,   &
-                                                  RHO,DZ8W,P_PHY
+      REAL, DIMENSION(ITS:ITE,KTS:KTE,JTS:JTE) :: DZ,RHO,DZ8W,P_PHY
       REAL, DIMENSION(ITS:ITE,KTS:KTE,JTS:JTE,NAERT) :: QAERO
       INTEGER :: I,J,K,NK,ITF,JTF
 
@@ -277,25 +276,17 @@
       DO J = JTS,JTF
          DO K = KTS,KTE
             DO I = ITS,ITF
-               IF (K.EQ.KTE) THEN
-                  ZATQ1(I,K,J) = z_at_q(I,K,J)-z_at_q(I,K-1,J)
-                  RHOA1(I,K,J) = 2.*RHOA(I,K-1,J)-RHOA(I,K-2,J)
-                  PRES1(I,K,J) = 2.*PRES(I,K-1,J)-PRES(I,K-2,J)
-               ELSE
-                  ZATQ1(I,K,J) = z_at_q(I,K+1,J)-z_at_q(I,K,J)
-                  RHOA1(I,K,J) = RHOA(I,K,J)
-                  PRES1(I,K,J) = PRES(I,K,J)
-               ENDIF
+               DZ(I,K,J) = (PHB(I,K,J)+PH(I,K,J))/G
             ENDDO
          ENDDO
       ENDDO
       DO J = JTS,JTF
-         DO K = KTS,KTE
+         DO K = KTS,KTE-1
             DO I = ITS,ITF
-               NK = KME-K+1
-               DZ8W(I,K,J) = ZATQ1(I,NK,J)
-               RHO(I,K,J) = RHOA1(I,NK,J)
-               P_PHY(I,K,J) = PRES1(I,NK,J)
+               NK = KME-K
+               DZ8W(I,K,J) = DZ(I,NK+1,J)-DZ(I,NK,J)
+               RHO(I,K,J) = 1./ALT(I,NK,J)*(1.+QV(I,NK,J))
+               P_PHY(I,K,J) = P(I,NK,J)+PB(I,NK,J)
                QAERO(I,K,J,1) = QDCN(I,NK,J)
                QAERO(I,K,J,2) = QTCN(I,NK,J)
                QAERO(I,K,J,3) = QCCN(I,NK,J)
@@ -309,9 +300,9 @@
               KDS,KDE,IMS,IME,JMS,JME,KMS,KME,ITS,ITE,JTS,JTE,KTS,KTE)
       ENDIF
       DO J = JTS,JTF
-         DO K = KTS,KTE
+         DO K = KTS,KTE-1
             DO I = ITS,ITF
-               NK = KME-K+1
+               NK = KME-K
                QDCN(I,NK,J) = QAERO(I,K,J,1)
                QTCN(I,NK,J) = QAERO(I,K,J,2)
                QCCN(I,NK,J) = QAERO(I,K,J,3)
@@ -1685,7 +1676,7 @@
       ENDDO                                                             ! FOR J LOOPS
 
       PRINT *,'aerosols_init,I,J,NAER',(ITS+ITE)/2,(JTS+JTE)/2,NAER
-      DO K = KTS,KTE
+      DO K = KTS,KTE-1
          WRITE(*,'(I2,X,20(E12.6,X))') K,(QAERO((ITS+ITE)/2,K,         &
          (JTS+JTE)/2,IV),IV=1,NAERT)
       ENDDO
@@ -2583,7 +2574,7 @@
       CALL PTFLUX(QG3D(1),VT_QG(1),RHO(1),DZ3D(1),KTE,DT,DTMN,GRAPNCV)
       CALL PTFLUX(QH3D(1),VT_QH(1),RHO(1),DZ3D(1),KTE,DT,DTMN,HAILNCV)
       RAINNC = RAINNC+CLODNCV+RAINNCV+ICENCV+SNOWNCV+GRAPNCV+HAILNCV
-      SNOWNC = SNOWNC+SNOWNCV
+      SNOWNC = SNOWNC+ICENCV+SNOWNCV
       GRAPNC = GRAPNC+GRAPNCV
       HAILNC = HAILNC+HAILNCV
       SR     = (ICENCV+SNOWNCV+GRAPNCV+HAILNCV)/                       &

--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -283,7 +283,7 @@
       DO J = JTS,JTF
          DO K = KTS,KTE-1
             DO I = ITS,ITF
-               NK = KME-K
+               NK = KTE-K
                DZ8W(I,K,J) = DZ(I,NK+1,J)-DZ(I,NK,J)
                RHO(I,K,J) = 1./ALT(I,NK,J)*(1.+QV(I,NK,J))
                P_PHY(I,K,J) = P(I,NK,J)+PB(I,NK,J)
@@ -302,7 +302,7 @@
       DO J = JTS,JTF
          DO K = KTS,KTE-1
             DO I = ITS,ITF
-               NK = KME-K
+               NK = KTE-K
                QDCN(I,NK,J) = QAERO(I,K,J,1)
                QTCN(I,NK,J) = QAERO(I,K,J,2)
                QCCN(I,NK,J) = QAERO(I,K,J,3)
@@ -1606,9 +1606,9 @@
       ENDDO
       IF (ID_DUST*ID_IN.NE.0) THEN                                      ! IF DUST EXISTS
          DUST_IN0 = 0.
-         DO IM = 1,NCCN
-            DUST_IN0 = DUST_IN0+ZCCN(IM,ID_DUST)
-         ENDDO
+!         DO IM = 1,NCCN
+!            DUST_IN0 = DUST_IN0+ZCCN(IM,ID_DUST)
+!         ENDDO
       ELSE                                                              ! NO DUST
          DUST_IN0 = BACKIN
       ENDIF
@@ -1728,7 +1728,7 @@
          I3MNCV(I,J) = 0.; SR(I,J) = 0.
 !----------------- write data from 3D to 1D and assign upside down -----
          DO K = KTS,KTE
-            NK = KME-K
+            NK = KTE-K+1
             S1D(K) = 0.
             TK1D(K) = TH(I,NK,J)*PII(I,NK,J)
             W1D(K)  = 0.5*(W(I,NK,J)+W(I,NK+1,J))                      ! W at half level
@@ -1775,7 +1775,7 @@
               KTS,KTE)
 
          DO K = KTS,KTE
-            NK = KME-K
+            NK = KTE-K+1
             TH(I,NK,J) = TK1D(K)/PII(I,NK,J)
             QV(I,NK,J) = MAX(0.,QV1D(K))
             QC(I,NK,J) = MAX(0.,QC1D(K))

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -53,8 +53,8 @@ CONTAINS
                          re_cloud, re_ice, re_snow,              & ! G. Thompson
                          has_reqc, has_reqi, has_reqs,           & ! G. Thompson
 #if ( EM_CORE == 1 )
-                         PRES,RHOA,CCNTY,QDCN,QTCN,QCCN,QRCN,    & ! for ntu3m
-                         QNIN,                                   & ! for ntu3m
+                         PHB,PH,P,PB,QV,CCNTY,QDCN,QTCN,QCCN,    & ! for ntu3m
+                         QRCN,QNIN,                              & ! for ntu3m
                          re_cloud_gsfc, re_ice_gsfc,             & 
                          re_snow_gsfc,                           & ! Goddard
                          re_graupel_gsfc, re_hail_gsfc,          &
@@ -726,7 +726,7 @@ CONTAINS
    REAL, OPTIONAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT) :: DL_U_BEP
 #if ( EM_CORE == 1 )
    INTEGER, OPTIONAL, INTENT(IN) :: CCNTY                                               ! for ntu3m
-   REAL, OPTIONAL, INTENT(IN), DIMENSION(ims:ime,kms:kme,jms:jme) :: PRES,RHOA          ! for ntu3m
+   REAL, OPTIONAL, INTENT(IN), DIMENSION(ims:ime,kms:kme,jms:jme) :: PHB,PH,P,PB,QV     ! for ntu3m
    REAL, INTENT(INOUT), DIMENSION(ims:ime,kms:kme,jms:jme) :: QDCN,QTCN,QCCN,QRCN,QNIN  ! for ntu3m
 #endif
 ! lake varibles:
@@ -1602,7 +1602,7 @@ CONTAINS
                 MPDT, DT, DX, DY, LOWLYR,                       &
                 F_ICE_PHY,F_RAIN_PHY,F_RIMEF_PHY,               &
 #if ( EM_CORE == 1 )
-                PRES,RHOA,XLAND,CCNTY,QDCN,QTCN,QCCN,QRCN,      & ! for ntu3m
+                PHB,PH,P,PB,QV,XLAND,CCNTY,QDCN,QTCN,QCCN,QRCN, & ! for ntu3m
                 QNIN,                                           & ! for ntu3m
 #endif
                 mp_restart_state,tbpvs_state,tbpvs0_state,      &
@@ -4323,8 +4323,8 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
                       MPDT, DT, DX, DY, LOWLYR,                   & ! for eta mp
                       F_ICE_PHY,F_RAIN_PHY,F_RIMEF_PHY,           & ! for eta mp
 #if ( EM_CORE == 1 )
-                      PRES,RHOA,XLAND,CCNTY,QDCN,QTCN,QCCN,QRCN,  & ! for ntu3m
-                      QNIN,                                       & ! for ntu3m
+                      PHB,PH,P,PB,QV,XLAND,CCNTY,QDCN,QTCN,QCCN,  & ! for ntu3m
+                      QRCN,QNIN,                                  & ! for ntu3m
 #endif
                       mp_restart_state,tbpvs_state,tbpvs0_state,   & ! eta mp
                       allowed_to_read, start_of_simulation,       &
@@ -4399,7 +4399,7 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
 #if ( EM_CORE == 1 )
    INTEGER, OPTIONAL, INTENT(IN) :: CCNTY                                              ! for ntu3m
    REAL, OPTIONAL, DIMENSION(ims:ime,jms:jme), INTENT(IN) :: XLAND                     ! for ntu3m
-   REAL, OPTIONAL, INTENT(IN), DIMENSION(ims:ime,kms:kme,jms:jme) :: PRES,RHOA         ! for ntu3m
+   REAL, OPTIONAL, INTENT(IN), DIMENSION(ims:ime,kms:kme,jms:jme) :: PHB,PH,P,PB,QV    ! for ntu3m
    REAL, INTENT(INOUT), DIMENSION(ims:ime,kms:kme,jms:jme) :: QDCN,QTCN,QCCN,QRCN,QNIN ! for ntu3m
 #endif
    REAL , DIMENSION(:) ,INTENT(INOUT)  :: mp_restart_state,tbpvs_state,tbpvs0_state
@@ -4552,9 +4552,10 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
           CALL wdm7init(rhoair0,rhowater,rhosnow,cliq,cpv,ccn_conc, allowed_to_read )
 #if (EM_CORE==1)
      CASE (NTU)
-          CALL ntu_init(PRES,z_at_q,RHOA,QDCN,QTCN,QCCN,QRCN,QNIN,      &
-                        XLAND,CCNTY,restart,ids,ide,jds,jde,kds,kde,    &
-                        ims,ime,jms,jme,kms,kme,its,ite,jts,jte,kts,kte)
+          CALL ntu_init(PHB,PH,P,PB,inv_dens,QV,QDCN,QTCN,QCCN,QRCN,   &
+                        QNIN,XLAND,CCNTY,restart,ids,ide,jds,jde,kds,  &
+                        kde,ims,ime,jms,jme,kms,kme,its,ite,jts,jte,   &
+                        kts,kte)
 #endif
 #if (EM_CORE==1)
     CASE (FULL_KHAIN_LYNN)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ntu_init, SNOWNC

SOURCE: Tzu-Chin Tsai (National Taiwan University)

DESCRIPTION OF CHANGES:
Problem:
1. The calculation of air density (RHOA) is divided by zero (producing NaN) at the top full level (k=kte) in 
start_em.F.  
2. Incompatible with the description of SNOWNC in the Registry (ACCUMULATED TOTAL GRID SCALE SNOW AND 
ICE).
3. Intel19 compiler error #1444

Solution:
1. The derivations of air density (RHOA), pressure (PRES), and height (z_at_q) are moved from the start_em.F to 
ntu_init through the passing of basic variables (PHB, PH, P, PB, ALT, and QV) from the WRF dynamics. Also, the 
ending indices of the vertical loop are changed to kte-1. 
2. The sedimentation of pristine ice (ICENCV) is appended to the accumulated snow precipitation (SNOWNCV+
ICENCV).
3. The loop for DUST_IN0 has been removed since dust emission is not included.   

LIST OF MODIFIED FILES:
dyn_em/start_em.F
phys/module_mp_ntu.F
phys/module_physics_init.F

TESTS CONDUCTED:
1. Idealized squall_line_2d_x run
The initial condition of background aerosols became a bit reduced (QDCN and QTCN were about -10% and QNIN 
was -5% on average) with the modification in this PR (red line, modify) compared to the results with the previous 
code (blue line, current). Also, another test made a new loop of kte-1 for RHOA and PRES in the start_em.F (green 
line, kte-1) for comparison. The below figures are the domain-mean vertical profiles in terms of different background 
aerosols at the initial time. This difference arose from the misplacement of the basic fields (thickness of the vertical 
layer, air density, and pressure) by one grid point because of the upside-down loop in ntu_init. In other words, the 
input fundamental fields were separately from kte to kts+1 and from kte-1 to kts using the previous and modified 
core. Note that this difference merely exists in the NTU scheme with the upside-down loop. At last, both the results 
of kte-1 and modify runs are almost identical to each other (the minor difference of 0.1% was from the z_at_w and 
z_at_q). 
![image](https://user-images.githubusercontent.com/73516426/112714163-0f13b600-8f14-11eb-89ca-590f113c271a.png)


PS, The initial value of QDCN is identical to QTCN. 