### PR TITLE
Bugfix for the NoahMP dynamic irrigation scheme irrigation option (iopt_irr=2)

### DIFF
--- a/phys/module_sf_noahmpdrv.F
+++ b/phys/module_sf_noahmpdrv.F
@@ -814,6 +814,11 @@ CONTAINS
 	 parameters%GDDS5  = SEASON_GDD(I,J) / 1770.0 * parameters%GDDS5
        end if
 
+       if(iopt_irr == 2) then ! based on planting and harvesting dates.
+         parameters%PLTDAY = PLANTING(I,J)
+         parameters%HSDAY  = HARVEST (I,J)
+       end if
+
 !=== hydrological processes for vegetation in urban model ===
 !=== irrigate vegetaion only in urban area, MAY-SEP, 9-11pm
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NoahMP, irrigation

SOURCE: Prasanth Valayamkunnath (NCAR)

DESCRIPTION OF CHANGES:
Problem: 
Previously, when using iopt_irr=2, the user needed to turn on the crop option (=1) as well. But we want the user to be
able to use the irrigation scheme without the crop scheme activated.

Solution:
If the Noah MP dynamic irrigation scheme is triggered with opt_irr=2, then assign 2D fields of Planting and Harvesting 
dates outside of the crop scheme.

LIST OF MODIFIED FILES:
M phys/module_sf_noahmpdrv.F

TESTS CONDUCTED: 
1. We just ran the test by running the model on Cheyenne with and without the irrigation scheme turned on.
2. Jenkins testing is OK