### PR TITLE
Fix hybrid vertical coordinate 1d array assignment

### DIFF
--- a/dyn_em/nest_init_utils.F
+++ b/dyn_em/nest_init_utils.F
@@ -1090,7 +1090,7 @@ SUBROUTINE compute_vcoord_1d_coeffs ( ht, etac, znw, &
          c3f(k) = znw(k)*sin(0.5*3.14159*znw(k))**2
          IF      ( k .EQ. kds ) THEN
             c3f(k) = 1.
-         ELSE IF ( k .EQ. kds ) THEN
+         ELSE IF ( k .EQ. kde ) THEN
             c3f(kde) = 0.
          END IF
       ELSE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: hybrid vertical coordinate, HVC, 1d

SOURCE: Bill Skamarock (NCAR), internal

DESCRIPTION OF CHANGES:
Problem:
The hybrid vertical coordinate has a default option (hyb_opt=2). For the not so frequently used option where the 
stretching uses a sin^2() function (hyb_opt=3), the bounding value for the weighting term at the top of the 
atmosphere should be identically zero. It is likely computed to be nearly zero, but an IF test cleanly assigns the 
value. However, that IF test uses the wrong logic for which k-index to check.

Solution:
All we do is swap `kds` with `kde` in the IF test:
```
         ELSE IF ( k .EQ. kds ) THEN
```
with
```
         ELSE IF ( k .EQ. kde ) THEN
```

LIST OF MODIFIED FILES: 
modified:   nest_init_utils.F

TESTS CONDUCTED: 
1. This option is not advertised, so the incorrect bounding value was not consequential. However, the modification is 
    correct based on surrounding code, and on the actual derivation of the purpose of the term.
   * The previous IF test for hybrid option 2 uses the correct logic, and the corrected IF test for the sin^2() function is 
      now identical to the logic used in hybrid option 2.
   * The term in question, c3f, is the full level weighting term. At the top of the atmosphere, this needs to be identically 
      zero, so that the pressure is entirely isobaric.
2. Jenkins is all pass.

RELEASE NOTE: A bug fix was found to the hybrid vertical coordinate. Those using the default with the hybrid option activated (hyb_opt=2), or those reverting back to a terrain following coordinate (hyb_opt=0) are not impacted. Basically, you are unlikely to be impacted.
