### PR TITLE
Moving nest hack

### DIFF
--- a/Registry/registry.em_shared_collection
+++ b/Registry/registry.em_shared_collection
@@ -19,7 +19,6 @@ include registry.ssib
 include registry.noahmp
 include registry.sbm
 include registry.polrad
-include registry.diags
 include registry.afwa
 include registry.rasm_diag
 include registry.elec
@@ -28,3 +27,4 @@ include registry.hyb_coord
 include registry.new3d_wif
 include registry.trad_fields
 include registry.solar_fields
+include registry.diags


### PR DESCRIPTION
TYPE: bug fix
    
KEYWORDS: moving nest, vortex tracking, segfault, Intel
    
SOURCE: internal
    
DESCRIPTION OF CHANGES:
Problem:
When the Intel compiler is used with the moving nest option (vortex tracking), the tools/registry program seg-faults,
and does not complete building the automatically generated files that are included via cpp into the WRF source code.
    
Solution:
This is a quick-fix for users. Simply swap the order of the list of registry files.
    
ISSUE: For use when this PR closes an issue.
Fixes #1521
    
LIST OF MODIFIED FILES:
M   Registry/registry.em_shared_collection
    
TESTS CONDUCTED:
1. This mod allows the code to build successfully for intel 19.0.5
2. The code compiles with option 15/3 using Intel OneAPI:  `ifort (IFORT) 2021.1 Beta 20201112`
3. The code compiles with option 15/3 and run using Intel HPC suit: `ifort (IFORT) 19.0.5.281 20190815`. The code 
runs at least 1-h with a triple-nests 501 x 601 x 841 Tropical Cyclone with 55 levels.
4. Jenkins is all pass.

RELEASE NOTES: A temporary fix has been put in place for the moving nest capability when using the Intel compiler. Previously, the WRF source code did not build due to a segmentation fault in the execution of the tools/registry program.
