### PR TITLE
set fractional_seaice=0 for ideal namelists with default of SLAB scheme

### DIFF
--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -62,7 +62,7 @@
  cudt                                = 0,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
- fractional_seaice		     = 0,
+ fractional_seaice		                 = 0,
  /
 
  &fdda

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -62,6 +62,7 @@
  cudt                                = 0,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
+ fractional_seaice		     = 0,
  /
 
  &fdda

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -62,7 +62,7 @@
  cudt                                = 0,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
- fractional_seaice		      = 0,
+ fractional_seaice		       = 0,
  /
 
  &fdda

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -62,7 +62,7 @@
  cudt                                = 0,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
- fractional_seaice		                 = 0,
+ fractional_seaice		            = 0,
  /
 
  &fdda

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -62,7 +62,7 @@
  cudt                                = 0,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
- fractional_seaice		            = 0,
+ fractional_seaice		          = 0,
  /
 
  &fdda

--- a/test/em_convrad/namelist.input
+++ b/test/em_convrad/namelist.input
@@ -62,7 +62,7 @@
  cudt                                = 0,
  bucket_mm                           =10.,
  bucket_J                            =1.e8,
- fractional_seaice		          = 0,
+ fractional_seaice		      = 0,
  /
 
  &fdda

--- a/test/em_seabreeze2d_x/namelist.input
+++ b/test/em_seabreeze2d_x/namelist.input
@@ -61,7 +61,7 @@
  tracer_pblmix                       = 1
  cu_physics                          = 0,
  cudt                                = 0,
- fractional_seaice		      = 0,
+ fractional_seaice		       = 0,
  /
 
  &fdda

--- a/test/em_seabreeze2d_x/namelist.input
+++ b/test/em_seabreeze2d_x/namelist.input
@@ -61,7 +61,7 @@
  tracer_pblmix                       = 1
  cu_physics                          = 0,
  cudt                                = 0,
- fractional_seaice		     = 0,
+ fractional_seaice		      = 0,
  /
 
  &fdda

--- a/test/em_seabreeze2d_x/namelist.input
+++ b/test/em_seabreeze2d_x/namelist.input
@@ -61,6 +61,7 @@
  tracer_pblmix                       = 1
  cu_physics                          = 0,
  cudt                                = 0,
+ fractional_seaice		     = 0,
  /
 
  &fdda

--- a/test/em_tropical_cyclone/namelist.input
+++ b/test/em_tropical_cyclone/namelist.input
@@ -53,7 +53,7 @@
  cu_physics                          = 0,
  cudt                                = 0,
  isftcflx                            = 1,
- fractional_seaice		     = 0,
+ fractional_seaice		       = 0,
  /
 
  &fdda

--- a/test/em_tropical_cyclone/namelist.input
+++ b/test/em_tropical_cyclone/namelist.input
@@ -53,6 +53,7 @@
  cu_physics                          = 0,
  cudt                                = 0,
  isftcflx                            = 1,
+ fractional_seaice		     = 0,
  /
 
  &fdda


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: fractional_seaice, ideal, convrad, seabreeze2d_x, tropical_cyclone, SLAB

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem: 
The namelist parameter "fractional_seaice" was recently modified in the Registry.EM_COMMON file to be set to "on" 
(1) by default. However, if using the SLAB scheme, fractional_seaice must be turned off. Three of the idealized cases 
(em_convrad, em_seabreeze2d_x, and em_tropical_cyclone), by default, use the SLAB scheme, but fractional_seaice 
was not included in the namelists, and since the default is "on," an error occurs when running wrf.

Solution:
Modified the namelists for the 3 cases, setting fractional_seaice = 0.

LIST OF MODIFIED FILES:
M  test/em_convrad/namelist.input
M  test/em_seabreeze2d_x/namelist.input
M  test/em_tropical_cyclone/namelist.input

TESTS CONDUCTED:
1. wrf runs without the fractional_seaice error with the mods.
2. Waiting on Jenkins