### PR TITLE
FIx "pressure" spelling in 4 files

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1465,7 +1465,7 @@ state   real    lon_lr_d       -       dyn_em       -         -     ir       "lo
 #BSINGH -ENDS
 
 state   real    t00            -       misc         -         -     i02rh     "t00"                   "BASE STATE TEMPERATURE   "  "K"
-state   real    p00            -       misc         -         -     i02rh     "p00"                   "BASE STATE PRESURE"         "Pa"
+state   real    p00            -       misc         -         -     i02rh     "p00"                   "BASE STATE PRESSURE"         "Pa"
 state   real    tlp            -       misc         -         -     i02rh     "tlp"                   "BASE STATE LAPSE RATE    "  ""
 state   real    tiso           -       misc         -         -     i02rh     "tiso"                  "TEMP AT WHICH THE BASE T TURNS CONST"  "K"
 state   real    tlp_strat      -       misc         -         -     i02rh     "tlp_strat"             "BASE STATE LAPSE RATE (DT/D(LN(P)) IN STRATOSPHERE"  "K"

--- a/Registry/Registry.EM_COMMON.var
+++ b/Registry/Registry.EM_COMMON.var
@@ -296,7 +296,7 @@ state   real    v_frame        -       misc         1         -     ir        "v
 # from the metadata?  Otherwise it's a field?
 state   real    p_top          -       misc         -         -     irh       "p_top"                 "PRESSURE TOP OF THE MODEL"  "Pa"
 state   real    t00            -       misc         -         -     i02rh     "t00"                   "BASE STATE TEMPERATURE   "  "K"
-state   real    p00            -       misc         -         -     i02rh     "p00"                   "BASE STATE PRESURE"         "Pa"
+state   real    p00            -       misc         -         -     i02rh     "p00"                   "BASE STATE PRESSURE"         "Pa"
 state   real    tlp            -       misc         -         -     i02rh     "tlp"                   "BASE STATE LAPSE RATE    "  ""
 state   real    tiso           -       misc         -         -     i02rh     "tiso"                  "TEMP AT WHICH THE BASE T TURNS CONST"  "K"
 state   real    tlp_strat      -       misc         -         -     i02rh     "tlp_strat"             "BASE STATE LAPSE RATE (DT/D(LN(P)) IN STRATOSPHERE"  "K"

--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -37,8 +37,8 @@ state    real   g_p            ijk     dyn_em      1         -      rh        "g
 state    real    a_z            ijk     misc        1         Z     -         " " " " " "
 state    real    g_z            ijk     misc        1         Z     -         " " " " " "
 # For KMA, pressure coefficient.
-state    real    kma_a          k       misc        1         Z     -         "A"  "KMA Constants A to convert surface presure to full level pressure" "dimensionless"
-state    real    kma_b          k       misc        1         Z     -         "B"  "KMA Constants B to convert surface presure to full level pressure" "dimensionless"
+state    real    kma_a          k       misc        1         Z     -         "A"  "KMA Constants A to convert surface pressure to full level pressure" "dimensionless"
+state    real    kma_b          k       misc        1         Z     -         "B"  "KMA Constants B to convert surface pressure to full level pressure" "dimensionless"
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 # Scalar (4D) arrays
 # Moist Scalars

--- a/phys/module_ra_cam.F
+++ b/phys/module_ra_cam.F
@@ -2444,7 +2444,7 @@ subroutine radabs(lchnk   ,ncol    ,pcols, pver, pverp,   &
    real(r8) r2sslp             ! 1/2 of rsslp
    real(r8) ds2c               ! Y in eq(7) in table A2 of R&D
    real(r8)  dplos             ! Ozone pathlength eq(A2) in R&Di
-   real(r8) dplol              ! Presure weighted ozone pathlength
+   real(r8) dplol              ! Pressure weighted ozone pathlength
    real(r8) tlocal             ! Local interface temperature
    real(r8) beta               ! Ozone mean line parameter eq(A3) in R&Di
 !                               (includes Voigt line correction factor)


### PR DESCRIPTION
TYPE: text only

KEYWORDS: correct misspellings

SOURCE: Piotr Kasprzyk (IETU Katowice)

DESCRIPTION OF CHANGES:
Problem:
The "pressure" spelling was wrong.

Solution:
Words "pressure" were corrected.

LIST OF MODIFIED FILES: 
M       README
M       Registry/Registry.EM_COMMON
M       Registry/Registry.EM_COMMON.var
M       Registry/registry.var
M       phys/module_ra_cam.F

TESTS CONDUCTED: 
1. Tests were not conducted, as this is a text only change.
2. All of the jenkins tests are passing.