### PR TITLE
Fix restart problem with 3 or more domains when o3input = 2

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -49,8 +49,8 @@
 # table entries are of the form
 #<Table> <Type> <Sym>         <Dims>   <Use>   <NumTLev> <Stagger> <IO>     <DNAME>             <DESCRIP>     <UNITS>
 #
-state    real  XLAT             ij      misc        1         -     i0123rh0156{22}{23}du=(copy_fcnm)      "XLAT"                "LATITUDE, SOUTH IS NEGATIVE"                                          "degree_north"
-state    real  XLONG            ij      misc        1         -     i0123rh0156{22}{23}d=(interp_fcn_blint_ll:xlat,input_from_file)u=(copy_fcnm)      "XLONG"               "LONGITUDE, WEST IS NEGATIVE"                                          "degree_east"
+state    real  XLAT             ij      misc        1         -     i0123rh0156{22}{23}d      "XLAT"                "LATITUDE, SOUTH IS NEGATIVE"                                          "degree_north"
+state    real  XLONG            ij      misc        1         -     i0123rh0156{22}{23}d=(interp_fcn_blint_ll:xlat,input_from_file)      "XLONG"               "LONGITUDE, WEST IS NEGATIVE"                                          "degree_east"
 
 # It is required that LU_INDEX appears before any variable that is
 # interpolated with a mask, as lu_index supplies that mask.
@@ -1686,7 +1686,7 @@ state    real  RTHRATENLW      ikj      misc        1         -      r        "R
 state    real  RTHRATENLWC     ikj      misc        1         -      r        "RTHRATLWC"             "UNCOUPLED THETA TEND DUE TO CLEAR SKY LONG WAVE RAD"    "K s-1"
 state    real  RTHRATENSW      ikj      misc        1         -      r        "RTHRATSW"              "UNCOUPLED THETA TENDENCY DUE TO SHORT WAVE RADIATION"   "K s-1"
 state    real  RTHRATENSWC     ikj      misc        1         -      r        "RTHRATSWC"             "UNCOUPLED THETA TEND DUE TO CLEAR SKY SHORT WAVE RAD"   "K s-1"
-state    real  CLDFRA          ikj      misc        1         -      irhdu    "CLDFRA"                "CLOUD FRACTION"   ""
+state    real  CLDFRA          ikj      misc        1         -      irh      "CLDFRA"                "CLOUD FRACTION"   ""
 state    real  CONVCLD          ij      misc        1         -      r        "CONVCLD"               "BMJ CONVECTIVE CLOUD" "kg m-2"
 state    real  CCLDFRA         ikj      misc        1         -      r        "CCLDFRA"               "CONVECTIVE CLOUD FRACTION" ""
 state    real  CLDFRA_OLD      ikj      misc        1         -      r        "CLDFRA_OLD"            "previous time level cldfra"                           ""


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: restart, at least 3 domains with feedback on, ozone input option 2

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
With o3input = 2 as a default option for RRTMG, and feedback on, the restart capability is not bit for bit when using three or more total domains. This is due to different XLAT and XLONG are used in the initial interpolation of ozone data to the model grid at model start time versus model restart time.

Solution:
Removing 'u' (the Registry "feedback" option) for XLAT and XLONG fixes the problem. While we were making these nesting changes in the Registry, the 'd' and 'u' options for cloud fraction are also removed. There is no need to do either horizontal interpolation or feedback for this variable.

LIST OF MODIFIED FILES:
M    Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. This PR fixes the none bit-for-bit restart problem with nests with at least 3 domains. 1. The restart now also works at non lateral boundary times - restart times at 2h 45 m and 1 h were tested and worked with 3-h lateral boundary condition interval. The code is also tested with no input files from domain 2 and 3.
2. All tests were conducted with feedback on, but smooth_option = 0.
3. The Jenkins tests are all passing.

RELEASE NOTE: Fixed a restart problem when using 3 or more total domains with feedback on and using RRTGM with o3input set to 2 (default). Restart now works at all times, though with smooth_option off.
