### PR TITLE
NML check: fractional seaice + SLAB not permitted

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2578,7 +2578,7 @@ rconfig   integer slope_rad               namelist,physics      max_domains    0
 rconfig   integer topo_shading            namelist,physics      max_domains    0       -     "topo_shading" "1: apply topographic shading to radiation, 0:not" ""
 rconfig   integer topo_wind               namelist,physics      max_domains    0       -     "topo_wind"  "2: Use Mass sfc drag scheme, 1: improve effects topography over surface wind, 0:not" ""
 rconfig   integer no_mp_heating           namelist,physics      1              0       -     "no_mp_heating" "switch to turn of latent heating in mp schemes"   ""
-rconfig   integer fractional_seaice       namelist,physics      1              0       -     "fractional_seaice" "Fractional sea-ice option"
+rconfig   integer fractional_seaice       namelist,physics      1              0       -     "fractional_seaice" "Fractional sea-ice option: 0=OFF; 1=ON"
 rconfig   integer seaice_snowdepth_opt    namelist,physics      1              0       -     "seaice_snowdepth_opt" "Method for treating snow depth on sea ice"
 rconfig   real    seaice_snowdepth_max    namelist,physics      1          1.E10       -     "seaice_snowdepth_max" "Maximum allowed accumulation (m) of snow on sea ice"
 rconfig   real    seaice_snowdepth_min    namelist,physics      1          0.001       -     "seaice_snowdepth_min" "Minimum snow depth (m) on sea ice"

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2596,9 +2596,6 @@ CONTAINS
            ENDDO
            ENDDO
 
-           IF ( FRACTIONAL_SEAICE == 1 ) THEN
-              CALL wrf_error_fatal('SLAB scheme cannot be used with fractional seaice')
-           ENDIF
         CALL wrf_debug(100,'in SLAB')
           CALL SLAB(t_phy,qv_curr,p_phy,flhc,flqc,  &
              psfc,xland,tmn,hfx,qfx,lh,tsk,qsfc,chklowq,          &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -859,6 +859,20 @@
       END IF
 
 !-----------------------------------------------------------------------
+! If fractional_seaice == 1, cannot have the simple land model slab 
+! scheme activated.
+!-----------------------------------------------------------------------
+
+      IF ( ( model_config_rec%fractional_seaice     .EQ. 1          ) .AND. &
+           ( model_config_rec%sf_surface_physics(1) .EQ. SLABSCHEME ) ) THEN
+         wrf_err_message = '--- ERROR: fractional seaice does not work with simple slab thermal diffusion land model'
+         CALL wrf_message ( TRIM( wrf_err_message ) )
+         wrf_err_message = '--- ERROR: Change either fractional_seaice=1 OR sf_surface_physics=1'
+         CALL wrf_message ( TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+      END IF
+
+!-----------------------------------------------------------------------
 ! Check that if fine_input_stream /= 0, io_form_auxinput2 must also be in use
 !-----------------------------------------------------------------------
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: namelist, fractional seaice, slab

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When a user specifies both the SLAB thermal diffusion land model and the fractional seaice option, the model fails 
from the surface driver. As these are namelist settings, the conventional place to detect this inconsistency is in
check_a_mundo.

Solution:
Put in a simple check to find this namelist inconsistency in check_a_mundo, and report this to the user.

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON
modified:   physics/module_surface_driver.F
modified:   share/module_check_a_mundo.F 

TESTS CONDUCTED:
1. When the namelist is set up with:
```
 &physics
 fractional_seaice                   = 1,
 sf_surface_physics                  = 1,     1,     1,
```
then the output from the WRF model (or real) is:
```
--- ERROR: fractional seaice does not work with simple slab thermal diffusion land model
--- ERROR: Change either fractional_seaice=1 OR sf_surface_physics=1
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2475
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
2. Jenkins tests are all PASS.

RELEASE NOTE: When a user specifies both the SLAB thermal diffusion land model and the fractional seaice option, the model now fails in a controlled manner from where all other namelist consistency checks are handled. 