### PR TITLE
Added NH3, CO2, CH4 fire emissions for RACM mechanisms.

### DIFF
--- a/chem/module_add_emiss_burn.F
+++ b/chem/module_add_emiss_burn.F
@@ -207,6 +207,12 @@ CONTAINS
                          +ebu(i,k,j,p_ebu_xyl)*conv_rho
         chem(i,k,j,p_ket)  =  chem(i,k,j,p_ket)                        &
                          +ebu(i,k,j,p_ebu_ket)*conv_rho
+        chem(i,k,j,p_ch4)  =  chem(i,k,j,p_ch4)                        &
+                          +ebu(i,k,j,p_ebu_ch4)*conv_rho
+        chem(i,k,j,p_co2)  =  chem(i,k,j,p_co2)                        &
+                          +ebu(i,k,j,p_ebu_co2)*conv_rho
+        chem(i,k,j,p_nh3)  =  chem(i,k,j,p_nh3)                        &
+                         +ebu(i,k,j,p_ebu_nh3)*conv_rho
         enddo
         enddo
         enddo


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: fire emissions, RACM

SOURCE: Megan Bela, Stu McKeen (CU Boulder CIRES / NOAA CSL)

DESCRIPTION OF CHANGES: 
Add NH3, CH4, CO2 fire emissions for RACM mechanisms. These emissions are present in fire emissions files generated 
by prep_chem_src. Prior to these changes, fire NH3, CH4, CO2 emissions in the fire emissions files generated by 
prep_chem_src were not read in to WRF-Chem, leading to low NH3, CH4, and CO2 values in fire impacted regions. 
Users should now expect significantly higher NH3, CH4, and CO2 values in fire impacted regions when using RACM 
chemical mechanisms.

LIST OF MODIFIED FILES: 
M chem/module_add_emiss_burn.F

TESTS CONDUCTED: 
1. Example of using the new emissions
![nh3](https://user-images.githubusercontent.com/24421315/114771442-680b8880-9d21-11eb-92c4-5786b05a2033.png)
2. Jenkins testing is OK.

RELEASE NOTES: The NH3, CH4, CO2 fire emissions have been added for RACM mechanisms. These emissions were already present in fire emissions files generated by prep_chem_src. however, prior to these changes, NH3, CH4, CO2 emissions in the fire emissions files generated by prep_chem_src were not read in to WRF-Chem, leading to low NH3, CH4, and CO2 values in fire impacted regions. Users should now expect significantly higher NH3, CH4, and CO2 values in fire impacted regions when using RACM chemical mechanisms.