### PR TITLE
WRFDA thin_conv code restructuring

### DIFF
--- a/Registry/registry.var
+++ b/Registry/registry.var
@@ -135,6 +135,7 @@ rconfig   integer   ob_format_gpsro         namelist,wrfvar3  1  2        - "ob_
 rconfig   integer   num_fgat_time           namelist,wrfvar3  1  1        - "num_fgat_time"            ""  ""
 rconfig   logical   thin_conv               namelist,wrfvar4  1  .true.   - "thin_conv"                ""  ""
 rconfig   logical   thin_conv_ascii         namelist,wrfvar4  1  .false.  - "thin_conv_ascii"          ""  ""
+rconfig   integer   thin_conv_opt           namelist,wrfvar4  num_ob_indexes 1      - "thin_conv_opt"  ""  "0=no thinning, >0:thinning on"
 rconfig   real      thin_mesh_conv          namelist,wrfvar4  num_ob_indexes 20.0   - "thin_mesh_conv"            ""  ""
 rconfig   logical   thin_rainobs            namelist,wrfvar4  1  .true.   - "thin_rainobs"             ""  ""
 rconfig   logical   use_synopobs            namelist,wrfvar4  1  .true.   - "use_synopobs"             ""  ""

--- a/var/da/da_control/da_control.f90
+++ b/var/da/da_control/da_control.f90
@@ -690,4 +690,10 @@ module da_control
 
    logical, allocatable :: fgat_rain_flags(:)
 
+   integer, parameter :: no_thin           = 0
+   integer, parameter :: thin_single       = 1
+   integer, parameter :: thin_multi        = 2
+   integer, parameter :: thin_superob      = 3
+   integer, parameter :: thin_superob_hv   = 4
+
 end module da_control

--- a/var/da/da_control/da_control.f90
+++ b/var/da/da_control/da_control.f90
@@ -691,9 +691,5 @@ module da_control
    logical, allocatable :: fgat_rain_flags(:)
 
    integer, parameter :: no_thin           = 0
-   integer, parameter :: thin_single       = 1
-   integer, parameter :: thin_multi        = 2
-   integer, parameter :: thin_superob      = 3
-   integer, parameter :: thin_superob_hv   = 4
 
 end module da_control

--- a/var/da/da_obs_io/da_obs_io.f90
+++ b/var/da/da_obs_io/da_obs_io.f90
@@ -32,7 +32,8 @@ module da_obs_io
       thin_conv, thin_conv_ascii, lsac_nh_step, lsac_nv_step, lsac_nv_start, lsac_print_details, &
       lsac_use_u, lsac_use_v, lsac_use_t, lsac_use_q, lsac_u_error, lsac_v_error, lsac_t_error, lsac_q_error, &
       gpsro_drift, max_gpseph_input, use_gpsephobs, gpseph, gpseph_loadbalance, kds, kde, kts, kte, &
-      use_radar_rhv, use_radar_rqv, use_radar_rf, use_radar_rv, multi_inc
+      use_radar_rhv, use_radar_rqv, use_radar_rf, use_radar_rv, multi_inc, &
+      thin_conv_opt, no_thin
 
    use da_wrf_interfaces, only : wrf_dm_bcast_integer, wrf_dm_bcast_real
 

--- a/var/da/da_obs_io/da_read_obs_ascii.inc
+++ b/var/da/da_obs_io/da_read_obs_ascii.inc
@@ -85,6 +85,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
    ilocal    = nlocal
    if ( thin_conv_ascii ) then
        do n = 1, num_ob_indexes
+          if ( .not. allocated(thinning_grid_conv(n)%icount) ) cycle
           if ( n == radar ) cycle
           call cleangrids_conv(n)
        end do
@@ -441,7 +442,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_synopobs .or. ntotal(synop) == max_synop_input  ) cycle reports
             if (n==1) ntotal(synop) = ntotal(synop)+1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(synop) > no_thin ) then
                crit = tdiff
                call map2grids_conv(synop,dlat_earth,dlon_earth,crit,nlocal(synop),itx,1,itt,ilocal(synop),iuse)
                if ( .not. iuse ) cycle reports
@@ -468,7 +469,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_shipsobs .or. ntotal(ships) == max_ships_input  ) cycle reports
             if (n==1) ntotal(ships) = ntotal(ships) + 1 
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(ships) > no_thin ) then
                crit = tdiff
                call map2grids_conv(ships,dlat_earth,dlon_earth,crit,nlocal(ships),itx,1,itt,ilocal(ships),iuse)
                 if ( .not. iuse ) cycle reports
@@ -495,7 +496,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_metarobs .or. ntotal(metar) == max_metar_input  ) cycle reports
             if (n==1) ntotal(metar) = ntotal(metar) + 1 
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(metar) > no_thin ) then
                crit = tdiff
                call map2grids_conv(metar,dlat_earth,dlon_earth,crit,nlocal(metar),itx,1,itt,ilocal(metar),iuse)
                 if ( .not. iuse ) cycle reports
@@ -522,7 +523,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_pilotobs .or. ntotal(pilot) == max_pilot_input  ) cycle reports
             if (n==1) ntotal(pilot) = ntotal(pilot) + 1 
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(pilot) > no_thin ) then
                crit = tdiff
                call map2grids_conv(pilot,dlat_earth,dlon_earth,crit,nlocal(pilot),itx,1,itt,ilocal(pilot),iuse)
                if ( .not. iuse ) cycle reports
@@ -577,7 +578,8 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
                end if
             end do
 
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(sound) > no_thin .or. &
+                 thin_conv_opt(sonde_sfc) > no_thin ) then
                crit = tdiff
                call map2grids_conv(sound,dlat_earth,dlon_earth,crit,nlocal(sound),itx,1,itt,ilocal(sound),iuse)
                crit = tdiff
@@ -691,7 +693,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
           if( is_surface) then
             if (n==1) ntotal(tamdar_sfc) = ntotal(tamdar_sfc) + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(tamdar_sfc) > no_thin ) then
                crit = tdiff
                call map2grids_conv(tamdar_sfc,dlat_earth,dlon_earth,crit,nlocal(tamdar_sfc),itx,1,itt,ilocal(tamdar_sfc),iuse)
                 if ( .not. iuse ) cycle reports
@@ -718,7 +720,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
 
             if ( levs > 0 .and. n==1) ntotal(tamdar) = ntotal(tamdar) + 1
             if (outside) cycle reports
-            if( .not. thin_conv_ascii) then
+            if( thin_conv_opt(tamdar) <= no_thin ) then
                    nlocal(tamdar) = nlocal(tamdar) + 1
                    ilocal(tamdar) = ilocal(tamdar) + 1
                 if( nlocal(tamdar) == ilocal(tamdar)) then
@@ -747,7 +749,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
                                           platform%each(i)%u%inv, platform%each(i)%v%inv, convert_uv2fd)
              end do
 
-            else ! if thin_conv_ascii==true
+            else ! if thin_conv_opt > no_thin
               thin_3d=.true.
               i1   = platform%loc%i
               j1   = platform%loc%j
@@ -837,7 +839,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (n==1) ntotal(mtgirs) = ntotal(mtgirs) + 1
             if (outside) cycle reports
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(mtgirs) > no_thin ) then
                crit = tdiff
                call map2grids_conv(mtgirs,dlat_earth,dlon_earth,crit,nlocal(mtgirs),itx,1,itt,ilocal(mtgirs),iuse)
                 if ( .not. iuse ) cycle reports
@@ -891,7 +893,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (platform%loc%pw%inv > 10.0) cycle reports
             if (n==1) ntotal(satem) = ntotal(satem) + 1
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(satem) > no_thin ) then
                crit = tdiff
                call map2grids_conv(satem,dlat_earth,dlon_earth,crit,nlocal(satem),itx,1,itt,ilocal(satem),iuse)
                 if ( .not. iuse ) cycle reports
@@ -959,7 +961,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
                if (n==1) ntotal(polaramv) = ntotal(polaramv) + 1
                if (outside) cycle reports
                if (n==1) ntotal(Polaramv) = ntotal(polaramv) + 1
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(polaramv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(polaramv,dlat_earth,dlon_earth,crit,nlocal(polaramv),itx,1,itt,ilocal(polaramv),iuse)
                    if ( .not. iuse ) cycle reports
@@ -992,7 +994,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
                if (.not.use_geoamvobs .or. ntotal(geoamv) == max_geoamv_input) cycle reports
                if (n==1) ntotal(geoamv) = ntotal(geoamv) + 1
                if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(geoamv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(geoamv,dlat_earth,dlon_earth,crit,nlocal(geoamv),itx,1,itt,ilocal(geoamv),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1029,7 +1031,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (n==1) ntotal(airep) = ntotal(airep) + 1
             if (outside) cycle reports
 
-            if( .not. thin_conv_ascii) then
+            if( thin_conv_opt(airep) <= no_thin ) then
                    nlocal(airep) = nlocal(airep) + 1
                    ilocal(airep) = ilocal(airep) + 1
               if( nlocal(airep) == ilocal(airep)) then
@@ -1058,7 +1060,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
                                           platform%each(i)%u%inv, platform%each(i)%v%inv, convert_uv2fd)
              end do
 
-            else ! if thin_conv_ascii==true
+            else ! if thin_conv_opt > no_thin
               thin_3d=.true.
               i1   = platform%loc%i
               j1   = platform%loc%j
@@ -1147,7 +1149,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if((.not.use_gpsztdobs .and. fm == 114) .or. ntotal(gpspw) == max_gpspw_input ) cycle reports
             if (n==1) ntotal(gpspw) = ntotal(gpspw) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(gpspw) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(gpspw,dlat_earth,dlon_earth,crit,nlocal(gpspw),itx,1,itt,ilocal(gpspw),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1163,7 +1165,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if ( ob_format_gpsro /= ob_format_ascii ) cycle reports
             if (n==1) ntotal(gpsref) = ntotal(gpsref) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(gpsref) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(gpsref,dlat_earth,dlon_earth,crit,nlocal(gpsref),itx,1,itt,ilocal(gpsref),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1265,7 +1267,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (n==1) ntotal(ssmt1) = ntotal(ssmt1) + 1
             if (outside) cycle reports
             if (n==1) ntotal(ssmt1) = ntotal(ssmt1) + 1
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(ssmt1) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(ssmt1,dlat_earth,dlon_earth,crit,nlocal(ssmt1),itx,1,itt,ilocal(ssmt1),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1290,7 +1292,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if(.not.use_ssmt2obs  .or. ntotal(ssmt2) == max_ssmt2_input ) cycle reports
             if (n==1) ntotal(ssmt2) = ntotal(ssmt2) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(ssmt2) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(ssmt2,dlat_earth,dlon_earth,crit,nlocal(ssmt2),itx,1,itt,ilocal(ssmt2),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1314,7 +1316,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if(.not.use_qscatobs  .or. ntotal(qscat) == max_qscat_input ) cycle reports
             if (n==1) ntotal(qscat) = ntotal(qscat) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(qscat) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(qscat,dlat_earth,dlon_earth,crit,nlocal(qscat),itx,1,itt,ilocal(qscat),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1346,7 +1348,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_profilerobs .or. ntotal(profiler) == max_profiler_input ) cycle reports
             if (n==1) ntotal(profiler) = ntotal(profiler) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(profiler) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(profiler,dlat_earth,dlon_earth,crit,nlocal(profiler),itx,1,itt,ilocal(profiler),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1382,7 +1384,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (n==1) ntotal(bogus) = ntotal(bogus) + 1
             if (outside) cycle reports
             if (n==1) ntotal(bogus) = ntotal(bogus) + 1
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(bogus) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(bogus,dlat_earth,dlon_earth,crit,nlocal(bogus),itx,1,itt,ilocal(bogus),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1437,7 +1439,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_buoyobs .or. ntotal(buoy) == max_buoy_input ) cycle reports
             if (n==1) ntotal(buoy) = ntotal(buoy) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(buoy) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(buoy,dlat_earth,dlon_earth,crit,nlocal(buoy),itx,1,itt,ilocal(buoy),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1465,7 +1467,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
             if (.not. use_airsretobs .or. ntotal(airsr) == max_airsr_input ) cycle reports
             if (n==1) ntotal(airsr) = ntotal(airsr) + 1
             if (outside) cycle reports
-                if ( thin_conv_ascii ) then
+                if ( thin_conv_opt(airsr) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(airsr,dlat_earth,dlon_earth,crit,nlocal(airsr),itx,1,itt,ilocal(airsr),iuse)
                    if ( .not. iuse ) cycle reports
@@ -1614,6 +1616,7 @@ subroutine da_read_obs_ascii (iv, filename, uvq_direct, grid)
    ! thinning check
    if ( thin_conv_ascii ) then
       do n = 1, num_ob_indexes
+          if ( .not. allocated(thinning_grid_conv(n)%icount) ) cycle
           if (n==radar) cycle
           allocate ( in(thinning_grid_conv(n)%itxmax) )
           allocate (out(thinning_grid_conv(n)%itxmax) )

--- a/var/da/da_obs_io/da_read_obs_bufr.inc
+++ b/var/da/da_obs_io/da_read_obs_bufr.inc
@@ -874,7 +874,8 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(sonde_sfc)%ntotal = iv%info(sonde_sfc)%ntotal + 1
                
                if (outside) cycle reports
-               if ( thin_conv ) then
+               if ( thin_conv_opt(sound) > no_thin .or. &
+                    thin_conv_opt(sonde_sfc) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(sound,dlat_earth,dlon_earth,crit,iv%info(sound)%nlocal,itx,1,itt,iout,iuse)
                   call map2grids_conv(sonde_sfc,dlat_earth,dlon_earth,crit,iv%info(sonde_sfc)%nlocal,itx,1,itt,iout,iuse)
@@ -893,7 +894,7 @@ bufrfile:  do ibufr=1,numbufr
                if (.not.use_pilotobs) cycle reports
                if (n==1) iv%info(pilot)%ntotal = iv%info(pilot)%ntotal + 1
                if (outside) cycle reports
-               if ( thin_conv ) then
+               if ( thin_conv_opt(pilot) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(pilot,dlat_earth,dlon_earth,crit,iv%info(pilot)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -914,7 +915,7 @@ bufrfile:  do ibufr=1,numbufr
                if (.not.use_airepobs) cycle reports
                if (n==1) iv%info(airep)%ntotal = iv%info(airep)%ntotal + 1
                if (outside)  cycle reports
-               if ( thin_conv ) then
+               if ( thin_conv_opt(airep) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(airep,dlat_earth,dlon_earth,crit,iv%info(airep)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -930,7 +931,7 @@ bufrfile:  do ibufr=1,numbufr
                if (.not.use_shipsobs) cycle reports
                if (n==1) iv%info(ships)%ntotal = iv%info(ships)%ntotal + 1
                if (outside) cycle reports
-               if ( thin_conv ) then
+               if ( thin_conv_opt(ships) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(ships,dlat_earth,dlon_earth,crit,iv%info(ships)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -947,7 +948,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(buoy)%ntotal = iv%info(buoy)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(buoy) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(buoy,dlat_earth,dlon_earth,crit,iv%info(buoy)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -965,7 +966,7 @@ bufrfile:  do ibufr=1,numbufr
                
                if (n==1) iv%info(synop)%ntotal = iv%info(synop)%ntotal + 1
                if (outside) cycle reports
-               if ( thin_conv ) then
+               if ( thin_conv_opt(synop) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(synop,dlat_earth,dlon_earth,crit,iv%info(synop)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -984,7 +985,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(metar)%ntotal = iv%info(metar)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(metar) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(metar,dlat_earth,dlon_earth,crit,iv%info(metar)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1003,7 +1004,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(geoamv)%ntotal = iv%info(geoamv)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(geoamv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(geoamv,dlat_earth,dlon_earth,crit,iv%info(geoamv)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1021,7 +1022,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(qscat)%ntotal = iv%info(qscat)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(qscat) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(qscat,dlat_earth,dlon_earth,crit,iv%info(qscat)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1039,7 +1040,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(gpspw)%ntotal = iv%info(gpspw)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(gpspw) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(gpspw,dlat_earth,dlon_earth,crit,iv%info(gpspw)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1057,7 +1058,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(profiler)%ntotal = iv%info(profiler)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(profiler) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(profiler,dlat_earth,dlon_earth,crit,iv%info(profiler)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1075,7 +1076,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(ssmi_rv)%ntotal = iv%info(ssmi_rv)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(ssmi_rv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(ssmi_rv,dlat_earth,dlon_earth,crit,iv%info(ssmi_rv)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1096,7 +1097,7 @@ bufrfile:  do ibufr=1,numbufr
                if (n==1) iv%info(bogus)%ntotal = iv%info(bogus)%ntotal + 1
                if (outside) cycle reports
                
-               if ( thin_conv ) then
+               if ( thin_conv_opt(bogus) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(bogus,dlat_earth,dlon_earth,crit,iv%info(bogus)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1168,6 +1169,7 @@ end do bufrfile
     do kk=1,num_fgat_time
       if ( thin_conv ) then
          do n = 1, num_ob_indexes
+            if ( .not. allocated(thinning_grid_conv(n)%icount) ) cycle
             call cleangrids_conv(n)
          end do
       end if
@@ -1215,7 +1217,8 @@ end do bufrfile
                     plink => plink%next
                     cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(sound) > no_thin .or. &
+                    thin_conv_opt(sonde_sfc) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(sound,dlat_earth,dlon_earth,crit,iv%info(sound)%nlocal,itx,1,itt,iout,iuse)
                   call map2grids_conv(sonde_sfc,dlat_earth,dlon_earth,crit,iv%info(sonde_sfc)%nlocal,itx,1,itt,iout,iuse)
@@ -1241,7 +1244,7 @@ end do bufrfile
                    plink => plink%next
                    cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(pilot) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(pilot,dlat_earth,dlon_earth,crit,iv%info(pilot)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1269,7 +1272,7 @@ end do bufrfile
                     plink => plink%next
                     cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(airep) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(airep,dlat_earth,dlon_earth,crit,iv%info(airep)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1292,7 +1295,7 @@ end do bufrfile
                   plink => plink%next
                   cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(ships) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(ships,dlat_earth,dlon_earth,crit,iv%info(ships)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1315,7 +1318,7 @@ end do bufrfile
                      plink => plink%next
                      cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(buoy) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(buoy,dlat_earth,dlon_earth,crit,iv%info(buoy)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1339,7 +1342,7 @@ end do bufrfile
                      plink => plink%next
                      cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(synop) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(synop,dlat_earth,dlon_earth,crit,iv%info(synop)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1363,7 +1366,7 @@ end do bufrfile
                     plink => plink%next
                     cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(metar) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(metar,dlat_earth,dlon_earth,crit,iv%info(metar)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1387,7 +1390,7 @@ end do bufrfile
                   plink => plink%next
                   cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(geoamv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(geoamv,dlat_earth,dlon_earth,crit,iv%info(geoamv)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1410,7 +1413,7 @@ end do bufrfile
                    plink => plink%next
                    cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(qscat) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(qscat,dlat_earth,dlon_earth,crit,iv%info(qscat)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1433,7 +1436,7 @@ end do bufrfile
                    plink => plink%next
                    cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(gpspw) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(gpspw,dlat_earth,dlon_earth,crit,iv%info(gpspw)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1456,7 +1459,7 @@ end do bufrfile
                   plink => plink%next
                   cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(profiler) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(profiler,dlat_earth,dlon_earth,crit,iv%info(profiler)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1479,7 +1482,7 @@ end do bufrfile
                     plink => plink%next
                     cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(ssmi_rv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(ssmi_rv,dlat_earth,dlon_earth,crit,iv%info(ssmi_rv)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1505,7 +1508,7 @@ end do bufrfile
                   plink => plink%next
                   cycle reports2
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(bogus) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(bogus,dlat_earth,dlon_earth,crit,iv%info(bogus)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) then
@@ -1564,6 +1567,7 @@ end if
 
        if ( thin_conv ) then
           do n = 1, num_ob_indexes
+             if ( .not. allocated(thinning_grid_conv(n)%icount) ) cycle
              call cleangrids_conv(n)
           end do
        end if
@@ -1606,7 +1610,8 @@ end if
                     plink => plink%next
                     cycle reports3
                end if
-                if ( thin_conv ) then
+                if ( thin_conv_opt(sound) > no_thin .or. &
+                     thin_conv_opt(sonde_sfc) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(sound,dlat_earth,dlon_earth,crit,nlocal(sound),itx,1,itt,ilocal(sound),iuse)
                   call map2grids_conv(sonde_sfc,dlat_earth,dlon_earth,crit,nlocal(sonde_sfc),itx,1,itt,ilocal(sonde_sfc),iuse)
@@ -1699,7 +1704,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(pilot) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(pilot,dlat_earth,dlon_earth,crit,nlocal(pilot),itx,1,itt,ilocal(pilot),iuse)
                   if ( .not. iuse ) then
@@ -1740,7 +1745,7 @@ end if
                     plink => plink%next
                     cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(airep) > no_thin ) then
                crit = tdiff
                call map2grids_conv(airep,dlat_earth,dlon_earth,crit,nlocal(airep),itx,1,itt,ilocal(airep),iuse)
                if ( .not. iuse ) then
@@ -1780,7 +1785,7 @@ end if
                   plink => plink%next
                   cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(ships) > no_thin ) then
                crit = tdiff
                call map2grids_conv(ships,dlat_earth,dlon_earth,crit,nlocal(ships),itx,1,itt,ilocal(ships),iuse)
                 if ( .not. iuse ) then
@@ -1811,7 +1816,7 @@ end if
                 plink => plink%next
                 cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(buoy) > no_thin ) then
                crit = tdiff
                call map2grids_conv(buoy,dlat_earth,dlon_earth,crit,nlocal(buoy),itx,1,itt,ilocal(buoy),iuse)
                if ( .not. iuse ) then
@@ -1850,7 +1855,7 @@ end if
                plink => plink%next
                cycle reports3
             end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(synop) > no_thin ) then
                crit = tdiff
                call map2grids_conv(synop,dlat_earth,dlon_earth,crit,nlocal(synop),itx,1,itt,ilocal(synop),iuse)
                 if ( .not. iuse ) then
@@ -1884,7 +1889,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(metar) > no_thin ) then
                crit = tdiff
                call map2grids_conv(metar,dlat_earth,dlon_earth,crit,nlocal(metar),itx,1,itt,ilocal(metar),iuse)
                 if ( .not. iuse ) then
@@ -1917,7 +1922,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(geoamv) > no_thin ) then
                crit = tdiff
                call map2grids_conv(geoamv,dlat_earth,dlon_earth,crit,nlocal(geoamv),itx,1,itt,ilocal(geoamv),iuse)
                 if ( .not. iuse ) then
@@ -1954,7 +1959,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(qscat) > no_thin ) then
                crit = tdiff
                call map2grids_conv(qscat,dlat_earth,dlon_earth,crit,nlocal(qscat),itx,1,itt,ilocal(qscat),iuse)
                if ( .not. iuse ) then
@@ -1987,7 +1992,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(gpspw) > no_thin ) then
                crit = tdiff
                call map2grids_conv(gpspw,dlat_earth,dlon_earth,crit,nlocal(gpspw),itx,1,itt,ilocal(gpspw),iuse)
                 if ( .not. iuse ) then
@@ -2013,7 +2018,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-               if ( thin_conv ) then
+               if ( thin_conv_opt(profiler) > no_thin ) then
                crit = tdiff
                call map2grids_conv(profiler,dlat_earth,dlon_earth,crit,nlocal(profiler),itx,1,itt,ilocal(profiler),iuse)
                 if ( .not. iuse ) then
@@ -2051,7 +2056,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-            if ( thin_conv ) then
+            if ( thin_conv_opt(ssmi_rv) > no_thin ) then
                crit = tdiff
                call map2grids_conv(ssmi_rv,dlat_earth,dlon_earth,crit,nlocal(ssmi_rv),itx,1,itt,ilocal(ssmi_rv),iuse)
                 if ( .not. iuse ) then
@@ -2102,7 +2107,7 @@ end if
                    plink => plink%next
                    cycle reports3
                end if
-                if ( thin_conv ) then
+                if ( thin_conv_opt(bogus) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(bogus,dlat_earth,dlon_earth,crit,nlocal(bogus),itx,1,itt,ilocal(bogus),iuse)
                   if ( .not. iuse ) then
@@ -2220,6 +2225,8 @@ end if
    if ( thin_conv ) then
       do n = 1, num_ob_indexes
 
+        if ( thin_conv_opt(n) <= no_thin ) cycle
+
         if ( ntotal(n)>0 ) then
 
             allocate ( in  (thinning_grid_conv(n)%itxmax) )
@@ -2283,6 +2290,7 @@ end if
 
 if ( thin_conv ) then
     do n = 1, num_ob_indexes
+        if ( thin_conv_opt(n) <= no_thin ) cycle
         if ( ntotal(n)>0 ) then
             if ( nlocal(n) > 0 ) then
                if ( ANY(iv%info(n)%thinned(:,:)) ) then

--- a/var/da/da_obs_io/da_scan_obs_ascii.inc
+++ b/var/da/da_obs_io/da_scan_obs_ascii.inc
@@ -48,6 +48,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
 ! Initialize 
       if ( thin_conv_ascii ) then
           do n = 1, num_ob_indexes
+             if ( .not. allocated(thinning_grid_conv(n)%icount) ) cycle
              if ( n == radar ) cycle
              call cleangrids_conv(n)
           end do
@@ -271,7 +272,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_synopobs .or. iv%info(synop)%ntotal == max_synop_input) cycle reports
             if (n==1) iv%info(synop)%ntotal = iv%info(synop)%ntotal + 1
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(synop) > no_thin ) then
                crit = tdiff
                call map2grids_conv(synop,dlat_earth,dlon_earth,crit,iv%info(synop)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -283,7 +284,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_shipsobs .or. iv%info(ships)%ntotal == max_ships_input) cycle reports
             if (n==1) iv%info(ships)%ntotal = iv%info(ships)%ntotal + 1
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(ships) > no_thin ) then
                crit = tdiff
                call map2grids_conv(ships,dlat_earth,dlon_earth,crit,iv%info(ships)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -296,7 +297,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_metarobs .or. iv%info(metar)%ntotal == max_metar_input) cycle reports
             if (n==1) iv%info(metar)%ntotal = iv%info(metar)%ntotal + 1
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(metar) > no_thin ) then
                crit = tdiff
                call map2grids_conv(metar,dlat_earth,dlon_earth,crit,iv%info(metar)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -308,7 +309,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_pilotobs .or. iv%info(pilot)%ntotal == max_pilot_input) cycle reports
             if (n==1) iv%info(pilot)%ntotal = iv%info(pilot)%ntotal + 1
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(pilot) > no_thin ) then
                crit = tdiff
                call map2grids_conv(pilot,dlat_earth,dlon_earth,crit,iv%info(pilot)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -321,7 +322,8 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (n==1) iv%info(sound)%ntotal     = iv%info(sound)%ntotal + 1
             if (n==1) iv%info(sonde_sfc)%ntotal = iv%info(sonde_sfc)%ntotal + 1
             if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(sound) > no_thin .or. &
+                  thin_conv_opt(sonde_sfc) > no_thin ) then
                 crit = tdiff
                 call map2grids_conv(sound,dlat_earth,dlon_earth,crit,iv%info(sound)%nlocal,itx,1,itt,iout,iuse)
                 crit = tdiff
@@ -353,7 +355,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
 
              if (n==1) iv%info(tamdar_sfc)%ntotal = iv%info(tamdar_sfc)%ntotal + 1
              if (outside) cycle reports
-             if ( thin_conv_ascii ) then
+             if ( thin_conv_opt(tamdar_sfc) > no_thin ) then
                 crit = tdiff
                 call map2grids_conv(tamdar_sfc,dlat_earth,dlon_earth,crit,iv%info(tamdar_sfc)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -363,9 +365,9 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
            else ! not is_surface
              if ( levs > 0 .and. n==1) iv%info(tamdar)%ntotal = iv%info(tamdar)%ntotal + 1
              if (outside) cycle reports
-             if( .not. thin_conv_ascii ) then
+             if( thin_conv_opt(tamdar) <= no_thin ) then
                 iv%info(tamdar)%nlocal         = iv%info(tamdar)%nlocal + 1
-             else  ! if thin_conv_ascii
+             else  ! if thin_conv_opt > no_thin
                 thin_3d=.true.
                 i1   = platform%loc%i
                 j1   = platform%loc%j
@@ -404,7 +406,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_mtgirsobs .or. iv%info(mtgirs)%ntotal == max_mtgirs_input) cycle reports
             if (n==1) iv%info(mtgirs)%ntotal     = iv%info(mtgirs)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(mtgirs) > no_thin ) then
                crit = tdiff
                call map2grids_conv(mtgirs,dlat_earth,dlon_earth,crit,iv%info(mtgirs)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -418,7 +420,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (platform%loc%pw%inv > 10.0) cycle reports
             if (n==1) iv%info(satem)%ntotal = iv%info(satem)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(satem) > no_thin ) then
                crit = tdiff
                call map2grids_conv(satem,dlat_earth,dlon_earth,crit,iv%info(satem)%nlocal,itx,1,itt,iout,iuse)
                 if ( .not. iuse ) cycle reports
@@ -434,7 +436,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
                if (.not.use_polaramvobs .or. iv%info(polaramv)%ntotal == max_polaramv_input) cycle reports
                if (n==1) iv%info(polaramv)%ntotal = iv%info(polaramv)%ntotal + 1
                if (outside) cycle reports
-               if ( thin_conv_ascii ) then
+               if ( thin_conv_opt(polaramv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(polaramv,dlat_earth,dlon_earth,crit,iv%info(polaramv)%nlocal,itx,1,itt,iout,iuse)
                   if ( .not. iuse ) cycle reports
@@ -446,7 +448,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
                if (.not.use_geoamvobs .or. iv%info(geoamv)%ntotal == max_geoamv_input) cycle reports
                if (n==1) iv%info(geoamv)%ntotal = iv%info(geoamv)%ntotal + 1
                if (outside) cycle reports
-               if ( thin_conv_ascii ) then
+               if ( thin_conv_opt(geoamv) > no_thin ) then
                   crit = tdiff
                   call map2grids_conv(geoamv,dlat_earth,dlon_earth,crit,iv%info(geoamv)%nlocal,itx,1,itt,iout,iuse)
                    if ( .not. iuse ) cycle reports
@@ -460,9 +462,9 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (n==1) iv%info(airep)%ntotal = iv%info(airep)%ntotal + 1
             if (outside) cycle reports
 
-            if( .not. thin_conv_ascii ) then
+            if( thin_conv_opt(airep) <= no_thin ) then
                iv%info(airep)%nlocal         = iv%info(airep)%nlocal + 1
-            else  ! if thin_conv_ascii
+            else  ! if thin_conv_opt > no_thin
                thin_3d=.true.
                i1   = platform%loc%i
                j1   = platform%loc%j
@@ -503,7 +505,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
                   iv%info(gpspw)%ntotal == max_gpspw_input) cycle reports
             if (n==1) iv%info(gpspw)%ntotal = iv%info(gpspw)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(gpspw) > no_thin ) then
                crit = tdiff
                call map2grids_conv(gpspw,dlat_earth,dlon_earth,crit,iv%info(gpspw)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -516,7 +518,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if ( ob_format_gpsro /= ob_format_ascii ) cycle reports
             if (n==1) iv%info(gpsref)%ntotal = iv%info(gpsref)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(gpsref) > no_thin ) then
                crit = tdiff
                call map2grids_conv(gpsref,dlat_earth,dlon_earth,crit,iv%info(gpsref)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -556,7 +558,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_ssmt1obs .or. iv%info(ssmt1)%ntotal == max_ssmt1_input) cycle reports
             if (n==1) iv%info(ssmt1)%ntotal = iv%info(ssmt1)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(ssmt1) > no_thin ) then
                crit = tdiff
                call map2grids_conv(ssmt1,dlat_earth,dlon_earth,crit,iv%info(ssmt1)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -570,7 +572,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_ssmt2obs .or. iv%info(ssmt2)%ntotal == max_ssmt2_input) cycle reports
             if (n==1) iv%info(ssmt2)%ntotal = iv%info(ssmt2)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(ssmt2) > no_thin ) then
                crit = tdiff
                call map2grids_conv(ssmt2,dlat_earth,dlon_earth,crit,iv%info(ssmt2)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -583,7 +585,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_qscatobs .or. iv%info(qscat)%ntotal == max_qscat_input) cycle reports
             if (n==1) iv%info(qscat)%ntotal = iv%info(qscat)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(qscat) > no_thin ) then
                crit = tdiff
                call map2grids_conv(qscat,dlat_earth,dlon_earth,crit,iv%info(qscat)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -594,7 +596,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_profilerobs .or. iv%info(profiler)%ntotal == max_profiler_input) cycle reports
             if (n==1) iv%info(profiler)%ntotal = iv%info(profiler)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(profiler) > no_thin ) then
                crit = tdiff
                call map2grids_conv(profiler,dlat_earth,dlon_earth,crit,iv%info(profiler)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -606,7 +608,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_bogusobs .or. iv%info(bogus)%ntotal == max_bogus_input) cycle reports
             if (n==1) iv%info(bogus)%ntotal = iv%info(bogus)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(bogus) > no_thin ) then
                crit = tdiff
                call map2grids_conv(bogus,dlat_earth,dlon_earth,crit,iv%info(bogus)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -618,7 +620,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_buoyobs .or. iv%info(buoy)%ntotal == max_buoy_input) cycle reports
             if (n==1) iv%info(buoy)%ntotal = iv%info(buoy)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(buoy) > no_thin ) then
                crit = tdiff
                call map2grids_conv(buoy,dlat_earth,dlon_earth,crit,iv%info(buoy)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports
@@ -630,7 +632,7 @@ subroutine da_scan_obs_ascii (iv, filename, grid)
             if (.not.use_airsretobs .or. iv%info(airsr)%ntotal == max_airsr_input) cycle reports
             if (n==1) iv%info(airsr)%ntotal = iv%info(airsr)%ntotal + 1
             if (outside) cycle reports
-            if ( thin_conv_ascii ) then
+            if ( thin_conv_opt(airsr) > no_thin ) then
                crit = tdiff
                call map2grids_conv(airsr,dlat_earth,dlon_earth,crit,iv%info(airsr)%nlocal,itx,1,itt,iout,iuse)
                if ( .not. iuse ) cycle reports

--- a/var/da/da_radiance/da_setup_radiance_structures.inc
+++ b/var/da/da_radiance/da_setup_radiance_structures.inc
@@ -14,9 +14,6 @@ subroutine da_setup_radiance_structures( grid, ob, iv )
    integer                     :: i, j, n, ios, ifgat
    logical                     :: lprinttovs 
 
-   ! thinning variables
-   integer  :: istart,iend,jstart,jend
-   real     :: rlonlat(4)
    ! crtm_cloud
    integer  :: n1,n2,k,its,ite,jts,jte,kts,kte,inst
    integer  :: data_format, iret ! AHI radiance related
@@ -37,50 +34,8 @@ subroutine da_setup_radiance_structures( grid, ob, iv )
    !-------------------------------
    ! 1.1 Make thinning grids
    !------------------------------
-   call init_constants_derived
 
    if (thinning) then
-      rlat_min =  r999
-      rlat_max = -r999
-      rlon_min =  r999
-      rlon_max = -r999
-
-      istart=MINVAL( grid%i_start(1:grid%num_tiles) )
-      iend  =MAXVAL( grid%i_end  (1:grid%num_tiles) )
-      jstart=MINVAL( grid%j_start(1:grid%num_tiles) )
-      jend  =MAXVAL( grid%j_end  (1:grid%num_tiles) )
-
-      do i = istart, iend
-         do j = jstart, jend
-            rlat_min=min(rlat_min, grid%xb%lat(i,j))
-            rlat_max=max(rlat_max, grid%xb%lat(i,j))
-            if( grid%xb%lon(i,j) < zero) then
-              rlon_min=min(rlon_min, (r360+grid%xb%lon(i,j)))
-              rlon_max=max(rlon_max, (r360+grid%xb%lon(i,j)))
-            else
-              rlon_min=min(rlon_min, grid%xb%lon(i,j))
-              rlon_max=max(rlon_max, grid%xb%lon(i,j))
-            endif
-         enddo
-      enddo
-
-#ifdef DM_PARALLEL
-      call mpi_reduce(rlat_min, rlonlat(1), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlon_min, rlonlat(2), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlat_max, rlonlat(3), 1, true_mpi_real, mpi_max, root, comm, ierr)
-      call mpi_reduce(rlon_max, rlonlat(4), 1, true_mpi_real, mpi_max, root, comm, ierr)
-
-      CALL mpi_bcast( rlonlat, 4 , true_mpi_real , root , comm, ierr )
-
-      rlat_min = rlonlat(1)
-      rlon_min = rlonlat(2)
-      rlat_max = rlonlat(3)
-      rlon_max = rlonlat(4)
-#endif
-
-      dlat_grid = rlat_max - rlat_min
-      dlon_grid = rlon_max - rlon_min
-
       allocate(thinning_grid(iv%num_inst,num_fgat_time))
       do ifgat=1,num_fgat_time
          do n=1,iv%num_inst

--- a/var/da/da_setup_structures/da_setup_obs_structures.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures.inc
@@ -14,6 +14,10 @@ subroutine da_setup_obs_structures( grid, ob, iv, j_cost)
    integer :: i,j,icode
    character (len=14)   :: ob_name
 
+   ! thinning variables
+   integer  :: istart,iend,jstart,jend
+   real     :: rlonlat(4)
+
    if (trace_use) call da_trace_entry("da_setup_obs_structures")
 
 ! Default values for fmt_info, fmt_srfc, and fmt_each(YRG, 02/25/2009):
@@ -267,6 +271,70 @@ subroutine da_setup_obs_structures( grid, ob, iv, j_cost)
       !to avoid errors when writing out filtered_obs for undefined variables
       anal_type_qcobs = .false.
    end if
+
+   if ( thin_conv .or. thin_conv_ascii ) then
+     thin_conv_opt(gpseph) = no_thin
+     thin_conv_opt(radar) = no_thin
+     thin_conv_opt(radiance) = no_thin
+     thin_conv_opt(rain) = no_thin
+     if ( thin_conv .and. ob_format==ob_format_bufr ) then
+        ! gpsref horizontal thinning is not implemented for bufr input
+        thin_conv_opt(gpsref) = no_thin
+     end if
+     do i = 1, num_ob_indexes
+        ! resetting thin_conv_opt to no_thin for ob types that are not used
+        if ( thin_conv_opt(i) > no_thin .and. &
+             (.not. obs_use(i)) ) then
+           thin_conv_opt(i) = no_thin
+        end if
+     end do
+     if ( thin_conv .and. ob_format==ob_format_bufr .and. &
+          all(thin_conv_opt(:) <= no_thin) ) thin_conv = .false.
+     if ( thin_conv_ascii .and. ob_format==ob_format_ascii .and. &
+          all(thin_conv_opt(:) <= no_thin) ) thin_conv_ascii = .false.
+   end if
+   if ( ((.not. thin_conv) .and. ob_format==ob_format_bufr) .or. &
+        ((.not. thin_conv_ascii) .and. ob_format==ob_format_ascii) ) then
+     thin_conv_opt(:) = no_thin
+   end if
+
+   ! get lat/lon info (rlat_min,rlat_max,rlon_min,rlon_max,dlat_grid,dlon_grid)
+   ! to be used for making thinning grids for conv (ascii/bufr), radiance and rain ob types.
+   call init_constants_derived
+   rlat_min =  r999
+   rlat_max = -r999
+   rlon_min =  r999
+   rlon_max = -r999
+   istart=MINVAL( grid%i_start(1:grid%num_tiles) )
+   iend  =MAXVAL( grid%i_end  (1:grid%num_tiles) )
+   jstart=MINVAL( grid%j_start(1:grid%num_tiles) )
+   jend  =MAXVAL( grid%j_end  (1:grid%num_tiles) )
+   do i = istart, iend
+      do j = jstart, jend
+         rlat_min=min(rlat_min, grid%xb%lat(i,j))
+         rlat_max=max(rlat_max, grid%xb%lat(i,j))
+         if( grid%xb%lon(i,j) < 0.0) then
+           rlon_min=min(rlon_min, (r360+grid%xb%lon(i,j)))
+           rlon_max=max(rlon_max, (r360+grid%xb%lon(i,j)))
+         else
+           rlon_min=min(rlon_min, grid%xb%lon(i,j))
+           rlon_max=max(rlon_max, grid%xb%lon(i,j))
+         endif
+      enddo
+   enddo
+#ifdef DM_PARALLEL
+   call mpi_reduce(rlat_min, rlonlat(1), 1, true_mpi_real, mpi_min, root, comm, ierr)
+   call mpi_reduce(rlon_min, rlonlat(2), 1, true_mpi_real, mpi_min, root, comm, ierr)
+   call mpi_reduce(rlat_max, rlonlat(3), 1, true_mpi_real, mpi_max, root, comm, ierr)
+   call mpi_reduce(rlon_max, rlonlat(4), 1, true_mpi_real, mpi_max, root, comm, ierr)
+   CALL mpi_bcast( rlonlat, 4 , true_mpi_real , root , comm, ierr )
+   rlat_min = rlonlat(1)
+   rlon_min = rlonlat(2)
+   rlat_max = rlonlat(3)
+   rlon_max = rlonlat(4)
+#endif
+   dlat_grid = rlat_max - rlat_min
+   dlon_grid = rlon_max - rlon_min
 
    !---------------------------------------------------------------------------      
    ! [1.0] Setup and read in fields from first guess:

--- a/var/da/da_setup_structures/da_setup_obs_structures_ascii.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures_ascii.inc
@@ -17,70 +17,22 @@ subroutine da_setup_obs_structures_ascii( ob, iv, grid )
    integer                      :: n, i, j, k
    logical                      :: outside, thin_3d
    logical                      :: uvq_direct=.false.
-   integer  :: istart,iend,jstart,jend
-   real     :: rlonlat(4)
 
    if (trace_use) call da_trace_entry("da_setup_obs_structures_ascii")
    !-------------------------------
    ! 0.0 Make thinning grids
    !------------------------------
-   call init_constants_derived
    thin_3d=.false.
    if ( thin_conv_ascii ) then
-      rlat_min =  r999
-      rlat_max = -r999
-      rlon_min =  r999
-      rlon_max = -r999
-
-      istart=MINVAL( grid%i_start(1:grid%num_tiles) )
-      iend  =MAXVAL( grid%i_end  (1:grid%num_tiles) )
-      jstart=MINVAL( grid%j_start(1:grid%num_tiles) )
-      jend  =MAXVAL( grid%j_end  (1:grid%num_tiles) )
-
-      do i = istart, iend
-         do j = jstart, jend
-            rlat_min=min(rlat_min, grid%xb%lat(i,j))
-            rlat_max=max(rlat_max, grid%xb%lat(i,j))
-            if( grid%xb%lon(i,j) < 0.0) then
-              rlon_min=min(rlon_min, (r360+grid%xb%lon(i,j)))
-              rlon_max=max(rlon_max, (r360+grid%xb%lon(i,j)))
-            else
-              rlon_min=min(rlon_min, grid%xb%lon(i,j))
-              rlon_max=max(rlon_max, grid%xb%lon(i,j))
-            endif
-         enddo
-      enddo
-
-#ifdef DM_PARALLEL
-      call mpi_reduce(rlat_min, rlonlat(1), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlon_min, rlonlat(2), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlat_max, rlonlat(3), 1, true_mpi_real, mpi_max, root, comm, ierr)
-      call mpi_reduce(rlon_max, rlonlat(4), 1, true_mpi_real, mpi_max, root, comm, ierr)
-
-      CALL mpi_bcast( rlonlat, 4 , true_mpi_real , root , comm, ierr )
-
-      rlat_min = rlonlat(1)
-      rlon_min = rlonlat(2)
-      rlat_max = rlonlat(3)
-      rlon_max = rlonlat(4)
-#endif
-
-      dlat_grid = rlat_max - rlat_min
-      dlon_grid = rlon_max - rlon_min
-
       allocate(thinning_grid_conv(num_ob_indexes))
       do n = 1, num_ob_indexes
-         if ( .not. obs_use(n) .or. &
-              n == gpseph      .or. &
-              n == radar       .or. &
-              n == radiance    .or. &
-              n == rain ) cycle
+         if ( thin_conv_opt(n) <= no_thin ) cycle
          if( n == airep .or. n == tamdar ) then
             thin_3d=.true.
             call make3grids (n,thin_mesh_conv(n), thin_3d)
          else
             call make3grids (n,thin_mesh_conv(n))
-         end if 
+         end if
       end do
    end if
 
@@ -201,6 +153,7 @@ subroutine da_setup_obs_structures_ascii( ob, iv, grid )
    !--------------------------------------------------------------------------
     if ( thin_conv_ascii ) then
        do i = 1, num_ob_indexes
+          if ( thin_conv_opt(i) <= no_thin ) cycle
           if (i == radar) cycle
           if ( iv%info(i)%ntotal > 0 ) then
              if ( iv%info(i)%nlocal > 0 ) then
@@ -232,11 +185,7 @@ subroutine da_setup_obs_structures_ascii( ob, iv, grid )
 
    if ( thin_conv_ascii ) then
       do n = 1, num_ob_indexes
-         if ( .not. obs_use(n) .or. &
-              n == gpseph      .or. &
-              n == radar       .or. &
-              n == radiance    .or. &
-              n == rain ) cycle
+         if ( thin_conv_opt(n) <= no_thin ) cycle
          if( n == airep .or. n==tamdar ) then
             thin_3d=.true.
             call destroygrids_conv (n, thin_3d)

--- a/var/da/da_setup_structures/da_setup_obs_structures_bufr.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures_bufr.inc
@@ -14,69 +14,19 @@ subroutine da_setup_obs_structures_bufr(grid, ob, iv)
 
    character(len=filename_len) :: filename
    integer                     :: n,i,j
-   
-   ! thinning variables
-   integer  :: istart,iend,jstart,jend
-   real     :: rlonlat(4)
 
    if (trace_use) call da_trace_entry("da_setup_obs_structures_bufr")
 
    !-------------------------------
    ! 0.0 Make thinning grids
    !------------------------------
-   call init_constants_derived
 
    if ( thin_conv ) then
-      rlat_min =  r999
-      rlat_max = -r999
-      rlon_min =  r999
-      rlon_max = -r999
-
-      istart=MINVAL( grid%i_start(1:grid%num_tiles) )
-      iend  =MAXVAL( grid%i_end  (1:grid%num_tiles) )
-      jstart=MINVAL( grid%j_start(1:grid%num_tiles) )
-      jend  =MAXVAL( grid%j_end  (1:grid%num_tiles) ) 
-
-      do i = istart, iend
-         do j = jstart, jend
-            rlat_min=min(rlat_min, grid%xb%lat(i,j))
-            rlat_max=max(rlat_max, grid%xb%lat(i,j))
-            if( grid%xb%lon(i,j) < 0.0) then
-              rlon_min=min(rlon_min, (r360+grid%xb%lon(i,j)))
-              rlon_max=max(rlon_max, (r360+grid%xb%lon(i,j)))
-            else
-              rlon_min=min(rlon_min, grid%xb%lon(i,j))
-              rlon_max=max(rlon_max, grid%xb%lon(i,j))
-            endif
-         enddo
-      enddo
-
-#ifdef DM_PARALLEL
-      call mpi_reduce(rlat_min, rlonlat(1), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlon_min, rlonlat(2), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlat_max, rlonlat(3), 1, true_mpi_real, mpi_max, root, comm, ierr)
-      call mpi_reduce(rlon_max, rlonlat(4), 1, true_mpi_real, mpi_max, root, comm, ierr)
-
-      CALL mpi_bcast( rlonlat, 4 , true_mpi_real , root , comm, ierr )
-
-      rlat_min = rlonlat(1)
-      rlon_min = rlonlat(2)
-      rlat_max = rlonlat(3)
-      rlon_max = rlonlat(4)
-#endif
-
-      dlat_grid = rlat_max - rlat_min
-      dlon_grid = rlon_max - rlon_min
-
       allocate(thinning_grid_conv(num_ob_indexes))
       do n = 1, num_ob_indexes
-         if ( .not. obs_use(n) .or. &
-              n == gpseph      .or. &
-              n == gpsref      .or. &
-              n == radar       .or. &
-              n == radiance    .or. &
-              n == rain ) cycle
-         call make3grids (n,thin_mesh_conv(n))
+         if ( thin_conv_opt(n) > no_thin ) then
+            call make3grids (n,thin_mesh_conv(n))
+         end if
       end do
    end if
 
@@ -99,13 +49,9 @@ subroutine da_setup_obs_structures_bufr(grid, ob, iv)
 
    if ( thin_conv ) then
       do n = 1, num_ob_indexes
-         if ( .not. obs_use(n) .or. &
-              n == gpseph      .or. &
-              n == gpsref      .or. &
-              n == radar       .or. &
-              n == radiance    .or. &
-              n == rain ) cycle
-         call destroygrids_conv (n)
+         if ( thin_conv_opt(n) > no_thin ) then
+            call destroygrids_conv (n)
+         end if
       end do
       deallocate(thinning_grid_conv)
    end if

--- a/var/da/da_setup_structures/da_setup_obs_structures_rain.inc
+++ b/var/da/da_setup_structures/da_setup_obs_structures_rain.inc
@@ -12,60 +12,14 @@ subroutine da_setup_obs_structures_rain(grid, ob, iv)
 
    character(len=filename_len)  :: filename
    integer                     :: n,i,j,k
-   
-   ! thinning variables
-   integer  :: istart,iend,jstart,jend
-   real     :: rlonlat(4)
 
    if (trace_use) call da_trace_entry("da_setup_obs_structures_rain")
 
    !-------------------------------
    ! 0.0 Make thinning grids
    !------------------------------
-   call init_constants_derived
 
    if ( thin_rainobs ) then
-      rlat_min =  r999
-      rlat_max = -r999
-      rlon_min =  r999
-      rlon_max = -r999
-
-      istart=MINVAL( grid%i_start(1:grid%num_tiles) )
-      iend  =MAXVAL( grid%i_end  (1:grid%num_tiles) )
-      jstart=MINVAL( grid%j_start(1:grid%num_tiles) )
-      jend  =MAXVAL( grid%j_end  (1:grid%num_tiles) ) 
-
-      do i = istart, iend
-         do j = jstart, jend
-            rlat_min=min(rlat_min, grid%xb%lat(i,j))
-            rlat_max=max(rlat_max, grid%xb%lat(i,j))
-            if( grid%xb%lon(i,j) < 0.0) then
-              rlon_min=min(rlon_min, (r360+grid%xb%lon(i,j)))
-              rlon_max=max(rlon_max, (r360+grid%xb%lon(i,j)))
-            else
-              rlon_min=min(rlon_min, grid%xb%lon(i,j))
-              rlon_max=max(rlon_max, grid%xb%lon(i,j))
-            endif
-         enddo
-      enddo
-
-#ifdef DM_PARALLEL
-      call mpi_reduce(rlat_min, rlonlat(1), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlon_min, rlonlat(2), 1, true_mpi_real, mpi_min, root, comm, ierr)
-      call mpi_reduce(rlat_max, rlonlat(3), 1, true_mpi_real, mpi_max, root, comm, ierr)
-      call mpi_reduce(rlon_max, rlonlat(4), 1, true_mpi_real, mpi_max, root, comm, ierr)
-
-      CALL mpi_bcast( rlonlat, 4 , true_mpi_real , root , comm, ierr )
-
-      rlat_min = rlonlat(1)
-      rlon_min = rlonlat(2)
-      rlat_max = rlonlat(3)
-      rlon_max = rlonlat(4)
-#endif
-
-      dlat_grid = rlat_max - rlat_min
-      dlon_grid = rlon_max - rlon_min
-
       allocate(thinning_grid(num_ob_indexes,num_fgat_time))
       do n=1, num_fgat_time
          call makegrids (rain,thin_mesh_conv(rain), n)

--- a/var/da/da_setup_structures/da_setup_structures.f90
+++ b/var/da/da_setup_structures/da_setup_structures.f90
@@ -74,7 +74,7 @@ module da_setup_structures
       chi_u_t_factor, chi_u_ps_factor,chi_u_rh_factor, t_u_rh_factor, ps_u_rh_factor, &
       interpolate_stats, be_eta, thin_rainobs, fgat_rain_flags, use_iasiobs, &
       use_seviriobs, jds_int, jde_int, anal_type_hybrid_dual_res, use_amsr2obs, nrange, use_4denvar, &
-      use_goesimgobs, use_ahiobs,use_gmiobs, obs_use
+      use_goesimgobs, use_ahiobs,use_gmiobs, obs_use, thin_conv_opt, no_thin
    use da_control, only: rden_bin, use_lsac
    use da_control, only: use_cv_w
    use da_control, only: pseudo_tpw, pseudo_ztd, pseudo_ref, pseudo_uvtpq, pseudo_elv, anal_type_qcobs


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: WRFDA, thin_conv

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
1. add a new namelist variable thin_conv_opt(num_ob_indexes) to complement thin_conv/thin_conv_ascii switch.
When thin_conv/thin_conv_ascii is .true., thin_conv_opt can be set differently for each ob type.
thin_conv_opt is further modified inside WRFDA to account for unused ob types (a different implementation to achieve the same memory reduction purpose as previous commit https://github.com/wrf-model/WRF/pull/1604).
2. Some redundant code in several subroutines is moved to a higher-level subroutine.
Now the calculation of some lat/lon info (rlat_min,rlat_max,rlon_min,rlon_max,dlat_grid,dlon_grid) to be used for making thinning grids is done only once in da_setup_obs_structures.inc, rather than in each da_setup_obs_structures_ascii.inc, da_setup_obs_structures_bufr.inc, da_setup_obs_structures_rain.inc, and da_setup_radiance_structures.inc.

LIST OF MODIFIED FILES:
M       Registry/registry.var
M       var/da/da_control/da_control.f90
M       var/da/da_obs_io/da_obs_io.f90
M       var/da/da_obs_io/da_read_obs_ascii.inc
M       var/da/da_obs_io/da_read_obs_bufr.inc
M       var/da/da_obs_io/da_scan_obs_ascii.inc
M       var/da/da_radiance/da_setup_radiance_structures.inc
M       var/da/da_setup_structures/da_setup_obs_structures.inc
M       var/da/da_setup_structures/da_setup_obs_structures_ascii.inc
M       var/da/da_setup_structures/da_setup_obs_structures_bufr.inc
M       var/da/da_setup_structures/da_setup_obs_structures_rain.inc
M       var/da/da_setup_structures/da_setup_structures.f90

TESTS CONDUCTED:
1. tested a few thin_conv and thin_conv_ascii cases and results are the same as V4.3.2.
2. WRFDA regression tests are needed, but I didn't do it.

RELEASE NOTE: N/A for now. Will add description for thin_conv_opt in a future PR.