### PR TITLE
PBL + LES restrictions

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3086,6 +3086,8 @@ package   drip           sf_surf_irr_alloc==2        -             state:irrigat
 package   sprinkler      sf_surf_irr_alloc==3        -             state:irrigation,irr_rand_field
 
 
+package   lesscheme      bl_pbl_physics==0           -             -
+package   nopblscheme    bl_pbl_physics==0           -             -
 package   ysuscheme      bl_pbl_physics==1           -             -
 package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
 package   gfsscheme      bl_pbl_physics==3           -             -

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3087,7 +3087,6 @@ package   sprinkler      sf_surf_irr_alloc==3        -             state:irrigat
 
 
 package   lesscheme      bl_pbl_physics==0           -             -
-package   nopblscheme    bl_pbl_physics==0           -             -
 package   ysuscheme      bl_pbl_physics==1           -             -
 package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
 package   gfsscheme      bl_pbl_physics==3           -             -

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -406,6 +406,34 @@
          END IF
       ENDDO
 
+
+!-----------------------------------------------------------------------
+! Check that LES PBL is only paired with acceptable other PBL options.
+! Currently, problems occur with any CG PBL option that has a packaged 
+! scalar (as opposed to state) component: MYNN2, MYNN3, EEPS.
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec % bl_pbl_physics(i) .EQ. LESscheme ) THEN
+            exists = .TRUE.
+         END IF
+      END DO
+      IF ( ( exists ) .AND. &
+           ( ( model_config_rec % bl_pbl_physics(1) .EQ. MYNNPBLSCHEME2 ) .OR. &
+             ( model_config_rec % bl_pbl_physics(1) .EQ. MYNNPBLSCHEME3 ) .OR. &
+             ( model_config_rec % bl_pbl_physics(1) .EQ. EEPSSCHEME     ) ) ) THEN
+         WRITE(wrf_err_message,fmt='(a,i2)') '--- ERROR: LES PBL on fine grid does not work with CG PBL option ',model_config_rec % bl_pbl_physics(1)
+         CALL wrf_message ( TRIM( wrf_err_message ) )
+         wrf_err_message = '           Choose a CG PBL option without any scalar components'
+         CALL wrf_message ( TRIM( wrf_err_message ) )
+         wrf_err_message = '           Fix bl_pbl_physics in namelist.input'
+         CALL wrf_message ( TRIM( wrf_err_message ) )
+         wrf_err_message = '           Alternatively, remove all of the packaged variables from the CG PBL selection'
+         CALL wrf_message ( TRIM( wrf_err_message ) )
+         count_fatal_error = count_fatal_error + 1
+      END IF 
+
+
 !-----------------------------------------------------------------------
 ! Urban physics set up. If the run-time option for use_wudapt_lcz = 0,
 ! then the number of urban classes is 3. Else, if the use_wudapt_lcz = 1, 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -410,7 +410,7 @@
 !-----------------------------------------------------------------------
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently, problems occur with any CG PBL option that has a packaged 
-! scalar (as opposed to state) component: MYNN2, MYNN3, EEPS.
+! scalar component: MYNN2, MYNN3, EEPS.
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -411,7 +411,8 @@
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently, problems occur with any CG PBL option that has a packaged 
 ! scalar component: MYNN2, MYNN3, EEPS. This test is also if a user 
-! chooses to not run a PBL scheme.
+! chooses to not run a PBL scheme on a finer domain, with a PBL on a
+! coarser domain (obviously, just for testing purposes).
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -411,8 +411,9 @@
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently, problems occur with any CG PBL option that has a packaged 
 ! scalar component: MYNN2, MYNN3, EEPS. This test is also if a user 
-! chooses to not run a PBL scheme on a finer domain, with a PBL on a
-! coarser domain (obviously, just for testing purposes).
+! chooses to not run a PBL scheme on a finer domain, wbut use a PBL 
+! parameterized scheme on a coarser domain (obviously, just for testing 
+! purposes).
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -410,7 +410,8 @@
 !-----------------------------------------------------------------------
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently, problems occur with any CG PBL option that has a packaged 
-! scalar component: MYNN2, MYNN3, EEPS.
+! scalar component: MYNN2, MYNN3, EEPS. This test is also if a user 
+! chooses to not run a PBL scheme.
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -424,9 +424,7 @@
              ( model_config_rec % bl_pbl_physics(1) .EQ. EEPSSCHEME     ) ) ) THEN
          WRITE(wrf_err_message,fmt='(a,i2)') '--- ERROR: LES PBL on fine grid does not work with CG PBL option ',model_config_rec % bl_pbl_physics(1)
          CALL wrf_message ( TRIM( wrf_err_message ) )
-         wrf_err_message = '           Choose a CG PBL option without any scalar components'
-         CALL wrf_message ( TRIM( wrf_err_message ) )
-         wrf_err_message = '           Fix bl_pbl_physics in namelist.input'
+         wrf_err_message = '           Fix bl_pbl_physics in namelist.input: choose a CG PBL option without any scalar components'
          CALL wrf_message ( TRIM( wrf_err_message ) )
          wrf_err_message = '           Alternatively, remove all of the packaged variables from the CG PBL selection'
          CALL wrf_message ( TRIM( wrf_err_message ) )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: PBL, LES

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
A few PBL schemes include scalar components that are advected. These fields are
required on all domains. With an LES option on a finer domain, that grid does not
have the additional scalar component, which causes a segfault when trying to
access that field.

Solution:
Restrict what PBL schemes are eligible for use with the LES (no PBL) option.

ISSUE:
Fixes #1514

LIST OF MODIFIED FILES:
modified:   Registry/Registry.EM_COMMON
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. When an incompatible CG PBL and FG LES are selected, the code successfully stops.
```
 &physics
 bl_pbl_physics                      =  5,     0,

--- ERROR: LES PBL on fine grid does not work with CG PBL option  5
           Choose a CG PBL option without any scalar components
           Fix bl_pbl_physics in namelist.input
           Alternatively, remove all of the packaged variables from the CG PBL selection
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2523
NOTE:       1 namelist settings are wrong. Please check and reset these options
```
```
 &physics
 bl_pbl_physics                      =  6,     0,

--- ERROR: LES PBL on fine grid does not work with CG PBL option  6
           Choose a CG PBL option without any scalar components
           Fix bl_pbl_physics in namelist.input
           Alternatively, remove all of the packaged variables from the CG PBL selection
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2523
NOTE:       1 namelist settings are wrong. Please check and reset these options
```
```
 &physics
 bl_pbl_physics                      = 16,     0,

--- ERROR: LES PBL on fine grid does not work with CG PBL option  16
           Choose a CG PBL option without any scalar components
           Fix bl_pbl_physics in namelist.input
           Alternatively, remove all of the packaged variables from the CG PBL selection
-------------- FATAL CALLED ---------------
FATAL CALLED FROM FILE:  <stdin>  LINE:    2523
NOTE:       1 namelist settings are wrong. Please check and reset these options
```
2. Hopefully we say All jenkins tests are a PASS.

RELEASE NOTE: A test was introduced to stop the incorrect combination of particular PBL schemes on coarser grids with the LES PBL option selected on a finer grid. Previously, this problem caused an inconsistent number of variables on the CG and FG, which caused segmentation faults when trying to do feedback or advection of unavailable fields.