### PR TITLE
build module_state_description.F -> force zero return code

### DIFF
--- a/frame/Makefile
+++ b/frame/Makefile
@@ -163,7 +163,7 @@ clean:
 	@ echo 'use the clean script'
 
 module_state_description.F : ../Registry/$(REGISTRY)
-		  ( cd .. ; tools/registry $(ARCHFLAGS) $(ENVCOMPDEFS) -DNEW_BDYS Registry/$(REGISTRY) ) ; 
+		  ( cd .. ; tools/registry $(ARCHFLAGS) $(ENVCOMPDEFS) -DNEW_BDYS Registry/$(REGISTRY) ; true ) ; 
 
 module_io_quilt.o : module_io_quilt.F module_io_quilt_old.F
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: 255, return code, true

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When building the WRF model, one of the early steps is to use the registry program to construct
a large number of include files, and to build the Fortran file module_state_description. This is
constructing a Fortran file, not an executable. The return from that build is non-zero, and that
causes a cascading failure on every AWS build, and (at least) many of the dual OS builds.

Solution:
We cheat. We add the the `true` command after the command that builds the file
module_state_description.F. The return code from the whole process is then, voila, zero.

LIST OF MODIFIED FILES:
modified:   frame/Makefile

TESTS CONDUCTED:
1. Reproducibly, the build fails due to the non-zero return code for the build of the file
module_state_description.F.
```
make[2]: [module_state_description.F] Error 255
```
With the mod, the error code is magically zero, and the WRF code builds without any issues.
2. Jenkins tests are all passing.

RELEASE NOTE: After the inclusion of the unix-y `true` command as the last command in a string of registry-based commands, now the WRF code builds on AWS with the Intel compiler. For other users, this will have no impact.