### PR TITLE
Allow more run-time fields in namelist-controlled streams

### DIFF
--- a/frame/module_domain.F
+++ b/frame/module_domain.F
@@ -1067,7 +1067,7 @@ CONTAINS
       TYPE(fieldlist), POINTER :: p, q
       INTEGER, PARAMETER :: read_unit = 10
       LOGICAL, EXTERNAL  :: wrf_dm_on_monitor
-      CHARACTER*256      :: inln, t1, fieldlst
+      CHARACTER*8000     :: inln, t1, fieldlst
       CHARACTER*256      :: fname, mess, dname, lookee
       CHARACTER*1        :: op, strmtyp
       CHARACTER*3        :: strmid

--- a/frame/module_domain.F
+++ b/frame/module_domain.F
@@ -68,7 +68,7 @@ MODULE module_domain
      MODULE PROCEDURE get_ijk_from_grid1, get_ijk_from_grid2
    END INTERFACE
 
-   INTEGER, PARAMETER :: max_hst_mods = 200
+   INTEGER, PARAMETER :: max_hst_mods = 1000
 
 CONTAINS
 
@@ -1011,7 +1011,7 @@ CONTAINS
      INTEGER,       INTENT(IN)    :: noutstr  ! length of outstr
      LOGICAL,       INTENT(INOUT) :: noerr     ! status
      !local
-     INTEGER, PARAMETER :: MAX_DEXES = 100
+     INTEGER, PARAMETER :: MAX_DEXES = 1000
      INTEGER I, PREV, IDEX
      INTEGER DEXES(MAX_DEXES)
      outstr = ""
@@ -1067,8 +1067,8 @@ CONTAINS
       TYPE(fieldlist), POINTER :: p, q
       INTEGER, PARAMETER :: read_unit = 10
       LOGICAL, EXTERNAL  :: wrf_dm_on_monitor
-      CHARACTER*256      :: fname, inln, mess, dname, t1, lookee
-      CHARACTER*256      :: fieldlst
+      CHARACTER*256      :: inln, t1, fieldlst
+      CHARACTER*256      :: fname, mess, dname, lookee
       CHARACTER*1        :: op, strmtyp
       CHARACTER*3        :: strmid
       CHARACTER*10       :: strmtyp_name
@@ -1134,10 +1134,10 @@ CONTAINS
                     WRITE(mess,*)'W A R N I N G : invalid stream id ',istrm,' (should be 0 <= id <= ',last_history,'). Line ',lineno
                     gavewarning = .TRUE.
                   ENDIF
-                  CALL get_fieldstr(4,':',inln,fieldlst,1024,noerr) ! get list of fields
+                  CALL get_fieldstr(4,':',inln,fieldlst,8000,noerr) ! get list of fields
                   IF ( noerr ) THEN
                     fieldno = 1
-                    CALL get_fieldstr(fieldno,',',fieldlst,t1,256,noerr)
+                    CALL get_fieldstr(fieldno,',',fieldlst,t1,8000,noerr)
                     CALL change_to_lower_case(t1,lookee)
                     DO WHILE ( noerr )    ! linear search, blargh...
                       p => grid%head_statevars%next


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: io_fields_filename, runtime I/O

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
I wanted to add 500 new fields to the history output stream for debugging purposes. There were a number of errors 
I ran into with that large number of additional fields.

Solution:
The run-time streams I/O routine had fairly small limits on how many new arrays were allowed (100), but even more 
restrictive was the length of the string of names (256 chars, so 1.56 characters per field when we include the 
comma separator). It is now 1000 fields, with the string length of 8000 characters.

LIST OF MODIFIED FILES: 
modified:   frame/module_domain.F

TESTS CONDUCTED: 
1. With the mods, I was able to add about 550 new fields to the history stream. Note that except for tossing out some _1 variables, the restart and model output are nearly the same size, not the usual 3x difference. I did cheat and make the "," characters in the text file spaces to get a proper word count.
```
 &time_control
 iofields_filename = "foo3.txt"
```
```
$ wc -w foo3.txt
554 foo3.txt
```
```
$ ls -ls ORIG/wrfout_d01_2000-01-24_12:15:00 ORIG/wrfrst_d01_2000-01-24_12:15:00 
33104 -rw-r--r-- 1 gill p66770001 33897987 Apr 22 22:02 ORIG/wrfout_d01_2000-01-24_12:15:00
37808 -rw-r--r-- 1 gill p66770001 38713716 Apr 22 22:02 ORIG/wrfrst_d01_2000-01-24_12:15:00
```
Before the mods, only a few new fields could be added. For clarity, I put the new fields in alphabetical order, and we
only get up to the "A's" from the list.
```
Domain  1: Current date being processed: 2000-01-24_12:00:00.0000, which is loop #   1 out of    5
 configflags%julyr, %julday, %gmt:        2000          24   12.0000000    
 Domain            1  W A R N I N G : Variable acgrdflx already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable achfx already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclhf already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwdnb already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwdnbc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwdnt already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwdntc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwupb already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwupbc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwupt already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable aclwuptc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acsnom already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  Setting history stream            0  for acsnow
 Domain            1  W A R N I N G : Variable acswdnb already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswdnbc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswdnt already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswdntc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswupb already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswupbc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswupt already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable acswuptc already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  Setting history stream            0  for activefrac
 Domain            1  Setting history stream            0  for aerasy2d
 Domain            1  Setting history stream            0  for aerssa2d
 Domain            1  Setting history stream            0  for akhs
 Domain            1  Setting history stream            0  for akms
 Domain            1  Setting history stream            0  for akpbl
 Domain            1  Setting history stream            0  for al
 Domain            1  Setting history stream            0  for alb
 Domain            1  W A R N I N G : Variable albbck already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  W A R N I N G : Variable albedo already on history stream            0 .  File: foo3.txt at line            1
 Domain            1  Setting history stream            0  for alswnirdif
 Domain            1  W A R N I N G : Variable al already on history stream            0 .  File: foo3.txt at line            1
 Ignoring problems reading foo3.txt
```
2. Jenkins is all PASS.