### PR TITLE
bug fix: initialization of 1000-h fuel moisture content, computation of the net fuel load

### DIFF
--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -709,7 +709,7 @@ IF ( wrf_dm_on_monitor() ) THEN
     fmc_gc_initial_value(1)=fmc_1h
     fmc_gc_initial_value(2)=fmc_10h
     fmc_gc_initial_value(3)=fmc_100h
-    fmc_gc_initial_value(3)=fmc_1000h
+    fmc_gc_initial_value(4)=fmc_1000h
     fmc_gc_initial_value(5)=fmc_live
     !
     ! end initialization from scalars tied to a particular model with 5 fuel moisture classes

--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -1250,7 +1250,7 @@ do j=jfts,jfte
         ratio = fp%betafl(i,j)/betaop
         gamma = gammax *(ratio**a) *exp(a*(1.-ratio)) !optimum rxn vel, 1/min
 
-        wn = fuelload / (1 + st(k))       ! net fuel loading, lb/ft^2
+        wn = fuelload/(1 + st(k))       ! net fuel loading, lb/ft^2
         rtemp1 = fp%fmc_g(i,j)/fuelmce(k)
         etam = 1.-2.59*rtemp1 +5.11*rtemp1**2 -3.52*rtemp1**3  !moist damp coef
         etas = 0.174* se(k)**(-0.19)                ! mineral damping coef

--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -1250,7 +1250,7 @@ do j=jfts,jfte
         ratio = fp%betafl(i,j)/betaop
         gamma = gammax *(ratio**a) *exp(a*(1.-ratio)) !optimum rxn vel, 1/min
 
-        wn = fuelload/(1 + st(k))       ! net fuel loading, lb/ft^2
+        wn = fuelload * (1 - st(k))       ! net fuel loading, lb/ft^2
         rtemp1 = fp%fmc_g(i,j)/fuelmce(k)
         etam = 1.-2.59*rtemp1 +5.11*rtemp1**2 -3.52*rtemp1**3  !moist damp coef
         etas = 0.174* se(k)**(-0.19)                ! mineral damping coef

--- a/phys/module_fr_fire_phys.F
+++ b/phys/module_fr_fire_phys.F
@@ -1250,7 +1250,7 @@ do j=jfts,jfte
         ratio = fp%betafl(i,j)/betaop
         gamma = gammax *(ratio**a) *exp(a*(1.-ratio)) !optimum rxn vel, 1/min
 
-        wn = fuelload * (1 - st(k))       ! net fuel loading, lb/ft^2
+        wn = fuelload / (1 + st(k))       ! net fuel loading, lb/ft^2
         rtemp1 = fp%fmc_g(i,j)/fuelmce(k)
         etam = 1.-2.59*rtemp1 +5.11*rtemp1**2 -3.52*rtemp1**3  !moist damp coef
         etas = 0.174* se(k)**(-0.19)                ! mineral damping coef


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: fuel moisture initialisation, net fuel load computation, WRF-Fire

SOURCE: Theodore M. Giannaros (National Observatory of Athens, Greece)

DESCRIPTION OF CHANGES:
Problem:
Incorrect indexing in the initialization of fuel moisture content in subroutine `read_namelist_fire`, in WRF file `phys/module_fr_fire_phys.F`. 

Solution:
Changed `fmc_gc_initial_value(3)=fmc_1000h` to `fmc_gc_initial_value(4)=fmc_1000h` in subroutine `read_namelist_fire`, in WRF file `phys/module_fr_fire_phys.F`. 

LIST OF MODIFIED FILES: 
M phys/module_fr_fire_phys.F

TESTS CONDUCTED:
1. The correction applied resolved the erroneous initialization of both 1000h and 100h fuel moisture content. Prior to 
this correction, `fmc_gc_initial_value(3)=fmc_1000h` and no initialization was carried out for fmc_gc_initial_value(4). 
This resulted to erroneously setting `fmc_gc_initial_value(3)=fmc_1000h` and `fmc_gc_initial_value(4)=0` (was 
left uninitialized). Following the correction, both variables are correctly set (`fmc_gc_initial_value(3)=fmc_100h` and 
`fmc_gc_initial_value(4)=fmc_1000h`). 
2. Jenkins is all PASS.

RELEASE NOTE: Bug fix for fire module related to the initialization of fuel moisture content due to an incorrect indexing assignment from the namelist entries for fuel classes.