### PR TITLE
Modify VEGPARM.TBL to make it work with NLCD Landuse Type

### DIFF
--- a/run/VEGPARM.TBL
+++ b/run/VEGPARM.TBL
@@ -186,6 +186,22 @@ LCZ_2
 26
 LCZ_3
 99
+LCZ_4
+34
+LCZ_5
+35
+LCZ_6
+36
+LCZ_7
+37
+LCZ_8
+38
+LCZ_9
+39
+LCZ_10
+40
+LCZ_11
+41
 Vegetation Parameters
 USGS-RUC
 28,1, 'ALBEDO    Z0   LEMI     PC   SHDFAC IFOR   RS      RGL      HS      SNUP    LAI    MAXALB'


### PR DESCRIPTION
TYPE: bug fix
KEYWORDS: VEGPARM, NLCD landuse 
SOURCE: internal
DESCRIPTION OF CHANGES: When the LCZ option is introduced into WRFV4.3, VEGPARM.TBL is changed to make it work with this new option. However, the changes of VEGPARM.TBL are not consistent with the NLCD landuse type. The model crashed immediately. This PR fixes this problem so that the model can work with NLCD landuse type.  

LIST OF MODIFIED FILES:
M    run/VEGPARM.TBL

TESTS CONDUCTED: 
1. A single case with NLCD landuse type is run to test the changes. 
2. Pending for Jenkins tests.

RELEASE NOTE: VEEGPARM.TBL is modified to make it work with  the NLCD landuse type. 
