### PR TITLE
fix WRFDA CRTM Cray Fortran build

### DIFF
--- a/var/external/crtm_2.3.0/libsrc/makefile
+++ b/var/external/crtm_2.3.0/libsrc/makefile
@@ -57,3 +57,10 @@ Sort_Utility.o:
            $(SFC) -c $(FCFLAGS_CRTM) $*.f90 ; \
         fi
 
+SOI_Module.o:
+	x=`echo "$(SFC)" | awk '{print $$1}'` ; export x ; \
+        if [ $$x = "ftn" ] ; then \
+           $(SFC) -c $(FCFLAGS_CRTM) -O1 $*.f90 ; \
+        else \
+           $(SFC) -c $(FCFLAGS_CRTM) $*.f90 ; \
+        fi


### PR DESCRIPTION
TYPE: bug fix (?)

KEYWORDS: WRFDA, CRTM, ftn compiler

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Problem:
One of the CRTM modules does not compile with Cray Fortran : Version 12.0.3 with default or -O2 optimization.
ftn -hnoomp -c  -N1023 -f free -h byteswapio   SOI_Module.f90
```
ERROR - Trying to add using unusual type properties
  op1_type :: <array[t$90] of real*8>
  op2_type :: <array[t$90] of real*8>
   Error message      ::  Optimization internal error
   Error detected     ::  File 'pdgcs/v_expr_pls.c', line 197
   Optimizer built    ::  2021-08-16 (production)
   File               ::  SOI_Module.f90
   Function           ::  crtm_soi_ad
   at or near line    ::  656
```
Solution:
Edit CRTM makefile to compile SOI_Module.f90 with -O1 flag when ftn compiler is used.

LIST OF MODIFIED FILES:
M       var/external/crtm_2.3.0/libsrc/makefile

TESTS CONDUCTED:
1. WRFDA builds on Cheyenne crayenv after the fix. (note that configure.wrf has to be edited to uncomment two lines that specify LIB_LOCAL as noted in 207c89ea)
2. Jenkins tests passed.

RELEASE NOTE: N/A