### PR TITLE
Add Namelist Option 'reasonable_time_step_ratio' to README.namelist File

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -169,7 +169,7 @@ For automatic moving nests: requires special input data, and environment variabl
                                                   set time_step = 60, time_step_fract_num = 3, and 
                                                   time_step_fract_den = 10
  time_step_dfi                       = 60,	! time step for DFI, may be different from regular time_step
- reasonable_time_step_ratio	     = 6.,	! Any d01, real-data case with a time step ratio larger than this is stopped. Except for specific circumstances (e.g., using IEVA), this value should be no larger than 6 (default).
+ reasonable_time_step_ratio          = 6.,	! Any d01, real-data case with a time step ratio larger than this is stopped. Except for specific circumstances (e.g., using IEVA), this value should be no larger than 6 (default). 
  max_dom                             = 1,	! number of domains - set it to > 1 if it is a nested run
  s_we (max_dom)                      = 1,	! start index in x (west-east) direction (leave as is)
  e_we (max_dom)                      = 91,	! end index in x (west-east) direction (staggered dimension)

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -169,6 +169,7 @@ For automatic moving nests: requires special input data, and environment variabl
                                                   set time_step = 60, time_step_fract_num = 3, and 
                                                   time_step_fract_den = 10
  time_step_dfi                       = 60,	! time step for DFI, may be different from regular time_step
+ reasonable_time_step_ratio	     = 6.,	! Any d01, real-data case with a time step ratio larger than this is stopped. Except for specific circumstances (e.g., using IEVA), this value should be no larger than 6 (default).
  max_dom                             = 1,	! number of domains - set it to > 1 if it is a nested run
  s_we (max_dom)                      = 1,	! start index in x (west-east) direction (leave as is)
  e_we (max_dom)                      = 91,	! end index in x (west-east) direction (staggered dimension)


### PR DESCRIPTION
TYPE: text only

KEYWORDS: reasonable_time_step_ratio, README.namelist, namelist

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
The new namelist option "reasonable_time_step_ratio" was not added to the README.namelist file when it was 
originally added to the Registry (PR #784). 

Solution:
Added it to the README.namelist file.

LIST OF MODIFIED FILES: 
M  run/README.namelist

TESTS CONDUCTED: 
1. Text only - no tests needed
2. Jenkins tests - ok