### PR TITLE
http -> https for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ### WRF-ARW Modeling System  ###
 
-We request that all new users of WRF please register. This allows us to better determine how to support and develop the model. Please register using this form:[http://www2.mmm.ucar.edu/wrf/users/download/wrf-regist.php](http://www2.mmm.ucar.edu/wrf/users/download/wrf-regist.php).
+We request that all new users of WRF please register. This allows us to better determine how to support and develop the model. Please register using this form:[https://www2.mmm.ucar.edu/wrf/users/download/wrf-regist.php](https://www2.mmm.ucar.edu/wrf/users/download/wrf-regist.php).
 
-For an overview of the WRF modeling system, along with information regarding downloads, user support, documentation, publications, and additional resources, please see the WRF Model Users' Web Site: [http://www2.mmm.ucar.edu/wrf/users/](http://www2.mmm.ucar.edu/wrf/users/).
+For an overview of the WRF modeling system, along with information regarding downloads, user support, documentation, publications, and additional resources, please see the WRF Model Users' Web Site: [https://www2.mmm.ucar.edu/wrf/users/](https://www2.mmm.ucar.edu/wrf/users/).
  
-Information regarding WRF Model citations (including a DOI) can be found here: [http://www2.mmm.ucar.edu/wrf/users/citing_wrf.html](http://www2.mmm.ucar.edu/wrf/users/citing_wrf.html).
+Information regarding WRF Model citations (including a DOI) can be found here: [https://www2.mmm.ucar.edu/wrf/users/citing_wrf.html](https://www2.mmm.ucar.edu/wrf/users/citing_wrf.html).
 
-The WRF Model is open-source code in the public domain, and its use is unrestricted. The name "WRF", however, is a registered trademark of the University Corporation for Atmospheric Research. The WRF public domain notice and related information may be found here: [http://www2.mmm.ucar.edu/wrf/users/public.html](http://www2.mmm.ucar.edu/wrf/users/public.html).
+The WRF Model is open-source code in the public domain, and its use is unrestricted. The name "WRF", however, is a registered trademark of the University Corporation for Atmospheric Research. The WRF public domain notice and related information may be found here: [https://www2.mmm.ucar.edu/wrf/users/public.html](https://www2.mmm.ucar.edu/wrf/users/public.html).
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: http, README

SOURCE: internal

DESCRIPTION OF CHANGES:
The README file incorrectly provided the WRF URL protocol as "http". It is actually "https". This presented no
troubles to users, as the web server resolved the address automatically.

LIST OF MODIFIED FILES: 
modified:   README.md

TESTS CONDUCTED: 
1. Text only, so no external testing required.
2. README.md, so no jenkins testing done.