### PR TITLE
got_var_sso needs to be in history file for DA

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1425,7 +1425,7 @@ state logical just_read_auxinput4  -      misc      -         -     r    "we_jus
 state logical just_read_boundary   -      misc      -         -     r    "we_just_d01_LBC"           "1=BOUNDARY  ALARM RINGING, 0=NO BOUNDARY  ALARM"  "-"
 state   real    mf_fft         -       misc         -         -     r        "mf_fft"                "Mass point map factor at equatorward FFT filter location"  ""
 state   real    p_top          -       misc         -         -     irh       "p_top"                "PRESSURE TOP OF THE MODEL"  "Pa"
-state logical got_var_sso	-	misc	    -	      -     i02r  "got_var_sso"		     "whether VAR_SSO was included in WPS output (beginning V3.4)" ""
+state logical got_var_sso      -       misc         -         -     i02rh    "got_var_sso"           "whether VAR_SSO was included in WPS output (beginning V3.4)" ""
 state logical v4_metgrid 	-	misc	    -	      -     -     "v4_metgrid"		     "for real, T/F: identify if this is v4 metgrid data" ""
 
 

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1428,7 +1428,6 @@ state   real    p_top          -       misc         -         -     irh       "p
 state logical got_var_sso      -       misc         -         -     i02rh    "got_var_sso"           "whether VAR_SSO was included in WPS output (beginning V3.4)" ""
 state logical v4_metgrid 	-	misc	    -	      -     -     "v4_metgrid"		     "for real, T/F: identify if this is v4 metgrid data" ""
 
-
 #BSINGH - Adding all these variables for CuP scheme[any var before t00]
 state   real    lat_ll_t       -       dyn_em       -         -     ir       "lat_ll_t"              "latitude lower left, temp point" "degrees"
 state   real    lat_ul_t       -       dyn_em       -         -     ir       "lat_ul_t"              "latitude up left, temp point" "degrees"


### PR DESCRIPTION
Add missing var to history file for DA application

TYPE: bug fix

KEYWORDS: topo_wind option 1, data flag got_var_sso

SOURCE: reported by Y. Zhang, fixed by internal

DESCRIPTION OF CHANGES:
Problem:
topo_wind option 1 requires input field var_sso (variance of the subgrid scale orography). When program real is run, a 
logical variable got_var_sso is defined upon checking whether the variance field exists or not. In the model, both 
namelist option for topo_wind as well as this internal logical are required to use this topo_wind option. If got_var_sso 
is not found when the topo_wind option is requested, the model produces an error "topo_wind requires VAR_SSO data", 
even if the field VAR_SSO field itself exists in the input. When the model history file is used in a DA cycle, missing this 
logical causes the model to stop.

Solution:
The registry file is modified to add 'got_var_sso' to the history file. 

LIST OF MODIFIED FILES: 
M   Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. The modification has been tested to show it corrects the problem reported.
2. Jenkins tests are passing.

RELEASE NOTE: Logical variable got_var_sso is added to the history file for cycling DA application for use with the topo_wind option.
