### PR TITLE
configure script missing quotes in two echo statements

### DIFF
--- a/configure
+++ b/configure
@@ -1044,8 +1044,8 @@ if [ -n "$NETCDF4" ] ; then
       echo "--enable-netcdf4                                                             "
       echo
       echo "OR set NETCDF_classic variable                                               "
-      echo "   bash/ksh : export NETCDF_classic=1
-      echo "        csh : setenv NETCDF_classic 1
+      echo "   bash/ksh : export NETCDF_classic=1                                        "
+      echo "        csh : setenv NETCDF_classic 1                                        "
       echo 
       echo "Then re-run this configure script                                            "
       echo


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: configure, shell, echo

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When building with NetCDF that does not support compression, the warning statements that
are printed out are misaligned, due to missing trailing quotes at the end of some `echo` statements in the
`configure` script.

Solution:
Add those quotes back in.

LIST OF MODIFIED FILES:
modified:   configure

TESTS CONDUCTED: 
1. The printout is now aesthetically appealing. Initially we had a mortifying display of the word `echo`, and the 
accompanying alignment disarray that would be associated with banal shell scripting encroaching upon a user's otherwise elevated build experience:
```
Please make sure NETCDF version is 4.1.3 or later and was built with         
--enable-netcdf4                                                             

OR set NETCDF_classic variable                                               
   bash/ksh : export NETCDF_classic=1
      echo  csh : setenv NETCDF_classic 1
```
After much soul searching, an appropriate solution was uncovered, resulting in reduced messaging dissonance:
```
Please make sure NETCDF version is 4.1.3 or later and was built with         
--enable-netcdf4                                                             

OR set NETCDF_classic variable                                               
   bash/ksh : export NETCDF_classic=1                                        
        csh : setenv NETCDF_classic 1     
```
2. Jenkins is all PASS.
