### PR TITLE
Bug fix: Adding eclipse module to radiation driver's dependency list

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -720,6 +720,7 @@ module_radiation_driver.o: \
 		module_ra_hs.o \
 		module_ra_goddard.o \
                 module_ra_flg.o \
+                module_ra_eclipse.o \
                 module_ra_aerosol.o \
                 module_mp_thompson.o \
 		../frame/module_driver_constants.o \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: eclipse module, radiation driver dependency 

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The newly added module_ra_eclipse.F was not added to the dependency list of radiation driver. This sometimes causes 
compilation failures.

Solution:
Add module_ra_eclipse to radiation dependency list.

LIST OF MODIFIED FILES: 
M      main/depend.common

TESTS CONDUCTED: 
1. It is hard to test that there are no more intermittent build failures caused by this missing dependency. :)
2. Jenkins tests are passing.

RELEASE NOTE: Adding module_ra_eclipse.o to radiation driver's dependency list to avoid occasional compilation failures.