### PR TITLE
IEVA: change upper case string "CFL" to lower case

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2691,7 +2691,7 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
 
            some1 = some1 + 1
 
-           WRITE(temp,FMT="(3(1x,i5,1x),'W-CRIT_CFL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") &
+           WRITE(temp,FMT="(3(1x,i5,1x),'w-crit_cfl: ',f7.4,2x,'w-cfl: ',f7.4,2x,'dETA: ',f7.4)") &
                                          i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
            CALL wrf_debug ( 100 , TRIM(temp) )
 
@@ -2701,7 +2701,7 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
 
            some2 = some2 + 1
 
-           WRITE(temp,FMT="(3(1x,i5,1x),'W-FLAG_CFL: ',f7.4,2x,'W-CFL: ',f7.4,2x,'dETA: ',f7.4))") &
+           WRITE(temp,FMT="(3(1x,i5,1x),'w-flag_cfl: ',f7.4,2x,'w-cfl: ',f7.4,2x,'dETA: ',f7.4)") &
                                          i,j,k,vert_cfl,w(i,k,j),-1./rdnw(k)
            CALL wrf_debug ( 100 , TRIM(temp) )
 
@@ -2722,12 +2722,12 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
      CALL get_current_time_string( time_str )
      CALL get_current_grid_name( grid_str )
      WRITE(temp,*) some1,                                            &
-            ' points exceeded W_CRITICAL_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+            ' points exceeded w_critical_cfl in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
      CALL wrf_debug ( 0 , TRIM(temp) )
-     WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'W-CFL: ',f7.2,2x,'dETA: ',f7.2))") &
+     WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'w-cfl: ',f7.2,2x,'dETA: ',f7.2)") &
                             maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
      CALL wrf_debug ( 0 , TRIM(temp) )
-     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'U-CFL: ',f7.2,2x,'V: ',f7.2,2x,'V-CFL: ',f7.2))") &
+     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'u-cfl: ',f7.2,2x,'V: ',f7.2,2x,'v-cfl: ',f7.2)") &
            maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
      CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF
@@ -2736,7 +2736,7 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
      CALL get_current_time_string( time_str )
      CALL get_current_grid_name( grid_str )
      WRITE(temp,*) some2,                                            &
-            ' points exceeded W_FLAG_CFL in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
+            ' points exceeded w_flag_cfl in domain '//TRIM(grid_str)//' at time '//TRIM(time_str)//' hours'
      CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF
 

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2727,9 +2727,9 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
      WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'w-cfl: ',f7.2,2x,'dETA: ',f7.2)") &
                             maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
      CALL wrf_debug ( 0 , TRIM(temp) )
-     WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'u-cfl: ',f7.2,2x,'V: ',f7.2,2x,'v-cfl: ',f7.2)") &
-           maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
-     CALL wrf_debug ( 0 , TRIM(temp) )
+!    WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'u-cfl: ',f7.2,2x,'V: ',f7.2,2x,'v-cfl: ',f7.2)") &
+!          maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
+!    CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF
 
    IF ( some2 .GT. 0 ) THEN   

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -2727,7 +2727,7 @@ SUBROUTINE w_damp( rw_tend, max_vert_cfl,max_horiz_cfl, &
      WRITE(temp,FMT="('Max   W: ',3(1x,i5,1x),'W: ',f7.2,2x,'w-cfl: ',f7.2,2x,'dETA: ',f7.2)") &
                             maxi, maxj, maxk, maxdub, max_vert_cfl, maxdeta
      CALL wrf_debug ( 0 , TRIM(temp) )
-!    WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'u-cfl: ',f7.2,2x,'V: ',f7.2,2x,'v-cfl: ',f7.2)") &
+!    WRITE(temp,FMT="('Max U/V: ',3(1x,i5,1x),'U: ',f7.2,2x,'u-cfl: ',f7.2,2x,'V: ',f7.2,2x,'v-cfl: ',f7.2)") & 
 !          maxi, maxj, maxk, u(maxi,maxk,maxj), dt*u(maxi,maxk,maxj)*rdx, v(maxi,maxk,maxj), dt*v(maxi,maxk,maxj)*rdy
 !    CALL wrf_debug ( 0 , TRIM(temp) )
    ENDIF


### PR DESCRIPTION
TYPE: text only

KEYWORDS: IEVA CFL cfl

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Historically, when a user has looked for any CFL violations that are reported in the print out, the string searched for
was "cfl". With the introduction of IEVA, a new series of CFL error messages now includes such information as 
horizontal and vertical stability. However, the strings were switched to uppercase.

Solution:
For the few output strings generated for the CFL prints, change the case from upper back to lower case.

Also, there was an extra ")" in a few of the internal write commands. I am not sure why those did not cause compiler 
errors. Those extra ")" characters were removed since I was changing those lines anyways.

LIST OF MODIFIED FILES: 
modified:   dyn_em/module_big_step_utilities_em.F

TESTS CONDUCTED: 
1. The code compiles.
2. There are no more uppercase CFL strings in the print out:
```
> grep CFL dyn_em/module_big_step_utilities_em.F
   INTEGER :: some1       ! Now have two catagories of CFL information, hence some1 & some2
!  First, the value of the W-CFL where damping is turned on can now be set in the namelist
!  W-CFL information.  Previously, both damping and W-CFL information was
!  printed at a W-CFL == 1.2.  This new capability does not need IEVA on to run.
!  IEVA, because many points can run with W-CFL > 1.2.  We now print this
!  W_damp will write out CFL information when the vertical courant number is > w_flag_cfl,
#ifdef OPTIMIZE_CFL_TEST
     CALL wrf_error_fatal('module_big_step_utilities_em.F: -DOPTIMIZE_CFL_TEST option does not support global domains')
# ifdef OPTIMIZE_CFL_TEST
#ifndef OPTIMIZE_CFL_TEST
```
3. Jenkins is all pass.
