### PR TITLE
Fixed staggering of shallow cumulus tendencies of u and v at periodic boundaries

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3280,7 +3280,7 @@ period    PERIOD_BDY_EM_E dyn_em 2:u_2,v_2,ht
 period    PERIOD_EM_HYDRO_UV dyn_em 1:u_2,v_2
 period    PERIOD_BDY_EM_A dyn_em 2:ru,rv,rw,ww,php,alt,p,muu,muv,mut,ph_2,al
 period    PERIOD_BDY_EM_A1  dyn_em 3:rdzw,rdz,z,zx,zy,ustm,ust
-period    PERIOD_BDY_EM_PHY_BC dyn_em 2:rublten,rvblten,rucuten,rvcuten,xkmh,xkmv,xkhh,xkhv,div,defor11,defor22,defor12,defor13,defor23,defor33,tke_2,rho,gamu,gamv,xkmv_meso
+period    PERIOD_BDY_EM_PHY_BC dyn_em 2:rublten,rvblten,rucuten,rvcuten,rushten,rvshten,xkmh,xkmv,xkhh,xkhv,div,defor11,defor22,defor12,defor13,defor23,defor33,tke_2,rho,gamu,gamv,xkmv_meso
 period    PERIOD_BDY_EM_FDDA_BC dyn_em 2:rundgdten,rvndgdten
 period    PERIOD_BDY_EM_B dyn_em 2:ru_tend,rv_tend,ph_2,al,p,t_1,t_save,u_save,v_save,mu_1,mu_2,mudf,php,alt,pb
 period    PERIOD_BDY_EM_B3 dyn_em 2:ph_2,al,p,mu_2,muts,mudf


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: shallow convection, period, periodic boundary conditions

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES:
Fixed staggering of shallow cumulus tendencies of u and v at periodic boundaries by adding the tendencies to a 
PERIOD communication.

In WRF, the u and v tendencies from the shallow cumulus scheme are computed on the mass points and then 
staggered to the velocity points. This staggering operation requires halo points at the domain and tile boundaries. 
Currently, there is no MPI communication for the halo points at the domain boundaries for periodic boundary 
conditions. Therefore, I added rushten and rvshten to one of the PERIOD communications that is called before 
the staggering. This PERIOD communication also includes the normal cumulus tendencies rucuten and rvcuten.

LIST OF MODIFIED FILES:   
Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. Checked with GNU debugger that halo points are filled
2. Jenkins testing is OK.

RELEASE NOTE: Fixed staggering of shallow cumulus tendencies of u and v at periodic boundaries with a PERIOD communication.
