### PR TITLE
Added two missing END PARALLEL DO directives for do_avgflx_em=1

### DIFF
--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -3458,6 +3458,7 @@ BENCH_END(bc_end_tim)
                  &   grid%avgflx_efu1,grid%avgflx_dfd1,grid%avgflx_efd1 )
             CALL wrf_debug(200,'In solve_em, after zero_avgflx call')
          ENDDO
+         !$OMP END PARALLEL DO
       ENDIF
 
 ! Update avgflx quantities
@@ -3479,6 +3480,7 @@ BENCH_END(bc_end_tim)
          CALL wrf_debug(200,'In solve_em, after upd_avgflx call')
          
       ENDDO
+      !$OMP END PARALLEL DO
       grid%avgflx_count = grid%avgflx_count + 1
    ENDIF
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: OMP, do_avgflx_em

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES:
The missing OMP directive END PARALLEL DO was added at two places: where the time-averaging of fluxes is 
initialized and updated (relevant for do_avgflx_em=1).

LIST OF MODIFIED FILES: 
dyn_em/solve_em.F

TESTS CONDUCTED:
1. Jenkins is OK, and a large number of jenkins tests are with OpenMP.

RELEASE NOTE: Added missing OMP directives in ARW solve for the option: do_avgflx_em=1. Many OpenMP implementations assume the "END PARALLEL DO", but it is more conventional within WRF to have it.