### PR TITLE
fractional_seaice turned off in registry, turned on in namelists for real cases

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2578,7 +2578,7 @@ rconfig   integer slope_rad               namelist,physics      max_domains    0
 rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
 rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
 rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
-rconfig   integer fractional_seaice       namelist,physics      1              1       -     "fractional_seaice" "Fractional sea-ice option"
+rconfig   integer fractional_seaice       namelist,physics      1              0       -     "fractional_seaice" "Fractional sea-ice option"
 rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
 rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
 rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"

--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -62,6 +62,7 @@
  icloud                              = 1,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
+ fractional_seaice                   = 1,
  /
 
  &fdda

--- a/test/em_real/namelist.input.global
+++ b/test/em_real/namelist.input.global
@@ -60,6 +60,7 @@
  cudt                                = 0,     0,     0,
  icloud                              = 1,
  num_land_cat                        = 21,
+ fractional_seaice                   = 1,
  /
 
  &fdda

--- a/test/em_real/namelist.input.jan00
+++ b/test/em_real/namelist.input.jan00
@@ -61,6 +61,7 @@
  cu_rad_feedback                     = .true.,.true.,.false.,
  num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
+ fractional_seaice                   = 1,
  /
 
  &fdda


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: fractional_seaice, registry, Registry.EM_COMMON, namelist.input, SLAB

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The namelist parameter "fractional_seaice" was recently modified in the Registry.EM_COMMON file to be set to "on"
(1) by default (commit 0fff69a1b117424d, PR #1401 "Change default fractional_seaice option from 0 to 1". However, if 
using the SLAB scheme, fractional_seaice must be turned off, which causes problems for some of the default 
idealized cases. Additionally, some other cases where users are running with the SLAB scheme (and not realizing it's 
turned on by default), would cause lots of user difficulty and confusion.

Solution:
Set fractional_seaice back to 0 (off) in Registry.EM_COMMON, but add it (and turned on) to three of the default 
namelists in the test/em_real directory as examples.

LIST OF MODIFIED FILES:
M test/em_real/namelist.input
M test/em_real/namelist.input.global
M test/em_real/namelist.input.jan00
M Registry/Registry.EM_COMMON

TESTS CONDUCTED:
1. The namelist changes have no impact on the build or run phases of the model.
2. When fractional seaice was activated by default, this uncovered several problems that were previously addressed. 
Reverting the default fractional seaice setting back to zero (OFF) is not problematic.
   * f87b449e6c04,  #1422 "Fix for fractional_seaice option, again"
   * 476990af1aa3, #1457 "Fix for fractional seaice using MYJ and QNSE surface layer with MYNN PBL"
