### PR TITLE
Fix for fractional seaice using MYJ and QNSE surface layer and MYNN PBL

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2313,6 +2313,7 @@ CONTAINS
               ims,ime, jms,jme, kms,kme,                           &
               i_start(ij),i_end(ij), j_start(ij),j_end(ij),     &
               kts,kte,scm_force_flux    )
+           ENDIF
 #if ( EM_CORE==1)
          DO j = j_start(ij),j_end(ij)
             DO i = i_start(ij),i_end(ij)
@@ -2322,9 +2323,7 @@ CONTAINS
             END DO
          END DO
 #endif         
-
-        ENDIF
-        ELSE
+       ELSE
          CALL wrf_error_fatal('Lacking arguments for QNSESFC in surface driver')
        ENDIF
 

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2227,16 +2227,6 @@ CONTAINS
               ids,ide, jds,jde, kds,kde,                           &
               ims,ime, jms,jme, kms,kme,                           &
               i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte    )
-#if ( EM_CORE==1)
-         DO j = j_start(ij),j_end(ij)
-            DO i = i_start(ij),i_end(ij)
-               wspd(i,j) = MAX(SQRT(u_phy(i,kts,j)**2+v_phy(i,kts,j)**2),0.001)
-               ch(i,j) = chs (i,j)
-!!           ch(i,j) = flhc(i,j)/( cpm(i,j)*rho(i,kts,j) )
-            END DO
-         END DO
-#endif         
-
         ENDIF
 #if ( EM_CORE==1)
 !       ustm is not available in NMM
@@ -2244,6 +2234,8 @@ CONTAINS
          DO j = j_start(ij),j_end(ij)
             DO i = i_start(ij),i_end(ij)
                ustm(i,j) = ust(i,j)
+               wspd(i,j) = MAX(SQRT(u_phy(i,kts,j)**2+v_phy(i,kts,j)**2),0.001)
+               ch(i,j) = chs (i,j)
             END DO
          END DO
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: fractional seaice, MYJ and QNSE surface layer, MYNN PBL

SOURCE: internal, reported by Lou Wicker (NSSL)

DESCRIPTION OF CHANGES:
Problem:
When MYNN PBL is used with MYJ surface layer with the fractional seaice option on, an input field wspd is not defined. 

Solution:
Define wspd just the same as when the fractional seaice option is off. Hence, the loop to define wspd is moved outside the existing `if (fractional_seaice == 1)` block. The same change is applied to QNSE surface layer option too.

LIST OF MODIFIED FILES: list of changed files 
M    phys/module_surface_driver.F

TESTS CONDUCTED: 
1. This allows MYJ surface layer option to work with MYNN PBL when fractional seaice is on.
2. Jenkins tests all pass.

RELEASE NOTE: When MYNN PBL is used with MYJ surface layer with the fractional seaice option on the model failed immediately, due to an input field wspd is not being defined. This has been fixed.
