### PR TITLE
Add new stanza for ARM aarch64/openmpi

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1999,7 +1999,7 @@ LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
 PROMOTION       =       #-fdefault-real-8
 ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
-CFLAGS_LOCAL    =       -w -O3 -c -march=armv8.2-a
+CFLAGS_LOCAL    =       -w -O3 -c -march=native
 LDFLAGS_LOCAL   =
 CPLUSPLUSLIB    =
 ESMF_LDFLAG     =      $(CPLUSPLUSLIB)

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1981,41 +1981,41 @@ LIB_BUNDLED     = \
                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
 
 ###########################################################
-#ARCH   Linux   aarch64,gnu OpenMPI #serial smpar dmpar dm+sm
+#ARCH   Linux   armv7l aarch64, gnu OpenMPI #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       GNU ($SFC/$SCC)
-DMPARALLEL      =        1
-OMPCPP          =        -D_OPENMP
-OMP             =        -fopenmp
-OMPCC           =        -fopenmp
+DMPARALLEL      =       # 1
+OMPCPP          =       # -D_OPENMP
+OMP             =       # -fopenmp
+OMPCC           =       # -fopenmp
 SFC             =       gfortran
 SCC             =       gcc
 CCOMP           =       gcc
 DM_FC           =       mpif90 -f90=$(SFC)
-DM_CC           =       mpicc -cc=$(SCC) -DMPI2_SUPPORT
+DM_CC           =       mpicc -cc=$(SCC)
 FC              =       CONFIGURE_FC
 CC              =       CONFIGURE_CC
 LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
 PROMOTION       =       #-fdefault-real-8
-ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
-CFLAGS_LOCAL    =       -w -O3 -c -march=native
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  CONFIGURE_D_CTSM
+CFLAGS_LOCAL    =       -w -O3 -c -march=native # -DRSL0_ONLY
 LDFLAGS_LOCAL   =
 CPLUSPLUSLIB    =
-ESMF_LDFLAG     =      $(CPLUSPLUSLIB)
+ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
 FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=native
 FCREDUCEDOPT    =       $(FCOPTIM)
 FCNOOPT         =       -O0
-FCDEBUG         =       # -g $(FCNOOPT)  # -fbacktrace -ggdb-fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
+FCDEBUG         =       # -g $(FCNOOPT)  # -fbacktrace -ggdb -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
-TRADFLAG        =      -traditional
-CPP             =      /lib/cpp -P
+TRADFLAG        =      CONFIGURE_TRADFLAG
+CPP             =      /lib/cpp CONFIGURE_CPPFLAGS
 AR              =      ar
 ARFLAGS         =      ru
 M4              =      m4 -G

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1980,6 +1980,51 @@ LIB_BUNDLED     = \
                      $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
 
+###########################################################
+#ARCH    Darwin (MACOS) intel compiler with clang EDIT FOR OPENMPI #serial smpar dmpar dm+sm
+#
+DESCRIPTION     =       INTEL ($SFC/$SCC)
+DMPARALLEL      =       # 1
+OMPCPP          =       # -D_OPENMP
+OMP             =       # -qopenmp -fpp -auto
+OMPCC           =       # -qopenmp
+SFC             =       ifort
+SCC             =       clang
+CCOMP           =       clang
+DM_FC           =       mpif90 -f90=$(SFC)
+DM_CC           =       mpicc -cc=$(SCC) # the -cc=cc option causes openmpi mpicc to fail (unrecognized option)
+FC              =       CONFIGURE_FC
+CC              =       CONFIGURE_CC
+LD              =       $(FC)
+RWORDSIZE       =       CONFIGURE_RWORDSIZE
+PROMOTION       =       -real-size `expr 8 \* $(RWORDSIZE)` -i4
+ARCH_LOCAL      =       -DMACOS -DNONSTANDARD_SYSTEM_FUNC  -DWRF_USE_CLM
+CFLAGS_LOCAL    =       -w -O3 -DMACOS #-xHost -fp-model fast=2 -no-prec-div -no-prec-sqrt -ftz -no-multibyte-chars -DMACOS # -DRSL0_ONLY
+# increase stack size; also note that for OpenMP, set environment OMP_STACKSIZE 4G or greater
+LDFLAGS_LOCAL   =       -Wl,-stack_addr,0xF10000000 -Wl,-stack_size,0x64000000 #-xHost -fp-model fast=2 -no-prec-div -no-prec-sqrt -ftz -align all -fno-alias -fno-common
+CPLUSPLUSLIB    =       
+ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
+FCOPTIM         =       -O3
+FCREDUCEDOPT	=       $(FCOPTIM)
+FCNOOPT         =       -O0 -fno-inline -no-ip
+FCDEBUG         =       # -g $(FCNOOPT) -traceback # -fpe0 -check noarg_temp_created,bounds,format,output_conversion,pointers,uninit -ftrapuv -unroll0 -u
+FORMAT_FIXED    =       -FI
+FORMAT_FREE     =       -FR
+FCSUFFIX        =
+BYTESWAPIO      =       -convert big_endian
+RECORDLENGTH    =       -assume byterecl
+FCBASEOPTS_NO_G =       -fp-model precise -w -ftz -align all -fno-alias -fno-common $(FORMAT_FREE) $(BYTESWAPIO) #-xHost -fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt
+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
+MODULE_SRCH_FLAG =
+TRADFLAG        =      CONFIGURE_TRADFLAG
+CPP             =      cpp CONFIGURE_CPPFLAGS -xassembler-with-cpp
+AR              =      ar
+ARFLAGS         =      ru
+M4              =      m4 -B 14000
+RANLIB          =      ranlib
+RLFLAGS		=	-c
+CC_TOOLS        =      cc
+
 #insert new stanza here
 
 ###########################################################

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -2003,7 +2003,7 @@ CFLAGS_LOCAL    =       -w -O3 -c -march=native
 LDFLAGS_LOCAL   =
 CPLUSPLUSLIB    =
 ESMF_LDFLAG     =      $(CPLUSPLUSLIB)
-FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=armv8.2-a
+FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=native
 FCREDUCEDOPT    =       $(FCOPTIM)
 FCNOOPT         =       -O0
 FCDEBUG         =       # -g $(FCNOOPT)  # -fbacktrace -ggdb-fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1981,49 +1981,47 @@ LIB_BUNDLED     = \
                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
 
 ###########################################################
-#ARCH    Darwin (MACOS) intel compiler with clang EDIT FOR OPENMPI #serial smpar dmpar dm+sm
+#ARCH   Linux   aarch64,gnu OpenMPI #serial smpar dmpar dm+sm
 #
-DESCRIPTION     =       INTEL ($SFC/$SCC)
-DMPARALLEL      =       # 1
-OMPCPP          =       # -D_OPENMP
-OMP             =       # -qopenmp -fpp -auto
-OMPCC           =       # -qopenmp
-SFC             =       ifort
-SCC             =       clang
-CCOMP           =       clang
+DESCRIPTION     =       GNU ($SFC/$SCC)
+DMPARALLEL      =        1
+OMPCPP          =        -D_OPENMP
+OMP             =        -fopenmp
+OMPCC           =        -fopenmp
+SFC             =       gfortran
+SCC             =       gcc
+CCOMP           =       gcc
 DM_FC           =       mpif90 -f90=$(SFC)
-DM_CC           =       mpicc -cc=$(SCC) # the -cc=cc option causes openmpi mpicc to fail (unrecognized option)
+DM_CC           =       mpicc -cc=$(SCC) -DMPI2_SUPPORT
 FC              =       CONFIGURE_FC
 CC              =       CONFIGURE_CC
 LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
-PROMOTION       =       -real-size `expr 8 \* $(RWORDSIZE)` -i4
-ARCH_LOCAL      =       -DMACOS -DNONSTANDARD_SYSTEM_FUNC  -DWRF_USE_CLM
-CFLAGS_LOCAL    =       -w -O3 -DMACOS #-xHost -fp-model fast=2 -no-prec-div -no-prec-sqrt -ftz -no-multibyte-chars -DMACOS # -DRSL0_ONLY
-# increase stack size; also note that for OpenMP, set environment OMP_STACKSIZE 4G or greater
-LDFLAGS_LOCAL   =       -Wl,-stack_addr,0xF10000000 -Wl,-stack_size,0x64000000 #-xHost -fp-model fast=2 -no-prec-div -no-prec-sqrt -ftz -align all -fno-alias -fno-common
-CPLUSPLUSLIB    =       
-ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-FCOPTIM         =       -O3
-FCREDUCEDOPT	=       $(FCOPTIM)
-FCNOOPT         =       -O0 -fno-inline -no-ip
-FCDEBUG         =       # -g $(FCNOOPT) -traceback # -fpe0 -check noarg_temp_created,bounds,format,output_conversion,pointers,uninit -ftrapuv -unroll0 -u
-FORMAT_FIXED    =       -FI
-FORMAT_FREE     =       -FR
+PROMOTION       =       #-fdefault-real-8
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
+CFLAGS_LOCAL    =       -w -O3 -c -march=armv8.2-a
+LDFLAGS_LOCAL   =
+CPLUSPLUSLIB    =
+ESMF_LDFLAG     =      $(CPLUSPLUSLIB)
+FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=armv8.2-a
+FCREDUCEDOPT    =       $(FCOPTIM)
+FCNOOPT         =       -O0
+FCDEBUG         =       # -g $(FCNOOPT)  # -fbacktrace -ggdb-fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
+FORMAT_FIXED    =       -ffixed-form
+FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =
-BYTESWAPIO      =       -convert big_endian
-RECORDLENGTH    =       -assume byterecl
-FCBASEOPTS_NO_G =       -fp-model precise -w -ftz -align all -fno-alias -fno-common $(FORMAT_FREE) $(BYTESWAPIO) #-xHost -fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt
+BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
-TRADFLAG        =      CONFIGURE_TRADFLAG
-CPP             =      cpp CONFIGURE_CPPFLAGS -xassembler-with-cpp
+TRADFLAG        =      -traditional
+CPP             =      /lib/cpp -P
 AR              =      ar
 ARFLAGS         =      ru
-M4              =      m4 -B 14000
+M4              =      m4 -G
 RANLIB          =      ranlib
-RLFLAGS		=	-c
-CC_TOOLS        =      cc
+RLFLAGS         =
+CC_TOOLS        =      $(SCC)
 
 #insert new stanza here
 


### PR DESCRIPTION
TYPE：enhancement

KEYWORDS: ARM 

DESCRIPTION OF CHANGES:
Problem:
There are no ARM-only stanzas in arch/configure.defaults. As the suggestion from https://github.com/wrf-model/WRF/pull/1535 , we need a separate PR for ARM specific update.

Solution:
Edit the arch/configure.defaults file and add a stanza for aarch64 and armv7l, using the GNU compiler options. 

The default optimization is -03, up from the usual -02. On two 36-h nested simulations on a raspberry pi, the difference
is a consistent 3% speed increase. This used CONUS, so the -03 seems robust.

LIST OF MODIFIED FILES:
M arch/configure.defaults

RELEASE NOTE: Added a new stanza that is only for ARM processors (right now aarch64 and armv7l) with GNU.