### PR TITLE
Bug fix longwave rad bep bem

### DIFF
--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -5312,13 +5312,13 @@ do iz= kts,kte
          grdflx_urb=grdflx_urb-gfl*ws(id)/(ws(id)+bs(id))/ndu  
  
          do iz=2,nzu
-            rl_emit=rl_emit-(emr_u*sigma*((1.-pv_frac_roof)*tr_av(id,iz)**4.+pv_frac_roof*tpvlev(id,iz)**4)+ &
-             (1-emr_u)*rld)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            rl_inc=rl_inc+(1-pv_frac_roof*rld+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            rs_abs=rs_abs+((1.-albr_u)*rs*(1.-pv_frac_roof))*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+             rl_emit=rl_emit-(emr_u*sigma*(1.-pv_frac_roof)*tr_av(id,iz)**4.+0.79*sigma*pv_frac_roof*tpvlev(id,iz)**4+ &
+                     (1-emr_u)*rld*(1.-pv_frac_roof)+(1-0.79)*pv_frac_roof*rld)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+            rl_inc=rl_inc+rld*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+            rs_abs=rs_abs+((1.-albr_u)*rs*(1.-pv_frac_roof)+(1.-0.11)*rs*pv_frac_roof)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
             gfl=(1.-albr_u)*rs*(1-pv_frac_roof)+emr_u*rld*((1-pv_frac_roof)+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4) &
                 -emr_u*sigma*(tr_av(id,iz)**4.)+(1-gr_frac_roof)*sfr(id,iz)+(sfrv(id,iz)+lfrv(id,iz))*gr_frac_roof+(1.-gr_frac_roof)*lfr(id,iz)
-            grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+            grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu  
          enddo
            
          do iz=1,nzu 

--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -5314,11 +5314,11 @@ do iz= kts,kte
          do iz=2,nzu
              rl_emit=rl_emit-(emr_u*sigma*(1.-pv_frac_roof)*tr_av(id,iz)**4.+0.79*sigma*pv_frac_roof*tpvlev(id,iz)**4+ &
                      (1-emr_u)*rld*(1.-pv_frac_roof)+(1-0.79)*pv_frac_roof*rld)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            rl_inc=rl_inc+rld*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            rs_abs=rs_abs+((1.-albr_u)*rs*(1.-pv_frac_roof)+(1.-0.11)*rs*pv_frac_roof)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            gfl=(1.-albr_u)*rs*(1-pv_frac_roof)+emr_u*rld*((1-pv_frac_roof)+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4) &
+             rl_inc=rl_inc+rld*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+             rs_abs=rs_abs+((1.-albr_u)*rs*(1.-pv_frac_roof)+(1.-0.11)*rs*pv_frac_roof)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+             gfl=(1.-albr_u)*rs*(1-pv_frac_roof)+emr_u*rld*((1-pv_frac_roof)+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4) &
                 -emr_u*sigma*(tr_av(id,iz)**4.)+(1-gr_frac_roof)*sfr(id,iz)+(sfrv(id,iz)+lfrv(id,iz))*gr_frac_roof+(1.-gr_frac_roof)*lfr(id,iz)
-            grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu  
+             grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu  
          enddo
            
          do iz=1,nzu 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: BEP+BEM, longwave radiation

SOURCE: Andrea Zonato (University of Trento, Italy)

DESCRIPTION OF CHANGES:
There was an error in the previous version on the calculation of long-wave radiation. The variable rl_emit now accounts for 
the emissivity by the photovoltaic panel. Moreover, the variable rld was incorrectly calculated. This will affect the calculation 
of TSK, in urban areas, that in the previous version was wrong.

LIST OF MODIFIED FILES: 
M phys/module_sf_bep_bem.F

TESTS CONDUCTED:
1. This error affects the calculation of TSK, which now is correctly calculated. As you can see in the figure, there is a 
large bias for the TSK of the roofs. Now it is more realistic.
![FIGURE_DIFFERENCES](https://user-images.githubusercontent.com/49075918/127457764-da8b3d38-b01c-4538-aa37-9bbee4298790.png)
2. Jenkins test are OK.

RELEASE NOTE: There was an error in the previous version on the calculation of long-wave radiation. The variable rl_emit now accounts for the emissivity by the photovoltaic panel. Moreover, the variable rld was incorrectly calculated. This will affect the calculation of TSK in urban areas.