### PR TITLE
Ensure URBPARM_LCZ.TBL is linked to em_* directory & error msg correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,6 +595,7 @@ em_real : wrf
 	  ( cd test/em_esmf_exp ; /bin/rm -f LANDUSE.TBL ; ln -s ../../run/LANDUSE.TBL . ) ; \
 	  ( cd test/em_esmf_exp ; /bin/rm -f SOILPARM.TBL ; ln -s ../../run/SOILPARM.TBL . ) ; \
 	  ( cd test/em_esmf_exp ; /bin/rm -f URBPARM.TBL ; ln -s ../../run/URBPARM.TBL . ) ; \
+	  ( cd test/em_esmf_exp ; /bin/rm -f URBPARM_LCZ.TBL ; ln -s ../../run/URBPARM_LCZ.TBL . ) ; \
 	  ( cd test/em_esmf_exp ; /bin/rm -f VEGPARM.TBL ; ln -s ../../run/VEGPARM.TBL . ) ; \
 	  ( cd test/em_esmf_exp ; /bin/rm -f MPTABLE.TBL ; ln -s ../../run/MPTABLE.TBL . ) ; \
 	  ( cd test/em_esmf_exp ; /bin/rm -f tr49t67 ; ln -s ../../run/tr49t67 . ) ; \
@@ -673,6 +674,7 @@ em_real : wrf
 	( cd test/em_real ; /bin/rm -f LANDUSE.TBL ; ln -s ../../run/LANDUSE.TBL . )
 	( cd test/em_real ; /bin/rm -f SOILPARM.TBL ; ln -s ../../run/SOILPARM.TBL . )
 	( cd test/em_real ; /bin/rm -f URBPARM.TBL ; ln -s ../../run/URBPARM.TBL . )
+	( cd test/em_real ; /bin/rm -f URBPARM_LCZ.TBL ; ln -s ../../run/URBPARM_LCZ.TBL . )
 	( cd test/em_real ; /bin/rm -f VEGPARM.TBL ; ln -s ../../run/VEGPARM.TBL . )
 	( cd test/em_real ; /bin/rm -f MPTABLE.TBL ; ln -s ../../run/MPTABLE.TBL . )
 	( cd test/em_real ; /bin/rm -f tr49t67 ; ln -s ../../run/tr49t67 . )

--- a/clean
+++ b/clean
@@ -52,7 +52,7 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  /bin/rm -f namelist.input ) >& /dev/null
     ( cd test/exp_real ; /bin/rm -f gm* out* fort* real* ) >& /dev/null
     ( cd test ; rm -f */*.exe */ETAMPNEW_DATA* */GENPARM.TBL */LANDUSE.TBL */README.namelist */README.physics_files \
-	  */RRTM_DATA */SOILPARM.TBL */VEGPARM.TBL */MPTABLE.TBL */URBPARM.TBL */grib2map.tbl \
+	  */RRTM_DATA */SOILPARM.TBL */VEGPARM.TBL */MPTABLE.TBL */URBPARM.TBL */URBPARM_LCZ.TBL */grib2map.tbl \
 	  */CAM_ABS_DATA */CAM_AEROPT_DATA \
 	  */CCN_ACTIVATE.BIN \
 	  */CAMtr_volume_mixing_ratio.RCP4.5 */CAMtr_volume_mixing_ratio.RCP6 */CAMtr_volume_mixing_ratio.RCP8.5 \

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -2008,6 +2008,11 @@ ENDIF
          ACTION='READ',          &
          POSITION='REWIND',      &
          IOSTAT=IOSTATUS)
+
+         IF (IOSTATUS > 0) THEN
+         FATAL_ERROR('Error opening URBPARM.TBL. Make sure URBPARM.TBL (found in run/) is linked to the running directory.')
+         ENDIF
+
  else
    OPEN (UNIT=11,                &
          FILE='URBPARM_LCZ.TBL', &
@@ -2016,12 +2021,12 @@ ENDIF
          ACTION='READ',          &
          POSITION='REWIND',      &
          IOSTAT=IOSTATUS)
+
+         IF (IOSTATUS > 0) THEN
+         FATAL_ERROR('Error opening URBPARM_LCZ.TBL. Make sure URBPARM_LCZ.TBL (found in run/) is linked to the running directory.')
+         ENDIF
  endif
  
-
-   IF (IOSTATUS > 0) THEN
-   FATAL_ERROR('ERROR OPEN URBPARM.TBL')
-   ENDIF
 
    READLOOP : do 
       read(11,'(A512)', iostat=iostatus) string


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: URBPARM.TBL, URBPARM_LCZ.TBL, urban, wudapt, lcz

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
The new URBPARM_LCZ.TBL was not automatically linked to the test/em_real directory, meaning users would always 
get a fatal error if running with use_wudapt_lcz = 1. Additionally, the error simply stated: "ERROR OPEN URBPARM.TBL", 
which was misleading. 

Solution:
Modified the Makefile to ensure URBPARM_LCZ.TBL gets automatically copied to the test/em_real directory during 
compile. Modified phys/module_sf_urban.F to ensure the error message given correctly applied to the type of urban 
case being run (i.e., either with or without wudapt LCZ).

LIST OF MODIFIED FILES: 
M     Makefile
M     clean
M     phys/module_sf_urban.F

TESTS CONDUCTED: 
1. Tests conclude that URBPARM_LCZ.TBL now copies to test/em_real during compile. 
2. Tests conclude that the correct error message prints when there is either no URBPARM.TBL or URBPARM_LCZ.TBL 
    in the running directory.
3. Jenkins tests are passing.