### PR TITLE
UW PBL: add missing exner multiplier for input radiation T tendency

### DIFF
--- a/phys/module_bl_camuwpbl_driver.F
+++ b/phys/module_bl_camuwpbl_driver.F
@@ -396,7 +396,7 @@ CONTAINS
              t8(      1,kflip)   = t_phy(i,k,j)  ! Temprature at the mid points (K)             [state%t     in CAM]
              
              s8(      1,kflip)   = cpair *t8(1,kflip) + gravit*zm8(1,kflip) + phis(1) ! Dry static energy (m2/s2) [state%s in CAM]-Formula tested in vertical_diffusion.F90 of CAM
-             qrl8(    1,kflip)   = rthratenlw(i,k,j)* cpair * dp ! Long Wave heating rate (W/kg*Pa)- Formula obtained from definition of qrlw(pcols,pver) in eddy_diff.F90 in CAM
+             qrl8(    1,kflip)   = rthratenlw(i,k,j) * exner(i,k,j) * cpair * dp ! Long Wave heating rate (W/kg*Pa)- Formula obtained from definition of qrlw(pcols,pver) in eddy_diff.F90 in CAM
 
              wsedl8(  1,kflip)   = wsedl3d(i,k,j)               ! Sedimentation velocity of stratiform liquid cloud droplet (m/s)
              


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: UW PBL, input radiative tendency fix

SOURCE: internal (reported by Xinzhong Liang)

DESCRIPTION OF CHANGES:
Problem:
The top-down mixing in this scheme requires a radiative temperature tendency but the theta tendency is provided. 
The error is small as this tendency is only used for clouds at the top of the PBL. 

Solution:
Convert input radiative tendency from theta to T (exner multiplier included)
qrl8(    1,kflip)   = rthratenlw(i,k,j) _*exner(i,k,j)_ * cpair * dp

ISSUE: 
Fixes one of the issues in #1297 (some still need investigating)

LIST OF MODIFIED FILES: 
M       phys/module_bl_camuwpbl_driver.F

TESTS CONDUCTED: 
1. Tests confirm small impact.
2. Jenkins testing is OK.

RELEASE NOTE: 
UW PBL: input radiative tendency corrected to be T tendency instead of theta (small effect through the PBL).
