### PR TITLE
Revert w_crit_cfl back to 1.0 (from temporary 1.2)

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2773,13 +2773,13 @@ rconfig   integer scm_force_flux          namelist,scm  1       0           rh  
 # dynamics option (see package definitions, below)
 rconfig   integer dyn_opt                 namelist,dynamics	1             2 
 rconfig   integer rk_ord                  namelist,dynamics	1             3       irh   "rk_order"               ""      ""
-rconfig   integer w_damping               namelist,dynamics	1             0       irh   "w_damping"             ""      ""
-rconfig   real    w_crit_cfl              namelist,dynamics 1             1.2     irh   "w_crit_cfl"        "W-CFL where w-damping is on" ""
-rconfig   integer zadvect_implicit        namelist,dynamics 1             0       irh   "zadvect_implicit"  "Turns on IEVA for vertical adv" ""
+rconfig   integer w_damping               namelist,dynamics	1             0       irh   "w_damping"              ""      ""
+rconfig   real    w_crit_cfl              namelist,dynamics	1             1.0     irh   "w_crit_cfl"             "W-CFL where w-damping is on" ""
+rconfig   integer zadvect_implicit        namelist,dynamics	1             0       irh   "zadvect_implicit"       "Turns on IEVA for vertical adv" ""
 # diff_opt 1=old diffusion, 2=new
-rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh   "diff_opt"              ""      ""
+rconfig   integer diff_opt                namelist,dynamics	max_domains   -1      irh   "diff_opt"               ""      ""
 # diff_opt_dfi is needed for backwards integration in dfi
-rconfig   integer diff_opt_dfi            namelist,dynamics	max_domains   0       irh   "diff_opt_dfi"          ""      ""
+rconfig   integer diff_opt_dfi            namelist,dynamics	max_domains   0       irh   "diff_opt_dfi"           ""      ""
 # km_opt   1=old coefs, 2=tke, 3=Smagorinksy
 rconfig   integer km_opt                  namelist,dynamics	max_domains   -1      irh    "km_opt"                ""      ""
 # km_opt_dfi is needed for backward integration in dfi


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: IEVA, cfl

SOURCE: internal

DESCRIPTION OF CHANGES:
This is a clean-up PR to 4412521401e6f #1373 "Implicit Explicit Vertical Advection (IEVA)". We are resetting the default critical value to activate the w_damping option to the previous setting.

Problem:
The new namelist option `w_crit_cfl` replaces `w_beta`, where `w_beta` used to be set in module_model_constants.F and had a value of 1.0. Before this PR, the default value of `w_crit_cfl` was set to 1.2 in the Registry. If one didn't use the new namelist option to manually reset the value of `w_crit_cfl` to 1., that meant that w_damping would behave 
differently from previous releases.

Solution:
1. With consultation with the developer, the value for `w_crit_cfl` is now set to 1.0 in the Registry file. This gives similar and expected behavior for when w_damping kicks in.
2. Also, a bit of column aligning in the neighborhood of this change was done to make the Registry a bit more tidy. "Try and leave this world a little better than you found it.", Robert Stephenson Smyth Baden-Powell.

LIST OF MODIFIED FILES: 
modified:   Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. There are no problems to test, just resetting the critical value for activating w_damping (from 1.2 to 1.0).
2. Let us all hope that Jenkins tests are all PASS.