### PR TITLE
Generalized method to handle different PBL options by domain

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2424,6 +2424,7 @@ rconfig   integer     irr_ph              namelist,physics      max_domains    0
 
 rconfig   integer     sf_surface_physics  namelist,physics	max_domains    -1      rh       "sf_surface_physics"            ""      ""
 rconfig   integer     bl_pbl_physics      namelist,physics	max_domains    -1      rh       "bl_pbl_physics"                ""      ""
+rconfig   integer     bl_pbl_physics_proxy derived         	max_domains    -1      rh       "bl_pbl_physics_proxy"          ""      ""
 rconfig   integer     bl_mynn_tkebudget   namelist,physics      max_domains    0       rh       "bl_mynn_tkebudget"             ""      ""
 rconfig   integer     ysu_topdown_pblmix  namelist,physics      1              1       rh       "ysu_topdown_pblmix"            ""      ""
 rconfig   integer     shinhong_tke_diag   namelist,physics      max_domains    0       rh       "shinhong_tke_diag"             ""      ""
@@ -3086,19 +3087,38 @@ package   drip           sf_surf_irr_alloc==2        -             state:irrigat
 package   sprinkler      sf_surf_irr_alloc==3        -             state:irrigation,irr_rand_field
 
 
+package   les_proxy      bl_pbl_physics_proxy==0     -             -
+package   ysu_proxy      bl_pbl_physics_proxy==1     -             -
+package   myjpbl_proxy   bl_pbl_physics_proxy==2     -             state:tke_pbl,el_pbl
+package   gfs_proxy      bl_pbl_physics_proxy==3     -             -
+package   qnsepbl_proxy  bl_pbl_physics_proxy==4     -             state:tke_pbl,el_pbl,massflux_EDKF,entr_EDKF,detr_EDKF,thl_up,thv_up,rv_up,rt_up,rc_up,u_up,v_up,frac_up,rc_mf
+package   mynnpbl_proxy2 bl_pbl_physics_proxy==5     -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
+package   mynnpbl_proxy3 bl_pbl_physics_proxy==6     -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
+package   acmpbl_proxy   bl_pbl_physics_proxy==7     -             -
+package   boulac_proxy   bl_pbl_physics_proxy==8     -             state:el_pbl,tke_pbl,wu_tur,wv_tur,wt_tur,wq_tur
+package   camuwpbl_proxy bl_pbl_physics_proxy==9     -             state:tauresx2d,tauresy2d,tpert2d,qpert2d,wpert2d,tke_pbl,smaw3d,wsedl3d,turbtype3d
+package   temfpbl_proxy  bl_pbl_physics_proxy==10    -             state:te_temf,kh_temf,km_temf,shf_temf,qf_temf,uw_temf,vw_temf,wupd_temf,mf_temf,thup_temf,qlup_temf,qtup_temf,cf3d_temf,hd_temf,lcl_temf,hct_temf,cfm_temf
+package   shinhong_proxy bl_pbl_physics_proxy==11    -             state:el_pbl,tke_pbl
+package   gbmpbl_proxy   bl_pbl_physics_proxy==12    -             state:exch_tke,el_pbl,tke_pbl
+package   eeps_proxy     bl_pbl_physics_proxy==16    -             scalar:pek_adv,pep_adv;state:tke_pbl,pep_pbl
+package   mrf_proxy      bl_pbl_physics_proxy==99    -             -
+
+# Note - add packaged dependencies to the above "proxy" list. This enables
+# LES PBL to be used on FG domains.
+package   lesscheme      bl_pbl_physics==0           -             -
 package   ysuscheme      bl_pbl_physics==1           -             -
-package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
+package   myjpblscheme   bl_pbl_physics==2           -             -
 package   gfsscheme      bl_pbl_physics==3           -             -
-package   qnsepblscheme  bl_pbl_physics==4           -             state:tke_pbl,el_pbl,massflux_EDKF,entr_EDKF,detr_EDKF,thl_up,thv_up,rv_up,rt_up,rc_up,u_up,v_up,frac_up,rc_mf
-package   mynnpblscheme2 bl_pbl_physics==5           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
-package   mynnpblscheme3 bl_pbl_physics==6           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
+package   qnsepblscheme  bl_pbl_physics==4           -             -
+package   mynnpblscheme2 bl_pbl_physics==5           -             -
+package   mynnpblscheme3 bl_pbl_physics==6           -             -
 package   acmpblscheme   bl_pbl_physics==7           -             -
-package   boulacscheme   bl_pbl_physics==8           -             state:el_pbl,tke_pbl,wu_tur,wv_tur,wt_tur,wq_tur
-package   camuwpblscheme bl_pbl_physics==9           -             state:tauresx2d,tauresy2d,tpert2d,qpert2d,wpert2d,tke_pbl,smaw3d,wsedl3d,turbtype3d
-package   temfpblscheme  bl_pbl_physics==10          -             state:te_temf,kh_temf,km_temf,shf_temf,qf_temf,uw_temf,vw_temf,wupd_temf,mf_temf,thup_temf,qlup_temf,qtup_temf,cf3d_temf,hd_temf,lcl_temf,hct_temf,cfm_temf
-package   shinhongscheme bl_pbl_physics==11          -             state:el_pbl,tke_pbl
-package   gbmpblscheme   bl_pbl_physics==12          -             state:exch_tke,el_pbl,tke_pbl
-package   eepsscheme     bl_pbl_physics==16          -             scalar:pek_adv,pep_adv;state:tke_pbl,pep_pbl
+package   boulacscheme   bl_pbl_physics==8           -             -
+package   camuwpblscheme bl_pbl_physics==9           -             -
+package   temfpblscheme  bl_pbl_physics==10          -             -
+package   shinhongscheme bl_pbl_physics==11          -             -
+package   gbmpblscheme   bl_pbl_physics==12          -             -
+package   eepsscheme     bl_pbl_physics==16          -             -
 package   mrfscheme      bl_pbl_physics==99          -             -
 
 package   mynn_tkebudget bl_mynn_tkebudget==1        -             state:qSHEAR,qBUOY,qDISS,qWT,dqke

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -435,7 +435,6 @@ DO i = 1, model_config_rec % max_dom
 print *,model_config_rec % bl_pbl_physics_proxy(i),model_config_rec % bl_pbl_physics(i)
 ENDDO
 print *,'        ------------------'
-stop
 
 !-----------------------------------------------------------------------
 ! Urban physics set up. If the run-time option for use_wudapt_lcz = 0,

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -407,6 +407,37 @@
       ENDDO
 
 !-----------------------------------------------------------------------
+! Handle the behind the scenes shuffling of the PBL package info, 
+! in support of generalizing usage of the LES PBL option on the FG.
+!-----------------------------------------------------------------------
+      exists = .FALSE.
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         model_config_rec % bl_pbl_physics_proxy(i) = model_config_rec % bl_pbl_physics(i) 
+         IF ( model_config_rec % bl_pbl_physics(i) .EQ. lesscheme ) THEN
+            exists = .TRUE.
+         END IF
+      ENDDO
+      IF ( ( exists ) .AND. (  model_config_rec % bl_pbl_physics(1) .NE. lesscheme ) ) THEN
+         DO i = 2, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+            IF ( model_config_rec % bl_pbl_physics(i) .EQ. lesscheme ) THEN
+               model_config_rec % bl_pbl_physics_proxy(i) = model_config_rec % bl_pbl_physics_proxy(1) 
+            END IF
+         ENDDO
+      END IF
+print *,'            DAVE TEST'
+print *,'          PBL      PBL ' 
+print *,'         PROXY   PHYSICS'
+print *,'         (mem)   (scheme)'
+print *,'        ------------------'
+DO i = 1, model_config_rec % max_dom
+print *,model_config_rec % bl_pbl_physics_proxy(i),model_config_rec % bl_pbl_physics(i)
+ENDDO
+print *,'        ------------------'
+stop
+
+!-----------------------------------------------------------------------
 ! Urban physics set up. If the run-time option for use_wudapt_lcz = 0,
 ! then the number of urban classes is 3. Else, if the use_wudapt_lcz = 1, 
 ! then the number increases to 11. The seemingly local variable 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: PBL, LES, proxy

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Only the YSU PBL scheme has no packaged variables. If a user wants to have any other PBL scheme on the CG,
and an LES PBL on the FG, the model will have memory corruption problems. This error is hard to track down.
Inside the model, the having different PBL schemes on different domains (basically any non-YSU PBL with LES 
PBL) causes an inconsistent number of variables on the CG and FG, which then causes segmentation faults when 
trying to do feedback or advection of unavailable fields.

Solution:
Introduce a derived namelist entry (MAX_DOM sized). This proxy namelist value is used for space allocation
due to packaging. The existing PBL physics definitions, and the associated packaged variables, have been
replicated. The proxy entries are used to define the space, and the original entries are used for the
automatically generated names.

1. There is no difference for the user facing namelist interface.
2. The developers see no differences inside of the WRF dynamics, or the physics schemes or drivers.
3. The only developer impact would be when adding additional packaged variables to an existing
PBL scheme, or when introducing a new scheme.

ISSUE:
Fixes #1514 "MYNN in parent, LES in a nest: sometimes the sim does not run"

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. A few test scenarios of the combinations of PBL options were tested. These results were printed out
from the real program (same part of check_a_mundo that the WRF model sees). In each of the examples,
the check_a_mundo logic translates the namelist entries into the required packages. To demonstrate the
availability of some variables, the Registry was modified to include `h` for some fields so that they would
be eligible to be checked in the model output.
   
* bl_pbl_physics = 5, 0,
The memory allocation on domain 2 is set to the same packaged variables as on domain 1.
```
           PBL      PBL
          PROXY   PHYSICS
          (mem)   (scheme)
         ------------------
           5           5
           5           0
         ------------------
```


   * bl_pbl_physics = 1, 0,
The memory allocation on domain 2 is set to the same packaged variables as on domain 1.
```
           PBL      PBL
          PROXY   PHYSICS
          (mem)   (scheme)
         ------------------
           1           1
           1           0
         ------------------
```

   * bl_pbl_physics = 1, 1,
The memory allocation remains the default, package definitions for domains 1 and 2 remain unchanged.
```
           PBL      PBL
          PROXY   PHYSICS
          (mem)   (scheme)
         ------------------
           1           1
           1           1
         ------------------
```

   * bl_pbl_physics = 0, 0,
The memory allocation remains the default, package definitions for domains 1 and 2 remain unchanged.
```
           PBL      PBL
          PROXY   PHYSICS
          (mem)   (scheme)
         ------------------
           0           0
           0           0
         ------------------
```
2. More confirmation that the correct variables are being allocated is by looking at the output from the 
netcdf files. 

With the standard code, with `bl_pbl_physics = 5, 0,`, there is `qke_adv` on d01, but not on d02:
```
$ ncdump -h wrfinput_d01 | grep -i qke_adv
	float qke_adv(Time, bottom_top, south_north, west_east) ;
		qke_adv:FieldType = 104 ;
		qke_adv:MemoryOrder = "XYZ" ;
		qke_adv:description = "twice TKE from MYNN" ;
		qke_adv:units = "m2 s-2" ;
		qke_adv:stagger = "" ;
		qke_adv:coordinates = "XLONG XLAT XTIME" ;

$ ncdump -h wrfinput_d02 | grep -i qke_adv
```
With the modified source, with `bl_pbl_physics = 5, 0,`, the `qke_adv` field is on both domains:
```
$ ncdump -h wrfinput_d01 | grep -i qke_adv
	float qke_adv(Time, bottom_top, south_north, west_east) ;
		qke_adv:FieldType = 104 ;
		qke_adv:MemoryOrder = "XYZ" ;
		qke_adv:description = "twice TKE from MYNN" ;
		qke_adv:units = "m2 s-2" ;
		qke_adv:stagger = "" ;
		qke_adv:coordinates = "XLONG XLAT XTIME" ;

$ ncdump -h wrfinput_d02 | grep -i qke_adv
	float qke_adv(Time, bottom_top, south_north, west_east) ;
		qke_adv:FieldType = 104 ;
		qke_adv:MemoryOrder = "XYZ" ;
		qke_adv:description = "twice TKE from MYNN" ;
		qke_adv:units = "m2 s-2" ;
		qke_adv:stagger = "" ;
		qke_adv:coordinates = "XLONG XLAT XTIME" ;
```
An `h` had to be added to the IO strings, but the `qke_adv` field with settings `bl_pbl_physics = 5, 0,` is in
the standard output file for both of the domains:
```
$ ncdump -h wrfout_d01_2000-01-24_12:00:00 | grep -i qke_adv
	float qke_adv(Time, bottom_top, south_north, west_east) ;
		qke_adv:FieldType = 104 ;
		qke_adv:MemoryOrder = "XYZ" ;
		qke_adv:description = "twice TKE from MYNN" ;
		qke_adv:units = "m2 s-2" ;
		qke_adv:stagger = "" ;
		qke_adv:coordinates = "XLONG XLAT XTIME" ;

$ ncdump -h wrfout_d02_2000-01-24_12:00:00 | grep -i qke_adv
	float qke_adv(Time, bottom_top, south_north, west_east) ;
		qke_adv:FieldType = 104 ;
		qke_adv:MemoryOrder = "XYZ" ;
		qke_adv:description = "twice TKE from MYNN" ;
		qke_adv:units = "m2 s-2" ;
		qke_adv:stagger = "" ;
		qke_adv:coordinates = "XLONG XLAT XTIME" ;
```
3. Jenkins tests are all PASS.

RELEASE NOTE: A generalized method to handle domain-wise inconsistent PBL options has been introduced. Previously, this problem caused an inconsistent number of variables on the CG and FG, which caused segmentation faults when trying to do feedback or advection of unavailable fields. For users that tried the LES PBL option and a non-YSU PBL scheme (AND it actually worked!), it is possible that the results will be somewhat different due to the CG<->FG interactions during feedback and the generation of lateral boundary conditions for the nest. Scheme developers are pointed to the new packaging for the PBL schemes (look for the string `_proxy` in Registry.EM_COMMON in the package area).