### PR TITLE
diffusion computed k-index == 0 for PBL

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -5160,7 +5160,7 @@ END SUBROUTINE vertical_diffusion_s
   DO j = j_start,j_end
   DO i = i_start,i_end
      IF(pblflg(i,j))THEN
-       k = kpbl(i,j) - 1
+       k = max(kpbl(i,j) - 1,1)
        wm3           = wstar3(i,j) + 5. * ust(i,j)**3
        wm2(i,j)      = wm3**h2
        bfxpbl(i,j)   = -0.15*thv(i,1,j)/g*wm3/hpbl(i,j)
@@ -5175,7 +5175,7 @@ END SUBROUTINE vertical_diffusion_s
        delb          = govrth(i,j)*dthv(i,j)
  
        deltaoh(i,j)  = d1*hpbl(i,j) + d2*wm2(i,j)/delb
-       deltaoh(i,j)  = max(ezfac*deltaoh(i,j),hpbl(i,j)-za(i,kpbl(i,j)-1,j)-1.)
+       deltaoh(i,j)  = max(ezfac*deltaoh(i,j),hpbl(i,j)-za(i,k,j)-1.)
        deltaoh(i,j)  = min(deltaoh(i,j), hpbl(i,j))
  
        if ((du .ne. 0) .or. (dv .ne. 0)) then

--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -5121,7 +5121,7 @@ END SUBROUTINE vertical_diffusion_s
   DO j = j_start, j_end
   DO i = i_start, i_end
      IF(hpbl(i,j).LT.zq(i,2,j)) kpbl(i,j) = 1
-     IF(kpbl(i,j).LT.1) pblflg(i,j) = .false.
+     IF(kpbl(i,j).LE.1) pblflg(i,j) = .false.
   ENDDO
   ENDDO
 
@@ -5160,7 +5160,7 @@ END SUBROUTINE vertical_diffusion_s
   DO j = j_start,j_end
   DO i = i_start,i_end
      IF(pblflg(i,j))THEN
-       k = max(kpbl(i,j) - 1,1)
+       k = kpbl(i,j) - 1
        wm3           = wstar3(i,j) + 5. * ust(i,j)**3
        wm2(i,j)      = wm3**h2
        bfxpbl(i,j)   = -0.15*thv(i,1,j)/g*wm3/hpbl(i,j)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: diffusion, ARW, bounds check, kpbl

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Running the code with bounds check uncovered several locations where a computed vertical index was outside the range 
of the array (the computed values was k==0). This is in the nonlocal_flux routine.

Solution:
In those two locations, use a MAX() function, where the minimum allowed value will be the lowest vertical index: 1.

LIST OF MODIFIED FILES:
modified:   dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
1. There are two mods. First, the assignment of the flag `pblflg` needs to be `.LE.`, not `.LT.`. Second, the value
kpbl(i,j)-1` has already been computed, so use that local `k` value. After the mods, the code runs with bounds 
checking on, through to model completion.

2. Jenkins is all PASS.

RELEASE NOTE: In the ARW diffusion, the nonlocal_flux routine has some vertical bounds fixed on the index layer for the PBL to avoid using a zero-valued vertical index. This only impacts users with diff_opt=2 AND km_opt=5.
