### PR TITLE
WORK IN PROGRESS: Remove diffs from restart with smoothing option activated

### DIFF
--- a/share/interp_fcn.F
+++ b/share/interp_fcn.F
@@ -3822,7 +3822,7 @@ END MODULE module_interp_info
                              nri, nrj,                             &  
                              ipos, jpos
       LOGICAL, INTENT(IN) :: xstag, ystag
-      INTEGER             :: smooth_option, feedback , spec_zone
+      INTEGER             :: smooth_option, feedback
    
       REAL, DIMENSION ( cims:cime, ckms:ckme, cjms:cjme ) :: cfld
 
@@ -3830,7 +3830,14 @@ END MODULE module_interp_info
 
       CALL nl_get_feedback       ( 1, feedback  )
       IF ( feedback == 0 ) RETURN
-      CALL nl_get_spec_zone ( 1, spec_zone )
+
+      !  The important part of feedback is when physics is activated, and we get unexpected and somewhat
+      !  horizontally assymmetrical values next to each other. Since physics is all column based, we do not
+      !  need to smooth U- or V-staggered fields.
+
+      IF ( ( xstag ) .OR. ( ystag ) ) THEN
+         RETURN
+      END IF
 
       !  These are the 2d smoothers used on the fedback data.  These filters
       !  are run on the coarse grid data (after the nested info has been


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: restart, smooth

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When running a nested restart, and the smoothing option is non-zero, then the restart results are different.

Solution:
Only smooth mass-based fields, as this is consistent with how feedback is done, AND physics terms on the fine grid are both notoriously non-isotropic and columnar.

LIST OF MODIFIED FILES: 
modified:   share/interp_fcn.F

TESTS CONDUCTED: 
1. Without these mods, the results after a restart are not bit-for-bit when smoothing is activated.  With these mods, both the smooth = 1 and 2 options give bit-wise identical results after a restart.
2. Jenkins is all pass.

RELEASE NOTE: When running a nested restart, and the smoothing option was non-zero, then the restart results were different. 