### PR TITLE
Another physics syntax error

### DIFF
--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -6220,7 +6220,7 @@
             ENDIF
             IF (AH1D.GE.ASMALL) THEN
                AhCLsh = (MVDX**2.-MVDH**2.)*NCLS1*ESH*VTASH*NH1D*(     &
-                        SASR2*GS3*+SASR1*2.*GH2*GS2+GH3)
+                        SASR2*GS3 +SASR1*2.*GH2*GS2+GH3)
             ENDIF
          ENDIF
          IF (QS1D.GE.QSMALL.AND.MVDS.GE.2.E-4) THEN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: syntax, physics *+

SOURCE: Patricia Balle (HPE)

DESCRIPTION OF CHANGES:
Problem:
As in hash 7c6fd575b7a8fe, PR #1577 "Syntax errors in physics routines: *- and *+", there is a single
remaining example of the unary operators next to each other.

Solution:
The author agreed that the `*+` combination was supposed to be just `+`.

I searched the WRF code for instances of this `*+` in PR #1577. When I did not find any, I put back one of them from 
NTU code to make sure that my grep was working. It found that example, and no others that I cared about. I forgot
to undo that change before the `git add`, `git commit`.

LIST OF MODIFIED FILES:
modified:   phys/module_mp_ntu.F

TESTS CONDUCTED:
1. Passes Cray compiler.
2. Jenkins tests are OK