### PR TITLE
Put KIAPS rad LW back to original

### DIFF
--- a/phys/module_ra_rrtmg_lwk.F
+++ b/phys/module_ra_rrtmg_lwk.F
@@ -6136,9 +6136,10 @@
 !                                  (high key - nothing; high minor-cfc11, cfc12)
 !
 !-------------------------------------------------------------------------------
-   use parrrtm_k,   only : ngs5
+   use parrrtm_k,   only : ng6, ngs5
    use rrlw_ref_k,  only : chi_mls
-   use rrlw_kg06_k
+   use rrlw_kg06_k, only : fracrefa, absa, ka, ka_mco2,                        &
+                         selfref, forref, cfc11adj, cfc12
 !
 ! Local 
 !
@@ -9010,8 +9011,11 @@
 !  old band 6:  820-980 cm-1 (low - h2o; high - nothing)
 !
 !-------------------------------------------------------------------------------
-   use parrrtm_k,   only : mg, nbndlw, ngptlw
-   use rrlw_kg06
+   use parrrtm_k,   only : mg, nbndlw, ngptlw, ng6
+   use rrlw_kg06_k, only : fracrefao, kao, kao_mco2, cfc11adjo, cfc12o,        &
+                         selfrefo, forrefo,                                    &
+                         fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12,         &
+                         selfref, forref
 !
 ! Local
 !
@@ -12818,7 +12822,8 @@
 !  etc.  The second index runs over the g-channel (1 to 16).
 !
 !-------------------------------------------------------------------------------
-   use rrlw_kg06_k
+   use rrlw_kg06_k, only : fracrefao, kao, kao_mco2, selfrefo, forrefo,        &
+                         cfc11adjo, cfc12o
 !
    implicit none
 !


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: KIAPS, radiation, LW

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
In an attempt to get the KIAPS radiation LW scheme to build with older GNU compilers,
some simplifications were introduced to remove ONLY clauses. However, an error was
introduced - a module from RRTMG was "USEd" (hash 911b8451bf7c9 introduced some
simplifications and the error, hash a83c7cb27d7f4a4 tried to fix the error in the
wrong way).

Solution:
Put the entire KIAPS radiation LW scheme back to the original pristine condition, as the
current GNU compilers have no troubles with building the scheme. And fix that bug!

LIST OF MODIFIED FILES:

TESTS CONDUCTED:
1. GNU builds the original KIAPS LW radiation scheme.
2. Jenkins is all PASS.

RELEASE NOTE: An error was introduced into the KIAPS LW radiation scheme. This problem
tried to fix a compilation failure, and ended up introducing yet another compile-time
failure. The solution is to revert the entire KIAPS LW radiation scheme to the original
pristine condition.