### PR TITLE
fix WRFDA stand-alone da_rad_diags.exe build with GNU Fortran 11

### DIFF
--- a/var/da/da_monitor/da_rad_diags.f90
+++ b/var/da/da_monitor/da_rad_diags.f90
@@ -22,12 +22,6 @@ program da_rad_diags
 !
 ! namelist variables
 !
-   namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
-           ! nproc: number of processsors used when writing out inv files
-           ! instid, eg dmsp-16-ssmis
-           ! file_prefix, inv or oma
-           ! start_date, end_date, eg 2006100100, 2006102800
-           ! cycle_period (hours) between dates, eg 6 or 12
    integer, parameter                     :: maxnum = 20, maxlvl = 100
    integer                                :: nml_unit = 87
    integer                                :: nproc, nlev, ilev, ich
@@ -35,6 +29,12 @@ program da_rad_diags
    character(len=20), dimension(maxnum)   :: instid
    character(len=6)                       :: file_prefix
    character(len=10)                      :: start_date, end_date
+   namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
+           ! nproc: number of processsors used when writing out inv files
+           ! instid, eg dmsp-16-ssmis
+           ! file_prefix, inv or oma
+           ! start_date, end_date, eg 2006100100, 2006102800
+           ! cycle_period (hours) between dates, eg 6 or 12
 !
 ! netcdf variables
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, da_rad_diags.exe, gfortran-11

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Problem:
On MacOS with GNU Fortran (Homebrew GCC 11.1.0_1) 11.1.0, the stand-alone utility da_rad_diags.exe does not build.
The error messages:
```
gfortran -c -O2 -ftree-vectorize -funroll-loops -w -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -fallow-argument-mismatch -fallow-invalid-boz  -fdefault-real-8 -I/usr/local/include da_rad_diags.f
da_rad_diags.f:1804:28:

 1804 |    namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
      |                            1
Error: Symbol 'nproc' in namelist 'record1' at (1) must be declared before the namelist is declared.
da_rad_diags.f:1804:36:

 1804 |    namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
      |                                    1
Error: Symbol 'instid' in namelist 'record1' at (1) must be declared before the namelist is declared.
da_rad_diags.f:1804:49:

 1804 |    namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
      |                                                 1
Error: Symbol 'file_prefix' in namelist 'record1' at (1) must be declared before the namelist is declared.
da_rad_diags.f:1804:61:

 1804 |    namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
      |                                                             1
Error: Symbol 'start_date' in namelist 'record1' at (1) must be declared before the namelist is declared.
da_rad_diags.f:1804:71:

 1804 |    namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
      |                                                                       1
Error: Symbol 'end_date' in namelist 'record1' at (1) must be declared before the namelist is declared.
da_rad_diags.f:1804:84:

 1804 |    namelist /record1/ nproc, instid, file_prefix, start_date, end_date, cycle_period
      |                                                                                    1
Error: Symbol 'cycle_period' in namelist 'record1' at (1) must be declared before the namelist is declared.
make[1]: [da_rad_diags.o] Error 1 (ignored)
```

Solution:
Move the namelist statement after variable declarations, then the code builds.

LIST OF MODIFIED FILES:
M       var/da/da_monitor/da_rad_diags.f90

TESTS CONDUCTED:
1. da_rad_diags.exe is generated after the fix.

RELEASE NOTE: N/A (it is probably not worth mentioning)