### PR TITLE
SFCLAY=1, add shallow water roughness calculation

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2569,7 +2569,7 @@ rconfig   integer sf_ocean_physics        namelist,physics      1            0  
 rconfig   integer traj_opt                namelist,physics      1            0         h     "traj_opt"    "activate trajectory calculation  0=no, 1=on"   ""
 rconfig   logical dm_has_traj             namelist,physics      max_domains  .false.   rh    "has_traj"    "activate trajectory calculation per domain"   ""
 rconfig   integer tracercall              namelist,physics      1            0         h     "tracercall"  "activate tracer calculation  0=no, 1=on"   ""
-rconfig   integer shalwater_rough         namelist,physics      max_domains  0         rh    "shalwater_rough"     "shallow water roughness flag"      ""
+rconfig   integer shalwater_z0            namelist,physics      max_domains  0         rh    "shalwater_z0"     "shallow water sea surface roughness flag"      ""
 rconfig   real    shalwater_depth         namelist,physics      1            -1.0      rh    "shalwater_depth"     "water depth for shallow water scheme"      "m"
 rconfig   real    OMDT                    namelist,physics      1            1         h     "OMDT"        "Timestep of ocean model"      "s"
 rconfig   real    oml_hml0                namelist,physics      1            50        h     "oml_hml0"    "oml initial mixed layer depth value"   "m"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -883,8 +883,8 @@ state    real   XLAIDYN          ij     misc        1         -     -         "X
 state    real   SSTSK            ij     misc        1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SSTSK"              "SKIN SEA SURFACE TEMPERATURE" "K"
 state    real   lake_depth            ij     misc        1    -     i012rd=(interp_mask_water_field:lu_index,islake)   "lake_depth"              "lake depth" "m"
 state    real     water_depth      ij     misc        1       -     i0rhd  "water_depth"  "global water depth" "m"
-rconfig  integer  shalwater_rough         namelist,physics      max_domains   0         rh    "shallow water roughness flag"     ""      ""
-rconfig  real     shalwater_depth         namelist,physics      1   -1.0       rh    "water depth for shallow water scheme"     ""      ""
+rconfig  integer  shalwater_rough         namelist,physics      max_domains   0         rh    "shalwater_rough"     "shallow water roughness flag"      ""
+rconfig  real     shalwater_depth         namelist,physics      1   -1.0       rh    "shalwater_depth"     "water depth for shallow water scheme"      "m"
 state    real   DTW              ij     misc        1         -     r   "DTW"              "WARM LAYER TEMP DIFF" "C"
 # Ocean surface currents
 state    real   UOCE            ij     misc        1         -     i0124rd=(interp_mask_water_field:lu_index,iswater)  "UOCE"  "SEA SURFACE ZONAL CURRENTS" "m s-1"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -171,6 +171,10 @@ state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"  
 state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
 state    real   erod           ij.      misc        1        -     i012rd  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
+# PSH - begin
+state    real   bathymetry     ij       dyn_em      1        -     i1  "bathymetry" "Bathymetry and topography" "m"
+state    integer  BATHYMETRY_FLAG   -     misc        1         -     i0        "BATHYMETRY_FLAG"   "Flag for bathymetry in the global attributes for metgrid data"
+# PSH - end  end   
 
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               
@@ -880,6 +884,11 @@ state    real   XLAIDYN          ij     misc        1         -     -         "X
 # SKIN SST
 state    real   SSTSK            ij     misc        1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SSTSK"              "SKIN SEA SURFACE TEMPERATURE" "K"
 state    real   lake_depth            ij     misc        1    -     i012rd=(interp_mask_water_field:lu_index,islake)   "lake_depth"              "lake depth" "m"
+# PSH - begin
+state    real     water_depth      ij     misc        1       -     i0rhd  "water_depth"  "global water depth" "m"
+rconfig  integer  shalwater_rough         namelist,physics      max_domains   0         rh    "shallow water roughness flag"     ""      ""
+rconfig  real     shalwater_depth         namelist,physics      1   0.0       rh    "water depth for shallow water scheme"     ""      ""
+# PSH - end  
 state    real   DTW              ij     misc        1         -     r   "DTW"              "WARM LAYER TEMP DIFF" "C"
 # Ocean surface currents
 state    real   UOCE            ij     misc        1         -     i0124rd=(interp_mask_water_field:lu_index,iswater)  "UOCE"  "SEA SURFACE ZONAL CURRENTS" "m s-1"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -887,7 +887,7 @@ state    real   lake_depth            ij     misc        1    -     i012rd=(inte
 # PSH - begin
 state    real     water_depth      ij     misc        1       -     i0rhd  "water_depth"  "global water depth" "m"
 rconfig  integer  shalwater_rough         namelist,physics      max_domains   0         rh    "shallow water roughness flag"     ""      ""
-rconfig  real     shalwater_depth         namelist,physics      1   0.0       rh    "water depth for shallow water scheme"     ""      ""
+rconfig  real     shalwater_depth         namelist,physics      1   -1.0       rh    "water depth for shallow water scheme"     ""      ""
 # PSH - end  
 state    real   DTW              ij     misc        1         -     r   "DTW"              "WARM LAYER TEMP DIFF" "C"
 # Ocean surface currents

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -171,10 +171,8 @@ state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"  
 state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
 state    real   erod           ij.      misc        1        -     i012rd  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
-# PSH - begin
 state    real   bathymetry     ij       dyn_em      1        -     i1  "bathymetry" "Bathymetry and topography" "m"
 state    integer  BATHYMETRY_FLAG   -     misc        1         -     i0        "BATHYMETRY_FLAG"   "Flag for bathymetry in the global attributes for metgrid data"
-# PSH - end  end   
 
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               
@@ -884,11 +882,9 @@ state    real   XLAIDYN          ij     misc        1         -     -         "X
 # SKIN SST
 state    real   SSTSK            ij     misc        1         -     rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)   "SSTSK"              "SKIN SEA SURFACE TEMPERATURE" "K"
 state    real   lake_depth            ij     misc        1    -     i012rd=(interp_mask_water_field:lu_index,islake)   "lake_depth"              "lake depth" "m"
-# PSH - begin
 state    real     water_depth      ij     misc        1       -     i0rhd  "water_depth"  "global water depth" "m"
 rconfig  integer  shalwater_rough         namelist,physics      max_domains   0         rh    "shallow water roughness flag"     ""      ""
 rconfig  real     shalwater_depth         namelist,physics      1   -1.0       rh    "water depth for shallow water scheme"     ""      ""
-# PSH - end  
 state    real   DTW              ij     misc        1         -     r   "DTW"              "WARM LAYER TEMP DIFF" "C"
 # Ocean surface currents
 state    real   UOCE            ij     misc        1         -     i0124rd=(interp_mask_water_field:lu_index,iswater)  "UOCE"  "SEA SURFACE ZONAL CURRENTS" "m s-1"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -172,7 +172,7 @@ state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"  
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
 state    real   erod           ij.      misc        1        -     i012rd  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
 state    real   bathymetry     ij       dyn_em      1        -     i1  "bathymetry" "Bathymetry and topography" "m"
-state   integer BATHYMETRY_FLAG -       misc        1        -     i   "BATHYMETRY_FLAG"   "Flag for bathymetry in the global attributes for metgrid data"
+state   integer BATHYMETRY_FLAG -       misc        1        -     i0rh   "BATHYMETRY_FLAG"   "Flag for bathymetry in the global attributes for metgrid data"
 
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -600,6 +600,7 @@ BENCH_START(surf_driver_tim)
      &        ,HUML=grid%huml, HVML=grid%hvml, F=grid%f                             &
      &        ,TMOML=grid%TMOML,ISWATER=iswater                                     &
      &        ,OML_RELAXATION_TIME=grid%OML_RELAXATION_TIME                         &
+     &        ,shalwater_rough=config_flags%shalwater_rough,water_depth=grid%water_depth & !PSH
      &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &   
      &        ,snowdp2d=grid%snowdp2d,          h2osno2d=grid%h2osno2d              & !lake
      &        ,snl2d=grid%snl2d,                t_grnd2d=grid%t_grnd2d              &   

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -600,7 +600,7 @@ BENCH_START(surf_driver_tim)
      &        ,HUML=grid%huml, HVML=grid%hvml, F=grid%f                             &
      &        ,TMOML=grid%TMOML,ISWATER=iswater                                     &
      &        ,OML_RELAXATION_TIME=grid%OML_RELAXATION_TIME                         &
-     &        ,shalwater_rough=config_flags%shalwater_rough                         &
+     &        ,shalwater_z0=config_flags%shalwater_z0                               &
      &        ,water_depth=grid%water_depth                                         & 
      &        ,shalwater_depth=config_flags%shalwater_depth                         & 
      &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &   

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -600,8 +600,8 @@ BENCH_START(surf_driver_tim)
      &        ,HUML=grid%huml, HVML=grid%hvml, F=grid%f                             &
      &        ,TMOML=grid%TMOML,ISWATER=iswater                                     &
      &        ,OML_RELAXATION_TIME=grid%OML_RELAXATION_TIME                         &
-     &        ,shalwater_rough=config_flags%shalwater_rough,water_depth=grid%water_depth & !PSH
-     &        ,shalwater_depth=config_flags%shalwater_depth                         & ! PSH
+     &        ,shalwater_rough=config_flags%shalwater_rough,water_depth=grid%water_depth & 
+     &        ,shalwater_depth=config_flags%shalwater_depth                         & 
      &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &   
      &        ,snowdp2d=grid%snowdp2d,          h2osno2d=grid%h2osno2d              & !lake
      &        ,snl2d=grid%snl2d,                t_grnd2d=grid%t_grnd2d              &   

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -601,6 +601,7 @@ BENCH_START(surf_driver_tim)
      &        ,TMOML=grid%TMOML,ISWATER=iswater                                     &
      &        ,OML_RELAXATION_TIME=grid%OML_RELAXATION_TIME                         &
      &        ,shalwater_rough=config_flags%shalwater_rough,water_depth=grid%water_depth & !PSH
+     &        ,shalwater_depth=config_flags%shalwater_depth                         & ! PSH
      &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &   
      &        ,snowdp2d=grid%snowdp2d,          h2osno2d=grid%h2osno2d              & !lake
      &        ,snl2d=grid%snl2d,                t_grnd2d=grid%t_grnd2d              &   

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -225,12 +225,12 @@ integer::oops1,oops2
             geogrid_flag_error = geogrid_flag_error + 1
          END IF
 
-         ! PSH
-         IF ( ( config_flags%shalwater_rough      .EQ. 1           ) .AND. ( flag_bathymetry .EQ. 0 ) ) THEN
-            CALL wrf_message ( '----- ERROR: shalwater_rough = 1 but no bathymetry data found. Need to download geog data.' )
-            geogrid_flag_error = geogrid_flag_error + 1
-         END IF
-         ! END PSH
+         !! PSH
+         !IF ( ( config_flags%shalwater_rough      .EQ. 1           ) .AND. ( flag_bathymetry .EQ. 0 ) .AND. (config_flags%shalwater_depth .EQ. 0.0) ) THEN
+         !   CALL wrf_message ( '----- ERROR: shalwater_rough = 1 but no bathymetry data found. Need to download geog data or set shalwater_depth.' )
+         !   geogrid_flag_error = geogrid_flag_error + 1
+         !END IF
+         !! END PSH
 
          IF ( ( config_flags%sf_surface_physics .EQ. pxlsmscheme  ) .AND. ( flag_imperv    .EQ. 0 ) ) THEN
             CALL wrf_message ( '----- ERROR: sf_surface_physics = 7 AND flag_imperv     = 0 ' )
@@ -336,26 +336,50 @@ integer::oops1,oops2
       IF ( grid%shalwater_rough   .EQ. 1 ) THEN
          grid%bathymetry_flag = flag_bathymetry
          IF ( flag_bathymetry .EQ. 0 ) THEN
-            CALL wrf_message ( " Warning: Please rerun WPS to get bathymetry information for shallow water roughness model" )
+            !IF ( grid%shalwater_depth .EQ. 0.0 ) THEN
+                CALL wrf_message ( " Warning: No bathymetry data found for shallow water roughness model. Filling." )
+                IF ( grid%shalwater_depth .LE. 0.0 ) THEN
+                   CALL wrf_message ( " Warning: shalwater_depth must be greater than 0.0 for WRF to run." )
+                END IF
+                DO j = jts, MIN(jde-1,jte)
+                   DO i = its, MIN(ide-1,ite)
+                      grid%water_depth(i,j) = 0.0 
+                   END DO
+                END DO
+            !ELSE
+            !    DO j = jts, MIN(jde-1,jte)
+            !       DO i = its, MIN(ide-1,ite)
+            !          grid%water_depth(i,j) = grid%shalwater_depth
+            !       END DO
+            !    END DO
+            !END IF
 
          ELSE
-            !  Set water_depth over land to be 2 m. Set water_depth over lakes to be lake depth..
-            !  This was done to re-create the LAKE_DEPTH field, but with ocean depth.
+            !IF ( grid%shalwater_depth .NE. 0.0 ) THEN
+            !    DO j = jts, MIN(jde-1,jte)
+            !       DO i = its, MIN(ide-1,ite)
+            !          grid%water_depth(i,j) = grid%shalwater_depth
+            !       END DO
+            !    END DO
+            !ELSE
+                !  Set water_depth over land to be 2 m. Set water_depth over lakes to be lake depth..
+                !  This was done to re-create the LAKE_DEPTH field, but with ocean depth.
 
-            DO j = jts, MIN(jde-1,jte)
-               DO i = its, MIN(ide-1,ite)
-                  grid%water_depth(i,j) = grid%bathymetry(i,j)
-                  IF      ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
-                     grid%water_depth(i,j) = -10
-                  ELSE IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
-                     grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
-                  END IF
-                  grid%water_depth(i,j) = grid%water_depth(i,j)*-1.0
-                  IF (grid%water_depth(i,j) .LT. 0.1) THEN
-                     grid%water_depth(i,j) = 0.1
-                  END IF
-               END DO
-            END DO
+                DO j = jts, MIN(jde-1,jte)
+                   DO i = its, MIN(ide-1,ite)
+                      grid%water_depth(i,j) = grid%bathymetry(i,j)
+                      IF      ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
+                         grid%water_depth(i,j) = -10
+                      ELSE IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
+                         grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
+                      END IF
+                      grid%water_depth(i,j) = grid%water_depth(i,j)*-1.0
+                      IF (grid%water_depth(i,j) .LT. 0.1) THEN
+                         grid%water_depth(i,j) = 0.1
+                      END IF
+                   END DO
+                END DO
+             !END IF
          END IF
       END IF
       ! END PSH

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -225,13 +225,6 @@ integer::oops1,oops2
             geogrid_flag_error = geogrid_flag_error + 1
          END IF
 
-         !! PSH
-         !IF ( ( config_flags%shalwater_rough      .EQ. 1           ) .AND. ( flag_bathymetry .EQ. 0 ) .AND. (config_flags%shalwater_depth .EQ. 0.0) ) THEN
-         !   CALL wrf_message ( '----- ERROR: shalwater_rough = 1 but no bathymetry data found. Need to download geog data or set shalwater_depth.' )
-         !   geogrid_flag_error = geogrid_flag_error + 1
-         !END IF
-         !! END PSH
-
          IF ( ( config_flags%sf_surface_physics .EQ. pxlsmscheme  ) .AND. ( flag_imperv    .EQ. 0 ) ) THEN
             CALL wrf_message ( '----- ERROR: sf_surface_physics = 7 AND flag_imperv     = 0 ' )
             geogrid_flag_error = geogrid_flag_error + 1

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -325,37 +325,43 @@ integer::oops1,oops2
          END IF
       END IF
 
-      ! PSH
-      IF ( grid%shalwater_rough   .EQ. 1 ) THEN
-         grid%bathymetry_flag = flag_bathymetry
-         IF ( flag_bathymetry .EQ. 0 ) THEN
-            CALL wrf_message ( " Warning: No bathymetry data found for shallow water roughness model. Filling." )
-            IF ( grid%shalwater_depth .LE. 0.0 ) THEN
-               CALL wrf_message ( " Warning: shalwater_depth must be greater than 0.0 for WRF to run." )
-            END IF
-            DO j = jts, MIN(jde-1,jte)
-               DO i = its, MIN(ide-1,ite)
-                  grid%water_depth(i,j) = 0.0 
-               END DO
+      grid%bathymetry_flag = flag_bathymetry
+      IF ( flag_bathymetry .EQ. 0 ) THEN
+         IF ( grid%shalwater_rough   .EQ. 1 ) THEN
+             CALL wrf_message ( " Warning: No bathymetry data found for shallow water roughness model." )
+             IF ( grid%shalwater_depth .LE. 0.0 ) THEN
+                CALL wrf_message ( " Warning: shalwater_depth must be greater than 0.0 for WRF to run." )
+             END IF
+         END IF
+         DO j = jts, MIN(jde-1,jte)
+            DO i = its, MIN(ide-1,ite)
+               grid%water_depth(i,j) = -4.0 
             END DO
-         ELSE
-            DO j = jts, MIN(jde-1,jte)
-               DO i = its, MIN(ide-1,ite)
-                  grid%water_depth(i,j) = grid%bathymetry(i,j)
-                  IF      ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
-                     grid%water_depth(i,j) = -10
-                  ELSE IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
-                     grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
-                  END IF
-                  grid%water_depth(i,j) = grid%water_depth(i,j)*-1.0
+         END DO
+      ELSE
+         CALL wrf_message ( " Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)." )
+         DO j = jts, MIN(jde-1,jte)
+            DO i = its, MIN(ide-1,ite)
+               grid%water_depth(i,j) = grid%bathymetry(i,j)
+               ! Get depth of lake based on height of water surface:
+               IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
+                  grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
+               END IF
+               ! Depth is positive:
+               grid%water_depth(i,j) = -grid%water_depth(i,j)
+               ! Set land cells to -10
+               IF ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
+                  grid%water_depth(i,j) = -2.0
+               ELSE ! Water cells:
+                  ! Find any water cells with negative (originally positive) values...
+                  ! ... indicative of mis-match of bathymetry and land mask.
                   IF (grid%water_depth(i,j) .LT. 0.1) THEN
                      grid%water_depth(i,j) = 0.1
                   END IF
-               END DO
+               END IF
             END DO
-         END IF
+         END DO
       END IF
-      ! END PSH
 
       !  Send out a quick message about the time steps based on the map scale factors.
 

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -225,6 +225,13 @@ integer::oops1,oops2
             geogrid_flag_error = geogrid_flag_error + 1
          END IF
 
+         ! PSH
+         IF ( ( config_flags%shalwater_rough      .EQ. 1           ) .AND. ( flag_bathymetry .EQ. 0 ) ) THEN
+            CALL wrf_message ( '----- ERROR: shalwater_rough = 1 but no bathymetry data found. Need to download geog data.' )
+            geogrid_flag_error = geogrid_flag_error + 1
+         END IF
+         ! END PSH
+
          IF ( ( config_flags%sf_surface_physics .EQ. pxlsmscheme  ) .AND. ( flag_imperv    .EQ. 0 ) ) THEN
             CALL wrf_message ( '----- ERROR: sf_surface_physics = 7 AND flag_imperv     = 0 ' )
             geogrid_flag_error = geogrid_flag_error + 1
@@ -325,6 +332,33 @@ integer::oops1,oops2
          END IF
       END IF
 
+      ! PSH
+      IF ( grid%shalwater_rough   .EQ. 1 ) THEN
+         grid%bathymetry_flag = flag_bathymetry
+         IF ( flag_bathymetry .EQ. 0 ) THEN
+            CALL wrf_message ( " Warning: Please rerun WPS to get bathymetry information for shallow water roughness model" )
+
+         ELSE
+            !  Set water_depth over land to be 2 m. Set water_depth over lakes to be lake depth..
+            !  This was done to re-create the LAKE_DEPTH field, but with ocean depth.
+
+            DO j = jts, MIN(jde-1,jte)
+               DO i = its, MIN(ide-1,ite)
+                  grid%water_depth(i,j) = grid%bathymetry(i,j)
+                  IF      ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
+                     grid%water_depth(i,j) = -10
+                  ELSE IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
+                     grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
+                  END IF
+                  grid%water_depth(i,j) = grid%water_depth(i,j)*-1.0
+                  IF (grid%water_depth(i,j) .LT. 0.1) THEN
+                     grid%water_depth(i,j) = 0.1
+                  END IF
+               END DO
+            END DO
+         END IF
+      END IF
+      ! END PSH
       !  Send out a quick message about the time steps based on the map scale factors.
 
       IF ( ( internal_time_loop .EQ. 1 ) .AND. ( grid%id .EQ. 1 ) .AND. &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -336,53 +336,34 @@ integer::oops1,oops2
       IF ( grid%shalwater_rough   .EQ. 1 ) THEN
          grid%bathymetry_flag = flag_bathymetry
          IF ( flag_bathymetry .EQ. 0 ) THEN
-            !IF ( grid%shalwater_depth .EQ. 0.0 ) THEN
-                CALL wrf_message ( " Warning: No bathymetry data found for shallow water roughness model. Filling." )
-                IF ( grid%shalwater_depth .LE. 0.0 ) THEN
-                   CALL wrf_message ( " Warning: shalwater_depth must be greater than 0.0 for WRF to run." )
-                END IF
-                DO j = jts, MIN(jde-1,jte)
-                   DO i = its, MIN(ide-1,ite)
-                      grid%water_depth(i,j) = 0.0 
-                   END DO
-                END DO
-            !ELSE
-            !    DO j = jts, MIN(jde-1,jte)
-            !       DO i = its, MIN(ide-1,ite)
-            !          grid%water_depth(i,j) = grid%shalwater_depth
-            !       END DO
-            !    END DO
-            !END IF
-
+            CALL wrf_message ( " Warning: No bathymetry data found for shallow water roughness model. Filling." )
+            IF ( grid%shalwater_depth .LE. 0.0 ) THEN
+               CALL wrf_message ( " Warning: shalwater_depth must be greater than 0.0 for WRF to run." )
+            END IF
+            DO j = jts, MIN(jde-1,jte)
+               DO i = its, MIN(ide-1,ite)
+                  grid%water_depth(i,j) = 0.0 
+               END DO
+            END DO
          ELSE
-            !IF ( grid%shalwater_depth .NE. 0.0 ) THEN
-            !    DO j = jts, MIN(jde-1,jte)
-            !       DO i = its, MIN(ide-1,ite)
-            !          grid%water_depth(i,j) = grid%shalwater_depth
-            !       END DO
-            !    END DO
-            !ELSE
-                !  Set water_depth over land to be 2 m. Set water_depth over lakes to be lake depth..
-                !  This was done to re-create the LAKE_DEPTH field, but with ocean depth.
-
-                DO j = jts, MIN(jde-1,jte)
-                   DO i = its, MIN(ide-1,ite)
-                      grid%water_depth(i,j) = grid%bathymetry(i,j)
-                      IF      ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
-                         grid%water_depth(i,j) = -10
-                      ELSE IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
-                         grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
-                      END IF
-                      grid%water_depth(i,j) = grid%water_depth(i,j)*-1.0
-                      IF (grid%water_depth(i,j) .LT. 0.1) THEN
-                         grid%water_depth(i,j) = 0.1
-                      END IF
-                   END DO
-                END DO
-             !END IF
+            DO j = jts, MIN(jde-1,jte)
+               DO i = its, MIN(ide-1,ite)
+                  grid%water_depth(i,j) = grid%bathymetry(i,j)
+                  IF      ( ( grid%lu_index(i,j) .NE. grid%islake ) .AND. ( grid%lu_index(i,j) .NE. grid%iswater ) ) THEN
+                     grid%water_depth(i,j) = -10
+                  ELSE IF   ( grid%lu_index(i,j) .EQ. grid%islake ) THEN
+                     grid%water_depth(i,j) = grid%bathymetry(i,j) - grid%ht_gc(i,j)
+                  END IF
+                  grid%water_depth(i,j) = grid%water_depth(i,j)*-1.0
+                  IF (grid%water_depth(i,j) .LT. 0.1) THEN
+                     grid%water_depth(i,j) = 0.1
+                  END IF
+               END DO
+            END DO
          END IF
       END IF
       ! END PSH
+
       !  Send out a quick message about the time steps based on the map scale factors.
 
       IF ( ( internal_time_loop .EQ. 1 ) .AND. ( grid%id .EQ. 1 ) .AND. &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -327,7 +327,7 @@ integer::oops1,oops2
 
       grid%bathymetry_flag = flag_bathymetry
       IF ( flag_bathymetry .EQ. 0 ) THEN
-         IF ( grid%shalwater_rough .EQ. 1 ) THEN
+         IF ( grid%shalwater_z0 .EQ. 1 ) THEN
              CALL wrf_message ( " Warning: No bathymetry data found for shallow water roughness model." )
              IF ( grid%shalwater_depth .LE. 0.0 ) THEN
                 CALL wrf_message ( " Warning: shalwater_depth must be greater than 0.0 for WRF to run." )

--- a/dyn_em/nest_init_utils.F
+++ b/dyn_em/nest_init_utils.F
@@ -46,6 +46,7 @@ SUBROUTINE init_domain_constants_em ( parent , nest )
    nest%traj_lat = parent%traj_lat
    nest%this_is_an_ideal_run = parent%this_is_an_ideal_run
    nest%lake_depth_flag = parent%lake_depth_flag
+   nest%bathymetry_flag = parent%bathymetry_flag
 
    CALL nl_get_mminlu ( 1, char_junk )
    CALL nl_get_iswater( 1, iswater )

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1171,7 +1171,7 @@ endif
                       grid%tkdry3d,      grid%tksatu3d,     grid%lake2d,                            & !lake
                       config_flags%lakedepth_default,        config_flags%lake_min_elev, grid%lake_depth,     & !lake
                       grid%lakemask,        grid%lakeflag,  grid%LAKE_DEPTH_FLAG, grid%use_lakedepth,     & !lake
-                      grid%water_depth,  grid%BATHYMETRY_FLAG, grid%shalwater_rough,grid%shalwater_depth, & !PSH bath 
+                      grid%water_depth,  grid%BATHYMETRY_FLAG, grid%shalwater_z0,grid%shalwater_depth, & ! bathymetry 
                       config_flags%sf_surface_mosaic, config_flags%mosaic_cat, config_flags%num_land_cat, & ! Noah tiling
                       config_flags%maxpatch,           &   ! start of CLM variables
               grid%numc,grid%nump,grid%snl,grid%snowdp,&   !

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1171,6 +1171,7 @@ endif
                       grid%tkdry3d,      grid%tksatu3d,     grid%lake2d,                            & !lake
                       config_flags%lakedepth_default,        config_flags%lake_min_elev, grid%lake_depth,     & !lake
                       grid%lakemask,        grid%lakeflag,  grid%LAKE_DEPTH_FLAG, grid%use_lakedepth,     & !lake
+                      grid%water_depth,  grid%BATHYMETRY_FLAG, grid%shalwater_rough,                   & !PSH bath 
                       config_flags%sf_surface_mosaic, config_flags%mosaic_cat, config_flags%num_land_cat, & ! Noah tiling
                       config_flags%maxpatch,           &   ! start of CLM variables
               grid%numc,grid%nump,grid%snl,grid%snowdp,&   !

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1171,7 +1171,7 @@ endif
                       grid%tkdry3d,      grid%tksatu3d,     grid%lake2d,                            & !lake
                       config_flags%lakedepth_default,        config_flags%lake_min_elev, grid%lake_depth,     & !lake
                       grid%lakemask,        grid%lakeflag,  grid%LAKE_DEPTH_FLAG, grid%use_lakedepth,     & !lake
-                      grid%water_depth,  grid%BATHYMETRY_FLAG, grid%shalwater_rough,                   & !PSH bath 
+                      grid%water_depth,  grid%BATHYMETRY_FLAG, grid%shalwater_rough,grid%shalwater_depth, & !PSH bath 
                       config_flags%sf_surface_mosaic, config_flags%mosaic_cat, config_flags%num_land_cat, & ! Noah tiling
                       config_flags%maxpatch,           &   ! start of CLM variables
               grid%numc,grid%nump,grid%snl,grid%snowdp,&   !

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -188,6 +188,7 @@ CONTAINS
                          lakemask,   lakeflag,                                   & !lake
 #endif
                          lake_depth_flag, use_lakedepth,                         & !lake
+                         water_depth, bathymetry_flag, shalwater_rough,       & ! PSH -bathymetry
                          sf_surface_mosaic, mosaic_cat, NLCAT,               & ! Noah tiling
 !CLM variables
                          maxpatch,                                           &
@@ -756,6 +757,7 @@ CONTAINS
   LOGICAL, DIMENSION( ims:ime, jms:jme ),intent(out)                      :: lake2d
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                      ::  HT
   REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  lake_depth
+  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  water_depth ! PSH
   real, intent(in)      ::      lakedepth_default, lake_min_elev
 #if ( EM_CORE == 1 )
   REAL,              dimension(ims:ime,jms:jme )      ::  lakemask
@@ -763,6 +765,8 @@ CONTAINS
 #endif
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
   INTEGER, INTENT(IN)      ::   use_lakedepth
+  INTEGER, INTENT(INOUT)   ::   bathymetry_flag ! PSH
+  INTEGER, INTENT(IN)      ::   shalwater_rough  ! PSH
  
 
 !CLM
@@ -1446,6 +1450,7 @@ CONTAINS
                 lakemask, lakeflag,                                    & !lake
 #endif
                 lake_depth_flag, use_lakedepth,                        & !lake
+                water_depth, bathymetry_flag, shalwater_rough,   & ! PSH
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
                 DZR, DZB, DZG,                                  & !Optional urban
                 TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D,   & !Optional urban
@@ -2470,6 +2475,7 @@ CONTAINS
                 lakemask, lakeflag,                                      & !lake
 #endif
                 lake_depth_flag, use_lakedepth,                          & !lake
+                water_depth,bathymetry_flag, shalwater_rough,    & ! PSH
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
 !                num_roof_layers,num_wall_layers,num_road_layers,& !Optional urban
                 DZR, DZB, DZG,                                  & !Optional urban
@@ -2939,12 +2945,15 @@ CONTAINS
  
   logical,    dimension(ims:ime,jms:jme ),intent(out)                        :: lake2d
   REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  lake_depth
+  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  water_depth ! PSH
 #if ( EM_CORE == 1 )
   REAL,              dimension(ims:ime,jms:jme ),intent(inout)      ::  lakemask
   INTEGER, INTENT(IN)      ::  lakeflag
 #endif
   INTEGER, INTENT(IN)      ::   use_lakedepth
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
+  INTEGER, INTENT(IN)      ::   shalwater_rough  ! PSH
+  INTEGER, INTENT(INOUT)   ::   bathymetry_flag ! PSH
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                         ::  HT
 
    REAL,  DIMENSION( ims:ime , jms:jme ) , OPTIONAL, INTENT(INOUT) ::    &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -758,7 +758,7 @@ CONTAINS
   LOGICAL, DIMENSION( ims:ime, jms:jme ),intent(out)                      :: lake2d
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                      ::  HT
   REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  lake_depth
-  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  water_depth 
+  REAL,              DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  water_depth 
   real, intent(in)      ::      lakedepth_default, lake_min_elev
 #if ( EM_CORE == 1 )
   REAL,              dimension(ims:ime,jms:jme )      ::  lakemask
@@ -2949,7 +2949,7 @@ CONTAINS
  
   logical,    dimension(ims:ime,jms:jme ),intent(out)                        :: lake2d
   REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  lake_depth
-  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  water_depth 
+  REAL,              DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  water_depth 
 #if ( EM_CORE == 1 )
   REAL,              dimension(ims:ime,jms:jme ),intent(inout)      ::  lakemask
   INTEGER, INTENT(IN)      ::  lakeflag

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -188,8 +188,8 @@ CONTAINS
                          lakemask,   lakeflag,                                   & !lake
 #endif
                          lake_depth_flag, use_lakedepth,                         & !lake
-                         water_depth, bathymetry_flag, shalwater_rough,       & ! PSH -bathymetry
-                         shalwater_depth,                                    & ! PSH - bathymetry
+                         water_depth, bathymetry_flag, shalwater_rough,       & !bathymetry
+                         shalwater_depth,                                    & ! bathymetry
                          sf_surface_mosaic, mosaic_cat, NLCAT,               & ! Noah tiling
 !CLM variables
                          maxpatch,                                           &
@@ -757,8 +757,8 @@ CONTAINS
   real,    dimension( ims:ime,-nlevsnow+0:nlevsoil, jms:jme ),INTENT(inout) :: zi3d
   LOGICAL, DIMENSION( ims:ime, jms:jme ),intent(out)                      :: lake2d
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                      ::  HT
-  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  lake_depth
-  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  water_depth ! PSH
+  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  lake_depth
+  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  water_depth 
   real, intent(in)      ::      lakedepth_default, lake_min_elev
 #if ( EM_CORE == 1 )
   REAL,              dimension(ims:ime,jms:jme )      ::  lakemask
@@ -766,9 +766,9 @@ CONTAINS
 #endif
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
   INTEGER, INTENT(IN)      ::   use_lakedepth
-  INTEGER, INTENT(INOUT)   ::   bathymetry_flag ! PSH
-  INTEGER, INTENT(IN)      ::   shalwater_rough  ! PSH
-  REAL,    INTENT(IN)      ::   shalwater_depth  ! PSH
+  INTEGER, INTENT(INOUT)   ::   bathymetry_flag 
+  INTEGER, INTENT(IN)      ::   shalwater_rough  
+  REAL,    INTENT(IN)      ::   shalwater_depth  
  
 
 !CLM
@@ -1452,8 +1452,8 @@ CONTAINS
                 lakemask, lakeflag,                                    & !lake
 #endif
                 lake_depth_flag, use_lakedepth,                        & !lake
-                water_depth, bathymetry_flag, shalwater_rough,   & ! PSH
-                shalwater_depth,                                 & ! PSH
+                water_depth, bathymetry_flag, shalwater_rough,   & 
+                shalwater_depth,                                 & 
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
                 DZR, DZB, DZG,                                  & !Optional urban
                 TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D,   & !Optional urban
@@ -2478,8 +2478,8 @@ CONTAINS
                 lakemask, lakeflag,                                      & !lake
 #endif
                 lake_depth_flag, use_lakedepth,                          & !lake
-                water_depth,bathymetry_flag, shalwater_rough,    & ! PSH
-                shalwater_depth,                                 & ! PSH
+                water_depth,bathymetry_flag, shalwater_rough,    & 
+                shalwater_depth,                                 & 
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
 !                num_roof_layers,num_wall_layers,num_road_layers,& !Optional urban
                 DZR, DZB, DZG,                                  & !Optional urban
@@ -2948,17 +2948,17 @@ CONTAINS
   real,    dimension( ims:ime,-nlevsnow+0:nlevsoil, jms:jme ),INTENT(inout) :: zi3d
  
   logical,    dimension(ims:ime,jms:jme ),intent(out)                        :: lake2d
-  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  lake_depth
-  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)    ::  water_depth ! PSH
+  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  lake_depth
+  REAL, OPTIONAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::  water_depth 
 #if ( EM_CORE == 1 )
   REAL,              dimension(ims:ime,jms:jme ),intent(inout)      ::  lakemask
   INTEGER, INTENT(IN)      ::  lakeflag
 #endif
   INTEGER, INTENT(IN)      ::   use_lakedepth
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
-  INTEGER, INTENT(IN)      ::   shalwater_rough  ! PSH
-  REAL,    INTENT(IN)      ::   shalwater_depth  ! PSH
-  INTEGER, INTENT(INOUT)   ::   bathymetry_flag ! PSH
+  INTEGER, INTENT(IN)      ::   shalwater_rough  
+  REAL,    INTENT(IN)      ::   shalwater_depth  
+  INTEGER, INTENT(INOUT)   ::   bathymetry_flag 
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                         ::  HT
 
    REAL,  DIMENSION( ims:ime , jms:jme ) , OPTIONAL, INTENT(INOUT) ::    &
@@ -3102,7 +3102,11 @@ CONTAINS
            CALL sfclayinit( allowed_to_read )
            isfc = 1
       CASE (SFCLAYREVSCHEME)
-            CALL sfclayrevinit
+            CALL sfclayrevinit(ims,ime,jms,jme,            &
+                         its,ite,jts,jte,                      &
+                         bathymetry_flag, shalwater_rough,     &
+                         shalwater_depth, water_depth,         &
+                         xland,LakeModel,lake_depth,lakemask   )
            isfc = 1
       CASE (PXSFCSCHEME)
            CALL pxsfclayinit( allowed_to_read )

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -189,6 +189,7 @@ CONTAINS
 #endif
                          lake_depth_flag, use_lakedepth,                         & !lake
                          water_depth, bathymetry_flag, shalwater_rough,       & ! PSH -bathymetry
+                         shalwater_depth,                                    & ! PSH - bathymetry
                          sf_surface_mosaic, mosaic_cat, NLCAT,               & ! Noah tiling
 !CLM variables
                          maxpatch,                                           &
@@ -767,6 +768,7 @@ CONTAINS
   INTEGER, INTENT(IN)      ::   use_lakedepth
   INTEGER, INTENT(INOUT)   ::   bathymetry_flag ! PSH
   INTEGER, INTENT(IN)      ::   shalwater_rough  ! PSH
+  REAL,    INTENT(IN)      ::   shalwater_depth  ! PSH
  
 
 !CLM
@@ -1451,6 +1453,7 @@ CONTAINS
 #endif
                 lake_depth_flag, use_lakedepth,                        & !lake
                 water_depth, bathymetry_flag, shalwater_rough,   & ! PSH
+                shalwater_depth,                                 & ! PSH
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
                 DZR, DZB, DZG,                                  & !Optional urban
                 TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D,   & !Optional urban
@@ -2476,6 +2479,7 @@ CONTAINS
 #endif
                 lake_depth_flag, use_lakedepth,                          & !lake
                 water_depth,bathymetry_flag, shalwater_rough,    & ! PSH
+                shalwater_depth,                                 & ! PSH
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
 !                num_roof_layers,num_wall_layers,num_road_layers,& !Optional urban
                 DZR, DZB, DZG,                                  & !Optional urban
@@ -2953,6 +2957,7 @@ CONTAINS
   INTEGER, INTENT(IN)      ::   use_lakedepth
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
   INTEGER, INTENT(IN)      ::   shalwater_rough  ! PSH
+  REAL,    INTENT(IN)      ::   shalwater_depth  ! PSH
   INTEGER, INTENT(INOUT)   ::   bathymetry_flag ! PSH
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                         ::  HT
 

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -188,7 +188,7 @@ CONTAINS
                          lakemask,   lakeflag,                                   & !lake
 #endif
                          lake_depth_flag, use_lakedepth,                         & !lake
-                         water_depth, bathymetry_flag, shalwater_rough,       & !bathymetry
+                         water_depth, bathymetry_flag, shalwater_z0,         & ! bathymetry
                          shalwater_depth,                                    & ! bathymetry
                          sf_surface_mosaic, mosaic_cat, NLCAT,               & ! Noah tiling
 !CLM variables
@@ -767,7 +767,7 @@ CONTAINS
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
   INTEGER, INTENT(IN)      ::   use_lakedepth
   INTEGER, INTENT(INOUT)   ::   bathymetry_flag 
-  INTEGER, INTENT(IN)      ::   shalwater_rough  
+  INTEGER, INTENT(IN)      ::   shalwater_z0  
   REAL,    INTENT(IN)      ::   shalwater_depth  
  
 
@@ -1452,8 +1452,8 @@ CONTAINS
                 lakemask, lakeflag,                                    & !lake
 #endif
                 lake_depth_flag, use_lakedepth,                        & !lake
-                water_depth, bathymetry_flag, shalwater_rough,   & 
-                shalwater_depth,                                 & 
+                water_depth, bathymetry_flag, shalwater_z0,     & 
+                shalwater_depth,                                & 
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
                 DZR, DZB, DZG,                                  & !Optional urban
                 TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D,   & !Optional urban
@@ -2478,8 +2478,8 @@ CONTAINS
                 lakemask, lakeflag,                                      & !lake
 #endif
                 lake_depth_flag, use_lakedepth,                          & !lake
-                water_depth,bathymetry_flag, shalwater_rough,    & 
-                shalwater_depth,                                 & 
+                water_depth,bathymetry_flag, shalwater_z0,      & 
+                shalwater_depth,                                & 
                 te_temf,cf3d_temf,wm_temf,                      & ! WA
 !                num_roof_layers,num_wall_layers,num_road_layers,& !Optional urban
                 DZR, DZB, DZG,                                  & !Optional urban
@@ -2956,7 +2956,7 @@ CONTAINS
 #endif
   INTEGER, INTENT(IN)      ::   use_lakedepth
   INTEGER, INTENT(INOUT)      ::   lake_depth_flag
-  INTEGER, INTENT(IN)      ::   shalwater_rough  
+  INTEGER, INTENT(IN)      ::   shalwater_z0  
   REAL,    INTENT(IN)      ::   shalwater_depth  
   INTEGER, INTENT(INOUT)   ::   bathymetry_flag 
 !  REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)                         ::  HT
@@ -3102,9 +3102,9 @@ CONTAINS
            CALL sfclayinit( allowed_to_read )
            isfc = 1
       CASE (SFCLAYREVSCHEME)
-            CALL sfclayrevinit(ims,ime,jms,jme,            &
+            CALL sfclayrevinit(ims,ime,jms,jme,                &
                          its,ite,jts,jte,                      &
-                         bathymetry_flag, shalwater_rough,     &
+                         bathymetry_flag, shalwater_z0,        &
                          shalwater_depth, water_depth,         &
                          xland,LakeModel,lake_depth,lakemask   )
            isfc = 1

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -25,7 +25,7 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     shalwater_rough,water_depth,shalwater_depth,  & 
+                     shalwater_z0,water_depth,shalwater_depth,     & 
                      scm_force_flux                                )
 !-------------------------------------------------------------------
       IMPLICIT NONE
@@ -193,7 +193,7 @@ CONTAINS
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
-      INTEGER,  INTENT(IN )   ::     shalwater_rough 
+      INTEGER,  INTENT(IN )   ::     shalwater_z0 
       REAL,     INTENT(IN )   ::     shalwater_depth 
       REAL,     DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth 
 ! LOCAL VARS
@@ -237,7 +237,7 @@ CONTAINS
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
                 P1000mb,                                           &
-                shalwater_rough,water_depth(ims,j),shalwater_depth,& 
+                shalwater_z0,water_depth(ims,j),shalwater_depth,   & 
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
@@ -263,7 +263,7 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
                      P1000mb,                                      &
-                     shalwater_rough,water_depth,shalwater_depth,  & 
+                     shalwater_z0,water_depth,shalwater_depth,     & 
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
@@ -329,7 +329,7 @@ CONTAINS
                                     
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
-      INTEGER,  INTENT(IN )   ::     shalwater_rough 
+      INTEGER,  INTENT(IN )   ::     shalwater_z0 
       REAL,     INTENT(IN )   ::     shalwater_depth 
       REAL,     DIMENSION( ims:ime ), INTENT(IN)  :: water_depth 
 ! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
@@ -984,7 +984,7 @@ CONTAINS
 !         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
           ! PSH - formulation for depth-dependent roughness from
           ! ... Jimenez and Dudhia, 2018
-          IF ( shalwater_rough .eq. 1 ) THEN
+          IF ( shalwater_z0 .eq. 1 ) THEN
              ZNT(I) = depth_dependent_z0(water_depth(I),ZNT(I),UST(I))
           ELSE
              ! Since V3.7 (ref: EC Physics document for Cy36r1)
@@ -1105,7 +1105,7 @@ CONTAINS
 !====================================================================
    SUBROUTINE sfclayrevinit(ims,ime,jms,jme,                    &
                             its,ite,jts,jte,                    &
-                            bathymetry_flag, shalwater_rough,   &
+                            bathymetry_flag, shalwater_z0,      &
                             shalwater_depth, water_depth,       &
                             xland,LakeModel,lake_depth,lakemask )
 
@@ -1113,7 +1113,7 @@ CONTAINS
     REAL                      ::      zolf
 
    INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
-   INTEGER, INTENT(IN)      ::   shalwater_rough 
+   INTEGER, INTENT(IN)      ::   shalwater_z0 
    REAL,    INTENT(IN)      ::   shalwater_depth 
    INTEGER, INTENT(IN)      ::   bathymetry_flag 
    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth
@@ -1134,10 +1134,10 @@ CONTAINS
        psih_unstab(n)=psih_unstable_full(zolf)
 
     ENDDO
-    IF ( shalwater_rough .EQ. 1 ) THEN
+    IF ( shalwater_z0 .EQ. 1 ) THEN
        CALL shalwater_init(ims,ime,jms,jme,            &
                  its,ite,jts,jte,                      &
-                 bathymetry_flag, shalwater_rough,     &
+                 bathymetry_flag, shalwater_z0,        &
                  shalwater_depth, water_depth,         &
                  xland,LakeModel,lake_depth,lakemask   )
     END IF
@@ -1146,12 +1146,12 @@ CONTAINS
 
    SUBROUTINE shalwater_init(ims,ime,jms,jme,                    &
                              its,ite,jts,jte,                    &
-                             bathymetry_flag, shalwater_rough,   &
+                             bathymetry_flag, shalwater_z0,      &
                              shalwater_depth, water_depth,       &
                              xland,LakeModel,lake_depth,lakemask )
 
    INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
-   INTEGER, INTENT(IN)      ::   shalwater_rough 
+   INTEGER, INTENT(IN)      ::   shalwater_z0 
    REAL,    INTENT(IN)      ::   shalwater_depth 
    INTEGER, INTENT(IN)      ::   bathymetry_flag 
    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1167,7 +1167,6 @@ CONTAINS
 
    IF ( bathymetry_flag .eq. 1 ) THEN
       IF ( shalwater_depth .LE. 0.0 ) THEN
-         CALL wrf_message ( " Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10     .5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)." )
          IF ( LakeModel .ge. 1 ) THEN
             DO j = jts,jte
                DO i = its,ite

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -984,11 +984,13 @@ CONTAINS
           ! ... Jimenez and Dudhia, 2018
           IF ( shalwater_rough .eq. 1 ) THEN
              ZNT(I) = depth_dependent_z0(water_depth(I),ZNT(I),UST(I))
+             print*,'PSH - shallow_water ',water_depth(I),ZNT(I)
           ELSE
-              ! Since V3.7 (ref: EC Physics document for Cy36r1)
-              ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
-              ! V3.9: Add limit as in isftcflx = 1,2
-              ZNT(I)=MIN(ZNT(I),2.85e-3)
+             ! Since V3.7 (ref: EC Physics document for Cy36r1)
+             print*,'PSH - Charnock'
+             ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+             ! V3.9: Add limit as in isftcflx = 1,2
+             ZNT(I)=MIN(ZNT(I),2.85e-3)
           ENDIF
 ! COARE 3.5 (Edson et al. 2013)
 !         CZC = 0.0017*WSPD(I)-0.005
@@ -1271,11 +1273,14 @@ CONTAINS
            effective_depth = 10.0
          ELSEIF ( water_depth .gt. 100.0 ) THEN
            effective_depth = 100.0
+         ELSE
+           effective_depth = water_depth
          ENDIF
  
          depth_b = 1 / 30.0 * log (1260.0 / effective_depth)
          depth_dependent_z0 = exp((2.7 * ust - 1.8 / depth_b) / (ust + 0.17 / depth_b) )
-         depth_dependent_z0 = MIN(z0,0.1)
+         depth_dependent_z0 = MIN(depth_dependent_z0,0.1)
+         print*,'PSH ',effective_depth,depth_dependent_z0
      return
      end function
 !-------------------------------------------------------------------          

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -980,10 +980,16 @@ CONTAINS
       DO 360 I=its,ite
         IF((XLAND(I)-1.5).GE.0)THEN                                            
 !         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
-! Since V3.7 (ref: EC Physics document for Cy36r1)
-          ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
-! V3.9: Add limit as in isftcflx = 1,2
-          ZNT(I)=MIN(ZNT(I),2.85e-3)
+          ! PSH - formulation for depth-dependent roughness from
+          ! ... Jimenez and Dudhia, 2018
+          IF ( shalwater_rough .eq. 1 ) THEN
+             ZNT(I) = depth_dependent_z0(water_depth(I),ZNT(I),UST(I))
+          ELSE
+              ! Since V3.7 (ref: EC Physics document for Cy36r1)
+              ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+              ! V3.9: Add limit as in isftcflx = 1,2
+              ZNT(I)=MIN(ZNT(I),2.85e-3)
+          ENDIF
 ! COARE 3.5 (Edson et al. 2013)
 !         CZC = 0.0017*WSPD(I)-0.005
 !         CZC = min(CZC,0.028)
@@ -1258,6 +1264,20 @@ CONTAINS
       return
       end function
 
+      function depth_dependent_z0(water_depth,z0,UST)
+      real :: depth_b
+      real :: effective_depth
+         IF ( water_depth .lt. 10.0 ) THEN
+           effective_depth = 10.0
+         ELSEIF ( water_depth .gt. 100.0 ) THEN
+           effective_depth = 100.0
+         ENDIF
+ 
+         depth_b = 1 / 30.0 * log (1260.0 / effective_depth)
+         depth_dependent_z0 = exp((2.7 * ust - 1.8 / depth_b) / (ust + 0.17 / depth_b) )
+         depth_dependent_z0 = MIN(z0,0.1)
+     return
+     end function
 !-------------------------------------------------------------------          
 
 END MODULE module_sf_sfclayrev

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -24,7 +24,9 @@ CONTAINS
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
-                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux           )
+                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
+                     shalwater_rough,water_depth,                   & ! PSH
+                     scm_force_flux           )
 !-------------------------------------------------------------------
       IMPLICIT NONE
 !-------------------------------------------------------------------
@@ -190,6 +192,9 @@ CONTAINS
 
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
+
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
+      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth ! PSH
 ! LOCAL VARS
 
       REAL,     DIMENSION( its:ite ) ::                       U1D, &
@@ -231,6 +236,7 @@ CONTAINS
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
                 P1000mb,                                           &
+                shalwater_rough,water_depth(ims,j),                 & ! PSH
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
@@ -256,6 +262,7 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
                      P1000mb,                                      &
+                     shalwater_rough,water_depth,                   & ! PSH
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
@@ -321,6 +328,8 @@ CONTAINS
                                     
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
+      REAL, OPTIONAL, DIMENSION( ims:ime ), INTENT(IN)  :: water_depth ! PSH
 ! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::  dz8w1d
 

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1184,7 +1184,7 @@ CONTAINS
       IF ( shalwater_depth .GT. 0.0 ) THEN
          overwrite_water_depth = .True.
       ELSE
-         CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not greater than 0.0.')
+         CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not greater than 0.0. Re-run WPS to get bathymetry data or set shalwater_depth > 0.0')
       END IF
    END IF
 

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -986,10 +986,8 @@ CONTAINS
           ! ... Jimenez and Dudhia, 2018
           IF ( shalwater_rough .eq. 1 ) THEN
              ZNT(I) = depth_dependent_z0(water_depth(I),ZNT(I),UST(I))
-             print*,'PSH - shallow_water ',water_depth(I),ZNT(I)
           ELSE
              ! Since V3.7 (ref: EC Physics document for Cy36r1)
-             print*,'PSH - Charnock'
              ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
              ! V3.9: Add limit as in isftcflx = 1,2
              ZNT(I)=MIN(ZNT(I),2.85e-3)

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -25,8 +25,8 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     shalwater_rough,water_depth,shalwater_depth,   & ! PSH
-                     scm_force_flux           )
+                     shalwater_rough,water_depth,shalwater_depth,  & 
+                     scm_force_flux                                )
 !-------------------------------------------------------------------
       IMPLICIT NONE
 !-------------------------------------------------------------------
@@ -193,9 +193,9 @@ CONTAINS
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
-      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
-      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth ! PSH
-      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth ! PSH
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough 
+      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth 
+      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth 
 ! LOCAL VARS
 
       REAL,     DIMENSION( its:ite ) ::                       U1D, &
@@ -237,7 +237,7 @@ CONTAINS
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
                 P1000mb,                                           &
-                shalwater_rough,water_depth(ims,j),shalwater_depth,& ! PSH
+                shalwater_rough,water_depth(ims,j),shalwater_depth,& 
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
@@ -263,7 +263,7 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
                      P1000mb,                                      &
-                     shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                     shalwater_rough,water_depth,shalwater_depth,  & 
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
@@ -329,9 +329,9 @@ CONTAINS
                                     
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
-      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
-      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth ! PSH
-      REAL, OPTIONAL, DIMENSION( ims:ime ), INTENT(IN)  :: water_depth ! PSH
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough 
+      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth 
+      REAL, OPTIONAL, DIMENSION( ims:ime ), INTENT(IN)  :: water_depth 
 ! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::  dz8w1d
 
@@ -1103,10 +1103,24 @@ CONTAINS
    END SUBROUTINE SFCLAYREV1D
 
 !====================================================================
-   SUBROUTINE sfclayrevinit
+   SUBROUTINE sfclayrevinit(ims,ime,jms,jme,                    &
+                            its,ite,jts,jte,                    &
+                            bathymetry_flag, shalwater_rough,   &
+                            shalwater_depth, water_depth,       &
+                            xland,LakeModel,lake_depth,lakemask )
 
     INTEGER                   ::      N
     REAL                      ::      zolf
+
+   INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
+   INTEGER, INTENT(IN)      ::   shalwater_rough 
+   REAL,    INTENT(IN)      ::   shalwater_depth 
+   INTEGER, INTENT(IN)      ::   bathymetry_flag 
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  xland 
+   INTEGER         ::     LakeModel
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  lake_depth
+   REAL,    DIMENSION( ims:ime, jms:jme )                   ::  lakemask  
 
     DO N=0,1000
 ! stable function tables
@@ -1120,8 +1134,73 @@ CONTAINS
        psih_unstab(n)=psih_unstable_full(zolf)
 
     ENDDO
+    IF ( shalwater_rough .EQ. 1 ) THEN
+       CALL shalwater_init(ims,ime,jms,jme,            &
+                 its,ite,jts,jte,                      &
+                 bathymetry_flag, shalwater_rough,     &
+                 shalwater_depth, water_depth,         &
+                 xland,LakeModel,lake_depth,lakemask   )
+    END IF
 
    END SUBROUTINE sfclayrevinit
+
+   SUBROUTINE shalwater_init(ims,ime,jms,jme,                    &
+                             its,ite,jts,jte,                    &
+                             bathymetry_flag, shalwater_rough,   &
+                             shalwater_depth, water_depth,       &
+                             xland,LakeModel,lake_depth,lakemask )
+
+   INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
+   INTEGER, INTENT(IN)      ::   shalwater_rough 
+   REAL,    INTENT(IN)      ::   shalwater_depth 
+   INTEGER, INTENT(IN)      ::   bathymetry_flag 
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  xland 
+   INTEGER         ::     LakeModel
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  lake_depth
+   REAL,    DIMENSION( ims:ime, jms:jme )                   ::  lakemask  
+
+   ! Local 
+   LOGICAL :: overwrite_water_depth
+
+   overwrite_water_depth = .False.
+
+   IF ( bathymetry_flag .eq. 1 ) THEN
+      IF ( shalwater_depth .LE. 0.0 ) THEN
+         CALL wrf_message ( " Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10     .5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)." )
+         IF ( LakeModel .ge. 1 ) THEN
+            DO j = jts,jte
+               DO i = its,ite
+                  IF ( lakemask(i,j) .EQ. 1 ) THEN
+                     water_depth(i,j) = lake_depth(i,j)
+                  END IF
+               END DO
+            END DO
+         END IF
+      ELSE
+         overwrite_water_depth = .True.
+      END IF
+   ELSE
+      IF ( shalwater_depth .GT. 0.0 ) THEN
+         overwrite_water_depth = .True.
+      ELSE
+         CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not greater than 0.0.')
+      END IF
+   END IF
+
+   IF (overwrite_water_depth) THEN 
+      DO j = jts,jte
+         DO i = its,ite
+            IF((XLAND(i,j)-1.5).GE.0)THEN
+               water_depth(i,j) = shalwater_depth
+            ELSE
+               water_depth(i,j) = -2.0 
+            END IF
+         END DO
+      END DO
+   END IF
+
+   END SUBROUTINE shalwater_init
 
       function zolri(ri,z,z0)
 !

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -25,7 +25,7 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     shalwater_rough,water_depth,                   & ! PSH
+                     shalwater_rough,water_depth,shalwater_depth,   & ! PSH
                      scm_force_flux           )
 !-------------------------------------------------------------------
       IMPLICIT NONE
@@ -194,6 +194,7 @@ CONTAINS
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
+      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth ! PSH
       REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth ! PSH
 ! LOCAL VARS
 
@@ -236,7 +237,7 @@ CONTAINS
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
                 P1000mb,                                           &
-                shalwater_rough,water_depth(ims,j),                 & ! PSH
+                shalwater_rough,water_depth(ims,j),shalwater_depth,& ! PSH
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
@@ -262,7 +263,7 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
                      P1000mb,                                      &
-                     shalwater_rough,water_depth,                   & ! PSH
+                     shalwater_rough,water_depth,shalwater_depth,  & ! PSH
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
@@ -329,6 +330,7 @@ CONTAINS
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
+      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth ! PSH
       REAL, OPTIONAL, DIMENSION( ims:ime ), INTENT(IN)  :: water_depth ! PSH
 ! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::  dz8w1d
@@ -1280,7 +1282,6 @@ CONTAINS
          depth_b = 1 / 30.0 * log (1260.0 / effective_depth)
          depth_dependent_z0 = exp((2.7 * ust - 1.8 / depth_b) / (ust + 0.17 / depth_b) )
          depth_dependent_z0 = MIN(depth_dependent_z0,0.1)
-         print*,'PSH ',effective_depth,depth_dependent_z0
      return
      end function
 !-------------------------------------------------------------------          

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -193,9 +193,9 @@ CONTAINS
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
-      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough 
-      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth 
-      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth 
+      INTEGER,  INTENT(IN )   ::     shalwater_rough 
+      REAL,     INTENT(IN )   ::     shalwater_depth 
+      REAL,     DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth 
 ! LOCAL VARS
 
       REAL,     DIMENSION( its:ite ) ::                       U1D, &
@@ -329,9 +329,9 @@ CONTAINS
                                     
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
-      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough 
-      REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth 
-      REAL, OPTIONAL, DIMENSION( ims:ime ), INTENT(IN)  :: water_depth 
+      INTEGER,  INTENT(IN )   ::     shalwater_rough 
+      REAL,     INTENT(IN )   ::     shalwater_depth 
+      REAL,     DIMENSION( ims:ime ), INTENT(IN)  :: water_depth 
 ! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::  dz8w1d
 

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -90,7 +90,7 @@ CONTAINS
 #if (EM_CORE==1)
      &          ,ch,fgdp,dfgdp,vdfg,grav_settling                       & ! Katata - fog dep
 #endif
-     &          ,shalwater_rough,water_depth,shalwater_depth             & 
+     &          ,shalwater_z0,water_depth,shalwater_depth               & 
      &          ,lakedepth2d,  savedtke12d,  snowdp2d,   h2osno2d       & !lake
      &          ,snl2d,        t_grnd2d,     t_lake3d,   lake_icefrac3d & !lake
      &          ,z_lake3d,     dz_lake3d,    t_soisno3d, h2osoi_ice3d   & !lake
@@ -1413,7 +1413,7 @@ CONTAINS
                                                                                tkmg3d,         &
                                                                                tkdry3d,        &
                                                                                tksatu3d
-    INTEGER, INTENT(IN)                            :: shalwater_rough 
+    INTEGER, INTENT(IN)                            :: shalwater_z0 
     REAL,    INTENT(IN)                            :: shalwater_depth 
     real,    dimension(ims:ime,jms:jme ),intent(inout) :: water_depth 
     real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
@@ -2120,7 +2120,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                          &
                  i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
-                 shalwater_rough,water_depth,shalwater_depth,        & 
+                 shalwater_z0,water_depth,shalwater_depth,           & 
                  scm_force_flux,sf_surface_physics  )
          ELSE
          CALL SFCLAYREV(u_phytmp,v_phytmp,t_phy,qv_curr,&
@@ -2135,7 +2135,7 @@ CONTAINS
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
-               shalwater_rough,water_depth,shalwater_depth,        & 
+               shalwater_z0,water_depth,shalwater_depth,           & 
                scm_force_flux          ) 
 #if ( EM_CORE==1)
            DO j = j_start(ij),j_end(ij)
@@ -5844,7 +5844,7 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     shalwater_rough,water_depth,shalwater_depth,  & 
+                     shalwater_z0,water_depth,shalwater_depth,     & 
                      scm_force_flux,sf_surface_physics             )
 
      USE module_sf_sfclayrev
@@ -5921,7 +5921,7 @@ CONTAINS
                INTENT(INOUT)   ::                            ustm
 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX,IZ0TLND
-     INTEGER,  INTENT(IN )   ::     shalwater_rough 
+     INTEGER,  INTENT(IN )   ::     shalwater_z0 
      REAL,     INTENT(IN )   ::     shalwater_depth 
      REAL,     DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
@@ -6100,7 +6100,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                 shalwater_rough,water_depth,shalwater_depth,  & 
+                 shalwater_z0,water_depth,shalwater_depth,     & 
                  scm_force_flux    )
 !
 !Restore land-point values calculated by SSiB (fds 12/2010)
@@ -6194,7 +6194,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd,&
-                 shalwater_rough,water_depth,shalwater_depth,  & 
+                 shalwater_z0,water_depth,shalwater_depth,     & 
                  scm_force_flux    ) 
 !
      DO j = JTS , JTE

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -90,7 +90,7 @@ CONTAINS
 #if (EM_CORE==1)
      &          ,ch,fgdp,dfgdp,vdfg,grav_settling                       & ! Katata - fog dep
 #endif
-     &          ,shalwater_rough,water_depth,shalwater_depth             & ! PSH
+     &          ,shalwater_rough,water_depth,shalwater_depth             & 
      &          ,lakedepth2d,  savedtke12d,  snowdp2d,   h2osno2d       & !lake
      &          ,snl2d,        t_grnd2d,     t_lake3d,   lake_icefrac3d & !lake
      &          ,z_lake3d,     dz_lake3d,    t_soisno3d, h2osoi_ice3d   & !lake
@@ -1413,9 +1413,9 @@ CONTAINS
                                                                                tkmg3d,         &
                                                                                tkdry3d,        &
                                                                                tksatu3d
-    INTEGER , OPTIONAL , INTENT(IN)                            :: shalwater_rough ! PSH
-    REAL,     OPTIONAL , INTENT(IN)                            :: shalwater_depth ! PSH
-    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(inout) :: water_depth ! PSH
+    INTEGER , OPTIONAL , INTENT(IN)                            :: shalwater_rough 
+    REAL,     OPTIONAL , INTENT(IN)                            :: shalwater_depth 
+    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(inout) :: water_depth 
     real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
 #if (EM_CORE==1)
     real ,    dimension(ims:ime,jms:jme )  ::  lakemask
@@ -2102,33 +2102,7 @@ CONTAINS
            PRESENT(mol)        .AND.  PRESENT(regime)  .AND.    &
                                                       .TRUE. ) THEN
          CALL wrf_debug( 100, 'in SFCLAY' )
-         ! PSH
-         IF ( shalwater_rough .EQ. 1 ) THEN
-            IF ( ( MAXVAL(MAXVAL(water_depth(:,:),1),1) .EQ. 0.0 ) .AND. &
-                 ( MINVAL(MINVAL(water_depth(:,:),1),1) .EQ. 0.0 ) ) THEN
-                IF ( shalwater_depth .LE. 0.0 ) THEN
-                   CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not valid.')
-                ELSE
-                   DO j = j_start(ij),j_end(ij)
-                      DO i = i_start(ij),i_end(ij)
-                        water_depth(i,j) = shalwater_depth
-                      end do
-                   end do
-                ENDIF
-            ELSE
 
-                IF ( ( MAXVAL(MAXVAL(water_depth(i_start(ij):i_end(ij),j_start(ij):j_end(ij)),1),1) .NE. shalwater_depth ) .AND. &
-                     ( MINVAL(MINVAL(water_depth(i_start(ij):i_end(ij),j_start(ij):j_end(ij)),1),1) .NE. shalwater_depth ) .AND. &
-                     ( shalwater_depth .GT. 0.0 ) ) THEN
-                   DO j = j_start(ij),j_end(ij)
-                      DO i = i_start(ij),i_end(ij)
-                        water_depth(i,j) = shalwater_depth
-                      end do
-                   end do
-                ENDIF
-            ENDIF
-         ENDIF
-         ! PSH - END
          IF ( FRACTIONAL_SEAICE == 1 ) THEN
             CALL SFCLAYREV_SEAICE_WRAPPER(u_phytmp,v_phytmp,t_phy,qv_curr,&
                  p_phy,dz8w,cp,g,rcp,r_d,xlv,psfc,chs,chs2,cqs2,cpm, &
@@ -2146,7 +2120,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                          &
                  i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
-                 shalwater_rough,water_depth,shalwater_depth,        & ! PSH
+                 shalwater_rough,water_depth,shalwater_depth,        & 
                  scm_force_flux,sf_surface_physics  )
          ELSE
          CALL SFCLAYREV(u_phytmp,v_phytmp,t_phy,qv_curr,&
@@ -2161,7 +2135,7 @@ CONTAINS
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
-               shalwater_rough,water_depth,shalwater_depth,        & ! PSH
+               shalwater_rough,water_depth,shalwater_depth,        & 
                scm_force_flux          ) 
 #if ( EM_CORE==1)
            DO j = j_start(ij),j_end(ij)
@@ -5870,7 +5844,7 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                     shalwater_rough,water_depth,shalwater_depth,  & 
                      scm_force_flux,sf_surface_physics             )
 
      USE module_sf_sfclayrev
@@ -5947,9 +5921,9 @@ CONTAINS
                INTENT(INOUT)   ::                            ustm
 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX,IZ0TLND
-     INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
-     REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth ! PSH
-     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth ! PSH
+     INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough 
+     REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth 
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
 !--------------------------------------------------------------------
@@ -6126,7 +6100,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                 shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                 shalwater_rough,water_depth,shalwater_depth,  & 
                  scm_force_flux    )
 !
 !Restore land-point values calculated by SSiB (fds 12/2010)
@@ -6220,7 +6194,7 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd,&
-                 shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                 shalwater_rough,water_depth,shalwater_depth,  & 
                  scm_force_flux    ) 
 !
      DO j = JTS , JTE

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -90,7 +90,7 @@ CONTAINS
 #if (EM_CORE==1)
      &          ,ch,fgdp,dfgdp,vdfg,grav_settling                       & ! Katata - fog dep
 #endif
-     &          ,shalwater_rough,water_depth                             & ! PSH
+     &          ,shalwater_rough,water_depth,shalwater_depth             & ! PSH
      &          ,lakedepth2d,  savedtke12d,  snowdp2d,   h2osno2d       & !lake
      &          ,snl2d,        t_grnd2d,     t_lake3d,   lake_icefrac3d & !lake
      &          ,z_lake3d,     dz_lake3d,    t_soisno3d, h2osoi_ice3d   & !lake
@@ -1414,7 +1414,8 @@ CONTAINS
                                                                                tkdry3d,        &
                                                                                tksatu3d
     INTEGER , OPTIONAL , INTENT(IN)                            :: shalwater_rough ! PSH
-    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(in)    :: water_depth ! PSH
+    REAL,     OPTIONAL , INTENT(IN)                            :: shalwater_depth ! PSH
+    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(inout) :: water_depth ! PSH
     real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
 #if (EM_CORE==1)
     real ,    dimension(ims:ime,jms:jme )  ::  lakemask
@@ -2101,6 +2102,33 @@ CONTAINS
            PRESENT(mol)        .AND.  PRESENT(regime)  .AND.    &
                                                       .TRUE. ) THEN
          CALL wrf_debug( 100, 'in SFCLAY' )
+         ! PSH
+         IF ( shalwater_rough .EQ. 1 ) THEN
+            IF ( ( MAXVAL(MAXVAL(water_depth(:,:),1),1) .EQ. 0.0 ) .AND. &
+                 ( MINVAL(MINVAL(water_depth(:,:),1),1) .EQ. 0.0 ) ) THEN
+                IF ( shalwater_depth .LE. 0.0 ) THEN
+                   CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not valid.')
+                ELSE
+                   DO j = j_start(ij),j_end(ij)
+                      DO i = i_start(ij),i_end(ij)
+                        water_depth(i,j) = shalwater_depth
+                      end do
+                   end do
+                ENDIF
+            ELSE
+
+                IF ( ( MAXVAL(MAXVAL(water_depth(i_start(ij):i_end(ij),j_start(ij):j_end(ij)),1),1) .NE. shalwater_depth ) .AND. &
+                     ( MINVAL(MINVAL(water_depth(i_start(ij):i_end(ij),j_start(ij):j_end(ij)),1),1) .NE. shalwater_depth ) .AND. &
+                     ( shalwater_depth .GT. 0.0 ) ) THEN
+                   DO j = j_start(ij),j_end(ij)
+                      DO i = i_start(ij),i_end(ij)
+                        water_depth(i,j) = shalwater_depth
+                      end do
+                   end do
+                ENDIF
+            ENDIF
+         ENDIF
+         ! PSH - END
          IF ( FRACTIONAL_SEAICE == 1 ) THEN
             CALL SFCLAYREV_SEAICE_WRAPPER(u_phytmp,v_phytmp,t_phy,qv_curr,&
                  p_phy,dz8w,cp,g,rcp,r_d,xlv,psfc,chs,chs2,cqs2,cpm, &
@@ -2118,8 +2146,8 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                          &
                  i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
-                 shalwater_rough,water_depth,scm_force_flux,         & ! PSH
-                 sf_surface_physics  )
+                 shalwater_rough,water_depth,shalwater_depth,        & ! PSH
+                 scm_force_flux,sf_surface_physics  )
          ELSE
          CALL SFCLAYREV(u_phytmp,v_phytmp,t_phy,qv_curr,&
                p_phy,dz8w,cp,g,rcp,r_d,xlv,psfc,chs,chs2,cqs2,cpm, &
@@ -2133,7 +2161,8 @@ CONTAINS
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
-               shalwater_rough,water_depth,scm_force_flux          ) ! PSH
+               shalwater_rough,water_depth,shalwater_depth,        & ! PSH
+               scm_force_flux          ) 
 #if ( EM_CORE==1)
            DO j = j_start(ij),j_end(ij)
            DO i = i_start(ij),i_end(ij)
@@ -5841,8 +5870,8 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     shalwater_rough,water_depth,scm_force_flux,   & ! PSH
-                     sf_surface_physics                            )
+                     shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                     scm_force_flux,sf_surface_physics             )
 
      USE module_sf_sfclayrev
      implicit none
@@ -5919,6 +5948,7 @@ CONTAINS
 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX,IZ0TLND
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
+     REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth ! PSH
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth ! PSH
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
@@ -6096,7 +6126,8 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                 shalwater_rough,water_depth,scm_force_flux    ) ! PSH
+                 shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                 scm_force_flux    )
 !
 !Restore land-point values calculated by SSiB (fds 12/2010)
      IF (itimestep .gt. 1 .and. sf_surface_physics .EQ. 8) then
@@ -6189,7 +6220,8 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd,&
-                 shalwater_rough,water_depth,scm_force_flux    ) ! PSH
+                 shalwater_rough,water_depth,shalwater_depth,  & ! PSH
+                 scm_force_flux    ) 
 !
      DO j = JTS , JTE
         DO i = ITS, ITE

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -90,6 +90,7 @@ CONTAINS
 #if (EM_CORE==1)
      &          ,ch,fgdp,dfgdp,vdfg,grav_settling                       & ! Katata - fog dep
 #endif
+     &          ,shalwater_rough,water_depth                             & ! PSH
      &          ,lakedepth2d,  savedtke12d,  snowdp2d,   h2osno2d       & !lake
      &          ,snl2d,        t_grnd2d,     t_lake3d,   lake_icefrac3d & !lake
      &          ,z_lake3d,     dz_lake3d,    t_soisno3d, h2osoi_ice3d   & !lake
@@ -1412,6 +1413,8 @@ CONTAINS
                                                                                tkmg3d,         &
                                                                                tkdry3d,        &
                                                                                tksatu3d
+    INTEGER , OPTIONAL , INTENT(IN)                            :: shalwater_rough ! PSH
+    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(in)    :: water_depth ! PSH
     real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
 #if (EM_CORE==1)
     real ,    dimension(ims:ime,jms:jme )  ::  lakemask
@@ -2076,7 +2079,7 @@ CONTAINS
                ids,ide, jds,jde, kds,kde,                          &
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
-               ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux  )
+               ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux  ) 
 #if ( EM_CORE==1)
            DO j = j_start(ij),j_end(ij)
            DO i = i_start(ij),i_end(ij)
@@ -2114,7 +2117,8 @@ CONTAINS
                  ids,ide, jds,jde, kds,kde,                          &
                  ims,ime, jms,jme, kms,kme,                          &
                  i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
-                 ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux, &
+                 ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
+                 shalwater_rough,water_depth,scm_force_flux,         & ! PSH
                  sf_surface_physics  )
          ELSE
          CALL SFCLAYREV(u_phytmp,v_phytmp,t_phy,qv_curr,&
@@ -2128,7 +2132,8 @@ CONTAINS
                ids,ide, jds,jde, kds,kde,                          &
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
-               ustm,ck,cka,cd,cda,isftcflx,iz0tlnd, scm_force_flux    )
+               ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
+               shalwater_rough,water_depth,scm_force_flux          ) ! PSH
 #if ( EM_CORE==1)
            DO j = j_start(ij),j_end(ij)
            DO i = i_start(ij),i_end(ij)
@@ -5836,7 +5841,8 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     scm_force_flux,sf_surface_physics             )
+                     shalwater_rough,water_depth,scm_force_flux,   & ! PSH
+                     sf_surface_physics                            )
 
      USE module_sf_sfclayrev
      implicit none
@@ -5912,6 +5918,8 @@ CONTAINS
                INTENT(INOUT)   ::                            ustm
 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX,IZ0TLND
+     INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough ! PSH
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth ! PSH
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
 !--------------------------------------------------------------------
@@ -6087,7 +6095,8 @@ CONTAINS
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
-                 ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux)
+                 ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
+                 shalwater_rough,water_depth,scm_force_flux    ) ! PSH
 !
 !Restore land-point values calculated by SSiB (fds 12/2010)
      IF (itimestep .gt. 1 .and. sf_surface_physics .EQ. 8) then
@@ -6179,7 +6188,8 @@ CONTAINS
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
-                 ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd,scm_force_flux)
+                 ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd,&
+                 shalwater_rough,water_depth,scm_force_flux    ) ! PSH
 !
      DO j = JTS , JTE
         DO i = ITS, ITE

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1413,9 +1413,9 @@ CONTAINS
                                                                                tkmg3d,         &
                                                                                tkdry3d,        &
                                                                                tksatu3d
-    INTEGER , OPTIONAL , INTENT(IN)                            :: shalwater_rough 
-    REAL,     OPTIONAL , INTENT(IN)                            :: shalwater_depth 
-    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(inout) :: water_depth 
+    INTEGER, INTENT(IN)                            :: shalwater_rough 
+    REAL,    INTENT(IN)                            :: shalwater_depth 
+    real,    dimension(ims:ime,jms:jme ),intent(inout) :: water_depth 
     real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
 #if (EM_CORE==1)
     real ,    dimension(ims:ime,jms:jme )  ::  lakemask
@@ -5921,9 +5921,9 @@ CONTAINS
                INTENT(INOUT)   ::                            ustm
 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX,IZ0TLND
-     INTEGER,  OPTIONAL,  INTENT(IN )   ::     shalwater_rough 
-     REAL,     OPTIONAL,  INTENT(IN )   ::     shalwater_depth 
-     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth 
+     INTEGER,  INTENT(IN )   ::     shalwater_rough 
+     REAL,     INTENT(IN )   ::     shalwater_depth 
+     REAL,     DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
 !--------------------------------------------------------------------

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1068,6 +1068,12 @@ Namelist variables for lake module:
                                                   the lake depth data, but this switch is set to 1, the program will stop and tell one to go back to geogrid
                                                   program. 
                                                   = 0, do not use lake depth data.
+ shalwater_rough                     = 1,       ! Shallow water roughness scheme on/off.
+                                                  Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and 
+                                                  publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)
+ shalwater_depth                     = 0.0,     ! Set constant depth for shallow water roughness scheme if no bathymetry data availabile.
+                                                  The scheme is intended for depths between 10.0 and 100.0 m. Any depths outside of this range will be
+                                                  rounded to the nearest limit value.
  lightning_option (max_dom)                       Lightning parameterization option to allow flash rate prediction without chemistry
                                      = 0        ! off
                                      = 1        ! PR92 based on maximum w, redistributes flashes within dBZ > 20 (for convection resolved runs; must also use 

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1071,7 +1071,7 @@ Namelist variables for lake module:
  shalwater_rough                     = 1,       ! Shallow water roughness scheme on/off.
                                                   Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and 
                                                   publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)
- shalwater_depth                     = 0.0,     ! Set constant depth [m] for shallow water roughness scheme if no bathymetry data availabile.
+ shalwater_depth                     = 0.0,     ! Set constant depth [m] (must be positive) for shallow water roughness scheme if no bathymetry data availabile.
                                                   The scheme is intended for depths between 10.0 and 100.0 m. Any depths outside of this range will be
                                                   rounded to the nearest limit value.
  lightning_option (max_dom)                       Lightning parameterization option to allow flash rate prediction without chemistry

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1068,7 +1068,7 @@ Namelist variables for lake module:
                                                   the lake depth data, but this switch is set to 1, the program will stop and tell one to go back to geogrid
                                                   program. 
                                                   = 0, do not use lake depth data.
- shalwater_rough                     = 1,       ! Shallow water roughness scheme on/off.
+ shalwater_z0                        = 0,       ! Shallow water roughness scheme on (1) or off (0). Only compatible with sf_sfclay_physics = 1.
                                                   Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and 
                                                   publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)
  shalwater_depth                     = 0.0,     ! Set constant depth [m] (must be positive) for shallow water roughness scheme if no bathymetry data availabile.

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -1071,7 +1071,7 @@ Namelist variables for lake module:
  shalwater_rough                     = 1,       ! Shallow water roughness scheme on/off.
                                                   Bathymetry dataset from GEBCO Compilation Group. Please acknowledge the following in presentations and 
                                                   publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)
- shalwater_depth                     = 0.0,     ! Set constant depth for shallow water roughness scheme if no bathymetry data availabile.
+ shalwater_depth                     = 0.0,     ! Set constant depth [m] for shallow water roughness scheme if no bathymetry data availabile.
                                                   The scheme is intended for depths between 10.0 and 100.0 m. Any depths outside of this range will be
                                                   rounded to the nearest limit value.
  lightning_option (max_dom)                       Lightning parameterization option to allow flash rate prediction without chemistry

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -413,11 +413,11 @@
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( ( model_config_rec % shalwater_rough(i)   .NE. 0               ) .AND. &
+         IF ( ( model_config_rec % shalwater_z0(i)   .NE. 0               ) .AND. &
               ( model_config_rec % sf_sfclay_physics(i) .NE. sfclayrevscheme ) ) THEN
             wrf_err_message = '--- ERROR: Shallow water surface roughness only works with sfclay_physics = 1'
             CALL wrf_message ( TRIM( wrf_err_message ) )
-            wrf_err_message = '           Fix shalwater_rough or sf_sfclay_physics in namelist.input.'
+            wrf_err_message = '           Fix shalwater_z0 or sf_sfclay_physics in namelist.input.'
             CALL wrf_message ( TRIM( wrf_err_message ) )
             count_fatal_error = count_fatal_error + 1
          END IF

--- a/share/module_optional_input.F
+++ b/share/module_optional_input.F
@@ -40,7 +40,8 @@ MODULE module_optional_input
    INTEGER :: flag_extra_levels
 
    INTEGER :: flag_canfra   , flag_clayfrac   , flag_erod     , flag_frc_urb2d , flag_imperv , &
-              flag_lai12m   , flag_lake_depth , flag_sandfrac , flag_urb_param , flag_var_sso
+              flag_lai12m   , flag_lake_depth , flag_sandfrac , flag_urb_param , flag_var_sso, &
+              flag_bathymetry
 
    integer :: flag_cldmask, flag_cldbasez, flag_cldtopz, flag_brtemp
 
@@ -761,6 +762,23 @@ USE module_io_domain
          flag_lake_depth      = itmp
       END IF
 
+      ! PSH
+      flag_name = '                                                                                '
+
+      flag_bathymetry      = 0
+
+      flag_name(1:10) = 'BATHYMETRY'
+!      print*,'flag_bathymetry before:',flag_bathymetry
+!      PRINT*,'PSH flag_bathymetry'
+!      print*,fid, 'FLAG_' // flag_name, itmp, 1, icnt, ierr
+      CALL wrf_get_dom_ti_integer ( fid, 'FLAG_' // flag_name, itmp, 1, icnt, ierr )
+      IF ( ierr .EQ. 0 ) THEN
+!         print*, 'got here...'
+         flag_bathymetry      = itmp
+      END IF
+!      print*,'flag_bathymetry after:',flag_bathymetry
+
+      ! END PSH
 
       flag_name = '                                                                                '
 

--- a/share/module_optional_input.F
+++ b/share/module_optional_input.F
@@ -762,23 +762,16 @@ USE module_io_domain
          flag_lake_depth      = itmp
       END IF
 
-      ! PSH
       flag_name = '                                                                                '
 
       flag_bathymetry      = 0
 
       flag_name(1:10) = 'BATHYMETRY'
-!      print*,'flag_bathymetry before:',flag_bathymetry
-!      PRINT*,'PSH flag_bathymetry'
-!      print*,fid, 'FLAG_' // flag_name, itmp, 1, icnt, ierr
       CALL wrf_get_dom_ti_integer ( fid, 'FLAG_' // flag_name, itmp, 1, icnt, ierr )
       IF ( ierr .EQ. 0 ) THEN
-!         print*, 'got here...'
          flag_bathymetry      = itmp
       END IF
-!      print*,'flag_bathymetry after:',flag_bathymetry
 
-      ! END PSH
 
       flag_name = '                                                                                '
 

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -76,12 +76,12 @@ Note, this is not a namelist.input file. Find what interests you, and cut and pa
 
 ** Using shallow water roughness (constant depth)
 &physics
-shalwater_rough                     = 1,       1,     1, 
+shalwater_z0                        = 1,       1,     1, 
 shalwater_depth                     = 40.0,
 
 ** Using shallow water roughness (with bathymetry data)
 &physics
-shalwater_rough                     = 1,       1,     1, 
+shalwater_z0                        = 1,       1,     1, 
 shalwater_depth                     = 0.0,
 
 ** Using stochastic backscatter scheme (new namelist record since v3.6)

--- a/test/em_real/examples.namelist
+++ b/test/em_real/examples.namelist
@@ -74,7 +74,16 @@ Note, this is not a namelist.input file. Find what interests you, and cut and pa
  lakedepth_default                   = 50.,    50.,   50.,
  lake_min_elev                       = 5.,     5.,    5.,
 
- 
+** Using shallow water roughness (constant depth)
+&physics
+shalwater_rough                     = 1,       1,     1, 
+shalwater_depth                     = 40.0,
+
+** Using shallow water roughness (with bathymetry data)
+&physics
+shalwater_rough                     = 1,       1,     1, 
+shalwater_depth                     = 0.0,
+
 ** Using stochastic backscatter scheme (new namelist record since v3.6)
 
 &stoch


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: shallow water, roughness, bathymetry

SOURCE: Patrick Hawbecker, Pedro A. Jiménez, and Jimy Dudhia (NCAR)

DESCRIPTION OF CHANGES:
This incorporates the shallow water drag module into the revised M-O surface layer scheme for over-water roughness calculation.

The new scheme is meant to incorporate the effects of roughness increasing over shallower waters (between 10 
and 100 m deep), mostly near coastlines. In order to include the shallow water roughness parameterization 
from Jiménez and Dudhia (2018) into the revised M-O surface layer scheme, a bathymetry dataset was 
downloaded and converted to the WPS tiled format, new variables and flags for the bathymetry data and 
which scheme is to be used over the ocean are added, and the source code is included into a module with 
module_sf_sfclayrev.F. 

The bathymetry data is open source from GEBCO Compilation Group (2021) GEBCO 2021 Grid ([doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f](https://www.gebco.net/data_and_products/gridded_bathymetry_data/)). Several checks are included to 
ensure users without the bathymetry data can still run with this new scheme using a namelist-defined 
variable (shalwater_depth) to designate the bathymetry over all water cells. If users have bathymetry data, 
they can run with this scheme (shalwater_z0 = 1; shalwater_depth <=0) or overwrite the bathymetry data 
with a user-defined value (shalwater_depth > 0).

LIST OF MODIFIED FILES: 
M Registry/Registry.EM_COMMON
M dyn_em/module_first_rk_step_part1.F
M dyn_em/module_initialize_real.F
M dyn_em/nest_init_utils.F
M dyn_em/start_em.F
M phys/module_physics_init.F
M phys/module_sf_sfclayrev.F
M phys/module_surface_driver.F
M run/README.namelist 
M share/module_check_a_mundo.F
M share/module_optional_input.F
M test/em_real/namelist.examples

TESTS CONDUCTED: 
Tests were conducted in 2 phases: within (1) real.exe and (2) wrf.exe.

1. Real.exe tests conducted:
![image](https://user-images.githubusercontent.com/39134281/129966384-83301f5d-49b4-470b-82f8-e44ee1538a9c.png)

For the case producing a warning (no bathymetry, shalwater_z0 = 1.0, shalwater_depth <= 0.0), the following 
warning is presented in rsl.error.* files:
```
Warning: No bathymetry data found for shallow water roughness model.
Warning: shalwater_depth must be greater than 0.0 for WRF to run.
```
The tests all performed as expected producing the following results for the WATER_DEPTH variable:
![image](https://user-images.githubusercontent.com/39134281/129966726-d81f993a-5485-423d-a490-00709526a289.png)

With incorrect namelist settings (use shallow water roughness drag, sfclay scheme other than revised MO):
```
--- ERROR: The shallow water roughness drag only works with sfclay_physics = 1
             Turn off the shallow water option, or change the surface layer scheme
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2513
NOTE:       1 namelist settings are wrong. Please check and reset these options
```


2. The tests performed for wrf.exe are as follows:
![image](https://user-images.githubusercontent.com/39134281/129966669-ac2450a7-e5c1-4d2b-a21f-e9608340f9ae.png)
The depth = 0.0 case produces the following error message:
```
No bathymetry data detected and shalwater_depth not greater than 0.0. Re-run WPS to get bathymetry data 
or set shalwater_depth > 0.0
```


The remaining cases produce WATER_DEPTH fields as follows:
![image](https://user-images.githubusercontent.com/39134281/129966955-0e94e669-c1dc-4a37-b5ee-47e822dbbdf5.png)

After running these cases for 36 hours and discarding the first 12 hours as model-spinup. The averaged field 
(output every 2 hours) for ZNT and wind speed can be seen to show the expected impacts from the new 
scheme. When the true bathymetry is used, ZNT is higher for depths between 10 and 100 m (green lines). 
However, when a constant shalwater_depth is used, the value is set over the whole domain and ZNT is 
increased (in this case) over all water cells. Additionally, when shalwater_depth is set to a valid number, it will 
overwrite the bathymetry data within wrf.exe and produce the same result as if you did not have bathymetry 
data.
![image](https://user-images.githubusercontent.com/39134281/129967047-69d08ca6-75f0-44bd-a0ff-cf32f5f0bbeb.png)
![image](https://user-images.githubusercontent.com/39134281/129967070-67a8a058-a797-4f9d-b281-b12e3d4b6b1d.png)

Additionally, in order to remain consistent with the lake model (sf_lake_physics > 0) we allow water_depth to 
be overwritten by lake_depth if sf_lake_physics > 0:
![image](https://user-images.githubusercontent.com/39134281/129967310-e847078f-51f2-4047-944d-bdcabca92e00.png)

3. The code passed bit-for-bit check and restart test.

RELEASE NOTE: The shallow-water roughness scheme from Jiménez and Dudhia (2018) is included for offshore roughness adjustment in water depths between 10 and 100 m. The bathymetry data is open source from GEBCO Compilation Group. Please acknowledge the following in presentations and publications: GEBCO Compilation Group (2021) GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f).
Jiménez, P. A., & Dudhia, J. (2018). On the need to modify the sea surface roughness formulation over shallow waters. Journal of Applied Meteorology and Climatology, 57(5), 1101-1110, DOI: [10.1175/JAMC-D-17-0137.1 ](https://doi.org/10.1175/JAMC-D-17-0137.1)
