### PR TITLE
Removed redundant code in vertical_diffusion_implicit

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -8099,13 +8099,7 @@ END SUBROUTINE phy_bc
     ENDDO
  
   CASE (1) ! use surface heat flux computed from surface routine
-    DO j = j_start, j_end
-    DO i = i_start, i_end
-       cpm = cp * (1. + 0.8 * moist(i,kts,j,P_QV))
-       heat_flux = hfx(i,j)/cpm/rho(i,1,j)
-    ENDDO
-    ENDDO
- 
+    ! do nothing
   CASE DEFAULT
     CALL wrf_error_fatal( 'isfflx value invalid for diff_opt=2' )
   END SELECT hflux


### PR DESCRIPTION
TYPE: no impact

SOURCE: Matthias Göbel (University of Innsbruck)

DESCRIPTION OF CHANGES:
Removed redundant code in vertical_diffusion_implicit

The case isfflx=1 in the routine vertical_diffusion_implicit contained do loops with no impact. In these loops, only 
unindexed variables that are not used within the do loop are set. There are no other assignments in the do loops, so 
the loops can be safely removed.

LIST OF MODIFIED FILES:  
dyn_em/module_diffusion_em.F

TESTS CONDUCTED:
1. Before vs after is identical. 
