### PR TITLE
Initializing smstav and a few other local variables before used

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -711,12 +711,6 @@ CONTAINS
 !
 !  END FASDAS
 !
-  FLX4  = 0.0 !BSINGH - Initialized to 0.0
-  FVB   = 0.0 !BSINGH - Initialized to 0.0
-  FBUR  = 0.0 !BSINGH - Initialized to 0.0
-  FGSN  = 0.0 !BSINGH - Initialized to 0.0
-  SOILW = 0.0 !BSINGH - Initialized to 0.0
-
   sigma_sb=5.67e-08
 
 ! MEK MAY 2007
@@ -788,6 +782,12 @@ CONTAINS
         SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
 ! convert from mixing ratio to specific humidity
          Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+! initializing local variables
+        SOILW=0.
+        FLX4=0.
+        FVB=0.
+        FBUR=0.
+        FGSN=0.
 !
 !         Q2SAT=QGH(I,j)
          Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
@@ -3106,6 +3106,13 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 !-----------------------------------------------------------------------
       ILOOP : DO I=its,ite
       
+! initializing local variables
+         SOILW = 0.
+         FLX4  = 0.
+         FVB   = 0.
+         FBUR  = 0.
+         FGSN  = 0.
+
          IF (((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
                
                IVGTYP_dominant(I,J)=IVGTYP(I,J)                                   ! save this


### PR DESCRIPTION
Local variables in noahdrv require initialization.

TYPE: bug fix

KEYWORDS: uninitializaed local variables in noahdrv, soilw, flx4, fvb, fbur, fgsn

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
MPAS tests revealed that Noah LSM variable SMSTAV does not give identical results when run using different number of processors. Note that this variable isn't in the standard wrfout file, and it was detected in the restart file comparison. Note also that this has no impact to model results, since SMSTAV is only a diagnostic variable. 

Solution:
The problem stems from the local variable, soilw, which sets the values for SMSTAV. This local variable is not initialized in the i,j loops before it is used (it is outside the do loops). Initializing this variable to 0 fixes the problem. The same problem is also fixed in the LSM mosaic option. Similarly a few local variables used for ua_phys option, flx4, fvb, fbur, fgsn, should be initialized inside the i,j loops as well, and hence it is done here too, though no known problem is caused by these variables at this time. The following plots show the before (first) and after (second) the fix for SMSTAV: the left frame was run with 108 processors, and right with 144:

![smstav_wrong](https://user-images.githubusercontent.com/12705680/137767276-e893d076-0c2d-4dac-8187-517b7f64af08.png)
![smstav_fixed](https://user-images.githubusercontent.com/12705680/137767303-d620bc9a-f63a-4747-b46a-52acd965abed.png)

ISSUE: For use when this PR closes an issue.
Fixes #868

LIST OF MODIFIED FILES: 
M    phys/module_sf_noahdrv.F

TESTS CONDUCTED: 
1. Tests show the problem is fixed.
2. The Jenkins tests are all passing.

RELEASE NOTE: Initialized a few local variables in Noah LSM routine.
