### PR TITLE
WRFDA memory usage reduction for thin_conv=true

### DIFF
--- a/var/da/da_setup_structures/da_setup_obs_structures.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures.inc
@@ -169,6 +169,38 @@ subroutine da_setup_obs_structures( grid, ob, iv, j_cost)
       rtminit_sensor   = pseudo_rad_senid
    end if
 
+   obs_use(1:num_ob_indexes) = .false.
+   if ( use_airepobs ) obs_use(airep) = .true.
+   if ( use_bogusobs ) obs_use(bogus) = .true.
+   if ( use_buoyobs ) obs_use(buoy) = .true.
+   if ( use_geoamvobs ) obs_use(geoamv) = .true.
+   if ( use_gpsephobs ) obs_use(gpseph) = .true.
+   if ( use_gpsrefobs ) obs_use(gpsref) = .true.
+   if ( use_gpsztdobs .or. use_gpspwobs ) obs_use(gpspw) = .true.
+   if ( use_metarobs ) obs_use(metar) = .true.
+   if ( use_mtgirsobs ) obs_use(mtgirs) = .true.
+   if ( use_pilotobs ) obs_use(pilot) = .true.
+   if ( use_polaramvobs ) obs_use(polaramv) = .true.
+   if ( use_profilerobs ) obs_use(profiler) = .true.
+   if ( use_qscatobs ) obs_use(qscat) = .true.
+   if ( use_radarobs ) obs_use(radar) = .true.
+   if ( use_rainobs ) obs_use(rain) = .true.
+   if ( use_satemobs ) obs_use(satem) = .true.
+   if ( use_shipsobs ) obs_use(ships) = .true.
+   if ( use_soundobs ) then
+      obs_use(sound) = .true.
+      obs_use(sonde_sfc) = .true.
+   end if
+   if ( use_ssmiretrievalobs ) obs_use(ssmi_rv) = .true.
+   if ( use_ssmitbobs ) obs_use(ssmi_tb) = .true.
+   if ( use_ssmt1obs ) obs_use(ssmt1) = .true.
+   if ( use_ssmt2obs ) obs_use(ssmt2) = .true.
+   if ( use_synopobs ) obs_use(synop) = .true.
+   if ( use_tamdarobs ) then
+      obs_use(tamdar) = .true.
+      obs_use(tamdar_sfc) = .true.
+   end if
+
    if (sfc_assi_options < 1 .OR. sfc_assi_options > 2) then
       write(unit=message(1),fmt='(A,I3)') &
          'Invalid sfc_assi_option = ', sfc_assi_options

--- a/var/da/da_setup_structures/da_setup_obs_structures_ascii.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures_ascii.inc
@@ -70,7 +70,11 @@ subroutine da_setup_obs_structures_ascii( ob, iv, grid )
 
       allocate(thinning_grid_conv(num_ob_indexes))
       do n = 1, num_ob_indexes
-         if (n == radar) cycle
+         if ( .not. obs_use(n) .or. &
+              n == gpseph      .or. &
+              n == radar       .or. &
+              n == radiance    .or. &
+              n == rain ) cycle
          if( n == airep .or. n == tamdar ) then
             thin_3d=.true.
             call make3grids (n,thin_mesh_conv(n), thin_3d)
@@ -228,7 +232,11 @@ subroutine da_setup_obs_structures_ascii( ob, iv, grid )
 
    if ( thin_conv_ascii ) then
       do n = 1, num_ob_indexes
-         if (n == radar) cycle
+         if ( .not. obs_use(n) .or. &
+              n == gpseph      .or. &
+              n == radar       .or. &
+              n == radiance    .or. &
+              n == rain ) cycle
          if( n == airep .or. n==tamdar ) then
             thin_3d=.true.
             call destroygrids_conv (n, thin_3d)

--- a/var/da/da_setup_structures/da_setup_obs_structures_bufr.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures_bufr.inc
@@ -70,6 +70,12 @@ subroutine da_setup_obs_structures_bufr(grid, ob, iv)
 
       allocate(thinning_grid_conv(num_ob_indexes))
       do n = 1, num_ob_indexes
+         if ( .not. obs_use(n) .or. &
+              n == gpseph      .or. &
+              n == gpsref      .or. &
+              n == radar       .or. &
+              n == radiance    .or. &
+              n == rain ) cycle
          call make3grids (n,thin_mesh_conv(n))
       end do
    end if
@@ -93,6 +99,12 @@ subroutine da_setup_obs_structures_bufr(grid, ob, iv)
 
    if ( thin_conv ) then
       do n = 1, num_ob_indexes
+         if ( .not. obs_use(n) .or. &
+              n == gpseph      .or. &
+              n == gpsref      .or. &
+              n == radar       .or. &
+              n == radiance    .or. &
+              n == rain ) cycle
          call destroygrids_conv (n)
       end do
       deallocate(thinning_grid_conv)

--- a/var/da/da_setup_structures/da_setup_structures.f90
+++ b/var/da/da_setup_structures/da_setup_structures.f90
@@ -74,7 +74,7 @@ module da_setup_structures
       chi_u_t_factor, chi_u_ps_factor,chi_u_rh_factor, t_u_rh_factor, ps_u_rh_factor, &
       interpolate_stats, be_eta, thin_rainobs, fgat_rain_flags, use_iasiobs, &
       use_seviriobs, jds_int, jde_int, anal_type_hybrid_dual_res, use_amsr2obs, nrange, use_4denvar, &
-      use_goesimgobs, use_ahiobs,use_gmiobs
+      use_goesimgobs, use_ahiobs,use_gmiobs, obs_use
    use da_control, only: rden_bin, use_lsac
    use da_control, only: use_cv_w
    use da_control, only: pseudo_tpw, pseudo_ztd, pseudo_ref, pseudo_uvtpq, pseudo_elv, anal_type_qcobs


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, memory, thin_conv

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Problem:
thin_conv is true by default. When ob_format=1 (bufr for conventional ob types), thinning_grid_conv(num_ob_indexes) and its sub data arrays are allocated for all ob types as defined in da_control.f90 (obs_names(num_ob_indexes)) even though not all ob types are used.

Solution:
Do not call make3grids (which allocates several data arrays based on the setting of thin_mesh_conv) for ob types that are not used in the assimilation and not coded for thinning.

Note that gpsref horizontal thinning is not implemented for ob_format=1 (but is implemented for ob_format=2), so its thinning grid does not need to be allocated in da_setup_obs_structures_bufr.inc. That is the reason the specific check for gpsref appears in da_setup_obs_structures_bufr.inc but not da_setup_obs_structures_ascii.inc.

Caveat: The same fix logic is done for thin_conv_ascii (default is .false. and only matters when ob_format=2). But I have never tested thin_conv_ascii=.true.

LIST OF MODIFIED FILES:
M       var/da/da_setup_structures/da_setup_obs_structures.inc
M       var/da/da_setup_structures/da_setup_obs_structures_ascii.inc
M       var/da/da_setup_structures/da_setup_obs_structures_bufr.inc
M       var/da/da_setup_structures/da_setup_structures.f90

TESTS CONDUCTED:
1. fixed code has been used extensively by Craig Schwartz.
2. WRFDA regression test?
3. Are the Jenkins tests all passing?

RELEASE NOTE: WRFDA has been fixed to reduce the memory usage for ob_format=1 (i.e. bufr for conventional obs) and thin_conv=true.