### PR TITLE
Adding a check to avoid using shcu = 5 and icloud_bl

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -554,6 +554,26 @@
       END IF
 
 !-----------------------------------------------------------------------
+! If Deng Shallow Convection is on, icloud_bl cannot be 1
+!-----------------------------------------------------------------------
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( ( model_config_rec%shcu_physics(i) .EQ. dengshcuscheme ) .AND. &
+              ( model_config_rec%icloud_bl .EQ. 1 ) ) THEN
+              oops = oops + 1
+         END IF
+      ENDDO
+
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = '--- ERROR: Options shcu_physics = 5 and icloud_bl = 1 should not be used together'
+         CALL wrf_message ( wrf_err_message )
+         wrf_err_message = '--- ERROR: Choose either one in namelist.input and rerun the model'
+         CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+      END IF
+
+!-----------------------------------------------------------------------
 ! For ARW users, a request for CU=4 (SAS) should be switched to option
 ! CU = 95. The option CU = 4 is a scaleaware scheme used by NMM.
 !-----------------------------------------------------------------------


### PR DESCRIPTION
TYPE:  Enhancement

KEYWORDS: Deng shcu, icloud_bl, check_a_mundo, 

SOURCE: Pedro A. Jimenez (NCAR)

DESCRIPTION OF CHANGES:
Problem:
Deng shcu and icloud_bl are incompatible options

Solution:
Add a check in check_a_mundo to stop if the user selects these options

ISSUE: Fixes #1042

LIST OF MODIFIED FILES: 
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
  Both Real and WRF stops if shcu = 5 and icloud_bl = 1 (and run if icloud_bl = 0)
2. Are the Jenkins tests all passing? Yes.

RELEASE NOTE: Adding a test to avoid running the model if Deng shcu = 5 and icloud_bl = 1
