### PR TITLE
Updated top-level README for V4.3 release

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 WRF Model Version 4.3
 
-http://www2.mmm.ucar.edu/wrf/users/
+https://www2.mmm.ucar.edu/wrf/users/
 
 ------------------------
 WRF PUBLIC DOMAIN NOTICE

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-WRF Model Version 4.2.2
+WRF Model Version 4.3
 
 http://www2.mmm.ucar.edu/wrf/users/
 

--- a/README
+++ b/README
@@ -29,18 +29,21 @@ This is the main directory for the WRF Version 4 source code release.
 ======================================
 
 Other README files are located in the WRF/doc directory:
+doc/README.crtm
+doc/README.CTSM
+doc/README.cygwin.md
 doc/README.DA
-doc/README.NMM
-doc/README.SSIB
-doc/README.WRFPLUS
 doc/README.hybrid_vert_coord
 doc/README.hydro
 doc/README.io_config
 doc/README.irr_diag
+doc/README.madwrf
+doc/README.NMM
 doc/README.rsl_output
-doc/README.windturbine
+doc/README.SSIB
 doc/README_test_cases
-doc/README.cygwin.md
+doc/README.windturbine
+doc/README.WRFPLUS
 
 - Beginning with version 4.0, for more information on the releases, visit 
   the WRF GitHub Release Page:


### PR DESCRIPTION
TYPE: text only

KEYWORDS: README, top-level, V4.3, release

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
Top-level README file needed updating for the v4.3 release:
1. Current version: v4.2.2 -> v4.3. 
2. Link to WRF home page was outdated: http -> https, which has been wrong for a long time.
3. New README files (README.CTSM, README.madwrf, README.crtm) needed to be added to list of docs in the 
    top-level README file.

Solution:
Updated README file with all of the above.

LIST OF MODIFIED FILES: 
M   README

TESTS CONDUCTED: 
1. Text only
2. Jenkins Test Passes