### PR TITLE
Update README.physics_files for new files since V4.2, and update chem_opt settings

### DIFF
--- a/run/README.physics_files
+++ b/run/README.physics_files
@@ -154,7 +154,7 @@ Other Options:
 
 Urban Physics (sf_urban_physics = 1, 2, and 3)
 	URBPARM.TBL
-	(if using WUDAPT LCZ use_wudapt_lcz - 1)
+	(if using WUDAPT LCZ use_wudapt_lcz = 1)
 		URBPARM_LCZ.TBL
 
 Chemistry

--- a/run/README.physics_files
+++ b/run/README.physics_files
@@ -152,10 +152,11 @@ Eclipse option (ra_sw_eclipse = 1)
 ----------------------------------------------------------------------------------
 Other Options:
 
-Urban Physics (sf_urban_physics = 1, 2, and 3)
+Urban Physics, no LCZ (sf_urban_physics = 1, 2, and 3)
 	URBPARM.TBL
-	(if using WUDAPT LCZ use_wudapt_lcz = 1)
-		URBPARM_LCZ.TBL
+
+Urban Physics (sf_urban_physics = 1, 2, and 3) with LCZ (use_wudapt_lcz = 1)
+	URBPARM_LCZ.TBL
 
 Chemistry
 	HLC.TBL

--- a/run/README.physics_files
+++ b/run/README.physics_files
@@ -29,8 +29,9 @@ SBM (Options 30 and 32):
 	termvels.asc
 
 P3 (Options 50, 51, and 52)
-	p3_lookup_table_1.dat-v4.1
-	p3_lookup_table_2.dat-v4.1
+	p3_lookupTable_1.dat-2momI_v5.1.6_oldDimax
+	p3_lookupTable_1.dat-3momI_v5.1.6.gz
+	p3_lookupTable_2.dat-4.1
 
 Jensen (Option 55):
 	ishmael-gamma-tab.bin
@@ -158,5 +159,5 @@ Urban Physics, no LCZ (sf_urban_physics = 1, 2, and 3)
 Urban Physics (sf_urban_physics = 1, 2, and 3) with LCZ (use_wudapt_lcz = 1)
 	URBPARM_LCZ.TBL
 
-Chemistry
+Chemistry (chem_opt = 112, 114, 111, 201, 202)
 	HLC.TBL

--- a/run/README.physics_files
+++ b/run/README.physics_files
@@ -153,7 +153,7 @@ Eclipse option (ra_sw_eclipse = 1)
 ----------------------------------------------------------------------------------
 Other Options:
 
-Urban Physics, no LCZ (sf_urban_physics = 1, 2, and 3)
+Urban Physics, no LCZ (sf_urban_physics = 1, 2, & 3)
 	URBPARM.TBL
 
 Urban Physics (sf_urban_physics = 1, 2, and 3) with LCZ (use_wudapt_lcz = 1)

--- a/run/README.physics_files
+++ b/run/README.physics_files
@@ -154,6 +154,8 @@ Other Options:
 
 Urban Physics (sf_urban_physics = 1, 2, and 3)
 	URBPARM.TBL
+	(if using WUDAPT LCZ use_wudapt_lcz - 1)
+		URBPARM_LCZ.TBL
 
 Chemistry
 	HLC.TBL


### PR DESCRIPTION
TYPE: text only

KEYWORDS: urban, wudapt, lcz, URBPARM_LCZ.TBL, README.physics_files, chem_opt, Henry's Law, P3

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
1. Since creating README.physics_files, the new table for WUDAPT LCZ option (URBPARM_LCZ.TBL) has been 
added to the run/ directory.
2. The specific chem_opt settings for using Henry's Law have been added for HLC.TBL.
3. Update the new files for the P3 MP scheme.

Solution:
Added this newer option to the README file for physics options.

LIST OF MODIFIED FILES: 
M   run/README.physics_files

TESTS CONDUCTED: 
1. No mods needed - text only
2. No testing needed