### PR TITLE
default values for LCZ PARAMS

### DIFF
--- a/run/URBPARM_LCZ.TBL
+++ b/run/URBPARM_LCZ.TBL
@@ -468,7 +468,41 @@ HSEQUIP: 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.5 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
 HSEQUIP_SCALE_FACTOR: 36.00, 20.00, 20.00, 36.00, 20.00, 20.00, 20.00, 36.00, 20.00, 20.00, 20.00 
 
 
+#
+# GR_FLAG: 1 to switch on green roof model (0-1)
+#      (sf_urban_physics=3)
+#
 
+GR_FLAG:0
+
+#
+# GR_TYPE: 1 for GRASS, 2 for SEDUM vegetation on the green roof
+#      (sf_urban_physics=3)
+#
+
+GR_TYPE: 2
+
+#
+# GR_FRAC_ROOF: fraction of green roof over the roof (0:1)
+#      (sf_urban_physics=3)
+#
+
+GR_FRAC_ROOF:0,0,0,0,0,0,0,0,0,0,0
+
+#
+# HSEQUIP:  Diurnal  profile of sprinkler irrigation for the green roof 
+#      (sf_urban_physics=3)
+#
+
+IRHO:0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1
+
+
+#
+# PV_FRAC_ROOF: fraction of photovoltaic panels over the roof (0:1)
+#      (sf_urban_physics=3)
+#
+
+PV_FRAC_ROOF: 0,0,0,0,0,0,0,0,0,0,0
 
 
 STREET PARAMETERS:

--- a/run/URBPARM_LCZ.TBL
+++ b/run/URBPARM_LCZ.TBL
@@ -46,7 +46,7 @@ ROAD_WIDTH: 98.9, 39.2, 108.0, 108.0, 108.0, 108.0, 108.0, 108.0, 108.0, 108.0, 
 #      (sf_urban_physics=1)
 #
 
-AH:  175.0, 37.5, 37.5, 25.0, 12.5, 12.5, 17.5, 25.0, 5.0, 350.0, 350.0
+AH:  100.0, 35.0, 30.0, 30.0, 15.0, 10.0, 30.0, 40.0, 5.0, 300.0, 0
 
 
 #
@@ -54,7 +54,7 @@ AH:  175.0, 37.5, 37.5, 25.0, 12.5, 12.5, 17.5, 25.0, 5.0, 350.0, 350.0
 #      (sf_urban_physics=1)
 #
 
-ALH:  20.0, 25.0, 40.0,20.0, 25.0, 40.0,20.0, 25.0, 40.0,20.0, 25.0
+ALH:  20.0, 25.0, 40.0, 20.0, 25.0, 40.0, 20.0, 25.0, 40.0, 20.0, 0
 
 #
 #  AKANDA_URBAN:  Coefficient modifying the Kanda approach to computing
@@ -238,84 +238,84 @@ FRC_URB: 1.00, 0.99, 1.00, 0.65, 0.7, 0.65, 0.3, 0.85, 0.3, 0.55, 1.00
 #      (sf_urban_physics=1,2,3)
 #
 
-CAPR: 1.32E6,1.32E6,1.32E6, 1.8E6, 1.32E6, 1.32E6, 2.0E6, 2.11E6, 1.32E6, 2.0E6, 1.94E6
+CAPR: 1.8E6, 1.8E6, 1.44E6, 1.8E6, 1.8E6, 1.44E6, 2.0E6, 1.8E6, 1.44E6, 2.0E6, 1.8E6
 
 #
 # CAPB:  Heat capacity of building wall [ J m{-3} K{-1} ]
 #      (sf_urban_physics=1,2,3)
 #
 
-CAPB: 1.54E6,1.54E6,1.54E6, 2.0E6, 1.54E6, 1.54E6, 2.0E6, 2.11E6, 1.54E6, 1.59E6, 1.94E6
+CAPB: 1.8E6, 2.67E6, 2.05E6, 2.0E6, 2.0E6, 2.05E6, 0.72E6, 1.8E6, 2.56E6, 1.69E6, 1.8E6
 
 #
 # CAPG:  Heat capacity of ground (road) [ J m{-3} K{-1} ]
 #      (sf_urban_physics=1,2,3)
 #
 
-CAPG:  1.74E6,1.74E6,1.74E6, 1.54E6, 1.94E6, 1.94E6, 1.74E6, 1.94E6, 1.47E6, 1.49E6, 1.94E6
+CAPG:  1.75E6, 1.68E6, 1.63E6, 1.54E6, 1.50E6, 1.47E6, 1.67E6, 1.38E6, 1.37E6, 1.49E6, 1.38E6
 
 #
 # AKSR:  Thermal conductivity of roof [ J m{-1} s{-1} K{-1} ]
 #      (sf_urban_physics=1,2,3)
 #
 
-AKSR:  1.54,1.54,1.54, 1.25, 1.54, 1.54, 0.35, 1.51, 1.00, 2.00, 0.75
+AKSR:  1.25, 1.25, 1.00, 1.25, 1.25, 1.00, 2.0, 1.25, 1.00, 2.00, 1.25
 
 #
 # AKSB:  Thermal conductivity of building wall [ J m{-1} s{-1} K{-1} ]
 #      (sf_urban_physics=1,2,3)
 #
 
-AKSB:  1.51,1.51,1.51, 1.45, 1.51, 1.51,0.35,1.51,1.51, 1.33, 0.75
+AKSB:  1.09, 1.5, 1.25, 1.45, 1.45, 1.25, 0.5, 1.25, 1.00, 1.33, 1.25
 
 #
 # AKSG:  Thermal conductivity of ground (road) [ J m{-1} s{-1} K{-1} ]
 #      (sf_urban_physics=1,2,3)
 #
 
-AKSG: 0.82, 0.82, 0.82, 0.64, 0.82, 0.82, 0.82, 0.82, 0.60, 0.75, 0.75
+AKSG: 0.77, 0.73, 0.69, 0.64, 0.62, 0.60, 0.72, 0.51, 0.55, 0.61, 0.51
 
 #
 # ALBR:   Surface albedo of roof [ fraction ]
 #      (sf_urban_physics=1,2,3)
 #
 
-ALBR: 0.30, 0.30, 0.30, 0.30, 0.30, 0.30, 0.70, 0.30, 0.30, 0.30, 0.12 
+ALBR: 0.13, 0.18, 0.15, 0.13, 0.13, 0.13, 0.15, 0.18, 0.13, 0.10, 0.13 
 
 #
 # ALBB:  Surface albedo of building wall [ fraction ]
 #      (sf_urban_physics=1,2,3)
 #
 
-ALBB: 0.35, 0.35, 0.35, 0.35, 0.35, 0.35, 0.70, 0.35, 0.35, 0.35, 0.12
+ALBB: 0.25, 0.20, 0.20, 0.25, 0.25, 0.25, 0.20, 0.25, 0.25, 0.20, 0.20
 
 #
 # ALBG:  Surface albedo of ground (road) [ fraction ]
 #      (sf_urban_physics=1,2,3)
 #
 
-ALBG: 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15 
+ALBG: 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.18, 0.14, 0.14, 0.14, 0.14 
 
 #
 # EPSR:  Surface emissivity of roof [ - ]
 #      (sf_urban_physics=1,2,3)
 #
 
-EPSR: 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.93
+EPSR: 0.91, 0.91, 0.91, 0.91, 0.91, 0.91, 0.28, 0.91, 0.91, 0.91, 0.95
 
 #
 # EPSB:  Surface emissivity of building wall [-]
 #      (sf_urban_physics=1,2,3)
 #
 
-EPSB: 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.93, 0.90, 0.90, 0.93
+EPSB: 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.95
 
 #
 # EPSG:  Surface emissivity of ground (road) [ - ]
 #      (sf_urban_physics=1,2,3)
 #
 
-EPSG: 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95
+EPSG: 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.92, 0.95, 0.95, 0.95, 0.95
 
 #
 # Z0B:  Roughness length for momentum, over building wall [ m ]
@@ -468,41 +468,7 @@ HSEQUIP: 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.5 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
 HSEQUIP_SCALE_FACTOR: 36.00, 20.00, 20.00, 36.00, 20.00, 20.00, 20.00, 36.00, 20.00, 20.00, 20.00 
 
 
-#
-# GR_FLAG: 1 to switch on green roof model (0-1)
-#      (sf_urban_physics=3)
-#
 
-GR_FLAG:0
-
-#
-# GR_TYPE: 1 for GRASS, 2 for SEDUM vegetation on the green roof
-#      (sf_urban_physics=3)
-#
-
-GR_TYPE: 2
-
-#
-# GR_FRAC_ROOF: fraction of green roof over the roof (0:1)
-#      (sf_urban_physics=3)
-#
-
-GR_FRAC_ROOF:0,0,0,0,0,0,0,0,0,0,0
-
-#
-# HSEQUIP:  Diurnal  profile of sprinkler irrigation for the green roof 
-#      (sf_urban_physics=3)
-#
-
-IRHO:0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1
-
-
-#
-# PV_FRAC_ROOF: fraction of photovoltaic panels over the roof (0:1)
-#      (sf_urban_physics=3)
-#
-
-PV_FRAC_ROOF: 0,0,0,0,0,0,0,0,0,0,0
 
 
 STREET PARAMETERS:


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Local Climate Zones (LCZ), urban parameters, urban canopy models

SOURCE: Matthias Demuzere (Ruhr University Bochum), Andrea Zonato (Trento University)

DESCRIPTION OF CHANGES:
Problem:
The values in the current version of the URBPARM_LCZ.TBL are specific for Zonato et al. (2020), reflecting city properties in Italy. Some of these values should be more universal.

Solution:
Changing some of the urban parameter values, to make them more generic. These universal values are based upon the following published materials:

- Stewart ID, Oke TR. Local Climate Zones for Urban Temperature Studies. Bull Am Meteorol Soc. 2012;93(12):1879-1900. doi:10.1175/BAMS-D-11-00019.1
- Stewart ID, Oke TR, Krayenhoff ES. Evaluation of the ‘local climate zone’ scheme using temperature observations and model simulations. Int J Climatol. 2014;34(4):1062-1080. doi:10.1002/joc.3746
- Varentsov M, Samsonov T, Demuzere M. Impact of Urban Canopy Parameters on a Megacity’s Modelled Thermal Environment. Atmosphere (Basel). 2020;11(12):1349. doi:10.3390/atmos11121349

LIST OF MODIFIED FILES: 
M       run/URBPARM_LCZ.TBL

TESTS CONDUCTED: 
1. Only concerns some parameter value changes.
2. Jenkins testing is all PASS.

RELEASE NOTE: 
LCZ-specific urban canopy parameters values in URBPARM_LCZ.TBL are sourced from Stewart and Oke (2012), Stewart et al. (2014) and Varentsov et al. (2020) where available.
