### PR TITLE
corrected variable output names for max_msftx and max_msfty

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1470,8 +1470,8 @@ state   real    tlp            -       misc         -         -     i02rh     "t
 state   real    tiso           -       misc         -         -     i02rh     "tiso"                  "TEMP AT WHICH THE BASE T TURNS CONST"  "K"
 state   real    tlp_strat      -       misc         -         -     i02rh     "tlp_strat"             "BASE STATE LAPSE RATE (DT/D(LN(P)) IN STRATOSPHERE"  "K"
 state   real    p_strat        -       misc         -         -     i02rh     "p_strat"               "BASE STATE PRESSURE AT BOTTOM OF STRATOSPHERE" "Pa"
-state   real    max_msftx      -       misc         -         -      rh       "max_mstfx"             "Max map factor in domain"  ""
-state   real    max_msfty      -       misc         -         -      rh       "max_mstfy"             "Max map factor in domain"  ""
+state   real    max_msftx      -       misc         -         -      rh       "max_msftx"             "Max map factor in domain"  ""
+state   real    max_msfty      -       misc         -         -      rh       "max_msfty"             "Max map factor in domain"  ""
 
 # NUWRF:  State variables for Goddard microphysics
 state   real    phys_tot       ikj      misc        1         -     h         "PHYS_TOT"              "TOTAL LATENT HEATING RATE"                       "K s-1"


### PR DESCRIPTION
TYPE: text only

KEYWORDS: Registry.EM_COMMON, max_msftx, max_msfty

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
In Registry.EM_COMMON, the variables max_msftx and max_msfty's output names were spelled incorrectly.

Solution:
corrected the spelling in Registry.EM_COMMON

LIST OF MODIFIED FILES: 
M   Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. Text only - no tests necessary
2. Jenkins tests are all passing.