### PR TITLE
Correct units for several NTU microphysics variables

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -685,9 +685,9 @@ state   real    dfi_qrcn       ikjftb   dfi_scalar      1         -     \
 state   real    dfi_qnin       ikjftb   dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)     "DFI_QNIN"      "Potential ice nuclei number mixing ratio" "# kg-1"
 state   real    dfi_fi         ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_FI"        "Shape moment mixing ratio for pristine ice" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_FI"        "Shape moment mixing ratio for pristine ice" "m^3 kg-1"
 state   real    dfi_fs         ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_FS"        "Shape moment mixing ratio for snow-aggregates" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_FS"        "Shape moment mixing ratio for snow-aggregates" "m^3 kg-1"
 state   real    dfi_vi         ikjftb   dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)     "DFI_VI"        "Volume moment mixing ratio for pristine ice" "m^3 kg-1"
 state   real    dfi_vs         ikjftb   dfi_scalar      1         -     \
@@ -695,15 +695,15 @@ state   real    dfi_vs         ikjftb   dfi_scalar      1         -     \
 state   real    dfi_vg         ikjftb   dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)     "DFI_VG"        "Volume moment mixing ratio for rimed ice" "m^3 kg-1"
 state   real    dfi_ai         ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_AI"        "Second moment mixing ratio for pristine ice" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_AI"        "Second moment mixing ratio for pristine ice" "m^2 kg-1"
 state   real    dfi_as         ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_AS"        "Second moment mixing ratio for snow-aggregates" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_AS"        "Second moment mixing ratio for snow-aggregates" "m^2 kg-1"
 state   real    dfi_ag         ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_AG"        "Second moment mixing ratio for rimed ice" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_AG"        "Second moment mixing ratio for rimed ice" "m^2 kg-1"
 state   real    dfi_ah         ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_AH"        "Second moment mixing ratio for hail" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_AH"        "Second moment mixing ratio for hail" "m^2 kg-1"
 state   real    dfi_i3m        ikjftb   dfi_scalar      1         -     \
-   rusdf=(bdy_interp:dt)     "DFI_I3M"       "Third moment mixing ratio for pristine ice" "kg kg-1"
+   rusdf=(bdy_interp:dt)     "DFI_I3M"       "Third moment mixing ratio for pristine ice" "m^3 kg-1"
 #-------------------------------------for ntu3m----------------------------------------------------------
 #
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -654,9 +654,9 @@ state   real    qrcn           ikjftb   scalar      1         -     \
 state   real    qnin           ikjftb   scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)  "QNIN"           "Potential ice nuclei number mixing ratio" "# kg-1"
 state   real    fi             ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "FI"             "Shape moment mixing ratio for pristine ice" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "FI"             "Shape moment mixing ratio for pristine ice" "m^3 kg-1"
 state   real    fs             ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "FS"             "Shape moment mixing ratio for snow-aggregates" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "FS"             "Shape moment mixing ratio for snow-aggregates" "m^3 kg-1"
 state   real    vi             ikjftb   scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)  "VI"             "Volume moment mixing ratio for pristine ice" "m^3 kg-1"
 state   real    vs             ikjftb   scalar      1         -     \
@@ -664,15 +664,15 @@ state   real    vs             ikjftb   scalar      1         -     \
 state   real    vg             ikjftb   scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)  "VG"             "Volume moment mixing ratio for rimed ice" "m^3 kg-1"
 state   real    ai             ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "AI"             "Second moment mixing ratio for pristine ice" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "AI"             "Second moment mixing ratio for pristine ice" "m^2 kg-1"
 state   real    as             ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "AS"             "Second moment mixing ratio for snow-aggregates" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "AS"             "Second moment mixing ratio for snow-aggregates" "m^2 kg-1"
 state   real    ag             ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "AG"             "Second moment mixing ratio for rimed ice" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "AG"             "Second moment mixing ratio for rimed ice" "m^2 kg-1"
 state   real    ah             ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "AH"             "Second moment mixing ratio for hail" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "AH"             "Second moment mixing ratio for hail" "m^2 kg-1"
 state   real    i3m            ikjftb   scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)  "I3M"            "Third moment mixing ratio for pristine ice" "kg kg-1"
+   i0rhusdf=(bdy_interp:dt)  "I3M"            "Third moment mixing ratio for pristine ice" "m^3 kg-1"
 
 state   real    dfi_qdcn       ikjftb   dfi_scalar      1         -     \
    rusdf=(bdy_interp:dt)     "DFI_QDCN"      "Mass mixing ratio for dry CN" "kg kg-1"


### PR DESCRIPTION
TYPE: text change

KEYWORDS: units in Registry

SOURCE: internal, Tzu-Chin Tsai (NTU)

DESCRIPTION OF CHANGES:
Problem:
The units for 7 new NTU microphysics variables are incorrectly specified in Registry.EM_COMMON.

Solution:
This PR corrects them.

LIST OF MODIFIED FILES: 
M     Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
1. Text change only. No effect on results
2. The Jenkins tests are all passing.

RELEASE NOTE: Units specified in Registry are corrected for several NTU microphysics variables.