### PR TITLE
Remove namelist spec_bdy_final_mu

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2880,7 +2880,6 @@ rconfig   logical open_ye                 namelist,bdy_control	max_domains    .f
 rconfig   logical polar                   namelist,bdy_control	max_domains    .false. rh    "polar"                 ""      ""
 rconfig   logical nested                  namelist,bdy_control	max_domains    .false. rh    "nested"                ""      ""
 rconfig   real    spec_exp                namelist,bdy_control          1     0.      irh    "spec_exp"              ""      ""
-rconfig   integer spec_bdy_final_mu       namelist,bdy_control	        1     1        rh    "call spec_bdy_final for mu"    ""      ""
 rconfig   integer real_data_init_type     namelist,bdy_control		1                 1    irh   "real_data_init_type"   "REAL DATA INITIALIZATION OPTIONS: 1=SI, 2=MM5, 3=GENERIC" "PRE-PROCESSOR TYPES"
 rconfig   logical have_bcs_moist          namelist,bdy_control  max_domains    .false. rh    "have_bcs_moist"           ""      ""
 rconfig   logical have_bcs_scalar         namelist,bdy_control  max_domains    .false. rh    "have_bcs_scalar"          ""      ""

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -4512,7 +4512,6 @@ BENCH_END(bc_2d_tim)
                                 grid%j_start(ij), grid%j_end(ij),       &
                                 k_start    , k_end                     )
 
-     IF( config_flags%spec_bdy_final_mu .EQ. 1 ) THEN
      CALL spec_bdy_final   ( grid%mu_2, grid%muts, grid%c1h, grid%c2h, grid%msfty,   &
                                 grid%mu_bxs, grid%mu_bxe, grid%mu_bys, grid%mu_bye,  &
                                 grid%mu_btxs,grid%mu_btxe,grid%mu_btys,grid%mu_btye, &
@@ -4525,7 +4524,6 @@ BENCH_END(bc_2d_tim)
                                 grid%i_start(ij), grid%i_end(ij),       &
                                 grid%j_start(ij), grid%j_end(ij),       &
                                 1  , 1                    )
-     ENDIF
 
      moisture_loop_bdy_3 : DO im = PARAM_FIRST_SCALAR , num_3d_m
 

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1621,8 +1621,6 @@ The following are for observation nudging:
  spec_exp                            = 0.       ! exponential multiplier for relaxation zone ramp for specified=.t.
                                                   (0.=linear ramp default, e.g. 0.33=~3*dx exp decay factor)
  constant_bc                         = .false.  ! constant boundary condition used with DFI
- spec_bdy_final_mu                   = 1,       ! whether to call spec_bdy_final for mu (this may cause different restart results in V3.8): 
-                                                  = 0, no call; = 1: call (this may cause different restart results)
 
  periodic_x (max_dom)                = .false., ! periodic boundary conditions in x direction
  symmetric_xs (max_dom)              = .false., ! symmetric boundary conditions at x start (west)

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -601,7 +601,6 @@ endif
      IF ( config_flags%perturb_bdy .NE. 0 ) THEN
           CALL wrf_put_dom_ti_integer( fid, 'PERTURB_BDY',        config_flags%perturb_bdy, 1, ierr )
      END IF
-     CALL wrf_put_dom_ti_integer( fid, 'SPEC_BDY_FINAL_MU',  config_flags%spec_bdy_final_mu, 1, ierr )
      CALL wrf_put_dom_ti_integer( fid, 'USE_Q_DIABATIC',     config_flags%use_q_diabatic,    1, ierr )
     END IF
 #endif

--- a/wrftladj/solve_em_ad.F
+++ b/wrftladj/solve_em_ad.F
@@ -4611,7 +4611,6 @@ BENCH_END(bc_2d_tim)
                                 grid%j_start(ij), grid%j_end(ij),       &
                                 k_start    , k_end                     )
 
-     IF( config_flags%spec_bdy_final_mu .EQ. 1 ) THEN
      CALL spec_bdy_final   ( grid%mu_2, grid%muts, grid%c1h, grid%c2h, grid%msfty,   &
                                 grid%mu_bxs, grid%mu_bxe, grid%mu_bys, grid%mu_bye,  &
                                 grid%mu_btxs,grid%mu_btxe,grid%mu_btys,grid%mu_btye, &
@@ -4624,7 +4623,6 @@ BENCH_END(bc_2d_tim)
                                 grid%i_start(ij), grid%i_end(ij),       &
                                 grid%j_start(ij), grid%j_end(ij),       &
                                 1  , 1                    )
-     ENDIF
 
      moisture_loop_bdy_3 : DO im = PARAM_FIRST_SCALAR , num_3d_m
 
@@ -5038,7 +5036,6 @@ BENCH_END(bc_2d_tim)
 
      END DO adj_moisture_loop_bdy_3
 
-     IF( config_flags%spec_bdy_final_mu .EQ. 1 ) THEN
      CALL a_spec_bdy_final ( grid%mu_2, grid%a_mu_2, grid%muts, grid%a_muts, grid%msfty, &
                                 grid%mu_bxs, grid%a_mu_bxs, grid%mu_bxe, grid%a_mu_bxe,  &
                                 grid%mu_bys, grid%a_mu_bys, grid%mu_bye, grid%a_mu_bye,  &
@@ -5053,7 +5050,6 @@ BENCH_END(bc_2d_tim)
                                 grid%i_start(ij), grid%i_end(ij),                        &
                                 grid%j_start(ij), grid%j_end(ij),                        &
                                 1  , 1                    )
-     ENDIF
 
      CALL a_spec_bdy_final ( grid%ph_2, grid%a_ph_2, grid%muts, grid%a_muts, grid%msfty, &
                                 grid%ph_bxs, grid%a_ph_bxs, grid%ph_bxe, grid%a_ph_bxe,  &

--- a/wrftladj/solve_em_tl.F
+++ b/wrftladj/solve_em_tl.F
@@ -4254,7 +4254,6 @@ BENCH_END(g_bc_2d_tim)
                                 grid%j_start(ij), grid%j_end(ij),                        &
                                 k_start    , k_end                     )
 
-     IF( config_flags%spec_bdy_final_mu .EQ. 1 ) THEN
      CALL g_spec_bdy_final ( grid%mu_2, grid%g_mu_2, grid%muts, grid%g_muts, grid%msfty, &
                                 grid%mu_bxs, grid%g_mu_bxs, grid%mu_bxe, grid%g_mu_bxe,  &
                                 grid%mu_bys, grid%g_mu_bys, grid%mu_bye, grid%g_mu_bye,  &
@@ -4269,7 +4268,6 @@ BENCH_END(g_bc_2d_tim)
                                 grid%i_start(ij), grid%i_end(ij),                        &
                                 grid%j_start(ij), grid%j_end(ij),                        &
                                 1  , 1                    )
-     ENDIF
 
      moisture_loop_bdy_3 : DO im = PARAM_FIRST_SCALAR , num_3d_m
 


### PR DESCRIPTION
Remove namelist spec_bdy_final_mu.

TYPE: no impact

KEYWORDS: lateral boundary call, spec_bdy_final, spec_bdy_final_mu

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The namelist spec_bdy_final_mu was introduced in 3.7 for an ad-hoc fix to the restart problem when spec_bdy_final calls were introduced to ensure the lateral boundary conditions do not drift by using tendencies only. The default has been to call this routine all the time, and not calling this routine does not fix any restart problem any more.

Solution:
Remove this namelist in the code, and make the code cleaner.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/solve_em.F
M       run/README.namelist
M       share/output_wrf.F
M       wrftladj/solve_em_ad.F
M       wrftladj/solve_em_tl.F

TESTS CONDUCTED: 
1. The code change does not have impact to the results.
2. The Jenkins tests all passing.

RELEASE NOTE: Namelist variable spec_bdy_final_mu is removed. It is redundant.
