### PR TITLE
Remove un-used w_up array from MSKF scheme

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1612,7 +1612,6 @@ state    real  MASS_FLUX        ij      misc        1         -      r        "M
 # ckay
 state    real  cldfra_dp        ikj     misc        1         -      r         "CLDFRA_DP"             "DEEP CONVECTIVE CLOUD FRACTION FROM KF"  ""
 state    real  cldfra_sh        ikj     misc        1         -      r         "CLDFRA_SH"             "SHALLOW CONVECTIVE CLOUD FRACTION FROM KF"  ""
-state    real  w_up             ikj     misc        1         -      rdu      "W_UP"                  "EFFECTIVE SUBGRID VELOCITY FROM KF"  "m s-1"
 state    real  udr_kf           ikj     misc        1         -      rh    "UDR_KF"                "UPDRAFT DETRAINMENT RATE FROM KF"  "kg s-1"
 state    real  ddr_kf           ikj     misc        1         -      rh    "DDR_KF"                "DOWNDRAFT DETRAINMENT RATE FROM KF"  "kg s-1"
 state    real  uer_kf           ikj     misc        1         -      rh    "UER_KF"                "UPDRAFT ENTRAINMENT RATE FROM KF"  "kg s-1"
@@ -3124,7 +3123,7 @@ package   g3scheme       cu_physics==5               -             state:cugd_qv
 package   tiedtkescheme  cu_physics==6               -             -
 package   camzmscheme    cu_physics==7               -             state:precz,zmdt,zmdq,zmdice,zmdliq,evaptzm,fzsntzm,evsntzm,evapqzm,zmflxprc,zmflxsnw,zmntprpd,zmntsnpd,zmeiheat,cmfmc,cmfmcdzm,preccdzm,pconvb,pconvt,cape,zmmtu,zmmtv,zmmu,zmmd,zmupgu,zmupgd,zmvpgu,zmvpgd,zmicuu,zmicud,zmicvu,zmicvd,evapcdp3d,icwmrdp3d,rprddp3d,dp3d,du3d,ed3d,eu3d,md3d,mu3d,dsubcld2d,ideep2d,jt2d,maxg2d,lengath2d,dlf,rliq,tpert2d
 package   kfcupscheme    cu_physics==10              -             state:cldfratend_cup,cldfra_cup,updfra_cup,qc_iu_cup,qc_ic_cup,qndrop_ic_cup,wup_cup,mfup_cup,mfup_ent_cup,mfdn_cup,mfdn_ent_cup,fcvt_qc_to_pr_cup,fcvt_qc_to_qi_cup,fcvt_qi_to_pr_cup,lnterms,w0avg
-package   mskfscheme   cu_physics==11              -             state:w0avg,w_up
+package   mskfscheme     cu_physics==11              -             state:w0avg
 package   ksasscheme     cu_physics==14              -             -
 package   nsasscheme     cu_physics==96              -             -
 package   ntiedtkescheme cu_physics==16              -             -

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1245,7 +1245,7 @@ BENCH_START(cu_driver_tim)
      &             ,CUDTACTTIME=grid%cudtacttime                                       & 
      &             ,RAINC=grid%rainc   ,RAINCV=grid%raincv   ,PRATEC=grid%pratec       &
      &             ,NCA=grid%nca                                                       &
-     &             ,CLDFRA_DP=grid%cldfra_dp  ,CLDFRA_SH=grid%cldfra_sh,W_UP=grid%w_up & ! ckay for subgrid cloud
+     &             ,CLDFRA_DP=grid%cldfra_dp  ,CLDFRA_SH=grid%cldfra_sh                &
      &             ,QC_CU=grid%QC_CU, QI_CU=grid%QI_CU, QR_CU=grid%QR_CU, QS_CU=grid%QS_CU &
      &             ,NC_CU=grid%NC_CU, NI_CU=grid%NI_CU, NR_CU=grid%NR_CU, NS_CU=grid%NS_CU &
      &             ,CCN_CU=grid%CCN_CU, CU_UAF=grid%CU_UAF                                 &

--- a/phys/module_cu_mskf.F
+++ b/phys/module_cu_mskf.F
@@ -3438,7 +3438,7 @@ CONTAINS
              ,RTHCUTEN,RQVCUTEN,RQCCUTEN,RQRCUTEN            &
              ,RQICUTEN,RQSCUTEN, RQVFTEN                     &
 !ckay
-             ,cldfra_dp_KF,cldfra_sh_KF,w_up                 &
+             ,cldfra_dp_KF,cldfra_sh_KF                      &
              ,qc_KF,qi_KF,qr_KF,qs_KF                        & ! TWG
              ,nc_KF,ni_KF,nr_KF,ns_KF                        & ! TWG
              ,ccn_KF,ainc_frac                               & ! TWG
@@ -3585,9 +3585,6 @@ CONTAINS
                                                         UST, &
                                                        PBLH, &
                                                        XLAND
-!ckaywup
-   REAL, DIMENSION( ims:ime,  kms:kme , jms:jme )          , &
-           INTENT(INOUT) ::                             w_up
 
 ! LOCAL VARS
 
@@ -3679,9 +3676,6 @@ CONTAINS
 !           New, to support adaptive time step:
 !
             W0AVG(I,K,J) = ( W0AVG(I,K,J) * W0AVGfctr + W0 * W0fctr ) / W0den
-!ckaywup
-!           w(I,K,J)=w(I,K,J)+w_up(i,K,j)  
-
          ENDDO
       ENDDO
    ENDDO
@@ -3876,7 +3870,6 @@ CONTAINS
                EFCS(I,k,J)=2.51
                EFIS(I,k,J)=5.01
               END IF
-               w_up(I,k,J)=0.
             ENDDO
              IF (aercu_opt.gt.0) THEN
                ainc_frac(I,J) = 0. ! TWG
@@ -3935,7 +3928,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,         &
                  its,ite, jts,jte, kts,kte,         &
 !ckay
-                 cldfra_dp_KF,cldfra_sh_KF,w_up,    &
+                 cldfra_dp_KF,cldfra_sh_KF,         &
                  qc_KF,qi_KF,qr_KF,qs_KF,           &
                  nc_KF,ni_KF,nr_KF,ns_KF,ccn_KF,    & !TWG
                  ainc_frac,                         & !TWG
@@ -4009,7 +4002,7 @@ CONTAINS
                       ims,ime, jms,jme, kms,kme,           &
                       its,ite, jts,jte, kts,kte,           &
 !ckay
-                      cldfra_dp_KF,cldfra_sh_KF,w_up,      &
+                      cldfra_dp_KF,cldfra_sh_KF,           &
                       qc_KF,qi_KF,qr_KF,qs_KF,             & !TWG
                       nc_KF,ni_KF,nr_KF,ns_KF,ccn_KF,      & !TWG
                       ainc_frac,                           & !TWG
@@ -4128,10 +4121,6 @@ CONTAINS
             INTENT(OUT) ::                          CUBOT, &
                                                     CUTOP
       REAL,  INTENT(IN   ) :: CUDT
-
-!ckaywup
-  REAL, DIMENSION( ims:ime,  kms:kme , jms:jme )         , &
-        INTENT(  OUT) ::                             w_up                       
 !
 !...DEFINE LOCAL VARIABLES...
 !
@@ -5325,7 +5314,6 @@ updraft:    DO NK=K,KL-1
                 EFSS(I,NK,J)=10.01
               END IF
 ! END TWG
-                w_up(I,NK,J)=0.
               ENDDO
 !        
             ELSEIF(CLDHGT(LC).GT.CHMIN .and. ABE.GT.1)THEN      ! Deep Convection allowed
@@ -5342,7 +5330,6 @@ updraft:    DO NK=K,KL-1
 !ckay
               DO NK=K,LTOP
                 cldfra_dp_KF(I,NK,J)=0.
-                w_up(I,NK,J)=0.
               ENDDO
               IF(NU.EQ.NUCHM)THEN
                 EXIT usl               ! Shallow Convection from this layer
@@ -5375,7 +5362,6 @@ updraft:    DO NK=K,KL-1
                   EFSS(I,NK,J)=10.01
                 END IF
 ! END TWG
-                  w_up(I,NK,J)=0.
                 ENDDO
               ENDIF
             ENDIF
@@ -5482,7 +5468,6 @@ updraft:    DO NK=K,KL-1
         EFSS(I,NK,J)=10.01
        END IF
 ! END TWG
-        w_up (I,NK,J)=0.
       ENDIF
       UDR(NK)=0.
       QDT(NK)=0.
@@ -5540,7 +5525,6 @@ updraft:    DO NK=K,KL-1
           EFIS(I,NK,J)=5.01
          END IF
 ! END TWG
-          w_up(I,NK,J)=0.
         ENDIF
         THTA0(NK)=0.
         THTAU(NK)=0.
@@ -6334,9 +6318,6 @@ iter:     DO NCOUNT=1,10
 !ckaywup
             DMF_new=DMF(NK)/updil
             FXM_new=FXM(NK)/dxsq
-!           w_up(I,NK,J) = (UMF_new+DMF_new-FXM_new)/denSplume
-!           w_up(I,NK,J) = w_up(I,NK,J)*Drag*DT/TIMEC
-           w_up(I,NK,J) = (UMF_new/denSplume)*Drag*DT/TIMEC
           ENDDO
         ELSE 
           DO NK=KLCL, LTOP
@@ -6349,10 +6330,6 @@ iter:     DO NCOUNT=1,10
 !new added downdraft impact
             DMF_new = DMF(NK)/updil
             FXM_new = FXM(NK)/dxsq
-!           w_up(I,NK,J) = (UMF_new+DMF_new-FXM_new)/denSplume
-!           w_up(I,NK,J) = w_up(I,NK,J)*Drag*DT/TIMEC
-           w_up(I,NK,J) = (UMF_new/denSplume)*Drag*DT/TIMEC
-
           ENDDO
         ENDIF
 !ckaywup
@@ -6363,9 +6340,6 @@ iter:     DO NCOUNT=1,10
            envQsat = 0.622*envEsat/(P0(NK)-envEsat)
            envRH  = Q0(NK)/envQsat
             envRHavg = envRHavg + envRH
-           if(envRH.gt.1.01) then
-             w_up(I,NK,J) = 0.0
-           end if
           END DO
 
 !kf_edrates

--- a/phys/module_cumulus_driver.F
+++ b/phys/module_cumulus_driver.F
@@ -20,7 +20,7 @@ CONTAINS
                      ,ccldfra,convcld,qcconv,qiconv                   &
                      ,bmj_rad_feedback                                & 
                      ,rainc,raincv,pratec,nca                         &
-                     ,cldfra_dp,cldfra_sh,w_up                        & !ckay for subgrid cloud
+                     ,cldfra_dp,cldfra_sh                             &
                      ,udr_kf,ddr_kf,uer_kf,der_kf,timec_kf,kf_edrates & !kf_edrates
                      ,QC_CU,QI_CU                                     &
                      ,z,z_at_w,dz8w,mavail,pblh,p8w,psfc,tsk          &
@@ -477,9 +477,6 @@ CONTAINS
           timec_kf
 
    INTEGER, INTENT(IN   )        ::   kf_edrates
-
-   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                 &
-         INTENT(INOUT ),OPTIONAL ::                        w_up
 
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN) ::           &
           GSW,HT,XLAND
@@ -1078,7 +1075,6 @@ CONTAINS
                ,F_QI=f_qi,F_QS=f_qs                             &
                ,CLDFRA_DP_KF=cldfra_dp                          & ! ckay for sub-grid cloud
                ,CLDFRA_SH_KF=cldfra_sh                          &
-               ,W_UP=w_up                                       & ! ckay
                ,QC_KF=QC_CU,QI_KF=QI_CU,QR_KF=QR_CU,QS_KF=QS_CU &
                ,NC_KF=NC_CU,NI_KF=NI_CU,NR_KF=NR_CU,NS_KF=NS_CU &
                ,CCN_KF=CCN_CU,AINC_FRAC=CU_UAF                  &


### PR DESCRIPTION
Remove un-used w_up array from MSKF scheme

TYPE: bug fix, enhancement, no impact

KEYWORDS: w_up, MSKF, nests

SOURCE: reported by Samm Elliott (TQI), internal

DESCRIPTION OF CHANGES:
Problem:
The array w_up is no longer used by the MSKF scheme, and this array also caused a problem in nesting when MSKF is turned off in the nest.

Solution:
Remove this array.

ISSUE: 
Fixes #1448

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_cu_mskf.F
M       phys/module_cumulus_driver.F

TESTS CONDUCTED: 
1. Tested before and after the array removal, model results are identical.
2. The Jenkins tests all passed.
