### PR TITLE
Fix PBL + LES logic initialization

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -395,10 +395,11 @@
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently, problems occur with any CG PBL option that has a packaged 
 ! scalar component: MYNN2, MYNN3, EEPS. This test is also if a user 
-! chooses to not run a PBL scheme on a finer domain, wbut use a PBL 
+! chooses to not run a PBL scheme on a finer domain, but use a PBL 
 ! parameterized scheme on a coarser domain (obviously, just for testing 
 ! purposes).
 !-----------------------------------------------------------------------
+      exists = .FALSE.
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % bl_pbl_physics(i) .EQ. LESscheme ) THEN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: PBL, LES, exists

SOURCE: Tim Juliano (NCAR)

DESCRIPTION OF CHANGES:
Problem:
A logical test relied on the existence of a condition, but the logical was a re-used, multi-purpose
variable (previously used for determining if time series output is requested). If the user has the file
`tslist` in the working directory, this flag will be .TRUE. even when failing the logical tests for the 
PBL and LES settings.

Solution:
Initialize the variable flag to .FALSE. before running through the existence test.

LIST OF MODIFIED FILES:
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. With this modification, the testing is as it should be.
2. Jenkins tests are all passing.