### PR TITLE
Deng shcu - limit to prevent negative QV1D

### DIFF
--- a/phys/module_shcu_deng.F
+++ b/phys/module_shcu_deng.F
@@ -282,7 +282,7 @@ CONTAINS
                W0AVG1D(k) = W0AVG(i,k,j)
                tke1d(k)  = tkeavg(i,k,j)
                RHO1D(K) =rho(I,K,J)
-               QV1D(K)=QV(I,K,J)
+               QV1D(K)=MAX(QV(I,K,J),1.E-12)
                RH1D(K)=RH(I,K,J)
 #ifdef DENG_SHCU1D
                ca_rad1d(k) = ca_rad(i,k,j)


### PR DESCRIPTION
TYPE: bug-fix

KEYWORDS: Deng shallow scheme, negative QV input fix

SOURCE: internal with WRF-Solar tests

DESCRIPTION OF CHANGES:
Problem:
Deng occasionally blows up when taking the log of a negative QV. Some microphysics schemes allow very small 
negative QV to persist.

Solution:
In Deng scheme only, limit internal QV1D minimum to 1.e-12. Because this is the local copy of the variable, there is no 
effect on Qv outside of this shallow CU scheme.

LIST OF MODIFIED FILES: 
M       phys/module_shcu_deng.F

TESTS CONDUCTED: 
1. Fix was tested and prevented blow-ups in WRF-Solar
2. jenkins is all passing

RELEASE NOTE:  Small bug-fix to allow the Deng shallow cumulus scheme to work with small negative water vapor input. Previously, the scheme died when taking the log of negative Qv.
