### PR TITLE
CPP directive around use of ISNAN() intrinsic function

### DIFF
--- a/configure
+++ b/configure
@@ -986,6 +986,26 @@ if [ $retval -ne 0 ] ; then
   fi
 fi
 
+# testing for Fortran 2003 IEEE features
+make fortran_2003_isnan_test > tools/fortran_2003_isnan_test.log 2>&1
+rm -f tools/fortran_2003_isnan_test.log
+retval=-1
+if [ -f tools/fortran_2003_isnan_test.exe ] ; then
+  retval=0
+fi
+if [ $retval -ne 0 ] ; then
+  sed -e '/^ARCH_LOCAL/s/$/ -DNO_ISNAN/' configure.wrf > configure.wrf.edit
+  mv configure.wrf.edit configure.wrf
+  echo " "
+  echo " "
+  echo "************************** W A R N I N G ************************************"
+  echo " "
+  echo "There are some intrinsic Fortran 2003 features in WRF that your compiler does not"
+  echo "recognize. The isnan function calls have been removed."
+  echo " "
+  echo "*****************************************************************************"
+fi
+
 # testing for Fortran 2008 intrinsic gamma function
 make fortran_2008_gamma_test > tools/fortran_2008_gamma.log 2>&1
 rm -f tools/fortran_2008_gamma.log

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -8027,7 +8027,9 @@ ENDIF   ! CROPTYPE == 0
     ELSE ! Equation (4)
        IRRLOSS   = 4.337*(EXP(0.077*WINDSPEED))*(((ESAT1-EAIR)*0.01)**(-0.098)) ! [%]
     END IF
+#if (! defined(NO_ISNAN) )    
     IF(ISNAN(IRRLOSS))IRRLOSS=4.0 ! In case if IRRLOSS is NaN
+#endif
     
     ! Sprinkler water (m) for sprinkler fraction 
     IRSIRATE  = IRSIRATE * SIFAC

--- a/tools/fortran_2003_isnan_test.F
+++ b/tools/fortran_2003_isnan_test.F
@@ -1,0 +1,14 @@
+      PROGRAM fortran_2003_test         
+
+      IMPLICIT NONE
+
+      REAL :: x, y
+
+      x = -1.
+      y =  sqrt(x)
+
+      IF ( ISNAN(y) ) THEN
+         PRINT *,'Apparently y is a NaN
+      ENDIF
+
+      END PROGRAM fortran_2003_test         


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: ISNAN, PGI compiler

SOURCE: Found by Prasanth, fixed by internal

DESCRIPTION OF CHANGES:
Problem:
Some PGI compilers do not support the 2003 intrinsic ISNAN() function.

Solution:
Put in an automatic test to include a CPP -Dflag if the ISNAN() function is not part of the compiler.

LIST OF MODIFIED FILES: 
	modified:   configure
	modified:   phys/module_sf_noahmplsm.F
	new file:   tools/fortran_2003_isnan_test.F

TESTS CONDUCTED: 
1. Going to see if this addresses the user's problem
2. Jenkins testing is OK (expected, as no real changes to the compiled code, except for a no opt CPP directive).