### PR TITLE
Switched off optimization for KPP compilation, to stop buffer overflow.

### DIFF
--- a/chem/KPP/configure_kpp
+++ b/chem/KPP/configure_kpp
@@ -61,11 +61,11 @@ if test -z "$FLEX_LIB_DIR" ; then
 fi
 
 
-#    Platform independent C compiler flags. By default "-O" is used which 
-#    turns on optimisation. If you are experiencing problems you may try 
+#    Platform independent C compiler flags. By default "-O0" is used which 
+#    turns off all optimisation. If you are experiencing problems you may try 
 #    "-g" to include debuging informations.
 
-CC_FLAGS="-O"
+CC_FLAGS="-O0"
 
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: KPP, GCC

SOURCE: Douglas Lowe (University of Manchester), Will Hatheway

DESCRIPTION OF CHANGES:
Problem:
Compiling of WRF-Chem with KPP chemistry schemes fails on
ubuntu systems, due to a buffer overflow error for the few largest
chemical schemes. This does not happen on HPC systems, so might
be a ubuntu specific issue (however we were unable to get to the root
cause of what compiler flag differences there might be).

Solution:
We switched off all optimization of the compilers for KPP only (using -O0).
This stopped the buffer overflow error. We did try minor optimization (-O1),
but this caused the error again, so we've left all optimization off. As this only
impacts the speed of the KPP program during compilation of WRF-Chem
(and marginally, at that), we felt this was an acceptable solution, rather than
trying to find the exact optimization flag which caused the problem. 

LIST OF MODIFIED FILES: 
chem/KPP/configure_kpp

TESTS CONDUCTED: 
1. Compilation on ubuntu now works.
2. Timing test - entire model with KPP:

| Compiler Optimization  | Compile Time|
| :----------------------: |:-------------:| 
|            -O                         | 55 min           |
|          -O0                         | 54 min           |  
|         -O3                          | 53 min           | 

3. Timing test - KPP mechanism isolated: To get a better idea of the KPP processing time I isolated the KPP chemical 
mechanism building step, and ran the compiler with each of these flags 20 times. I don't think there's any systematic 
differences in build time between each of the optimization options - probably the KPP run time is short enough for it 
not to be noticeable. The results with standard deviations:

| Compiler Optimization  | Compile Time|
| :----------------------: |:-------------:| 
|            -O                         | 55.6± 2 s       |
|          -O0                         | 58.4 ± 6.7 s   |  
|         -O3                          | 57.6 ± 1.9 s    | 

4. Jenkins tests are all PASS.

RELEASE NOTE: KPP is now compiled unoptimized. This will help with compiling WRF-Chem on ubuntu (and other smaller memory) systems. Timing tests indicate that this does not cause a significant timing impact on the WRF build time (less than 5%).