### PR TITLE
Restrict which CG PBLs may use FG LES PBL

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3086,6 +3086,7 @@ package   drip           sf_surf_irr_alloc==2        -             state:irrigat
 package   sprinkler      sf_surf_irr_alloc==3        -             state:irrigation,irr_rand_field
 
 
+package   lesscheme      bl_pbl_physics==0           -             -
 package   ysuscheme      bl_pbl_physics==1           -             -
 package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
 package   gfsscheme      bl_pbl_physics==3           -             -

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3086,7 +3086,7 @@ package   drip           sf_surf_irr_alloc==2        -             state:irrigat
 package   sprinkler      sf_surf_irr_alloc==3        -             state:irrigation,irr_rand_field
 
 
-package   lesscheme      bl_pbl_physics==0           -             -
+package   lesscheme      bl_pbl_physics==0           -             state:tke_pbl,el_pbl
 package   ysuscheme      bl_pbl_physics==1           -             -
 package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
 package   gfsscheme      bl_pbl_physics==3           -             -

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -386,17 +386,22 @@
       ENDDO
 
 !-----------------------------------------------------------------------
-! Check that MYNN PBL on a coarse grid is not paired with LES PBL
-! on a fine grid. This MYNN PBL + LES PBL is not permitted.
+! Check that LES PBL is only paired with acceptable other PBL options.
+! Currently OK: YSU(1), MYJ(2), ShinHong(11)
 !-----------------------------------------------------------------------
-      IF ( ( model_config_rec % bl_pbl_physics(1) .EQ. mynnpblscheme2 ) .OR. &
-           ( model_config_rec % bl_pbl_physics(1) .EQ. mynnpblscheme3 ) ) THEN
+      IF ( ( model_config_rec % bl_pbl_physics(1) .NE. ysuscheme      ) .AND. &
+           ( model_config_rec % bl_pbl_physics(1) .NE. myjpblscheme   ) .AND. &
+           ( model_config_rec % bl_pbl_physics(1) .NE. shinhongscheme ) ) THEN 
          DO i = 2, model_config_rec % max_dom
             IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
             IF ( model_config_rec % bl_pbl_physics(i) .EQ. LESscheme ) THEN
-               wrf_err_message = '--- ERROR: MYNN-PBL schemes do not work with LES PBL on a finer domain'
+               WRITE(wrf_err_message,fmt='(a,i2)') '--- ERROR: LES PBL on fine grid does not work with CG PBL option ',model_config_rec % bl_pbl_physics(1)
+               CALL wrf_message ( TRIM( wrf_err_message ) )
+               wrf_err_message = '--- ERROR: Only YSU(1), MYJPBL(2), and ShinHong(11) are acceptable options for LES PBL on the fine grid'
                CALL wrf_message ( TRIM( wrf_err_message ) )
                wrf_err_message = '--- ERROR: Fix bl_pbl_physics in namelist.input.'
+               CALL wrf_message ( TRIM( wrf_err_message ) )
+               wrf_err_message = '--- ERROR: Alternatively, remove all of the packaged variables from the CG PBL selection'
                CALL wrf_message ( TRIM( wrf_err_message ) )
                count_fatal_error = count_fatal_error + 1
             END IF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -389,7 +389,8 @@
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently OK: YSU(1), MYJ(2), ShinHong(11)
 !-----------------------------------------------------------------------
-      IF ( ( model_config_rec % bl_pbl_physics(1) .NE. ysuscheme      ) .AND. &
+      IF ( ( model_config_rec % bl_pbl_physics(1) .NE. lesscheme      ) .AND. &
+           ( model_config_rec % bl_pbl_physics(1) .NE. ysuscheme      ) .AND. &
            ( model_config_rec % bl_pbl_physics(1) .NE. myjpblscheme   ) .AND. &
            ( model_config_rec % bl_pbl_physics(1) .NE. shinhongscheme ) ) THEN 
          DO i = 2, model_config_rec % max_dom

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -386,6 +386,24 @@
       ENDDO
 
 !-----------------------------------------------------------------------
+! Check that MYNN PBL on a coarse grid is not paired with LES PBL
+! on a fine grid. This MYNN PBL + LES PBL is not permitted.
+!-----------------------------------------------------------------------
+      IF ( ( model_config_rec % bl_pbl_physics(1) .EQ. mynnpblscheme2 ) .OR. &
+           ( model_config_rec % bl_pbl_physics(1) .EQ. mynnpblscheme3 ) ) THEN
+         DO i = 2, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+            IF ( model_config_rec % bl_pbl_physics(i) .EQ. LESscheme ) THEN
+               wrf_err_message = '--- ERROR: MYNN-PBL schemes do not work with LES PBL on a finer domain'
+               CALL wrf_message ( TRIM( wrf_err_message ) )
+               wrf_err_message = '--- ERROR: Fix bl_pbl_physics in namelist.input.'
+               CALL wrf_message ( TRIM( wrf_err_message ) )
+               count_fatal_error = count_fatal_error + 1
+            END IF
+         ENDDO
+      END IF 
+
+!-----------------------------------------------------------------------
 ! Check that SMS-3DTKE scheme Must work with Revised MM5 surface layer 
 ! scheme (sf_sfclay_physics = 1), MYNN surface (sf_sfclay_physics = 5)
 ! and old MM5 surface scheme (sf_sfclay_physics = 91). Also, SMS-3DTKE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: PBL, LES

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Only the YSU PBL scheme has no packaged variables. If a user wants to have any other PBL scheme on the CG,
and an LES PBL on the FG, the model will have memory corruption problems. This error is hard to detect.

Solution:
1. The variables el_pbl and tke_pbl are added to the list of packaged variables for the LES PBL. While this
scheme does not need them, this does not add any memory, _and_ this permits both the MYJ and 
ShinHong PBL schemes to be used.
2. A controlled stop is now in place when any incompatible PBL namelist options are selected.

ISSUES:
Partially addresses #1514 

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. When an incompatible CG PBL and FG LES are selected, the code successfully stops.
```
--- ERROR: LES PBL on fine grid does not work with CG PBL option  5
--- ERROR: Only YSU(1), MYJPBL(2), and ShinHong(11) are acceptable options for LES PBL on the fine grid
--- ERROR: Fix bl_pbl_physics in namelist.input.
--- ERROR: Alternatively, remove all of the packaged variables from the CG PBL selection
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2534
NOTE:       1 namelist settings are wrong. Please check and reset these options
-------------------------------------------
```
2. Jenkins is all PASS.

RELEASE NOTE: A test was introduced to stop the incorrect combination of particular PBL schemes on coarser grids with the LES PBL option selected on a finer grid. Previously, this problem caused an inconsistent number of variables on the CG and FG, which caused segmentation faults when trying to do feedback or advection of unavailable fields.