### PR TITLE
Output photolysis rates for NO2 and O1D to history stream by default

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -1314,9 +1314,9 @@ state    real  asmpsoa_a03      ikj     misc          1         -      -        
 state    real  asmpsoa_a04      ikj     misc          1         -      -         "asmpsoa_a04"             "asmpsoa_a04"                              "ug m^-3"
 
 # photolysis rates
-state    real  ph_o31d         ikj     misc        1         -      r        "PHOTR2"                "O31D Photolysis Rate" "min{-1}"
+state    real  ph_o31d         ikj     misc        1         -      rh       "PHOTR2"                "O31D Photolysis Rate" "min{-1}"
 state    real  ph_o33p         ikj     misc        1         -      r        "PHOTR3"                "O33P Photolysis Rate" "min{-1}"
-state    real  ph_no2          ikj     misc        1         -      r        "PHOTR4"                "NO2 Photolysis Rate" "min{-1}"
+state    real  ph_no2          ikj     misc        1         -      rh       "PHOTR4"                "NO2 Photolysis Rate" "min{-1}"
 state    real  ph_no3o2        ikj     misc        1         -      r        "PHOTR5"                "NO3O2 Photolysis Rate" "min{-1}"
 state    real  ph_no3o         ikj     misc        1         -      r        "PHOTR6"                "NO3O Photolysis Rate" "min{-1}"
 state    real  ph_hno2         ikj     misc        1         -      r        "PHOTR7"                "HNO2 Photolysis Rate" "min{-1}"


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: photolysis rate, no2, o3_o1d

SOURCE: internal

DESCRIPTION OF CHANGES:
Output photolysis rates for NO2 and O1D to history stream by default

Adds Jno2 and JO1D to history stream by default

LIST OF MODIFIED FILES:
M       Registry/registry.chem

TESTS CONDUCTED: 
1. Just including additional fields with the "h" option.
2. Jenkins tests all all passing.

RELEASE NOTE: Output photolysis rates for NO2 and O1D to history stream by default