### PR TITLE
Syntax errors in physics routines: *- and *+

### DIFF
--- a/phys/module_mp_nssl_2mom.F
+++ b/phys/module_mp_nssl_2mom.F
@@ -1208,7 +1208,7 @@ MODULE module_mp_nssl_2mom
         write(0,*) 'READ_NAMELIST: PROBLEM WITH NSSL_MP_PARAMS namelist: not found or bad token'
       ENDIF
         IF ( wrf_dm_on_monitor() .and. .not. wrote_namelist ) THEN
-          open(15,file='namelist.output',status='old',action='readwrite', access='append',form='formatted')
+          open(15,file='namelist.output',status='old',action='readwrite', position='append',form='formatted')
           write(15,NML=nssl_mp_params)
           close(15)
           wrote_namelist = .true.

--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -6203,7 +6203,7 @@
             ENDIF
             QCLsh = QCLS1*ESH*VTQSH*NH1D*(SASR2*GSM3+SASR1*2.*GH2*GSM2+&
                     GH3*GSM1)
-            NCLsh = NCLS1*ESH*VTNSH*NH1D*(SASR2*GS3*+SASR1*2.*GH2*GS2+ &
+            NCLsh = NCLS1*ESH*VTNSH*NH1D*(SASR2*GS3 +SASR1*2.*GH2*GS2+ &
                     GH3)
             QCLsh = MIN(QCLsh,QS1D*iDT)
             NCLsh = MIN(NCLsh,NS1D*iDT)

--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -7919,8 +7919,8 @@ ENDIF   ! CROPTYPE == 0
       SMCAVL = 0.0
       SMCLIM = 0.0
       ! estimate available water and field capacity for the root zone
-      SMCAVL = (SH2O(1)-parameters%SMCWLT(1))*-1*ZSOIL(1)              ! current soil water (m) 
-      SMCLIM = (parameters%SMCREF(1)-parameters%SMCWLT(1))*-1*ZSOIL(1) ! available water (m)
+      SMCAVL = (SH2O(1)-parameters%SMCWLT(1))*(-1)*ZSOIL(1)              ! current soil water (m) 
+      SMCLIM = (parameters%SMCREF(1)-parameters%SMCWLT(1))*(-1)*ZSOIL(1) ! available water (m)
       DO K = 2, parameters%NROOT
          SMCAVL = SMCAVL + (SH2O(K)-parameters%SMCWLT(K))*(ZSOIL(K-1) - ZSOIL(K))
          SMCLIM = SMCLIM + (parameters%SMCREF(K)-parameters%SMCWLT(K))*(ZSOIL(K-1) - ZSOIL(K))


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: HPE, CCE, syntax

SOURCE: Tricia Balle (HPE)

DESCRIPTION OF CHANGES:
Problem:
There were three types of syntax errors that were uncovered by the HPE CCE compiler.
1. Open statement used `action="append"`.
2. Multiple unary operators next to each other `*+`
3. Multiple unary operators next to each other `*-1`.

Solution:
1. The correct usage is `position="append"`.
2. The developer agrees with the new modification to `GS3*+SASR1` was the original intent.
3. Typically, `*(-1)` is intended, and this is the case.

Via some grep'ing, no other occurrences of `*+` or `*-` exist in the physics directory in the compilable
source code. Syntactically OK source code with `/-` (such as for DATA statements) were the only compilable 
examples found. So, we fixed the above problems identified in this PR, and we could not find any other 
similar examples in the source code.

LIST OF MODIFIED FILES:
modified:   phys/module_mp_nssl_2mom.F
modified:   phys/module_mp_ntu.F
modified:   phys/module_sf_noahmplsm.F

TESTS CONDUCTED:
1. These fixes allow the WRF code to build with the CCE compiler.
2. Jenkins tests are all PASS.
3. One of the errors was a typo in the sink term of aggregates number from hail. A quick evaluation of its impact was
quite minor from the 2D idealized simulation (the figure is not shown).

RELEASE NOTE: A few syntax errors in NSSL, NTU, an NoahMP were fixed. Most compilers skipped over them. No impact for users for whom the code already compiled.