### PR TITLE
Remove ASCII chars outside of 32-127 range

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -394,7 +394,7 @@ call wrf_message("**************************************************************
    endif
 
    if ( config_flags%cu_diag == 1) then
-   !BSINGH (12/17/2013): Added Kain–Fritsch Cumulus Potential (KF-CuP) scheme (cu_physics = 10)
+   !BSINGH (12/17/2013): Added Kain-Fritsch Cumulus Potential (KF-CuP) scheme (cu_physics = 10)
    !HSBADR (02/12/2019): Added Grell-Devenyi (GD) ensemble scheme (cu_physics = 93)
    if ( config_flags%cu_physics /= 3 .AND. config_flags%cu_physics /= 5 .AND. &
         config_flags%cu_physics /= 10 .AND. config_flags%cu_physics /= 93 ) then

--- a/chem/module_mosaic_newnucb.F
+++ b/chem/module_mosaic_newnucb.F
@@ -592,7 +592,7 @@
 !     rates at tropospheric conditions,
 !       j. geophys. res., 112, d15207, doi:10.1029/2006jd0027977
 !
-!    vehkamäki, h., m. kulmala, i. napari, k.e.j. lehtinen,
+!    vehkamaki, h., m. kulmala, i. napari, k.e.j. lehtinen,
 !       c. timmreck, m. noppel and a. laaksonen, 2002,
 !       an improved parameterization for sulfuric acid-water nucleation
 !       rates for tropospheric and stratospheric conditions,
@@ -1204,7 +1204,7 @@
 !
 ! calculates binary nucleation rate and critical cluster size
 ! using the parameterization in  
-!     vehkamäki, h., m. kulmala, i. napari, k.e.j. lehtinen,
+!     vehkamaki, h., m. kulmala, i. napari, k.e.j. lehtinen,
 !        c. timmreck, m. noppel and a. laaksonen, 2002,
 !        an improved parameterization for sulfuric acid-water nucleation
 !        rates for tropospheric and stratospheric conditions,

--- a/hydro/Routing/module_gw_gw2d.F
+++ b/hydro/Routing/module_gw_gw2d.F
@@ -263,7 +263,7 @@ module module_gw_gw2d
       integer            :: its, ite, jts, jte, ifs, ife, jfs, jfe, &
                             xdim, ydim, fxdim, fydim
                           
-! die müssen noch sortiert, geprüft und aufgeräumt werden
+! die mussen noch sortiert, gepruft und aufgerumt werden
       integer ::                &
         iter,                   &
         j,                      &

--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -47,7 +47,7 @@ end type fire_params
 !***    with common ancestor as submitted to V3.3 in 01/2017 commit 3f78267b38e0f0a3 ***!
 !*** Reference: J. Mandel, S. Amram, J.D. Beezley, G. Kelman, A.K. Kochanski, V.Y.   ***!
 !***    Kondratenko, B.H. Lynn, B. Regev, M. Vejmelka, Recent advances and           ***!
-!***    applications of WRF–SFIRE. Natural Hazards and Earth System Science, 14,     ***!
+!***    applications of WRF-SFIRE. Natural Hazards and Earth System Science, 14,     ***!
 !***    2829-2845, 2014, doi:10.5194/nhess-14-2829-2014                              ***!
 !***************************************************************************************!
 

--- a/phys/module_gocart_coupling.F
+++ b/phys/module_gocart_coupling.F
@@ -8875,7 +8875,7 @@
 !
 ! Citations
 ! DeMott, P. J., Coauthors 2010: Predicting global atmospheric ice nuclei distributions and 
-!     their impacts on climate. Proc. Natl. Acad. Sci. USA, 107:11217–11222.
+!     their impacts on climate. Proc. Natl. Acad. Sci. USA, 107:11217-11222.
 !
 !------------------------------------------------------------------------
  real,intent(in) :: p_air !air pressure [hPa]

--- a/phys/module_mp_fast_sbm.F
+++ b/phys/module_mp_fast_sbm.F
@@ -9064,7 +9064,7 @@ end if
 
      PI=3.1415927d0
      rho=1.0d0            ! Water Density,[rho]=g/cm^3
-     sigma=72.8d0         ! Surf. Tension,(H2O,20°C)=7.28d-2 N/m
+     sigma=72.8d0         ! Surf. Tension,(H2O,20C)=7.28d-2 N/m
                       ! [sigma]=g/s^2
      ak10=rho*PI/12.0d0
 

--- a/phys/module_mp_gsfcgce_4ice_nuwrf.F
+++ b/phys/module_mp_gsfcgce_4ice_nuwrf.F
@@ -2151,7 +2151,7 @@ CONTAINS
 !   Stephen E. Lang, Wei-Kuo Tao, Jiun-Dar Chern, Di Wu,                  c
 !   and Xiaowen Li, 2014: Benefits of a Fourth Ice Class                  c
 !   in the Simulated Radar Reflectivities of Convective Systems           c
-!   Using a Bulk Microphysics Scheme. J. Atmos. Sci., 71, 3583–3612.      c
+!   Using a Bulk Microphysics Scheme. J. Atmos. Sci., 71, 3583-3612.      c
 !   doi: http://dx.doi.org/10.1175/JAS-D-13-0330.1                        c
 !                                                                         c
 !   Lang, S., W.-K. Tao, J.-D. Chern, D. Wu, and X. Li, 2014:             c

--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -7,15 +7,15 @@
 !-------------------------------------------------------------------------------------------------------------------------------
 ! References :
 ! 1. Chen, J.-P. and S.-T. Liu, 2004: Physically based two-moment bulkwater parametrization for warm-cloud microphysics.
-!       Quart. J. Roy. Meteor. Soc., 130, 51–78.
+!       Quart. J. Roy. Meteor. Soc., 130, 51-78.
 ! 2. Cheng, C.-T., W.-C. Wang, and J.-P. Chen, 2007: A modeling study of aerosol impacts on cloud microphysics and radiative 
-!       properties. Quart. J. Roy. Meteor. Soc., 133, 283–297.
+!       properties. Quart. J. Roy. Meteor. Soc., 133, 283-297.
 ! 3. Cheng, C.-T., W.-C. Wang, and J.-P. Chen, 2010: Simulation of the effects of increasing cloud condensation nuclei on 
-!       mixed-phase clouds and precipitation of a front system. Atmos. Res., 96, 461–476.
+!       mixed-phase clouds and precipitation of a front system. Atmos. Res., 96, 461-476.
 ! 4. Chen, J.-P. and T.-C. Tsai, 2016: Triple-moment modal parameterization for the adaptive growth habit of pristine ice 
-!       crystals. J. Atmos. Sci., 73, 2105–2122.
+!       crystals. J. Atmos. Sci., 73, 2105-2122.
 ! 5. Tsai, T.-C., and J.-P. Chen, 2020: Multi-moment ice bulk microphysics scheme with consideration for particle shape 
-!       and apparent density. Part I: Methodology and idealized simulation. J. Atmos. Sci., 77, 1821–1850.
+!       and apparent density. Part I: Methodology and idealized simulation. J. Atmos. Sci., 77, 1821-1850.
 !
 !--------------------------------------------------------------------------------------------------------------------------------
 ! The notation for terms involving two interacting categories are denoted by B(x,y)MPxy, where B is the prognostic variable

--- a/phys/module_ra_eclipse.F
+++ b/phys/module_ra_eclipse.F
@@ -5,9 +5,9 @@ contains
 !--------------------------------------------
 ! Solar eclipse prediction moduel
 !
-! Alex Montornès and Bernat Codina. University of Barcelona. 2015
+! Alex Montornes and Bernat Codina. University of Barcelona. 2015
 !
-! Based on Montornès A., Codina B., Zack J., Sola, Y.: Implementation of the 
+! Based on Montornes A., Codina B., Zack J., Sola, Y.: Implementation of the 
 ! Bessel's method for solar eclipses prediction in the WRF-ARW model. 2015
 !
 ! This key point of this subroutine is the evaluation of the degree of obscuration,
@@ -292,7 +292,7 @@ subroutine solar_eclipse(ims,ime,jms,jme,its,ite,jts,jte,    &
 	eta1   = sin_lat1 * cos(rd1) * E - cos_lat1 * sin(rd1) * cos(H)
 	zeta1  = sin_lat1 * sin(rd2) * E + cos_lat1 * cos(rd2) * cos(H)
 
-	!-- Correct cy (sembla que no és necessari)
+	!-- Correct cy (sembla que no es necessari)
 	cy1  = cy/rho1
 
         !-- Distance to the shadow axis

--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -487,7 +487,7 @@ use module_wrf_error
 ! 261-304
 !
 ! F. Salamanca and A. Martilli, 2009: 'A new Building Energy Model coupled 
-! with an Urban Canopy Parameterization for urban climate simulationsâ€”part II. 
+! with an Urban Canopy Parameterization for urban climate simulations: part II. 
 ! Validation with one dimension off-line simulations'. Theor Appl Climatol
 ! DOI 10.1007/s00704-009-0143-8 
 !------------------------------------------------------------------------
@@ -1419,18 +1419,18 @@ do iz= kts,kte
       real alaf(nf_u+1)     ! Floor thermal diffusivity at each wall layers [W/m K]     
       real alagb(ngb_u+1)   ! Ground thermal diffusivity below the building at each wall layer [W/m K] 
 
-      real sfrb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/mÂ²]
+      real sfrb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
       real sfrbpv(ndm,nbui_max)      ! Sensible heat flux from PV panels [W/m2]
       real sfrpv(ndm,nz_um)          ! Sensible heat flux from PV panels [W/m2]
-      real sfrvb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/mÂ²]
-      real lfrvb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/mÂ²]
-      real lfrb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/mÂ²]
+      real sfrvb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
+      real lfrvb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
+      real lfrb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
   
-      real gfrb(ndm,nbui_max)        ! Heat flux flowing inside the roofs [W/mÂ²]
-      real sfwb1D(2*ndm,nz_um)    !Sensible heat flux from the walls [W/mÂ²] 
-      real sfwin(2*ndm,nz_um,nbui_max)!Sensible heat flux from windows [W/mÂ²]
-      real sfwinb1D(2*ndm,nz_um)  !Sensible heat flux from windows [W/mÂ²]
-      real gfwb1D(2*ndm,nz_um)    !Heat flux flowing inside the walls [W/mÂ²]
+      real gfrb(ndm,nbui_max)        ! Heat flux flowing inside the roofs [W/m2]
+      real sfwb1D(2*ndm,nz_um)    !Sensible heat flux from the walls [W/m2] 
+      real sfwin(2*ndm,nz_um,nbui_max)!Sensible heat flux from windows [W/m2]
+      real sfwinb1D(2*ndm,nz_um)  !Sensible heat flux from windows [W/m2]
+      real gfwb1D(2*ndm,nz_um)    !Heat flux flowing inside the walls [W/m2]
 
       real qlev(nz_um,nbui_max)      !specific humidity [kg/kg]
       real qlevb1D(nz_um)         !specific humidity [kg/kg] 
@@ -1455,7 +1455,7 @@ do iz= kts,kte
       real consumlev1D(nz_um)     ! consumption due to the air conditioning systems [W]
       real eppvlev(nz_um)         ! Electricity production of PV panels [W]
 	   real tpvlev(ndm,nz_um)
-      real tpvlevb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/mÂ²]
+      real tpvlevb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
       real sfvlev(nz_um,nz_um)    ! sensible heat flux due to ventilation [W]
       real lfvlev(nz_um,nz_um)    ! latent heat flux due to ventilation [W]
       real sfvlev1D(nz_um)        ! sensible heat flux due to ventilation [W]
@@ -1614,7 +1614,7 @@ do iz= kts,kte
        gfrb=0.     !Heat flux flowing inside the roof
        sfwb1D=0.   !Sensible heat flux from walls
        sfwinb1D=0. !Sensible heat flux from windows
-       gfwb1D=0.   !Heat flux flowing inside the walls[W/mÂ²]
+       gfwb1D=0.   !Heat flux flowing inside the walls[W/m2]
 
 
        twb1D=0.    !Wall temperature
@@ -5234,16 +5234,16 @@ do iz= kts,kte
       real rlw(2*ndm,nz_um)         ! Long wave radiation at the walls for a given canyon direction [W/m2]
       real rsg(ndm)                   ! Short wave radiation at the canyon for a given canyon direction [W/m2]
       real rlg(ndm)                   ! Long wave radiation at the ground for a given canyon direction [W/m2]
-      real rs                        ! Short wave radiation at the horizontal surface from the sun [W/mÂ²]  
-      real sfw(2*ndm,nz_um)      ! Sensible heat flux from walls [W/mÂ²]
-      real sfg(ndm)              ! Sensible heat flux from ground (road) [W/mÂ²]
+      real rs                        ! Short wave radiation at the horizontal surface from the sun [W/m2]  
+      real sfw(2*ndm,nz_um)      ! Sensible heat flux from walls [W/m2]
+      real sfg(ndm)              ! Sensible heat flux from ground (road) [W/m2]
       real lfg(ndm)
-      real sfr(ndm,nz_um)      ! Sensible heat flux from roofs [W/mÂ²]   
+      real sfr(ndm,nz_um)      ! Sensible heat flux from roofs [W/m2]   
       real lfr(ndm,nz_um)
       real lfrv(ndm,nz_um)
       real sfrv(ndm,nz_um)
       real gr_frac_roof
-      real rld                        ! Long wave radiation from the sky [W/mÂ²]
+      real rld                        ! Long wave radiation from the sky [W/m2]
       real albg_u                    ! albedo of the ground/street
       real albw_u                    ! albedo of the walls
       real albr_u                    ! albedo of the roof 
@@ -5272,7 +5272,7 @@ do iz= kts,kte
       real twlev(2*ndm,nz_um)   !Averaged Temperature of the windows 
       real pwin                 !Coverage area fraction of the windows
       real gflwin               !Heat stored for the windows
-      real sfwind(2*ndm,nz_um)  !Sensible heat flux from windows [W/mÂ²]
+      real sfwind(2*ndm,nz_um)  !Sensible heat flux from windows [W/m2]
 
 !OUTPUT/INPUT
       real rs_abs  ! absrobed solar radiationfor this street direction

--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -487,7 +487,7 @@ use module_wrf_error
 ! 261-304
 !
 ! F. Salamanca and A. Martilli, 2009: 'A new Building Energy Model coupled 
-! with an Urban Canopy Parameterization for urban climate simulations: part II. 
+! with an Urban Canopy Parameterization for urban climate simulations- part II. 
 ! Validation with one dimension off-line simulations'. Theor Appl Climatol
 ! DOI 10.1007/s00704-009-0143-8 
 !------------------------------------------------------------------------

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -8169,7 +8169,7 @@ ENDIF   ! CROPTYPE == 0
    ISOIL = 1
    CALL WDFCND2 (parameters,WDF,WCND,SH2O(ISOIL),SICEMAX,ISOIL)
 
-  ! sorptivity based on Eq. 10b from Kutílek, Miroslav, and Jana Valentová (1986) 
+  ! sorptivity based on Eq. 10b from Kutilek, Miroslav, and Jana Valentova (1986) 
   ! sorptivity approximations. Transport in Porous Media 1.1, 57-62.
    SP = SQRT(2.0 * (parameters%SMCMAX(ISOIL) - SMC(ISOIL)) * (parameters%DWSAT(ISOIL) - WDF)) 
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2006,7 +2006,7 @@
                 CALL wrf_message ( wrf_err_message )
                 wrf_err_message = '---          Grell 3D (G3) CU scheme'
                 CALL wrf_message ( wrf_err_message )
-                wrf_err_message = '---          Kain–Fritsch Cumulus Potential (KF-CuP) CU scheme'
+                wrf_err_message = '---          Kain-Fritsch Cumulus Potential (KF-CuP) CU scheme'
                 CALL wrf_message ( wrf_err_message )
                 wrf_err_message = '---          Grell-Devenyi (GD) CU scheme'
             CALL wrf_debug ( 0, TRIM( wrf_err_message ) )

--- a/tools/non_ascii_finder.F
+++ b/tools/non_ascii_finder.F
@@ -10,6 +10,9 @@
 ! the range of 32 to 127 (the standard printable ASCII character 
 ! set).
 
+! To easily see the offending characters:
+! vim -c "e ++enc=latin1" file
+
 ! The "Fortran 2003 Handbook" (Adams et al. 2009), in section 3.1.1,
 ! lists the standard Fortran character set, which is consistent 
 ! with the restriction of the ASCII character codes from 32 


### PR DESCRIPTION
TYPE: text only

KEYWORDS: ASCII

SOURCE: internal

DESCRIPTION OF CHANGES:
Remove instances of non Fortran character set entries in the WRF source. All of these changes are comments.
1. The \textemdash becomes "-"
2. The non-American keyboard letters become a, e, i, o, u without the dots or accents
3. The superscript 2 is removed, and replaced by a regular 2: W/m2
4. Extra DOS carriage returns are removed (likely when the files come from windows machines)
5. The degree symbol was removed
6. An extra handy vim command was added

LIST OF MODIFIED FILES:
	modified:   chem/chemics_init.F
	modified:   chem/module_mosaic_newnucb.F
	modified:   hydro/Routing/module_gw_gw2d.F
	modified:   phys/module_fr_fire_phys.F
	modified:   phys/module_gocart_coupling.F
	modified:   phys/module_mp_fast_sbm.F
	modified:   phys/module_mp_gsfcgce_4ice_nuwrf.F
	modified:   phys/module_mp_ntu.F
	modified:   phys/module_ra_eclipse.F
	modified:   phys/module_sf_bep_bem.F
	modified:   phys/module_sf_noahmplsm.F
	modified:   share/module_check_a_mundo.F
	modified:   tools/non_ascii_finder.F

TESTS CONDUCTED: 
1. Text only, no changes to compiled code
2. Jenkins is all PASS

