### PR TITLE
MYNN PBL clouds in photolysis option 4 (TUV)

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -3816,6 +3816,7 @@ rconfig   real        lambda_cutoff       namelist,chem          max_domains    
 # for cloud handling in TUV photolysis scheme
 rconfig   integer     cld_od_opt          namelist,chem          max_domains    1       rh    "cld_od_opt"          ""      ""
 rconfig   integer     pht_cldfrc_opt      namelist,chem          max_domains    1       rh    "pht_cldfrc_opt"      ""      ""
+rconfig   logical     phot_blcld          namelist,chem          max_domains    .false. rh    "phot_blcld"          ""      ""
 rconfig   integer     vertmix_onoff       namelist,chem          max_domains    1       rh    "vertmix_onoff"       ""      ""
 rconfig   integer     chem_in_opt         namelist,chem          max_domains    0       rh    "chem_in_opt"         ""      ""
 rconfig   integer     phot_opt            namelist,chem          max_domains    0       rh    "phot_opt"            ""      ""

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -960,6 +960,7 @@
               chem,rho,dz8w,grid%xlat,grid%xlong,                                     &
               zmid,z_at_w,                                                            &
               grid%qc_cu,grid%qi_cu,                                                  &
+              grid%qc_bl,grid%qi_bl,                                                  &
               grid%ph_macr,grid%ph_o31d,grid%ph_o33p,grid%ph_no2,                     &
               grid%ph_clno2,                                                          &
               grid%ph_no3o2,                                                          &

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -441,9 +441,10 @@ has_daylight : &
                  if ( config_flags%phot_blcld .and. config_flags%icloud_bl == 1 ) then
                     call cldfrac_fractional( cldfrac(kts:kte), &
                                         moist(i,kts:kte,j,p_qv), &
-                                        moist(i,kts:kte,j,p_qc) + gd_cloud(i,kts:kte,j),  &
+                                        moist(i,kts:kte,j,p_qc) + gd_cloud(i,kts:kte,j)  + &
+                                        bl_cld(i,kts:kte,j),  &
                                         moist(i,kts:kte,j,p_qi) + gd_cloud2(i,kts:kte,j) + &
-                                        bl_cld(i,kts:kte,j) + bl_cld2(i,kts:kte,j),  &
+                                        bl_cld2(i,kts:kte,j),  &
                                         moist(i,kts:kte,j,p_qs), &
                                         p_phy(i,kts:kte,j), t_phy(i,kts:kte,j), kts, kte )
                  else

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -75,6 +75,7 @@
                gmt, julday, t_phy, moist, aerwrf,                         &
                p8w, t8w, p_phy, chem, rho_phy,                            &
                dz8w, xlat, xlong, z, z_at_w, gd_cloud, gd_cloud2,         &
+               bl_cld,bl_cld2,                                            &
                tauaer1,tauaer2,tauaer3,tauaer4,                           &
                gaer1,gaer2,gaer3,gaer4,                                   &
                waer1,waer2,waer3,waer4,                                   &
@@ -117,7 +118,7 @@
                pm2_5_dry,pm2_5_water
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                   &
          INTENT(INOUT ) ::                                         &
-               gd_cloud,gd_cloud2
+               gd_cloud,gd_cloud2,bl_cld,bl_cld2
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),              &
          INTENT(IN   ) :: tauaer1, tauaer2, tauaer3, tauaer4, &
                           waer1, waer2, waer3, waer4,         &
@@ -436,13 +437,23 @@ has_daylight : &
                                   moist(i,kts:kte,j,p_qc), moist(i,kts:kte,j,p_qi), &
                                   moist(i,kts:kte,j,p_qs), kts, kte )
            elseif( config_flags%pht_cldfrc_opt == 2 ) then
-             if( config_flags%cu_diag == 1 ) then
-               call cldfrac_fractional( cldfrac(kts:kte), &
+             if( config_flags%cu_diag == 1 ) then 
+                 if ( config_flags%phot_blcld .and. config_flags%icloud_bl == 1 ) then
+                    call cldfrac_fractional( cldfrac(kts:kte), &
+                                        moist(i,kts:kte,j,p_qv), &
+                                        moist(i,kts:kte,j,p_qc) + gd_cloud(i,kts:kte,j),  &
+                                        moist(i,kts:kte,j,p_qi) + gd_cloud2(i,kts:kte,j) + &
+                                        bl_cld(i,kts:kte,j) + bl_cld2(i,kts:kte,j),  &
+                                        moist(i,kts:kte,j,p_qs), &
+                                        p_phy(i,kts:kte,j), t_phy(i,kts:kte,j), kts, kte )
+                 else
+                    call cldfrac_fractional( cldfrac(kts:kte), &
                                         moist(i,kts:kte,j,p_qv), &
                                         moist(i,kts:kte,j,p_qc) + gd_cloud(i,kts:kte,j),  &
                                         moist(i,kts:kte,j,p_qi) + gd_cloud2(i,kts:kte,j), &
                                         moist(i,kts:kte,j,p_qs), &
                                         p_phy(i,kts:kte,j), t_phy(i,kts:kte,j), kts, kte )
+                 endif
              else
                call cldfrac_fractional( cldfrac(kts:kte), &
                                         moist(i,kts:kte,j,p_qv), moist(i,kts:kte,j,p_qc), &
@@ -513,7 +524,14 @@ has_daylight : &
          qll(:)            = 0.
          qll(kts:kte)      = moist(i,kts:kte,j,p_qc) + moist(i,kts:kte,j,p_qi)
          if( config_flags%cu_diag == 1 ) then
-           qll(kts:kte) = qll(kts:kte) + gd_cloud(i,kts:kte,j) + gd_cloud2(i,kts:kte,j)
+           if ( config_flags%phot_blcld .and. config_flags%icloud_bl == 1 ) then
+              qll(kts:kte) = qll(kts:kte) + gd_cloud(i,kts:kte,j)  + &
+                                            gd_cloud2(i,kts:kte,j) + &
+                                            bl_cld(i,kts:kte,j)    + &
+                                            bl_cld2(i,kts:kte,j)
+           else
+             qll(kts:kte) = qll(kts:kte) + gd_cloud(i,kts:kte,j) + gd_cloud2(i,kts:kte,j)
+           endif
          endif
          qll(kts:kte) = 1.e3*rhoa(kts:kte)*qll(kts:kte)
          where( qll(kts:kte) < 1.e-5 )

--- a/chem/photolysis_driver.F
+++ b/chem/photolysis_driver.F
@@ -5,6 +5,7 @@
                dt_cld,af_dir,af_dn,af_up,par,erythema,                   &
                gmt,julday,t_phy,moist,aerwrf,p8w,t8w,p_phy,              &
                chem,rho_phy,dz8w,xlat,xlong,z,z_at_w,gd_cloud,gd_cloud2, &
+               bl_cld,bl_cld2,                                           &
                ph_macr,ph_o31d,ph_o33p,ph_no2,                           &
                ph_clno2,                                                 &
                ph_no3o2,                                                 &
@@ -99,7 +100,7 @@
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                       &  
          OPTIONAL,                                                     &
          INTENT(INOUT ) ::                                             &
-           gd_cloud,gd_cloud2
+           gd_cloud,gd_cloud2,bl_cld,bl_cld2
 !
 ! arrays that hold the aerosol optical properties
 !
@@ -225,6 +226,7 @@
                gmt, julday, t_phy, moist, aerwrf,                      &
                p8w, t8w, p_phy, chem, rho_phy,                         &
                dz8w, xlat, xlong, z, z_at_w, gd_cloud, gd_cloud2,      &
+               bl_cld,bl_cld2,                                         &
                tauaer1,tauaer2,tauaer3,tauaer4,                        &
                gaer1,gaer2,gaer3,gaer4,                                &
                waer1,waer2,waer3,waer4,                                &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1587,8 +1587,8 @@
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- NOTE: Need MYNN PBL for icloud_bl = 1'
-         CALL wrf_debug(1,wrf_err_message)
+         wrf_err_message = 'Need MYNN PBL for icloud_bl = 1, resetting to 0'
+         CALL wrf_debug ( 1, wrf_err_message )
       END IF
 
 #if (WRF_CHEM == 1)

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1592,6 +1592,30 @@
       END IF
 
 !-----------------------------------------------------------------------
+! Make sure phot_blcld is only used when icloud_bl==1 and  MYNN is chosen.
+!-----------------------------------------------------------------------
+
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec%phot_blcld(i) .EQV. .TRUE. ) THEN
+           IF ( model_config_rec%icloud_bl .eq. 1 .AND.  &
+               ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
+                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) ) THEN
+                !CORRECTLY CONFIGURED
+           ELSE
+              model_config_rec%phot_blcld(i) = .false.
+              oops = oops + 1
+           END IF
+         END IF
+      ENDDO      ! Loop over domains
+      IF ( oops .GT. 0 ) THEN
+         wrf_err_message = 'Need MYNN PBL and icloud_bl = 1 for phot_blcld = .true., resetting to false'
+         CALL wrf_debug ( 1, wrf_err_message )
+      END IF
+
+
+!-----------------------------------------------------------------------
 !  We need to know if any of the cumulus schemes are active. This
 !  allows the model to allocate space.
 !-----------------------------------------------------------------------

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1587,34 +1587,35 @@
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = 'Need MYNN PBL for icloud_bl = 1, resetting to 0'
-         CALL wrf_debug ( 1, wrf_err_message )
+         wrf_err_message = '--- ERROR: Need MYNN PBL for icloud_bl = 1'
+         CALL wrf_message(wrf_err_message)
+         count_fatal_error = count_fatal_error + 1
       END IF
 
+#if (WRF_CHEM == 1)
 !-----------------------------------------------------------------------
-! Make sure phot_blcld is only used when icloud_bl==1 and  MYNN is chosen.
+! Make sure phot_blcld is only used when icloud_bl==1 and MYNN is chosen.
 !-----------------------------------------------------------------------
 
       oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( model_config_rec%phot_blcld(i) .EQV. .TRUE. ) THEN
-           IF ( model_config_rec%phot_opt(i) .EQ. TUV .AND. &
-                model_config_rec%icloud_bl .eq. 1 .AND.  &
-               ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
-                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) ) THEN
+         IF ( model_config_rec%phot_blcld(i) ) THEN
+           IF ( ( model_config_rec%icloud_bl .eq. 1 ) .AND.  &
+                ( ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 ) .OR. &
+                  ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) ) ) THEN
                 !CORRECTLY CONFIGURED
            ELSE
-              model_config_rec%phot_blcld(i) = .false.
               oops = oops + 1
            END IF
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = 'Need MYNN PBL and icloud_bl = 1 for phot_blcld = .true., resetting to false'
-         CALL wrf_debug ( 1, wrf_err_message )
+         wrf_err_message = '--- ERROR: Need MYNN PBL and icloud_bl = 1 for phot_blcld = .true.'
+         CALL wrf_message(wrf_err_message)
+         count_fatal_error = count_fatal_error + 1
       END IF
-
+#endif
 
 !-----------------------------------------------------------------------
 !  We need to know if any of the cumulus schemes are active. This

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1587,9 +1587,8 @@
          END IF
       ENDDO      ! Loop over domains
       IF ( oops .GT. 0 ) THEN
-         wrf_err_message = '--- ERROR: Need MYNN PBL for icloud_bl = 1'
-         CALL wrf_message(wrf_err_message)
-         count_fatal_error = count_fatal_error + 1
+         wrf_err_message = '--- NOTE: Need MYNN PBL for icloud_bl = 1'
+         CALL wrf_debug(1,wrf_err_message)
       END IF
 
 #if (WRF_CHEM == 1)

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -1599,7 +1599,8 @@
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%phot_blcld(i) .EQV. .TRUE. ) THEN
-           IF ( model_config_rec%icloud_bl .eq. 1 .AND.  &
+           IF ( model_config_rec%phot_opt(i) .EQ. TUV .AND. &
+                model_config_rec%icloud_bl .eq. 1 .AND.  &
                ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
                 model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) ) THEN
                 !CORRECTLY CONFIGURED


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: MYNN PBL, subgrid clouds, boundary layer clouds, photolysis, TUV

SOURCE: internal 

DESCRIPTION OF CHANGES:
Adds capability to include sub-grid boundary layer clouds from the MYNN PBL schemes to photolysis option 4 (new TUV)

This update allows subgrid boundary layer clouds from the MYNN PBL scheme to be accounted for in photolysis using `phot_opt =4`. This feature is activated by setting the &chem namelist option `phot_blcld = .true.` The setting `icloud_bl = 1` must also be set.

LIST OF MODIFIED FILES: 

M       Registry/registry.chem
M       chem/chem_driver.F
M       chem/module_phot_tuv.F
M       chem/photolysis_driver.F
M       share/module_check_a_mundo.F


TESTS CONDUCTED: 
1. Jenkins tests are all passing.

RELEASE NOTE: Add MYNN PBL clouds to WRF Chem photolysis option phot_opt = 4 (TUV).