### PR TITLE
smooth_cg_topo=T requires soil elevation data

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -672,7 +672,8 @@ integer::oops1,oops2
               ( internal_time_loop .EQ. 1 ) .AND. &
               ( grid%id .EQ. 1 ) .AND. &
               ( flag_soilhgt .NE. 1) ) THEN
-            CALL wrf_message    (' --- ERROR: NML option smooth_cg_topo=T, but found no soil elevation data in metgrid files')
+            CALL wrf_message    (' --- ERROR: NML option smooth_cg_topo=T')
+            CALL wrf_message    ('            But found no soil elevation / terrain / topography data in metgrid files)
             CALL wrf_message    ('            The field SOILHGT is required when smoothing the CG topography on d01')
             CALL wrf_error_fatal('            If using ERA5 data, possibly need to add more time invariant fields')
          END IF

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -672,7 +672,8 @@ integer::oops1,oops2
               ( internal_time_loop .EQ. 1 ) .AND. &
               ( grid%id .EQ. 1 ) .AND. &
               ( flag_soilhgt .NE. 1) ) THEN
-            CALL wrf_error_fatal(' --- ERROR: NML option smooth_cg_topo=T, but found no soil elevation data in metgrid files')
+            CALL wrf_message    (' --- ERROR: NML option smooth_cg_topo=T, but found no soil elevation data in metgrid files')
+            CALL wrf_error_fatal('            If using ERA5 data, requires including additional time invariant data files')
          END IF
 
          IF ( ( config_flags%smooth_cg_topo ) .AND. &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -672,7 +672,7 @@ integer::oops1,oops2
               ( internal_time_loop .EQ. 1 ) .AND. &
               ( grid%id .EQ. 1 ) .AND. &
               ( flag_soilhgt .NE. 1) ) THEN
-            CALL wrf_error_fatal(' --- ERROR: NML option smooth_cg_topo=T, but no first guess soil elevation data')
+            CALL wrf_error_fatal(' --- ERROR: NML option smooth_cg_topo=T, but found no soil elevation data in metgrid files')
          END IF
 
          IF ( ( config_flags%smooth_cg_topo ) .AND. &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -673,7 +673,7 @@ integer::oops1,oops2
               ( grid%id .EQ. 1 ) .AND. &
               ( flag_soilhgt .NE. 1) ) THEN
             CALL wrf_message    (' --- ERROR: NML option smooth_cg_topo=T')
-            CALL wrf_message    ('            But found no soil elevation / terrain / topography data in metgrid files)
+            CALL wrf_message    ('            But found no soil elevation / terrain / topography data in metgrid files')
             CALL wrf_message    ('            The field SOILHGT is required when smoothing the CG topography on d01')
             CALL wrf_error_fatal('            If using ERA5 data, possibly need to add more time invariant fields')
          END IF

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -665,6 +665,16 @@ integer::oops1,oops2
          !  coarse grid since we are going to make the interface consistent
          !  in the model betwixt the CG and FG domains.
 
+         !  An important point is to inform the user if their request cannot
+         !  be satisfied. Do not skip over this quietly.
+
+         IF ( ( config_flags%smooth_cg_topo ) .AND. &
+              ( internal_time_loop .EQ. 1 ) .AND. &
+              ( grid%id .EQ. 1 ) .AND. &
+              ( flag_soilhgt .NE. 1) ) THEN
+            CALL wrf_error_fatal(' --- ERROR: NML option smooth_cg_topo=T, but no first guess soil elevation data')
+         END IF
+
          IF ( ( config_flags%smooth_cg_topo ) .AND. &
               ( internal_time_loop .EQ. 1 ) .AND. &
               ( grid%id .EQ. 1 ) .AND. &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -673,7 +673,8 @@ integer::oops1,oops2
               ( grid%id .EQ. 1 ) .AND. &
               ( flag_soilhgt .NE. 1) ) THEN
             CALL wrf_message    (' --- ERROR: NML option smooth_cg_topo=T, but found no soil elevation data in metgrid files')
-            CALL wrf_error_fatal('            If using ERA5 data, requires including additional time invariant data files')
+            CALL wrf_message    ('            The field SOILHGT is required when smoothing the CG topography on d01')
+            CALL wrf_error_fatal('            If using ERA5 data, possibly need to add more time invariant fields')
          END IF
 
          IF ( ( config_flags%smooth_cg_topo ) .AND. &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ERA5, smooth_cg_topo, elevation data

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
If a user does not include all of the correct ERA5 invariant files, then there could be
no soil elevation field coming from the metgrid program. Without that field, the flag
`flag_soilhgt` is not set. Then the real program will not generate any topo differences along
the lateral boundary (when requested with smooth_cg_topo = T). This is a quiet failure,
and difficult to track down.

Solution:
If the user asks to smooth the lateral boundary topo on d01, AND the user has no input
soil elevation data from the first-guess model, then this is now a fatal error.

LIST OF MODIFIED FILES:
modified:   dyn_em/module_initialize_real.F

TESTS CONDUCTED:
1. The original intent of the option still works - smoothed topo on d01 along the outer few rows and columns.
The first figure shows the change in topography. The second figure below shows which grid cells are
impacted. Basically, these two figures show that topography smoothing still is available.
<img width="1296" alt="Screen Shot 2021-11-05 at 11 27 03 AM" src="https://user-images.githubusercontent.com/12666234/140584624-40a71752-d718-44d3-8c3a-05f6fd710ee1.png">

<img width="1295" alt="Screen Shot 2021-11-05 at 11 45 57 AM" src="https://user-images.githubusercontent.com/12666234/140584653-f3546331-1c95-4ea3-a324-5f3a6e0cb3ee.png">

2. By artificially setting the metgrid flags in a debugging mode within the real program, we can successfully 
emulate missing soil elevation data by setting flag_soilhgt = 0. Whether or not we artificially set the value,
there is now a controlled stop to the real program.
```
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:     766
 --- ERROR: NML option smooth_cg_topo=T, but no first guess soil elevation data
-------------------------------------------
```
3. All jenkins tests are PASS.

RELEASE NOTE: A fatal error in the real program is now issued when a user requests lateral boundary topography smoothing, but lacks the first-guess soil elevation data to do the weighted averaging of topography. Previously, this discrepancy was ignored, and the d01 high-resolution elevation data was quietly left undisturbed.