### PR TITLE
Reduce sfc aerosols in Thompson MP initialization (bug fix)

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -4360,7 +4360,7 @@ endif
          do i = its, min(ide-1,ite)
             z1 = (grid%phb(i,2,j)-grid%phb(i,1,j))/g
             airmass = 1./grid%alt(i,1,j) * z1 * config_flags%dx*config_flags%dy          ! kg
-            grid%qnwfa2d(i,j) = grid%QNWFA_now(i,1,j) * 0.000196 * (airmass*2.E-10)
+            grid%qnwfa2d(i,j) = grid%QNWFA_now(i,1,j) * 0.000196 * (airmass*5.E-11)
      if(i.eq.its .and. j.eq.jts) then
       write(a_message,*) 'aero_sfc_flux: ', i,j,z1,1./grid%alt(i,1,j),airmass,grid%QNWFA_now(i,1,j),grid%qnwfa2d(i,j)
       CALL wrf_debug (1, a_message)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Thompson, aerosol, emission 

SOURCE: Laura Fowler, Mary Barth, Tim Juliano (NCAR), Greg Thompson (JCSDA), internal

DESCRIPTION OF CHANGES:
Problem:
In commit c54cc0a1602d995c, PR #1423 "Thompson MP: reduce fake aerosol emissions by 4x", a change was made 
to the "fake" surface aerosols for the Thompson MP scheme. This change was accidentally not included in the 
initialization step for ARW real.

Solution:
Add the same mods to the fake surface number concentration of water friendly aerosols in the ARW real program.

LIST OF MODIFIED FILES: 
modified:   dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. The developer proposed these mods.
2. Jenkins tests are all PASS.