### PR TITLE
Run-time option for climate GHG for radiation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -546,12 +546,13 @@ em_real : wrf
                ln -sf ../../run/CAM_AEROPT_DATA . ;                    \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP4.5 . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP6   . ;   \
-               ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 CAMtr_volume_mixing_ratio ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.A1B    . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.A2     . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP119 . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP126 . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP245 . ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP245 CAMtr_volume_mixing_ratio ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP370 . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP585 . ;   \
                ln -sf ../../run/CLM_ALB_ICE_DFS_DATA . ;               \
@@ -616,12 +617,13 @@ em_real : wrf
              ln -sf ../../run/CAM_AEROPT_DATA . ;                   \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP4.5 . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP6   . ;  \
-             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 CAMtr_volume_mixing_ratio ;   \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.A1B    . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.A2     . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP119 . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP126 . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP245 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP245 CAMtr_volume_mixing_ratio ;   \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP370 . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP585 . ;  \
              ln -sf ../../run/CLM_ALB_ICE_DFS_DATA . ;              \

--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,11 @@ em_real : wrf
                ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 CAMtr_volume_mixing_ratio ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.A1B    . ;   \
                ln -sf ../../run/CAMtr_volume_mixing_ratio.A2     . ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP119 . ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP126 . ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP245 . ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP370 . ;   \
+               ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP585 . ;   \
                ln -sf ../../run/CLM_ALB_ICE_DFS_DATA . ;               \
                ln -sf ../../run/CLM_ALB_ICE_DRC_DATA . ;               \
                ln -sf ../../run/CLM_ASM_ICE_DFS_DATA . ;               \
@@ -614,6 +619,11 @@ em_real : wrf
              ln -sf ../../run/CAMtr_volume_mixing_ratio.RCP8.5 CAMtr_volume_mixing_ratio ;   \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.A1B    . ;  \
              ln -sf ../../run/CAMtr_volume_mixing_ratio.A2     . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP119 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP126 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP245 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP370 . ;  \
+             ln -sf ../../run/CAMtr_volume_mixing_ratio.SSP585 . ;  \
              ln -sf ../../run/CLM_ALB_ICE_DFS_DATA . ;              \
              ln -sf ../../run/CLM_ALB_ICE_DRC_DATA . ;              \
              ln -sf ../../run/CLM_ASM_ICE_DFS_DATA . ;              \

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2397,7 +2397,7 @@ rconfig   integer     compute_radar_ref   derived               1              0
 rconfig   integer     ra_lw_physics       namelist,physics	max_domains    -1      rh       "ra_lw_physics"         ""      ""
 rconfig   integer     ra_sw_physics       namelist,physics	max_domains    -1      rh       "ra_sw_physics"         ""      ""
 rconfig   integer     ra_sw_eclipse       namelist,physics	1              0       rh       "ra_sw_eclipse"         "0/1 flag: 1=turn eclipse on"      ""
-rconfig   integer     ghg_input           namelist,physics	1              1       rh       "ghg_input"             "CAM, RRTM, RRTMG, RRTMG_fast: 0/1 flag: 0=constant (CO2 is a function of year); 1=time-varying GHG from CAMtr climate file"
+rconfig   integer     ghg_input           namelist,physics	1              1       rh       "ghg_input"             "for CAM, RRTM, RRTMG, RRTMG_fast: 0/1 flag: 0=constant (CO2 is a function of year for RRTM*); 1=time-varying GHG from CAMtr climate file"
 rconfig   real    radt                    namelist,physics	max_domains    0       h    "RADT"          ""      ""
 rconfig   real    naer                    namelist,physics      max_domains    1e9     rh   "NAER"          ""      ""
 rconfig   integer     sf_sfclay_physics   namelist,physics	max_domains    -1      rh       "sf_sfclay_physics"             ""      ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2397,7 +2397,7 @@ rconfig   integer     compute_radar_ref   derived               1              0
 rconfig   integer     ra_lw_physics       namelist,physics	max_domains    -1      rh       "ra_lw_physics"         ""      ""
 rconfig   integer     ra_sw_physics       namelist,physics	max_domains    -1      rh       "ra_sw_physics"         ""      ""
 rconfig   integer     ra_sw_eclipse       namelist,physics	1              0       rh       "ra_sw_eclipse"         "0/1 flag: 1=turn eclipse on"      ""
-rconfig   integer     ghg_input           namelist,physics	1              1       rh       "ghg_input"             "0/1 flag: 1=time-varying GHG from CAMtr climate file"
+rconfig   integer     ghg_input           namelist,physics	1              1       rh       "ghg_input"             "CAM, RRTM, RRTMG, RRTMG_fast: 0/1 flag: 0=constant (CO2 is a function of year); 1=time-varying GHG from CAMtr climate file"
 rconfig   real    radt                    namelist,physics	max_domains    0       h    "RADT"          ""      ""
 rconfig   real    naer                    namelist,physics      max_domains    1e9     rh   "NAER"          ""      ""
 rconfig   integer     sf_sfclay_physics   namelist,physics	max_domains    -1      rh       "sf_sfclay_physics"             ""      ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2397,6 +2397,7 @@ rconfig   integer     compute_radar_ref   derived               1              0
 rconfig   integer     ra_lw_physics       namelist,physics	max_domains    -1      rh       "ra_lw_physics"         ""      ""
 rconfig   integer     ra_sw_physics       namelist,physics	max_domains    -1      rh       "ra_sw_physics"         ""      ""
 rconfig   integer     ra_sw_eclipse       namelist,physics	1              0       rh       "ra_sw_eclipse"         "0/1 flag: 1=turn eclipse on"      ""
+rconfig   integer     ghg_input           namelist,physics	1              1       rh       "ghg_input"             "0/1 flag: 1=time-varying GHG from CAMtr climate file"
 rconfig   real    radt                    namelist,physics	max_domains    0       h    "RADT"          ""      ""
 rconfig   real    naer                    namelist,physics      max_domains    1e9     rh   "NAER"          ""      ""
 rconfig   integer     sf_sfclay_physics   namelist,physics	max_domains    -1      rh       "sf_sfclay_physics"             ""      ""

--- a/clean
+++ b/clean
@@ -57,6 +57,9 @@ if ( "$arg" == '-a' || "$arg" == '-aa' ) then
 	  */CCN_ACTIVATE.BIN \
 	  */CAMtr_volume_mixing_ratio.RCP4.5 */CAMtr_volume_mixing_ratio.RCP6 */CAMtr_volume_mixing_ratio.RCP8.5 \
 	  */CAMtr_volume_mixing_ratio.A1B */CAMtr_volume_mixing_ratio.A2 */CAMtr_volume_mixing_ratio \
+	  */CAMtr_volume_mixing_ratio.SSP119 */CAMtr_volume_mixing_ratio.SSP126 \
+	  */CAMtr_volume_mixing_ratio.SSP245 */CAMtr_volume_mixing_ratio.SSP370 \
+	  */CAMtr_volume_mixing_ratio.SSP585 \
 	  */CLM_*DATA */RRTMG_LW_DATA */RRTMG_SW_DATA \
 	  */p3_lookup* */BROADBAND_CLOUD_GODDARD.bin \
 	  */ozone.formatted */ozone_lat.formatted */ozone_plev.formatted \

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -438,7 +438,7 @@ BENCH_START(rad_driver_tim)
      &        ,progn=config_flags%progn                                            &
 #endif
      &         ,slope_rad=config_flags%slope_rad,topo_shading=config_flags%topo_shading     &
-     &         ,shadowmask=grid%shadowmask   &
+     &         ,shadowmask=grid%shadowmask,ghg_input=config_flags%ghg_input   &
      &         ,ht=grid%ht,dx=grid%dx,dy=grid%dy,dx2d=grid%dx2d,area2d=grid%area2d &           
      &         ,diffuse_frac=grid%diffuse_frac &  
      &         ,obscur=grid%ECOBSC, mask=grid%ECMASK                       &

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -1025,6 +1025,7 @@ endif
                       grid%rublten,grid%rvblten,grid%rthblten,               &
                       grid%rqvblten,grid%rqcblten,grid%rqiblten,             &
                       grid%rthraten,grid%rthratenlw,grid%rthratensw,         &
+                      grid%this_is_an_ideal_run,                             &
                       !BSINGH - For WRFCuP scheme(11/12/2013)
                       grid%cupflag,grid%cldfra_cup,grid%cldfratend_cup,      & !wig, 18-Sep-2006
                       grid%shall,                                            & !wig, 18-Sep-2006

--- a/main/depend.common
+++ b/main/depend.common
@@ -516,6 +516,7 @@ module_physics_init.o : \
 		module_ra_cam.o		\
 		$(PHYS_CU) $(PHYS_BL) \
 		module_ra_cam_support.o		\
+		module_ra_clWRF_support.o	\
 		module_ra_sw.o			\
 		module_ra_gsfcsw.o		\
 		module_ra_gfdleta.o		\

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -16,6 +16,7 @@ MODULE module_physics_init
 #if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
    USE module_dm, ONLY : wrf_dm_max_real
 #endif
+   USE module_ra_clWRF_support
 
 !  USE module_ssib_veg , ONLY : init_module_ssib_veg !fds (SSiB constants)
    !Local data for CAM's MG MP scheme
@@ -910,6 +911,11 @@ CONTAINS
   INTEGER, OPTIONAL :: irr_ph,irr_freq 
 !-----------------------------------------------------------------
 
+! Climate GHG file read for radiation
+REAL(KIND=8) :: co2dum,n2odum,ch4dum,f11dum,f12dum
+CHARACTER(LEN=8) :: name
+!-----------------------------------------------------------------
+
 #if ( EM_CORE == 1 )
 
    !  Compute 2d grid distance and 2d grid cell area. For use with
@@ -925,6 +931,20 @@ CONTAINS
       end if
    end if
 #endif
+
+   name = "        "
+   IF ( config_flags%ghg_input .EQ. 1 ) THEN
+      IF      ( config_flags%ra_lw_physics .EQ. RRTMSCHEME          ) THEN
+         name = "RRTM"
+      ELSE IF ( config_flags%ra_lw_physics .EQ. CAMLWSCHEME         ) THEN
+         name = "CAM"
+      ELSE IF ( config_flags%ra_lw_physics .EQ. RRTMG_LWSCHEME      ) THEN
+         name = "RRTMG"
+      ELSE IF ( config_flags%ra_lw_physics .EQ. RRTMG_LWSCHEME_FAST ) THEN
+         name = "RRTMG"
+      END IF
+      CALL read_CAMgases(2000,1.,.true.,TRIM(name),co2dum,n2odum,ch4dum,f11dum,f12dum)
+   END IF
 
    aercu_opt=config_flags%aercu_opt !PSH/TWG 06/10/16
    aercu_fct=config_flags%aercu_fct !PSH/TWG 06/10/16

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -945,7 +945,21 @@ CHARACTER(LEN=8) :: name
       ELSE IF ( config_flags%ra_lw_physics .EQ. RRTMG_LWSCHEME_FAST ) THEN
          name = "RRTMG"
       END IF
-      CALL read_CAMgases(2000,1.,.true.,TRIM(name),co2dum,n2odum,ch4dum,f11dum,f12dum)
+      CALL read_CAMgases(julyr,float(julday),.true.,TRIM(name),co2dum,n2odum,ch4dum,f11dum,f12dum)
+      WRITE(message,*) 'GHG annual values from CAM trace gas file'
+      CALL wrf_message(TRIM(message))
+      WRITE(message,*) 'Year = ',julyr,', Julian day = ',julday
+      CALL wrf_message(TRIM(message))
+      WRITE(message,*) 'CO2   = ',co2dum,' volume mixing ratio'
+      CALL wrf_message(TRIM(message))
+      WRITE(message,*) 'N2O   = ',n2odum,' volume mixing ratio'
+      CALL wrf_message(TRIM(message))
+      WRITE(message,*) 'CH4   = ',ch4dum,' volume mixing ratio'
+      CALL wrf_message(TRIM(message))
+      WRITE(message,*) 'CFC11 = ',f11dum,' volume mixing ratio'
+      CALL wrf_message(TRIM(message))
+      WRITE(message,*) 'CFC12 = ',f12dum,' volume mixing ratio'
+      CALL wrf_message(TRIM(message))
    END IF
 
    aercu_opt=config_flags%aercu_opt !PSH/TWG 06/10/16

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -40,6 +40,7 @@ CONTAINS
                          RUBLTEN,RVBLTEN,RTHBLTEN,               &
                          RQVBLTEN,RQCBLTEN,RQIBLTEN,             &
                          RTHRATEN,RTHRATENLW,RTHRATENSW,         &
+                         this_is_an_ideal_run,                   &
 #if ( EM_CORE == 1 )
                          !BSINGH - For WRFCuP scheme(11/12/2013)
                          cupflag,cldfra_cup,cldfratend_cup,      & !wig, 18-Sep-2006
@@ -309,7 +310,7 @@ CONTAINS
    INTEGER , INTENT(OUT) ,OPTIONAL      :: nyear
    REAL    , INTENT(OUT) ,OPTIONAL      :: nday
 
-   LOGICAL,  INTENT(IN)        :: start_of_simulation
+   LOGICAL,  INTENT(IN)        :: start_of_simulation, this_is_an_ideal_run
    REAL,     INTENT(IN)        :: DT, p_top, DX, DY
    REAL, DIMENSION(ims:ime,jms:jme), INTENT(INOUT), OPTIONAL :: DX2D, AREA2D
    LOGICAL,  INTENT(IN)        :: restart
@@ -933,7 +934,8 @@ CHARACTER(LEN=8) :: name
 #endif
 
    name = "        "
-   IF ( config_flags%ghg_input .EQ. 1 ) THEN
+   IF ( ( config_flags%ghg_input .EQ. 1 ) .AND. &
+        ( .NOT. this_is_an_ideal_run ) )   THEN
       IF      ( config_flags%ra_lw_physics .EQ. RRTMSCHEME          ) THEN
          name = "RRTM"
       ELSE IF ( config_flags%ra_lw_physics .EQ. CAMLWSCHEME         ) THEN

--- a/phys/module_ra_cam.F
+++ b/phys/module_ra_cam.F
@@ -488,7 +488,7 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
 #ifdef CLWRFGHG
 ! CLWRF-UC June.09  (Copy from share/wrf_tsin.F)
 
-   CALL read_CAMgases(yr,julian,"CAM",co2vmr,n2ovmr,ch4vmr,f11vmr,f12vmr)
+   CALL read_CAMgases(yr,julian,.false.,"CAM",co2vmr,n2ovmr,ch4vmr,f11vmr,f12vmr)
 
    IF ( wrf_dm_on_monitor() ) THEN
      WRITE(message,*)'write 1 CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian

--- a/phys/module_ra_cam.F
+++ b/phys/module_ra_cam.F
@@ -1102,7 +1102,7 @@ subroutine oznint(julday,julian,dt,gmt,xtime,ozmixmj,ozmix,levsiz,num_months,pco
 END subroutine oznint
 
 
-subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, &
+subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, &
   aerosoljn, m_hybi, paerlev, naer_c, pint, pcols, pver, pverp, pverr, pverrp, AEROSOLt, scale)
 !------------------------------------------------------------------
 !
@@ -1144,7 +1144,6 @@ subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_inpu
    real(r8), intent(in   )   ::        m_hybi(paerlev)
 
    real(r8), intent(out) :: AEROSOLt(pcols, pver, naer_all) ! aerosols
-   INTEGER, INTENT(IN )  :: GHG_INPUT
 !
 ! Local workspace
 !
@@ -1230,8 +1229,8 @@ subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_inpu
 !  call vert_interpolate (M_ps_cam_col(1,c,nm), pint, nm, AEROSOLm, ncol, c)
 !  call vert_interpolate (M_ps_cam_col(1,c,np), pint, np, AEROSOLp, ncol, c)
 
-   call vert_interpolate (m_psp, aerosoljp, m_hybi, paerlev, naer_c, pint, nm, AEROSOLm, pcols, pver, pverp, ncol, ghg_input,c)
-   call vert_interpolate (m_psn, aerosoljn, m_hybi, paerlev, naer_c, pint, np, AEROSOLp, pcols, pver, pverp, ncol, ghg_input,c)
+   call vert_interpolate (m_psp, aerosoljp, m_hybi, paerlev, naer_c, pint, nm, AEROSOLm, pcols, pver, pverp, ncol, c)
+   call vert_interpolate (m_psn, aerosoljn, m_hybi, paerlev, naer_c, pint, np, AEROSOLp, pcols, pver, pverp, ncol, c)
 
 !
 ! Time interpolate.
@@ -1273,11 +1272,9 @@ subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_inpu
             if (AEROSOLt(i, k, m) < speciesmin(m)) then
                write(6,*) 'AEROSOL_INTERPOLATE: negative mass mixing ratio, exiting'
                write(6,*) 'm, column, pver',m, i, k ,AEROSOLt(i, k, m)
-               if(ghg_input.eq.1) then
-                 print *,'naer:',naer,' pver:',pver,' ncol:',ncol
-                 PRINT *,'ERROR -- error -- ERROR -- error -- ERROR -- error'
-                 CALL wrf_error_fatal('CLWRF-module_ra_cam. : AEROSOLt=NaN')
-               endif
+               print *,'naer:',naer,' pver:',pver,' ncol:',ncol
+               PRINT *,'ERROR -- error -- ERROR -- error -- ERROR -- error'
+               CALL wrf_error_fatal('CLWRF-module_ra_cam. : AEROSOLt=NaN')
                call endrun ()
             end if
          end do
@@ -1806,7 +1803,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 
          call get_rf_scales(scales)
 
-         call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, &
+         call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, &
            aerosoljn, m_hybi, paerlev, naer, pint, pcols, pver, pverp, pverr, pverrp, aerosol, scales)
 
          ! overwrite with prognostics aerosols
@@ -1858,7 +1855,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 
       call get_int_scales(scales)
 
-      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, aerosoljn, &
+      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, aerosoljn, &
              m_hybi, paerlev, naer, pint, pcols, pver, pverp, pverr, pverrp, aerosol, scales)
 
       ! overwrite with prognostics aerosols
@@ -1962,7 +1959,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 
       call get_int_scales(scales)
 
-      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, aerosoljn, &
+      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, aerosoljn, &
              m_hybi, paerlev, naer, pint, pcols, pver, pverp, pverr, pverrp, aerosol, scales)
 
 !

--- a/phys/module_ra_cam.F
+++ b/phys/module_ra_cam.F
@@ -213,16 +213,16 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
                      SWDDIR,SWDDIF,SWDDNI,                         & ! amontornes-bcodina (2014-04-20)
                      F_QV,F_QC,F_QR,F_QI,F_QS,F_QG,                &
                      f_ice_phy,f_rain_phy,                         &
-                     p_phy,p8w,z,pi_phy,rho_phy,dz8w,               &
-                     CLDFRA,XLAND,XICE,SNOW,                        &
-                     ozmixm,pin0,levsiz,num_months,                 &
-                     m_psp,m_psn,aerosolcp,aerosolcn,m_hybi0,       &
-                     cam_abs_dim1, cam_abs_dim2,                    &
-                     paerlev,naer_c,                                &
-                     GMT,JULDAY,JULIAN,YR,DT,XTIME,DECLIN,SOLCON,         &
-                     RADT,DEGRAD,n_cldadv,                                  &
+                     p_phy,p8w,z,pi_phy,rho_phy,dz8w,              &
+                     CLDFRA,XLAND,XICE,SNOW,                       &
+                     ozmixm,pin0,levsiz,num_months,                &
+                     m_psp,m_psn,aerosolcp,aerosolcn,m_hybi0,      &
+                     cam_abs_dim1, cam_abs_dim2,                   &
+                     paerlev,naer_c,                               &
+                     GMT,JULDAY,JULIAN,YR,DT,XTIME,DECLIN,SOLCON,  &
+                     RADT,DEGRAD,n_cldadv,                         &
                      abstot_3d, absnxt_3d, emstot_3d,              &
-                     doabsems,                                     &
+                     doabsems, ghg_input,                          &
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
@@ -249,10 +249,11 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
    REAL,       INTENT(IN  )  ::        JULIAN
    INTEGER,    INTENT(IN  )  ::        YR
    REAL,       INTENT(IN  )  ::        DT
-   INTEGER,      INTENT(IN   )    ::   levsiz, num_months
-   INTEGER,      INTENT(IN   )    ::   paerlev, naer_c
-   INTEGER,      INTENT(IN   )    ::   cam_abs_dim1, cam_abs_dim2
+   INTEGER,    INTENT(IN  )  ::   levsiz, num_months
+   INTEGER,    INTENT(IN  )  ::   paerlev, naer_c
+   INTEGER,    INTENT(IN  )  ::   cam_abs_dim1, cam_abs_dim2
 
+   INTEGER,    INTENT(IN  )  ::    ghg_input
 
    REAL, INTENT(IN    )      ::        RADT,DEGRAD,             &
                                        XTIME,DECLIN,SOLCON,GMT
@@ -444,10 +445,7 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
    CHARACTER(LEN=256) :: msgstr
 
 !ccc
-#ifdef CLWRFGHG
-! CLWRF-UC June.09 
    REAL(r8)                                         :: co2vmr, n2ovmr, ch4vmr, f11vmr, f12vmr
-#endif
    LOGICAL, EXTERNAL                                :: wrf_dm_on_monitor
    CHARACTER(LEN=256)                               :: message
 
@@ -484,41 +482,27 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
 ! of interpolation factors to within 32-bit roundoff
 ! assume that day of year is 1 for all input data
 !
-!ccc
-#ifdef CLWRFGHG
-! CLWRF-UC June.09  (Copy from share/wrf_tsin.F)
 
-   CALL read_CAMgases(yr,julian,.false.,"CAM",co2vmr,n2ovmr,ch4vmr,f11vmr,f12vmr)
-
-   IF ( wrf_dm_on_monitor() ) THEN
-     WRITE(message,*)'write 1 CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian
-     call wrf_debug( 100, message)
-     WRITE(message,*)'  CAM-CLWRF co2vmr: ',co2vmr,' n2ovmr:',n2ovmr,' ch4vmr:',ch4vmr,' cfc11:'&
-       ,f11vmr,' cfc12:',f12vmr
-     call wrf_debug( 100, message)
-   ENDIF
-
-#else
-!ccc
-   nyrm     = yr - yrdata(1) + 1
-   nyrp     = nyrm + 1
-   doymodel = yr*365.    + julian
-   doydatam = yrdata(nyrm)*365. + 1.
-   doydatap = yrdata(nyrp)*365. + 1.
-   deltat   = doydatap - doydatam
-   fact1    = (doydatap - doymodel)/deltat
-   fact2    = (doymodel - doydatam)/deltat
-   co2vmr = (co2(nyrm)*fact1 + co2(nyrp)*fact2)*1.e-06
-!ccc
-   IF ( wrf_dm_on_monitor() ) THEN
-     WRITE(message,*)'CAM interpolated values_____ year:',yr,' julian day:',julian
-     call wrf_debug( 100, message)
-     WRITE(message,*)'CAM co2vmr: ',co2vmr,' n2ovmr:',n2ovmr,' ch4vmr:',ch4vmr,' cfc11:',f11vmr,&
-       ' cfc12:',f12vmr
-     call wrf_debug( 100, message)
-   ENDIF
-#endif
-!ccc
+   IF (ghg_input.eq.1) then
+       CALL read_CAMgases(yr,julian,.false.,"CAM",co2vmr,n2ovmr,ch4vmr,f11vmr,f12vmr)
+       IF ( wrf_dm_on_monitor() ) THEN
+         WRITE(message,*)'write  CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian
+         call wrf_debug( 100, message)
+         WRITE(message,*)'  CAM-CLWRF co2vmr: ',co2vmr,' n2ovmr:',n2ovmr,' ch4vmr:',ch4vmr,' cfc11:'&
+           ,f11vmr,' cfc12:',f12vmr
+         call wrf_debug( 100, message)
+       ENDIF
+  ELSE
+       nyrm     = yr - yrdata(1) + 1
+       nyrp     = nyrm + 1
+       doymodel = yr*365.    + julian
+       doydatam = yrdata(nyrm)*365. + 1.
+       doydatap = yrdata(nyrp)*365. + 1.
+       deltat   = doydatap - doydatam
+       fact1    = (doydatap - doymodel)/deltat
+       fact2    = (doymodel - doydatam)/deltat
+       co2vmr = (co2(nyrm)*fact1 + co2(nyrp)*fact2)*1.e-06
+  ENDIF
 
    co2mmr=co2vmr*mwco2/mwdry
 !
@@ -767,7 +751,7 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
                    pint, lnpmid, lnpint, pdel, t, q,   &
                    cld, cicewp, cliqwp, tauxcl, tauxci, coszrs, clat, asdir, asdif,               &
                    aldir, aldif, solcon, GMT,JULDAY,JULIAN,DT,XTIME,   &
-                   pin, ozmixmj, ozmix, levsiz, num_months,  & 
+                   pin, ozmixmj, ozmix, levsiz, num_months,ghg_input,  & 
                    m_psjp,m_psjn, aerosoljp, aerosoljn,  m_hybi, paerlev, naer_c, pmxrgn, nmxrgn, &
                    dolw, dosw, doabsems, abstot, absnxt, emstot, &
                    fsup, fsupc, fsdn, fsdnc,            &
@@ -776,12 +760,7 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,RTHRATENLWC,RTHRATENSWC,   &
                    fsns, fsnt    ,flns    ,flnt    , &
                    qrs, qrscs, qrl, qrlcs, flwds, rel, rei,             &
                    sols, soll, solsd, solld,                  &
-!ccc
-#ifdef CLWRFGHG
-!CLWRF-UC June.09
                    n2ovmr, ch4vmr, f11vmr, f12vmr  , &
-#endif
-!ccc
                    landfrac, zm, fsds, fsdsdir, fsdsdif) ! amontornes-bcodina (2014-04-20) Dir/Dif fluxes
 
       do k = kts,kte
@@ -1123,7 +1102,7 @@ subroutine oznint(julday,julian,dt,gmt,xtime,ozmixmj,ozmix,levsiz,num_months,pco
 END subroutine oznint
 
 
-subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, &
+subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, &
   aerosoljn, m_hybi, paerlev, naer_c, pint, pcols, pver, pverp, pverr, pverrp, AEROSOLt, scale)
 !------------------------------------------------------------------
 !
@@ -1165,6 +1144,7 @@ subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosolj
    real(r8), intent(in   )   ::        m_hybi(paerlev)
 
    real(r8), intent(out) :: AEROSOLt(pcols, pver, naer_all) ! aerosols
+   INTEGER, INTENT(IN )  :: GHG_INPUT
 !
 ! Local workspace
 !
@@ -1250,8 +1230,8 @@ subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosolj
 !  call vert_interpolate (M_ps_cam_col(1,c,nm), pint, nm, AEROSOLm, ncol, c)
 !  call vert_interpolate (M_ps_cam_col(1,c,np), pint, np, AEROSOLp, ncol, c)
 
-   call vert_interpolate (m_psp, aerosoljp, m_hybi, paerlev, naer_c, pint, nm, AEROSOLm, pcols, pver, pverp, ncol, c)
-   call vert_interpolate (m_psn, aerosoljn, m_hybi, paerlev, naer_c, pint, np, AEROSOLp, pcols, pver, pverp, ncol, c)
+   call vert_interpolate (m_psp, aerosoljp, m_hybi, paerlev, naer_c, pint, nm, AEROSOLm, pcols, pver, pverp, ncol, ghg_input,c)
+   call vert_interpolate (m_psn, aerosoljn, m_hybi, paerlev, naer_c, pint, np, AEROSOLp, pcols, pver, pverp, ncol, ghg_input,c)
 
 !
 ! Time interpolate.
@@ -1293,14 +1273,11 @@ subroutine get_aerosol(c, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosolj
             if (AEROSOLt(i, k, m) < speciesmin(m)) then
                write(6,*) 'AEROSOL_INTERPOLATE: negative mass mixing ratio, exiting'
                write(6,*) 'm, column, pver',m, i, k ,AEROSOLt(i, k, m)
-!ccc
-#ifdef CLWRFGHG
-!CLWRF-UC July.09
-               print *,'naer:',naer,' pver:',pver,' ncol:',ncol
-               PRINT *,'ERROR -- error -- ERROR -- error -- ERROR -- error'
-               CALL wrf_error_fatal('CLWRF-module_ra_cam. : AEROSOLt=NaN')
-#endif
-!ccc
+               if(ghg_input.eq.1) then
+                 print *,'naer:',naer,' pver:',pver,' ncol:',ncol
+                 PRINT *,'ERROR -- error -- ERROR -- error -- ERROR -- error'
+                 CALL wrf_error_fatal('CLWRF-module_ra_cam. : AEROSOLt=NaN')
+               endif
                call endrun ()
             end if
          end do
@@ -1575,7 +1552,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 !                 qm1     ,cld     ,cicewp  ,cliqwp  ,coszrs,  clat, &
                   qm1     ,cld     ,cicewp  ,cliqwp  ,tauxcl, tauxci, coszrs,  clat, &
                   asdir   ,asdif   ,aldir   ,aldif   ,solcon, GMT,JULDAY,JULIAN,DT,XTIME,  &
-                  pin, ozmixmj, ozmix, levsiz, num_months,      &
+                  pin, ozmixmj, ozmix, levsiz, num_months,  ghg_input,    &
                   m_psp, m_psn,  aerosoljp, aerosoljn, m_hybi, paerlev, naer_c, pmxrgn  , &
                   nmxrgn  ,                   &
                   dolw, dosw, doabsems, abstot, absnxt, emstot, &
@@ -1586,12 +1563,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
                   fsns    ,fsnt    ,flns    ,flnt    , &
                   qrs     ,qrscs   ,qrl     ,qrlcs   ,flwds   ,rel     ,rei     , &
                   sols    ,soll    ,solsd   ,solld   , &
-!ccc
-#ifdef CLWRFGHG
-!CLWRF-UC June.09
                   n2ovmr, ch4vmr, f11vmr, f12vmr     , &
-#endif
-!ccc
                   landfrac,zm      ,fsds, fsdsdir,fsdsdif     ) ! amontornes-bcodina (2014-04-20) Dir/Dif fluxes
 !----------------------------------------------------------------------- 
 ! 
@@ -1630,6 +1602,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
    integer, intent(in) :: ncol                  ! number of atmospheric columns
    integer, intent(in) :: levsiz                ! number of ozone data levels
    integer, intent(in) :: num_months            ! 12 months
+   integer, intent(in) :: ghg_input
    integer, intent(in) :: paerlev,naer_c          ! aerosol vertical level and # species
    integer, intent(in) :: pcols, pver, pverp, pverr, pverrp, ppcnst, pcnst
    logical, intent(in) :: dolw,dosw,doabsems
@@ -1783,12 +1756,8 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
    real(r8) aerosol(pcols, pver, naer_all) ! aerosol mass mixing ratios
    real(r8) scales(naer_all)               ! scaling factors for aerosols
 
-!ccc
-#ifdef CLWRFGHG
-!CLWRF-UC July.09
    real(r8), INTENT(IN)        ::    n2ovmr, ch4vmr, f11vmr, f12vmr
-#endif
-   LOGICAL, EXTERNAL                                :: wrf_dm_on_monitor
+   LOGICAL, EXTERNAL           ::    wrf_dm_on_monitor
    CHARACTER (LEN=256)         ::    message
 !ccc
 
@@ -1837,7 +1806,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 
          call get_rf_scales(scales)
 
-         call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, &
+         call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, &
            aerosoljn, m_hybi, paerlev, naer, pint, pcols, pver, pverp, pverr, pverrp, aerosol, scales)
 
          ! overwrite with prognostics aerosols
@@ -1889,7 +1858,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 
       call get_int_scales(scales)
 
-      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, aerosoljn, &
+      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, aerosoljn, &
              m_hybi, paerlev, naer, pint, pcols, pver, pverp, pverr, pverrp, aerosol, scales)
 
       ! overwrite with prognostics aerosols
@@ -1993,7 +1962,7 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
 
       call get_int_scales(scales)
 
-      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, aerosoljp, aerosoljn, &
+      call get_aerosol(lchnk, julday, julian, dt, gmt, xtime, m_psp, m_psn, ghg_input, aerosoljp, aerosoljn, &
              m_hybi, paerlev, naer, pint, pcols, pver, pverp, pverr, pverrp, aerosol, scales)
 
 !
@@ -2031,21 +2000,21 @@ subroutine radctl(j, lchnk   ,ncol    , pcols, pver, pverp, pverr, pverrp, ppcns
                        aerosol(:,:,idxVOLC))
 !        call t_stopf("radclwmx")
       else
-!ccc
-#ifdef CLWRFGHG
-         IF ( wrf_dm_on_monitor() ) THEN
-           WRITE(message,*)'CLWRF-CAM_call-trcmix n2ovmr:',n2ovmr,' ch4vmr:',ch4vmr,' f11vmr:',f11vmr,' f12vmr:',f12vmr
-           CALL wrf_debug(1, message)
-         END IF
-         call trcmix_clwrf(lchnk   ,ncol    ,pcols, pver,  &
-                     pmid    ,clat, n2ovmr, ch4vmr, f11vmr, f12vmr, n2o,   &
-                     ch4, cfc11, cfc12 )
 
-#else
-         call trcmix(lchnk   ,ncol    ,pcols, pver,  &
-                     pmid    ,clat, n2o     ,ch4     ,                     &
-                     cfc11   ,cfc12   )
-#endif
+         IF (ghg_input.eq.1) THEN
+           IF ( wrf_dm_on_monitor() ) THEN
+             WRITE(message,*)'CLWRF-CAM_call-trcmix n2ovmr:',n2ovmr,' ch4vmr:',ch4vmr,' f11vmr:',f11vmr,' f12vmr:',f12vmr
+             CALL wrf_debug(1, message)
+           END IF
+           call trcmix_clwrf(lchnk   ,ncol    ,pcols, pver,  &
+                       pmid    ,clat, n2ovmr, ch4vmr, f11vmr, f12vmr, n2o,   &
+                       ch4, cfc11, cfc12 )
+  
+         ELSE
+           call trcmix(lchnk   ,ncol    ,pcols, pver,  &
+                       pmid    ,clat, n2o     ,ch4     ,                     &
+                       cfc11   ,cfc12   )
+         ENDIF
          IF ( wrf_dm_on_monitor() ) THEN
            WRITE(message,*)'CLWRF post_trcmix_values. n2o:', n2o(pcols/2,pver/2), ' ch4:',      &
              ch4(pcols/2,pver/2),' cfc11:', cfc11(pcols/2,pver/2),' cfc12:', cfc12(pcols/2,pver/2) 

--- a/phys/module_ra_cam_support.F
+++ b/phys/module_ra_cam_support.F
@@ -2048,7 +2048,7 @@ subroutine get_int_scales(scales)
   return
 end subroutine get_int_scales
 
-subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, n, AEROSOL_mmr, pcols, pver, pverp, ncol,ghg_input, c)
+subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, n, AEROSOL_mmr, pcols, pver, pverp, ncol, c)
 !--------------------------------------------------------------------
 ! Input: match surface pressure, cam interface pressure,
 !        month index, number of columns, chunk index
@@ -2064,7 +2064,7 @@ subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, 
 
 !  use physconst,     only: gravit
 
-   integer, intent(in)  :: paerlev,naer_c,pcols,pver,pverp,ghg_input
+   integer, intent(in)  :: paerlev,naer_c,pcols,pver,pverp
    real(r8), intent(out) :: AEROSOL_mmr(pcols,pver,naer)  ! aerosol mmr from MATCH
    real(r8), intent(in) :: Match_ps(pcols)                ! surface pressure at a particular month
    real(r8), intent(in) :: pint(pcols,pverp)              ! interface pressure from CAM
@@ -2220,9 +2220,7 @@ subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, 
                write(6,*)'vert_interpolate: aerosol(k),(k+1)',AEROSOL(i,k,m),AEROSOL(i,k+1,m)
                write(6,*)'vert_interpolate: pint(k+1),(k)',pint(i,k+1),pint(i,k)
                write(6,*)'n,c',n,c
-               if(ghg_input.eq.1) then
-                 CALL wrf_error_fatal('CLWRF-module_ra_cam_support. vert_interpolate: ERROR -- error -- Error of computation pint=NaN')
-               endif
+               CALL wrf_error_fatal('CLWRF-module_ra_cam_support. vert_interpolate: ERROR -- error -- Error of computation pint=NaN')
                call endrun()
             end if
          end do

--- a/phys/module_ra_cam_support.F
+++ b/phys/module_ra_cam_support.F
@@ -259,27 +259,13 @@ real(r8) :: gdst(ndstsz, nspint) ! dust asymmetry parameter
       real(r8) cplos    ! constant for ozone path length integral
       real(r8) cplol    ! constant for ozone path length integral
 
-!ccc
-#ifdef CLWRFGHG
-!! UC-CLWRF June.09
    real(r8) :: co2vmr = 3.550e-4         ! co2   volume mixing ratio
    real(r8) :: n2ovmr = 0.311e-6         ! n2o   volume mixing ratio
    real(r8) :: ch4vmr = 1.714e-6         ! ch4   volume mixing ratio
    real(r8) :: f11vmr = 0.280e-9         ! cfc11 volume mixing ratio
    real(r8) :: f12vmr = 0.503e-9         ! cfc12 volume mixing ratio
 
-   integer, parameter               :: cyr = 500     ! maximum num. of lines in 'CAMtr_volume_mixing_ratio' file
-#else
-!ccc
-
-!From ghg_surfvals.F90 module
-   real(r8) :: co2vmr = 3.550e-4         ! co2   volume mixing ratio
-   real(r8) :: n2ovmr = 0.311e-6         ! n2o   volume mixing ratio
-   real(r8) :: ch4vmr = 1.714e-6         ! ch4   volume mixing ratio
-   real(r8) :: f11vmr = 0.280e-9         ! cfc11 volume mixing ratio
-   real(r8) :: f12vmr = 0.503e-9         ! cfc12 volume mixing ratio
-
-integer, parameter :: cyr = 233  ! number of years of co2 data
+   integer, parameter  :: cyr = 233  ! number of years of co2 data
 
    integer  :: yrdata(cyr) = &
  (/ 1869, 1870, 1871, 1872, 1873, 1874, 1875, &
@@ -351,8 +337,7 @@ integer, parameter :: cyr = 233  ! number of years of co2 data
     723.308, 730.1008, 736.9958, 743.993, 751.0975, 758.3183, 765.6594,     &
     773.1207, 780.702, 788.4033, 796.2249, 804.1667, 812.2289, 820.4118,    &
     828.6444, 828.6444 /)
-#endif
-!ccc
+
       integer  :: ntoplw      ! top level to solve for longwave cooling (WRF sets this to 1 for model top below 10 mb)
 
       logical :: masterproc = .true.
@@ -1439,9 +1424,6 @@ subroutine trcmix(lchnk   ,ncol     ,pcols, pver, &
 !
 end subroutine trcmix
 
-!ccc
-#ifdef CLWRFGHG
-
 subroutine trcmix_clwrf(lchnk   ,ncol     ,pcols, pver,       &
                   pmid    ,clat, n2ovmr, ch4vmr, f11vmr,      &
                   f12vmr, n2o      ,ch4     ,                 &
@@ -1594,11 +1576,6 @@ subroutine trcmix_clwrf(lchnk   ,ncol     ,pcols, pver,       &
    return
 !
 end subroutine trcmix_clwrf
-
-
-#endif
-
-!ccc
 
 subroutine trcplk(lchnk   ,ncol    ,pcols, pver, pverp,         &
                   tint    ,tlayr   ,tplnke  ,emplnk  ,abplnk1 , &
@@ -2071,7 +2048,7 @@ subroutine get_int_scales(scales)
   return
 end subroutine get_int_scales
 
-subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, n, AEROSOL_mmr, pcols, pver, pverp, ncol, c)
+subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, n, AEROSOL_mmr, pcols, pver, pverp, ncol,ghg_input, c)
 !--------------------------------------------------------------------
 ! Input: match surface pressure, cam interface pressure,
 !        month index, number of columns, chunk index
@@ -2087,7 +2064,7 @@ subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, 
 
 !  use physconst,     only: gravit
 
-   integer, intent(in)  :: paerlev,naer_c,pcols,pver,pverp
+   integer, intent(in)  :: paerlev,naer_c,pcols,pver,pverp,ghg_input
    real(r8), intent(out) :: AEROSOL_mmr(pcols,pver,naer)  ! aerosol mmr from MATCH
    real(r8), intent(in) :: Match_ps(pcols)                ! surface pressure at a particular month
    real(r8), intent(in) :: pint(pcols,pverp)              ! interface pressure from CAM
@@ -2113,13 +2090,6 @@ subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, 
    real(r8) v_coord                    ! vertical coordinate
    real(r8) m_to_mmr                   ! mass to mass mixing ratio conversion factor
    real(r8) AER_diff                   ! temp var for difference between aerosol masses
-!ccc
-#ifdef CLWRFGHG
-!CLWRF-UC July.09
-!   LOGICAL ISNAND, EXTERNAL           ! NaN values detection
-#endif
-!ccc
-!  call t_startf ('vert_interpolate')
 !
 ! Initialize index array
 !
@@ -2250,17 +2220,9 @@ subroutine vert_interpolate (Match_ps, aerosolc, m_hybi, paerlev, naer_c, pint, 
                write(6,*)'vert_interpolate: aerosol(k),(k+1)',AEROSOL(i,k,m),AEROSOL(i,k+1,m)
                write(6,*)'vert_interpolate: pint(k+1),(k)',pint(i,k+1),pint(i,k)
                write(6,*)'n,c',n,c
-!ccc
-#ifdef CLWRFGHG
-!CLWRF-UC July.09
-!               IF (ISNAND(pint(i,k+1))) THEN
+               if(ghg_input.eq.1) then
                  CALL wrf_error_fatal('CLWRF-module_ra_cam_support. vert_interpolate: ERROR -- error -- Error of computation pint=NaN')
-!               ENDIF
-!               IF (ISNAND(pint(i,k))) THEN
-!                 CALL wrf_error_fatal('CLWRF-module_ra_cam_support. vert_interpolate: ERROR -- error -- Error of computation pint=NaN')
-!               ENDIF
-#endif
-!ccc
+               endif
                call endrun()
             end if
          end do

--- a/phys/module_ra_clWRF_support.F
+++ b/phys/module_ra_clWRF_support.F
@@ -97,35 +97,31 @@ MODULE module_ra_clWRF_support
 
 CONTAINS
   
-  SUBROUTINE read_CAMgases(yr, julian, model, co2vmr, n2ovmr, ch4vmr, cfc11vmr, cfc12vmr) 
+  SUBROUTINE read_CAMgases(yr, julian, READtrFILE, model, co2vmr, n2ovmr, ch4vmr, cfc11vmr, cfc12vmr) 
 
-    INTEGER, INTENT(IN)            :: yr
-    REAL, INTENT(IN)               :: julian
-    CHARACTER(LEN=*), INTENT(IN)   :: model           ! Radiation scheme name
-    REAL(r8), OPTIONAL, INTENT(OUT)    :: co2vmr, n2ovmr, ch4vmr, cfc11vmr, cfc12vmr
+    INTEGER, INTENT(IN)              :: yr
+    REAL, INTENT(IN)                 :: julian
+    CHARACTER(LEN=*), INTENT(IN)     :: model           ! Radiation scheme name
+    REAL(r8), INTENT(OUT)            :: co2vmr, n2ovmr, ch4vmr, cfc11vmr, cfc12vmr
+    LOGICAL                          :: READtrFILE
 
 !Local
     
-    INTEGER                                          :: yearIN, found_yearIN, iyear  &
-                                                       ,yr1,yr2
-    INTEGER                                         :: mondata(1:cyr)
-    LOGICAL, EXTERNAL                                :: wrf_dm_on_monitor
-    INTEGER, EXTERNAL                                :: get_unused_unit
+    INTEGER                                   :: yearIN, found_yearIN, iyear,yr1,yr2
+    INTEGER                                   :: mondata(1:cyr)
+    LOGICAL, EXTERNAL                         :: wrf_dm_on_monitor
+    INTEGER, EXTERNAL                         :: get_unused_unit
       
-    INTEGER                                          :: istatus, iunit, idata
-!ccc VARCAM_in_years is a module variable, needs something else here!        
+    INTEGER                                   :: istatus, iunit, idata
     INTEGER, SAVE                             :: max_years 
-    integer                                          :: nyrm, nyrp, njulm, njulp
-    LOGICAL                                          :: exists
-    LOGICAL, SAVE                                    :: READtrFILE=.FALSE.
-    CHARACTER(LEN=256)                               :: message
+    integer                                   :: nyrm, nyrp, njulm, njulp
+    LOGICAL                                   :: exists
+    CHARACTER(LEN=256)                        :: message
     INTEGER                                   :: monday(13)=(/0,31,28,31,30,31,30,31,31,30,31,30,31/)
     INTEGER                                   :: mondayi(13)
     INTEGER                                   :: my1,my2,my3, tot_valid
     
-! CLWRF-UC June.09  (Copy from share/wrf_tsin.F)
-    IF ( .NOT. READtrFILE ) THEN
-       READtrFILE= .TRUE.
+    IF ( READtrFILE ) THEN
        
        INQUIRE(FILE='CAMtr_volume_mixing_ratio', EXIST=exists)
        
@@ -152,24 +148,31 @@ CONTAINS
                 READ(UNIT=iunit, FMT='(I4, 1x, F8.3,1x, 4(F10.3,1x))', IOSTAT=istatus)    &
                      yrdata(idata), co2r(idata), n2or(idata), ch4r(idata), cfc11r(idata), &
                      cfc12r(idata)
-                IF ( wrf_dm_on_monitor() ) THEN
-                   WRITE(message,*)'CLWRF reading...: istatus:',istatus,' idata:',idata,   &
-                        ' year:', yrdata(idata), ' co2: ',co2r(idata), ' n2o: ',&
-                        n2or(idata),' ch4:',ch4r(idata)
-                   call wrf_debug( 0, message) 
-                ENDIF
                 mondata(idata) = 6
-                
                 idata=idata+1
              END DO
+             CLOSE(iunit)
+
+             IF ( wrf_dm_on_monitor() ) THEN
+                WRITE(message,*)'Climate GHG input from file from year ',yrdata(1),' to ',yrdata(idata-2),'.'
+                CALL wrf_message( message) 
+                WRITE(message,*)'CO2   range = ',co2r  (1),co2r  (idata-2),' ppm'
+                CALL wrf_message( message) 
+                WRITE(message,*)'N2O   range = ',n2or  (1),n2or  (idata-2),' ppb'
+                CALL wrf_message( message) 
+                WRITE(message,*)'CH4   range = ',ch4r  (1),ch4r  (idata-2),' ppb'
+                CALL wrf_message( message) 
+                WRITE(message,*)'CFC11 range = ',cfc11r(1),cfc11r(idata-2),' ppt'
+                CALL wrf_message( message) 
+                WRITE(message,*)'CFC12 range = ',cfc12r(1),cfc12r(idata-2),' ppt'
+                CALL wrf_message( message) 
+             ENDIF
 
              IF (istatus /= -1) THEN
-                PRINT *,'CLWRF -- clwrf -- CLWRF ALERT!'
-                PRINT *,"   Not normal ending of 'CAMtr_volume_mixing_ratio' file"
-                PRINT *,"   Lecture ends with 'IOSTAT'=",istatus
+                WRITE(message,*) "   Not normal ending of CAMtr_volume_mixing_ratio file"
+                call wrf_error_fatal( message) 
              END IF
-             max_years = idata - 1
-             CLOSE(iunit)
+             max_years = idata - 2
 
              ! Calculate the julian day for each month.
              DO idata=1,max_years
@@ -195,11 +198,12 @@ CONTAINS
        ENDIF ! CAMtr_volume_mixing_ratio exists
        
     ENDIF ! File already opened and read 
+
+    !  We have already read the data once. Now we process it to find the valid value 
+    !  for this year day combination.
     
     found_yearIN=0
     iyear=1
-    !ccc Crash if iyear get > cyr (max. # of years in the mixing ratio file) ?
-    !DO WHILE (found_yearIN == 0) 
     DO WHILE (found_yearIN == 0 .and. iyear <= cyr)
        IF (yrdata(iyear) .GT. yr )  THEN
           yearIN=iyear
@@ -212,7 +216,6 @@ CONTAINS
     ENDDO
     
     ! Prevent yr > last year in data
-!    IF (yearIN .ge. VARCAM_in_years) yearIN=VARCAM_in_years-1
     IF (iyear .ge. max_years) then
        yearIN=max_years-1
        found_yearIN = 1
@@ -226,136 +229,57 @@ CONTAINS
        njulp = juldata(yearIN)
     ENDIF
 
-    IF (PRESENT(co2vmr)) THEN
-       co2vmr=-9999.999
-       if (found_yearIN /= 0) then
-          ! Interpolate data only if we have at least 2 valid concentrations.
-          tot_valid = count(co2r(1:max_years) > 0)
-          IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, co2r, max_years,yr1, yr2)
+    co2vmr   = -9999.999
+    n2ovmr   = -9999.999
+    ch4vmr   = -9999.999
+    cfc11vmr = -9999.999
+    cfc12vmr = -9999.999
+    if (found_yearIN /= 0) then
+       ! Interpolate data only if we have at least 2 valid concentrations.
+       tot_valid = count(co2r(1:max_years) > 0)
+       IF (tot_valid >= 2 ) THEN
+          CALL valid_years(yearIN, co2r, max_years,yr1, yr2)
 
-             ! Set nyrm, njulm, nyrp, njulp
-             nyrm = yrdata(yr1)
-             njulm = juldata(yr1)
-             nyrp = yrdata(yr2)
-             njulp = juldata(yr2)
+          ! Set nyrm, njulm, nyrp, njulp
+          nyrm  = yrdata (yr1)
+          njulm = juldata(yr1)
+          nyrp  = yrdata (yr2)
+          njulp = juldata(yr2)
 
-             CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, co2r, co2vmr)
-          ENDIF
-       endif
-       ! Verification of interpolated values. In case of no value 
-       ! original values extracted from ghg_surfvals.F90 module
-
-       IF (co2vmr < 0. .or. found_yearIN == 0) THEN
-          CALL orig_val("CO2",model,co2vmr)
-       ELSE
-          ! If extrapolation, need to bound the data to pre-industrial concentrations
-          if (co2vmr < 270.) co2vmr = 270.
-          co2vmr=co2vmr*1.e-06
-       END IF
-    ENDIF
-
-    IF (PRESENT(n2ovmr)) THEN
-       n2ovmr=-9999.999
-       if (found_yearIN /= 0) then
-          tot_valid = count(n2or(1:max_years) > 0)
-          IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, n2or, max_years,yr1, yr2)
-
-             ! Set nyrm, njulm, nyrp, njulp
-             nyrm = yrdata(yr1)
-             njulm = juldata(yr1)
-             nyrp = yrdata(yr2)
-             njulp = juldata(yr2)
-
-             CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, n2or, n2ovmr)
-          ENDIF
-       endif
-       
-       IF (n2ovmr < 0. .or. found_yearIN == 0) THEN
-          CALL orig_val("N2O",model,n2ovmr)
-       ELSE
-          ! If extrapolation, need to bound the data to pre-industrial concentrations
-          if (n2ovmr < 270.) n2ovmr = 270.          
-          n2ovmr=n2ovmr*1.e-09
+          CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, max_years, co2r  , co2vmr  )
+          CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, max_years, n2or  , n2ovmr  )
+          CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, max_years, ch4r  , ch4vmr  )
+          CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, max_years, cfc11r, cfc11vmr)
+          CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, max_years, cfc12r, cfc12vmr)
        ENDIF
-       
-    ENDIF
-    
-    IF (PRESENT(ch4vmr)) THEN
-       ch4vmr=-9999.999
-       if (found_yearIN /= 0) then
-          tot_valid = count(ch4r(1:max_years) > 0)
-          IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, ch4r, max_years,yr1, yr2)
+    endif
 
-             ! Set nyrm, njulm, nyrp, njulp
-             nyrm = yrdata(yr1)
-             njulm = juldata(yr1)
-             nyrp = yrdata(yr2)
-             njulp = juldata(yr2)
+    ! Verification of interpolated values. In case of no value 
+    ! original values extracted from ghg_surfvals.F90 module
 
-             CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, ch4r, ch4vmr)
-          endif
-       endif
-       
-       IF (ch4vmr < 0. .or. found_yearIN == 0) THEN
-          CALL orig_val("CH4",model,ch4vmr)
-       ELSE
-          ! If extrapolation, need to bound the data to pre-industrial concentrations
-          if (ch4vmr < 700. ) ch4vmr = 700.
-          ch4vmr=ch4vmr*1.e-09
-       ENDIF
-    ENDIF
-    
-    IF (PRESENT(cfc11vmr)) THEN
-       cfc11vmr = -9999.999
-       if (found_yearIN /= 0) then
-          tot_valid = count(cfc11r(1:max_years) > 0)
-          IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, cfc11r, max_years,yr1, yr2)
+    IF ( (co2vmr   < 0.) .OR. &
+         (n2ovmr   < 0.) .OR. &
+         (ch4vmr   < 0.) .OR. &
+         (cfc11vmr < 0.) .OR. &
+         (cfc12vmr < 0.) .OR. &
+         (found_yearIN == 0) ) THEN
+       CALL orig_val("CO2"  ,model,co2vmr  )
+       CALL orig_val("N2O"  ,model,n2ovmr  )
+       CALL orig_val("CH4"  ,model,ch4vmr  )
+       CALL orig_val("CFC11",model,cfc11vmr)
+       CALL orig_val("CFC12",model,cfc12vmr)
+    ELSE
+       ! If extrapolation, need to bound the data to pre-industrial concentrations
+       if (co2vmr < 270.) co2vmr = 270.
+       if (n2ovmr < 270.) n2ovmr = 270.          
+       if (ch4vmr < 700.) ch4vmr = 700.
+       co2vmr  =co2vmr  *1.e-06
+       n2ovmr  =n2ovmr  *1.e-09
+       ch4vmr  =ch4vmr  *1.e-09
+       cfc11vmr=cfc11vmr*1.e-12
+       cfc12vmr=cfc12vmr*1.e-12
+    END IF
 
-             ! Set nyrm, njulm, nyrp, njulp
-             nyrm = yrdata(yr1)
-             njulm = juldata(yr1)
-             nyrp = yrdata(yr2)
-             njulp = juldata(yr2)
-
-             CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, cfc11r, cfc11vmr)
-          endif
-       endif
-       
-       IF (cfc11vmr < 0. .or. found_yearIN == 0) THEN
-          CALL orig_val("CFC11",model,cfc11vmr)
-       ELSE
-          cfc11vmr=cfc11vmr*1.e-12
-       ENDIF
-    ENDIF
-    
-    IF (PRESENT(cfc12vmr)) THEN
-       cfc12vmr = -9999.999
-       if (found_yearIN /= 0) then
-          tot_valid = count(cfc12r(1:max_years) > 0)
-          IF (tot_valid >= 2 ) THEN
-             CALL valid_years(yearIN, cfc12r, max_years,yr1, yr2)
-
-             ! Set nyrm, njulm, nyrp, njulp
-             nyrm = yrdata(yr1)
-             njulm = juldata(yr1)
-             nyrp = yrdata(yr2)
-             njulp = juldata(yr2)
-
-             CALL interpolate_CAMgases(yr, julian, nyrm, njulm, yr1, yr2, nyrp, njulp, cfc12r, cfc12vmr)
-          endif
-       endif
-       
-       IF (cfc12vmr < 0. .or. found_yearIN == 0) THEN
-          CALL orig_val("CFC12",model,cfc12vmr)
-       ELSE
-          cfc12vmr=cfc12vmr*1.e-12
-       ENDIF
-    ENDIF
-       
   END SUBROUTINE read_CAMgases
   
   SUBROUTINE valid_years(yearIN, gas, tot_years, yr1, yr2)
@@ -376,14 +300,12 @@ CONTAINS
     ! If all valid dates are > yearIN then find the 2 lowest dates with
     ! valid data.
     IF (count(gas(1:yr_loc-1) > 0.) == 0) THEN
-!ccc       DO idata = yr_loc-1, tot_years-1
        DO idata = yr_loc, tot_years-1
           IF (gas(idata) > 0.) THEN
              yr1 = idata
              EXIT
           ENDIF
        ENDDO
-!ccc       DO idata = yr1, tot_years
        DO idata = yr1+1, tot_years
           IF (gas(idata) > 0.) THEN
              yr2 = idata
@@ -431,13 +353,13 @@ CONTAINS
     ENDIF
   END SUBROUTINE valid_years
 
-  SUBROUTINE interpolate_CAMgases(yr, julian, yeari, juli, yr1, yr2, yearf, julf, gas, interp_gas)
+  SUBROUTINE interpolate_CAMgases(yr, julian, yeari, juli, yr1, yr2, yearf, julf, max_years, gas, interp_gas)
     IMPLICIT NONE
 ! These subroutine interpolates a trace gas concentration from a non-homogeneously 
 ! distributed gas concentration evolution
-    INTEGER, INTENT (IN)                      :: yr, yeari, yr1, yr2, yearf, juli, julf
+    INTEGER, INTENT (IN)                      :: yr, yeari, yr1, yr2, yearf, juli, julf, max_years
     REAL, INTENT (IN)                         :: julian
-    REAL(r8), DIMENSION(500), INTENT (IN)         :: gas
+    REAL(r8), DIMENSION(max_years), INTENT(IN):: gas
     REAL(r8), INTENT (OUT)                    :: interp_gas
 !Local
     REAL(r8)                                  :: yearini, yearend, gas1, gas2

--- a/phys/module_ra_clWRF_support.F
+++ b/phys/module_ra_clWRF_support.F
@@ -154,7 +154,7 @@ CONTAINS
              CLOSE(iunit)
 
              IF ( wrf_dm_on_monitor() ) THEN
-                WRITE(message,*)'Climate GHG input from file from year ',yrdata(1),' to ',yrdata(idata-2),'.'
+                WRITE(message,*)'Climate GHG input from file from year ',yrdata(1),' to ',yrdata(idata-2)
                 CALL wrf_message( message) 
                 WRITE(message,*)'CO2   range = ',co2r  (1),co2r  (idata-2),' ppm'
                 CALL wrf_message( message) 

--- a/phys/module_ra_rrtm.F
+++ b/phys/module_ra_rrtm.F
@@ -1858,7 +1858,8 @@ CONTAINS
    !  n2ovmr = 0.
    !  ch4vmr = 0.
 ! values updated to RRTMG in V3.5
-      co2vmr = 379.e-6
+      co2vmr = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+!     co2vmr = 379.e-6
       n2ovmr = 319.e-9
       ch4vmr = 1774.e-9
    END IF

--- a/phys/module_ra_rrtm.F
+++ b/phys/module_ra_rrtm.F
@@ -1741,7 +1741,7 @@ CONTAINS
                        ,qi3d,qs3d,qg3d,cldfra3d                   &
                        ,f_qv,f_qc,f_qr,f_qi,f_qs,f_qg             &
 !ccc Added for time-varying trace gases.
-                       ,yr, julian                                )
+                       ,yr, julian, ghg_input                     )
 !ccc
 !------------------------------------------------------------------
 !ccc
@@ -1756,7 +1756,7 @@ CONTAINS
                                        ims,ime, jms,jme, kms,kme, &
                                        its,ite, jts,jte, kts,kte
 
-   INTEGER, INTENT(IN )      ::        ICLOUD
+   INTEGER, INTENT(IN )      ::        ICLOUD, ghg_input
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -1850,18 +1850,18 @@ CONTAINS
 
 !----- Calculate the trace gas concentrations from file.
 !ccc
-#ifdef CLWRFGHG
-   CALL read_CAMgases(yr,julian,.false.,"RRTM",co2vmr,n2ovmr,ch4vmr,cfc11vmr,cfc12vmr)
-#else
+   IF(ghg_input .EQ. 1 ) THEN 
+      CALL read_CAMgases(yr,julian,.false.,"RRTM",co2vmr,n2ovmr,ch4vmr,cfc11vmr,cfc12vmr)
+   ELSE
 ! values used in pre-V3.5
-!  co2vmr = 330.e-6
-!  n2ovmr = 0.
-!  ch4vmr = 0.
+   !  co2vmr = 330.e-6
+   !  n2ovmr = 0.
+   !  ch4vmr = 0.
 ! values updated to RRTMG in V3.5
-   co2vmr = 379.e-6
-   n2ovmr = 319.e-9
-   ch4vmr = 1774.e-9
-#endif
+      co2vmr = 379.e-6
+      n2ovmr = 319.e-9
+      ch4vmr = 1774.e-9
+   END IF
  
   IF ( wrf_dm_on_monitor() ) THEN
      WRITE(message,*)'CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian

--- a/phys/module_ra_rrtm.F
+++ b/phys/module_ra_rrtm.F
@@ -1827,6 +1827,7 @@ CONTAINS
 
 ! Add variables for variable trace gas concentrations (ccc)
     REAL(8)  :: co2vmr, n2ovmr, ch4vmr
+    REAL(8)  :: cfc11vmr, cfc12vmr ! NOT USED
     LOGICAL, EXTERNAL :: wrf_dm_on_monitor
     CHARACTER(LEN=256) :: message
 
@@ -1850,7 +1851,7 @@ CONTAINS
 !----- Calculate the trace gas concentrations from file.
 !ccc
 #ifdef CLWRFGHG
-   CALL read_CAMgases(yr,julian,"RRTM",co2vmr,n2ovmr,ch4vmr)
+   CALL read_CAMgases(yr,julian,.false.,"RRTM",co2vmr,n2ovmr,ch4vmr,cfc11vmr,cfc12vmr)
 #else
 ! values used in pre-V3.5
 !  co2vmr = 330.e-6

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11988,7 +11988,7 @@ CONTAINS
 !
 #ifdef CLWRFGHG
 
-   CALL read_CAMgases(yr,julian,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
 
    IF ( wrf_dm_on_monitor() ) THEN
      WRITE(message,*)'CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11595,7 +11595,7 @@ CONTAINS
                        progn,calc_clean_atm_diag,                 & !czhao
                        qndrop3d,f_qndrop,                         & !czhao
 !ccc added for time varying gases.
-                       yr,julian,                                 &
+                       yr,julian,ghg_input,                       &
 !ccc
                        mp_physics,                                &
                        ids,ide, jds,jde, kds,kde,                 & 
@@ -11616,7 +11616,7 @@ CONTAINS
                                        ims,ime, jms,jme, kms,kme, &
                                        its,ite, jts,jte, kts,kte
 
-   INTEGER, INTENT(IN )      ::        ICLOUD
+   INTEGER, INTENT(IN )      ::        ICLOUD, GHG_INPUT
    INTEGER, INTENT(IN )      ::        MP_PHYSICS
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
@@ -11832,28 +11832,9 @@ CONTAINS
 
 !ccc To add time-varying trace gases (CO2, N2O and CH4). Read the conc.  from file
 ! then interpolate to date of run.
-#ifdef CLWRFGHG
-! CLWRF-UC June.09
       REAL(8)                                      :: co2, n2o, ch4, cfc11, cfc12
-#else
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
-    real :: co2
-!   data co2 / 379.e-6 / 
-! methane (1774 ppbv)
-    real :: ch4
-    data ch4 / 1774.e-9 / 
-! nitrous oxide (319 ppbv)
-    real :: n2o
-    data n2o / 319.e-9 / 
-! cfc-11 (251 ppt)
-    real :: cfc11
-    data cfc11 / 0.251e-9 / 
-! cfc-12 (538 ppt)
-    real :: cfc12
-    data cfc12 / 0.538e-9 / 
-#endif
 ! cfc-22 (169 ppt)
     real :: cfc22
     data cfc22 / 0.169e-9 / 
@@ -11981,23 +11962,28 @@ CONTAINS
 ! All fields are ordered vertically from bottom to top
 ! Pressures are in mb
 !
-! Annual function for co2 in WRF v4.2
-      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !ccc Read time-varying trace gases concentrations and interpolate them to run date.
 !
-#ifdef CLWRFGHG
+   IF ( GHG_INPUT .EQ. 1 ) THEN 
+      CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+      IF ( wrf_dm_on_monitor() ) THEN
+        WRITE(message,*)'RRTMG LW CLWRF interpolated GHG values year:',yr,' julian day:',julian
+        call wrf_debug( 1, message)
+        WRITE(message,*)'  co2vmr: ',co2,' n2ovmr:',n2o,' ch4vmr:',ch4,' cfc11vmr:',cfc11,' cfc12vmr:',cfc12
+        call wrf_debug( 1, message)
+      ENDIF
+   ELSE
+! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+!     co2 = 379.e-6
+      ch4 = 1774.e-9
+      n2o = 319.e-9
+      cfc11 = 0.251e-9
+      cfc12 = 0.538e-9
+   END IF
 
-   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
-
-   IF ( wrf_dm_on_monitor() ) THEN
-     WRITE(message,*)'CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian
-     call wrf_debug( 100, message)
-     WRITE(message,*)'  CAM-CLWRF co2vmr: ',co2,' n2ovmr:',n2o,' ch4vmr:',ch4,' cfc11vmr:',cfc11,' cfc12vmr:',cfc12
-     call wrf_debug( 100, message)
-   ENDIF
-
-#endif
 !ccc
 
 ! latitude loop

--- a/phys/module_ra_rrtmg_lwf.F
+++ b/phys/module_ra_rrtmg_lwf.F
@@ -15273,7 +15273,7 @@ integer,external :: omp_get_thread_num
                        progn,                                     & !czhao
                        qndrop3d,f_qndrop,                         & !czhao
 !ccc added for time varying gases.
-                       yr,julian,                                 &
+                       yr,julian,ghg_input,                       &
 !ccc
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
@@ -15293,7 +15293,7 @@ integer,external :: omp_get_thread_num
                                        ims,ime, jms,jme, kms,kme, &
                                        its,ite, jts,jte, kts,kte
 
-   INTEGER, INTENT(IN )      ::        ICLOUD
+   INTEGER, INTENT(IN )      ::        ICLOUD, GHG_INPUT
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -15491,28 +15491,10 @@ integer,external :: omp_get_thread_num
 
 !ccc To add time-varying trace gases (CO2, N2O and CH4). Read the conc.  from file
 ! then interpolate to date of run.
-#ifdef CLWRFGHG
-! CLWRF-UC June.09
       REAL(8)                                      :: co2, n2o, ch4, cfc11, cfc12
-#else
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
-    real :: co2
-!   data co2 / 379.e-6 /
-! methane (1774 ppbv)
-    real :: ch4
-    data ch4 / 1774.e-9 / 
-! nitrous oxide (319 ppbv)
-    real :: n2o
-    data n2o / 319.e-9 / 
-! cfc-11 (251 ppt)
-    real :: cfc11
-    data cfc11 / 0.251e-9 / 
-! cfc-12 (538 ppt)
-    real :: cfc12
-    data cfc12 / 0.538e-9 / 
-#endif
+
 ! cfc-22 (169 ppt)
     real :: cfc22
     data cfc22 / 0.169e-9 / 
@@ -15639,23 +15621,28 @@ integer,external :: omp_get_thread_num
 !                                                              
 ! All fields are ordered vertically from bottom to top
 ! Pressures are in mb
-! Annual function for co2 in WRF v4.2
-      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 !
 !ccc Read time-varying trace gases concentrations and interpolate them to run date.
 !
-#ifdef CLWRFGHG
+   IF ( GHG_INPUT .EQ. 1 ) THEN
+      CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+      IF ( wrf_dm_on_monitor() ) THEN
+        WRITE(message,*)'RRTMG LWF CLWRF interpolated GHG values year:',yr,' julian day:',julian
+        call wrf_debug( 1, message)
+        WRITE(message,*)'  co2vmr: ',co2,' n2ovmr:',n2o,' ch4vmr:',ch4,' cfc11vmr:',cfc11,' cfc12vmr:',cfc12
+        call wrf_debug( 1, message)
+      ENDIF
+   ELSE 
+! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+!     co2 = 379.e-6
+      ch4 = 1774.e-9
+      n2o = 319.e-9
+      cfc11 = 0.251e-9
+      cfc12 = 0.538e-9
+   END IF
 
-   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
-
-   IF ( wrf_dm_on_monitor() ) THEN
-     WRITE(message,*)'CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian
-     call wrf_debug( 100, message)
-     WRITE(message,*)'  CAM-CLWRF co2vmr: ',co2,' n2ovmr:',n2o,' ch4vmr:',ch4,' cfc11vmr:',cfc11,' cfc12vmr:',cfc12
-     call wrf_debug( 100, message)
-   ENDIF
-
-#endif
 !ccc
 
    ncol = (jte-jts+1)*(ite-its+1)

--- a/phys/module_ra_rrtmg_lwf.F
+++ b/phys/module_ra_rrtmg_lwf.F
@@ -15646,7 +15646,7 @@ integer,external :: omp_get_thread_num
 !
 #ifdef CLWRFGHG
 
-   CALL read_CAMgases(yr,julian,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
 
    IF ( wrf_dm_on_monitor() ) THEN
      WRITE(message,*)'CAM-CLWRF interpolated values______ year:',yr,' julian day:',julian

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -10051,7 +10051,7 @@ CONTAINS
                        tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
                        swddir, swddni, swddif,                    & ! jararias 2013/08
                        swdownc, swddnic, swddirc,                 & ! PAJ
-                       xcoszen,yr,julian,                          & ! jararias 2013/08
+                       xcoszen,yr,julian,ghg_input,                & ! jararias 2013/08
                        obscur                                     & ! amontornes-bcodina 2015/09 solar eclipses
                        )
 !------------------------------------------------------------------
@@ -10065,7 +10065,7 @@ CONTAINS
                                        ims,ime, jms,jme, kms,kme, &
                                        its,ite, jts,jte, kts,kte
 
-   INTEGER, INTENT(IN )      ::        ICLOUD
+   INTEGER, INTENT(IN )      ::        ICLOUD, GHG_INPUT
    INTEGER, INTENT(IN )      ::        MP_PHYSICS
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
@@ -10343,21 +10343,8 @@ CONTAINS
     integer:: idx_rei
     real:: corr
 
-#ifdef CLWRFGHG
 ! Using data from CAMtr_volume_mixing_ratio data file
     real(kind=8)                                 :: co2, n2o, ch4, cfc11, cfc12
-#else
-! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
-    real :: co2
-!   data co2 / 379.e-6 /
-! methane (1774 ppbv)
-    real :: ch4
-    data ch4 / 1774.e-9 / 
-! nitrous oxide (319 ppbv)
-    real :: n2o
-    data n2o / 319.e-9 / 
-#endif
 ! Set oxygen volume mixing ratio (for o2mmr=0.23143)
     real :: o2
     data o2 / 0.209488 /
@@ -10421,9 +10408,10 @@ CONTAINS
 
     REAL :: da, eot ! jararias, 14/08/2013
 
+    CHARACTER(LEN=256) :: message
+    LOGICAL, EXTERNAL :: wrf_dm_on_monitor
+
 !------------------------------------------------------------------
-! Annual function for co2 in WRF v4.2
-      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then
       IF ( .NOT. &
@@ -10447,10 +10435,23 @@ CONTAINS
 
 !-----CALCULATE SHORT WAVE RADIATION
 !                                                              
-#ifdef CLWRFGHG
 ! Read time-varying trace gases concentrations and interpolate them to run date
-   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
-#endif
+   IF ( GHG_INPUT .EQ. 1 ) THEN
+      CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+      IF ( wrf_dm_on_monitor() ) THEN
+        WRITE(message,*)'RRTMG SW CLWRF interpolated GHG values year:',yr,' julian day:',julian
+        call wrf_debug( 1, message)
+        WRITE(message,*)'  co2vmr: ',co2,' n2ovmr:',n2o,' ch4vmr:',ch4,' cfc11vmr:',cfc11,' cfc12vmr:',cfc12
+        call wrf_debug( 1, message)
+      END IF
+   ELSE
+! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+!     co2 = 379.e-6
+      ch4 = 1774.e-9
+      n2o = 319.e-9
+   END IF
 
 ! All fields are ordered vertically from bottom to top
 ! Pressures are in mb

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -10449,7 +10449,7 @@ CONTAINS
 !                                                              
 #ifdef CLWRFGHG
 ! Read time-varying trace gases concentrations and interpolate them to run date
-   CALL read_CAMgases(yr,julian,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
 #endif
 
 ! All fields are ordered vertically from bottom to top

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11651,7 +11651,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
 !
 #ifdef CLWRFGHG
 ! Read time-varying trace gases concentrations and interpolate them to run date.
-   CALL read_CAMgases(yr,julian,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
 #endif
 
 ! jararias, 14/08/2013

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11225,7 +11225,8 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
                        coszr, julday, solcon,                     &
                        albedo, t3d, t8w, tsk,                     &
                        p3d, p8w, pi3d, rho3d,                     &
-                       dz8w, cldfra3d, lradius, iradius,          & 
+                       dz8w, cldfra3d, ghg_input,                 &
+                       lradius, iradius,                          & 
                        is_cammgmp_used, r, g,                     &
                        re_cloud,re_ice,re_snow,                   &
                        has_reqc,has_reqi,has_reqs,                &
@@ -11269,7 +11270,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
                                        ims,ime, jms,jme, kms,kme, &
                                        its,ite, jts,jte, kts,kte
 
-   INTEGER, INTENT(IN )      ::        ICLOUD
+   INTEGER, INTENT(IN )      ::        ICLOUD, GHG_INPUT
 !
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          INTENT(IN   ) ::                                   dz8w, &
@@ -11524,20 +11525,8 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
     integer:: idx_rei
     real:: corr
 
-#ifdef CLWRFGHG
     real(kind=8)                                 :: co2, n2o, ch4, cfc11, cfc12
-#else
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
-! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
-    real :: co2
-!   data co2 / 379.e-6 /
-! methane (1774 ppbv)
-    real :: ch4
-    data ch4 / 1774.e-9 / 
-! nitrous oxide (319 ppbv)
-    real :: n2o
-    data n2o / 319.e-9 / 
-#endif
 ! Set oxygen volume mixing ratio (for o2mmr=0.23143)
     real :: o2
     data o2 / 0.209488 /
@@ -11610,9 +11599,10 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
 ! mji - write
 !    REAL, DIMENSION( ims:ime, jms:jme ) ::         SWDB, SWUT
 
+    CHARACTER(LEN=256) :: message
+    LOGICAL, EXTERNAL :: wrf_dm_on_monitor
+
 !------------------------------------------------------------------
-! Annual function for co2 in WRF v4.2
-      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 #if ( WRF_CHEM == 1 )
       IF ( aer_ra_feedback == 1) then
       IF ( .NOT. &
@@ -11649,10 +11639,23 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
 ! All fields are ordered vertically from bottom to top
 ! Pressures are in mb
 !
-#ifdef CLWRFGHG
 ! Read time-varying trace gases concentrations and interpolate them to run date.
-   CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
-#endif
+   IF ( GHG_INPUT .EQ. 1 ) THEN
+      CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
+      IF ( wrf_dm_on_monitor() ) THEN
+        WRITE(message,*)'RRTMG SWF CLWRF interpolated GHG values year:',yr,' julian day:',julian
+        call wrf_debug( 1, message)
+        WRITE(message,*)'  co2vmr: ',co2,' n2ovmr:',n2o,' ch4vmr:',ch4,' cfc11vmr:',cfc11,' cfc12vmr:',cfc12
+        call wrf_debug( 1, message)
+      END IF
+   ELSE
+! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+!     co2 = 379.e-6
+      ch4 = 1774.e-9
+      n2o = 319.e-9
+   END IF
 
 ! jararias, 14/08/2013
       if (present(xcoszen)) then

--- a/phys/module_ra_sw.F
+++ b/phys/module_ra_sw.F
@@ -10,7 +10,7 @@ CONTAINS
    SUBROUTINE SWRAD(dt,RTHRATEN,GSW,XLAT,XLONG,ALBEDO,            &
                     rho_phy,T3D,QV3D,QC3D,QR3D,                   &
                     QI3D,QS3D,QG3D,P3D,pi3D,dz8w,GMT,             &
-                    R,CP,G,JULDAY,                                &
+                    R,CP,G,JULDAY,GHG_INPUT,                      &
                     XTIME,DECLIN,SOLCON,                          &
                     F_QV,F_QC,F_QR,F_QI,F_QS,F_QG,                &
                     pm2_5_dry,pm2_5_water,pm2_5_dry_ec,           &
@@ -28,7 +28,7 @@ CONTAINS
                                        its,ite, jts,jte, kts,kte
 
    LOGICAL,    INTENT(IN   ) ::        warm_rain
-   INTEGER,    INTENT(IN   ) ::        icloud
+   INTEGER,    INTENT(IN   ) ::        icloud,ghg_input
 
    REAL, INTENT(IN    )      ::        RADFRQ,DEGRAD,             &
                                        XTIME,DECLIN,SOLCON

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1950,7 +1950,7 @@ CONTAINS
                   calc_clean_atm_diag=calc_clean_atm_diag,          &
                   QNDROP3D=qndrop,F_QNDROP=f_qndrop,                &
 !ccc Added for time-varying trace gases.
-                  YR=YR,JULIAN=JULIAN,                              &
+                  YR=YR,JULIAN=JULIAN,GHG_INPUT=GHG_INPUT,          &
 !ccc
                   IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde,&
                   IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme,&
@@ -2407,7 +2407,7 @@ CONTAINS
                      COSZR=COSZR,JULDAY=JULDAY,SOLCON=SOLCON,          &
                      ALBEDO=ALBEDO,t3d=t,t8w=t8w,TSK=TSK,              &
                      p3d=p,p8w=p8w,pi3d=pi,rho3d=rho,                  &
-                     dz8w=dz8w,CLDFRA3D=CLDFRA,                        &
+                     dz8w=dz8w,CLDFRA3D=CLDFRA,GHG_INPUT=GHG_INPUT,    &
 #if (EM_CORE == 1)
                      LRADIUS=lradius, IRADIUS=iradius,                 &
 #endif

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -1874,7 +1874,7 @@ CONTAINS
                      GMT=GMT,JULDAY=JULDAY,JULIAN=JULIAN,YR=YR,DT=DT,XTIME=XTIME,DECLIN=DECLIN,  &
                      SOLCON=SOLCON,RADT=RADT,DEGRAD=DEGRAD,n_cldadv=3  &
                    ,abstot_3d=abstot,absnxt_3d=absnxt,emstot_3d=emstot &
-                   ,doabsems=doabsems                               &
+                   ,doabsems=doabsems, ghg_input=ghg_input             &
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &     
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
                  ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte &
@@ -2374,7 +2374,7 @@ CONTAINS
                      GMT=GMT,JULDAY=JULDAY,JULIAN=JULIAN,YR=YR,DT=DT,XTIME=XTIME,DECLIN=DECLIN,  &
                      SOLCON=SOLCON,RADT=RADT,DEGRAD=DEGRAD,n_cldadv=3  &
                    ,abstot_3d=abstot,absnxt_3d=absnxt,emstot_3d=emstot &
-                   ,doabsems=doabsems                               &
+                   ,doabsems=doabsems,ghg_input=ghg_input              &
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &     
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
                  ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte &

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -2039,7 +2039,7 @@ CONTAINS
 #endif
                   QNDROP3D=qndrop,F_QNDROP=f_qndrop,                &
 !ccc Added for time-varying trace gases.
-                  YR=YR,JULIAN=JULIAN,                              &
+                  YR=YR,JULIAN=JULIAN,GHG_INPUT=GHG_INPUT,          &
 !ccc
                   IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde,&
                   IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme,&
@@ -2495,6 +2495,7 @@ CONTAINS
                      ALBEDO=ALBEDO,t3d=t,t8w=t8w,TSK=TSK,              &
                      p3d=p,p8w=p8w,pi3d=pi,rho3d=rho,                  &
                      dz8w=dz8w,CLDFRA3D=CLDFRA,                        &
+                     GHG_INPUT=GHG_INPUT,                              &
 #if (EM_CORE == 1)
                      LRADIUS=lradius, IRADIUS=iradius,                 &
 #endif

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -173,6 +173,7 @@ CONTAINS
               ,mp_physics                                                 &
               ,EFCG,EFCS,EFIG,EFIS,EFSG,aercu_opt                         &
               ,EFSS,QS_CU                                                 &
+              ,GHG_INPUT                                                  &
 #if (WRF_CHEM == 1)
               ,chem                                                       &
               ,aod_out                                                    &
@@ -429,6 +430,7 @@ CONTAINS
                                        num_tiles
 
    INTEGER, INTENT(IN)            :: lw_physics, sw_physics, mp_physics, sw_eclipse
+   INTEGER, INTENT(IN)            :: ghg_input
    INTEGER, INTENT(IN)            :: o3input, aer_opt
    INTEGER, INTENT(IN)            :: id
    integer, intent(in)            :: swint_opt
@@ -1719,7 +1721,7 @@ CONTAINS
                  ,F_QI=F_QI,F_QS=F_QS,F_QG=F_QG                     &
                  ,ICLOUD=icloud,WARM_RAIN=warm_rain                 &
 !ccc Added for time-varying trace gases.
-                 ,YR=YR,JULIAN=JULIAN                               &
+                 ,YR=YR,JULIAN=JULIAN,GHG_INPUT=GHG_INPUT           &
 !ccc
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &     
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
@@ -2208,6 +2210,7 @@ CONTAINS
                     ,RHO_PHY=rho,T3D=t                                 &
                     ,P3D=p,PI3D=pi,DZ8W=dz8w,GMT=gmt                   &
                     ,R=r_d,CP=cp,G=g,JULDAY=julday                     &
+                    ,GHG_INPUT=ghg_input                               &
                     ,XTIME=xtime,DECLIN=declin,SOLCON=solcon           &
                     ,RADFRQ=radt,ICLOUD=icloud,DEGRAD=degrad           &
                     ,warm_rain=warm_rain                               &

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -573,7 +573,8 @@ Namelist variables for controlling the adaptive time step option:
  ra_lw_physics (max_dom)             longwave radiation option
                                      = 0, no longwave radiation
                                      = 1, rrtm scheme 
-				       (Default values for GHG in V3.5: co2vmr=379.e-6, n2ovmr=319.e-9, ch4vmr=1774.e-9;
+                                       (Default values for GHG in V4.2: co2vmr=(280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+                                                                        n2ovmr=319.e-9, ch4vmr=1774.e-9
                                         Values used in previous versions: co2vmr=330.e-6, n2ovmr=0., ch4vmr=0.)
                                      = 3, cam scheme
                                           also requires levsiz, paerlev, cam_abs_dim1/2 (see below)
@@ -583,6 +584,9 @@ Namelist variables for controlling the adaptive time step option:
                                                                         cfc11=0.251e-9, cfc12=0.538e-9,
                                      = 14, rrtmg-k scheme from KIAPS
                                      = 24, fast rrtmg scheme for GPU and MIC (since 3.7)
+                                       (Default values for GHG in V4.2: co2vmr=(280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+                                                                        n2ovmr=319.e-9, ch4vmr=1774.e-9,
+                                                                        cfc11=0.251e-9, cfc12=0.538e-9
                                      = 5, Goddard longwave scheme
                                      = 7, FLG (UCLA) scheme 
                                      = 31, Earth Held-Suarez forcing
@@ -615,6 +619,7 @@ Namelist variables for controlling the adaptive time step option:
                                               Applies to RRTMG, Goddard, old Goddard and Dudhia schemes
  ghg_input                           = 1,   ! Option to read CAMtr_volume_mixing_ratio files of green house gas values,
                                               as of v4.4, the default is SSP 2 with RCP 4.5 => SSP245
+                                              Used for CAM LW and SW, RRTM, RRTMG LW and SW, RRTMG_fast LW and SW
                                               0 = do not read in the annual data
                                               1 = read in time dependent data for CO2, N2O, CH4, CFC11, CFC12
 

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -573,8 +573,7 @@ Namelist variables for controlling the adaptive time step option:
  ra_lw_physics (max_dom)             longwave radiation option
                                      = 0, no longwave radiation
                                      = 1, rrtm scheme 
-                                       (Default values for GHG in V4.2: co2vmr=(280. + 90.*exp(0.02*(yr-2000)))*1.e-6
-                                                                        n2ovmr=319.e-9, ch4vmr=1774.e-9;
+				       (Default values for GHG in V3.5: co2vmr=379.e-6, n2ovmr=319.e-9, ch4vmr=1774.e-9;
                                         Values used in previous versions: co2vmr=330.e-6, n2ovmr=0., ch4vmr=0.)
                                      = 3, cam scheme
                                           also requires levsiz, paerlev, cam_abs_dim1/2 (see below)

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -573,12 +573,15 @@ Namelist variables for controlling the adaptive time step option:
  ra_lw_physics (max_dom)             longwave radiation option
                                      = 0, no longwave radiation
                                      = 1, rrtm scheme 
-                                       (Default values for GHG in V3.5: co2vmr=379.e-6, n2ovmr=319.e-9, ch4vmr=1774.e-9;
+                                       (Default values for GHG in V4.2: co2vmr=(280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+                                                                        n2ovmr=319.e-9, ch4vmr=1774.e-9;
                                         Values used in previous versions: co2vmr=330.e-6, n2ovmr=0., ch4vmr=0.)
                                      = 3, cam scheme
                                           also requires levsiz, paerlev, cam_abs_dim1/2 (see below)
                                      = 4, rrtmg scheme
-                                       (Default values for GHG in V3.5: co2vmr=379.e-6, n2ovmr=319.e-9, ch4vmr=1774.e-9)
+                                       (Default values for GHG in V4.2: co2vmr=(280. + 90.*exp(0.02*(yr-2000)))*1.e-6
+                                                                        n2ovmr=319.e-9, ch4vmr=1774.e-9,
+                                                                        cfc11=0.251e-9, cfc12=0.538e-9,
                                      = 14, rrtmg-k scheme from KIAPS
                                      = 24, fast rrtmg scheme for GPU and MIC (since 3.7)
                                      = 5, Goddard longwave scheme
@@ -611,6 +614,10 @@ Namelist variables for controlling the adaptive time step option:
                                               1 = latitude-varying decorrelation length
  ra_sw_eclipse                       = 0,   ! eclipse effect on shortwave radiation. 0: off, 1: on. 
                                               Applies to RRTMG, Goddard, old Goddard and Dudhia schemes
+ ghg_input                           = 1,   ! Option to read CAMtr_volume_mixing_ratio files of green house gas values,
+                                              as of v4.4, the default is SSP 2 with RCP 4.5 => SSP245
+                                              0 = do not read in the annual data
+                                              1 = read in time dependent data for CO2, N2O, CH4, CFC11, CFC12
 
  nrads (max_dom)                     = FOR NMM: number of fundamental timesteps between 
                                                 calls to shortwave radiation; the value

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -886,11 +886,11 @@
          ENDDO
 
          IF ( oops .GT. 0 ) THEN
-            wrf_err_message = '--- ERROR: ghg_input can only radiation schemes: CAM, RRTM, RRTMG, RRTMG_fast'
+            wrf_err_message = '--- ERROR: ghg_input available only for these radiation schemes: CAM, RRTM, RRTMG, RRTMG_fast'
             CALL wrf_message ( TRIM( wrf_err_message ) )
-            wrf_err_message = '           And the LW and SW schemes must be reasonably paired together'  
+            wrf_err_message = '           And the LW and SW schemes must be reasonably paired together:'  
             CALL wrf_message ( TRIM( wrf_err_message ) )
-            wrf_err_message = '           CAM LW with CAM SW; RRTM, RRTMG, RRTMG_fast LW and SW may be mixed'
+            wrf_err_message = '           OK = CAM LW with CAM SW; OK = RRTM, RRTMG, RRTMG_fast LW and SW may be mixed'
             CALL wrf_message ( TRIM( wrf_err_message ) )
          END IF
       END IF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -890,7 +890,9 @@
             CALL wrf_message ( TRIM( wrf_err_message ) )
             wrf_err_message = '           And the LW and SW schemes must be reasonably paired together:'  
             CALL wrf_message ( TRIM( wrf_err_message ) )
-            wrf_err_message = '           OK = CAM LW with CAM SW; OK = RRTM, RRTMG, RRTMG_fast LW and SW may be mixed'
+            wrf_err_message = '           OK = CAM LW with CAM SW'
+            CALL wrf_message ( TRIM( wrf_err_message ) )
+            wrf_err_message = '           OK = RRTM, RRTMG LW or SW, RRTMG_fast LW or SW may be mixed'
             CALL wrf_message ( TRIM( wrf_err_message ) )
          END IF
       END IF

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -859,6 +859,43 @@
 #endif
 
 !-----------------------------------------------------------------------
+! Climate GHG from an input file requires coordinated pairing of
+! LW and SW schemes, and restricts which schemes are eligible.
+! Only radiation schemes CAM, RRTM, RRTMG, RRTMG_fast may be used.
+! CAM LW and CAM SW must be used together.
+! RRTM, RRTMG, RRTMG_fast LW and SW may be wildly mixed and matched 
+! together.
+!-----------------------------------------------------------------------
+
+      IF ( model_config_rec % ghg_input .EQ. 1 ) THEN
+         oops = 0
+         DO i = 1, model_config_rec % max_dom
+            IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+            IF ( ( ( model_config_rec % ra_lw_physics(i) .EQ. CAMLWSCHEME          )   .AND. &
+                   ( model_config_rec % ra_sw_physics(i) .EQ. CAMSWSCHEME          ) ) .OR.  &
+               ( ( ( model_config_rec % ra_lw_physics(i) .EQ. RRTMSCHEME           )   .OR.  &
+                   ( model_config_rec % ra_lw_physics(i) .EQ. RRTMG_LWSCHEME       )   .OR.  &
+                   ( model_config_rec % ra_lw_physics(i) .EQ. RRTMG_LWSCHEME_FAST  ) ) .AND. &
+                 ( ( model_config_rec % ra_sw_physics(i) .EQ. SWRADSCHEME          )   .OR.  &
+                   ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME       )   .OR.  &
+                   ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME_FAST  ) ) ) ) THEN
+               ! This is OK, no way would a negation have been understandable!
+            ELSE
+               oops = oops + 1
+            END IF
+         ENDDO
+
+         IF ( oops .GT. 0 ) THEN
+            wrf_err_message = '--- ERROR: ghg_input can only radiation schemes: CAM, RRTM, RRTMG, RRTMG_fast'
+            CALL wrf_message ( TRIM( wrf_err_message ) )
+            wrf_err_message = '           And the LW and SW schemes must be reasonably paired together'  
+            CALL wrf_message ( TRIM( wrf_err_message ) )
+            wrf_err_message = '           CAM LW with CAM SW; RRTM, RRTMG, RRTMG_fast LW and SW may be mixed'
+            CALL wrf_message ( TRIM( wrf_err_message ) )
+         END IF
+      END IF
+
+!-----------------------------------------------------------------------
 ! If fractional_seaice = 0, and tice2tsk_if2cold = .true, nothing will happen
 !-----------------------------------------------------------------------
 

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -47,6 +47,7 @@
     INTEGER sf_urban_physics, w_damping, smooth_option, feedback, surface_input_source, sst_update
     INTEGER skebs_on, sppt_on, rand_perturb_on, nens,ISEED_SKEBS,ISEED_SPPT,ISEED_RAND_PERT
     INTEGER skebs_vertstruc, sppt_vertstruc, rand_pert_vertstruc
+    INTEGER ghg_input
     INTEGER LMINFORC,LMAXFORC,KMINFORC,KMAXFORC,LMINFORCT,LMAXFORCT,KMINFORCT,KMAXFORCT
     INTEGER NTASKS_X, NTASKS_Y
     REAL    gridpt_stddev_rand_pert,stddev_cutoff_rand_pert,timescale_rand_pert
@@ -177,6 +178,7 @@
     call nl_get_swrad_scat           ( 1      ,  swrad_scat           )
     call nl_get_sf_urban_physics     ( grid%id,  sf_urban_physics     )
     call nl_get_w_damping            ( 1      ,  w_damping            )
+    call nl_get_ghg_input            ( 1      ,  ghg_input            )
 
 #if (EM_CORE == 1)
     call nl_get_hypsometric_opt    ( 1, hypsometric_opt           )
@@ -646,6 +648,7 @@ endif
          ( use_package( io_form ) == IO_PNETCDF ) ) THEN
       CALL wrf_put_dom_ti_integer ( fid, 'SURFACE_INPUT_SOURCE', surface_input_source , 1 , ierr )
       CALL wrf_put_dom_ti_integer ( fid, 'SST_UPDATE', sst_update , 1 , ierr )
+      CALL wrf_put_dom_ti_integer ( fid, 'GHG_INPUT', ghg_input , 1 , ierr )
 #if (EM_CORE == 1)
       CALL wrf_put_dom_ti_integer ( fid, 'GRID_FDDA', grid_fdda , 1 , ierr )
       CALL wrf_put_dom_ti_integer ( fid, 'GFDDA_INTERVAL_M', gfdda_interval_m , 1 , ierr )


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: GHG, run-time, radiation, green house gas

SOURCE: internal

DESCRIPTION OF CHANGES:
This PR improves the way to handle green house gases in radiation schemes (CAM, RRTMG, RRTMGF, RRTM). Previously green house gases (GHGs) were either specified to be constant values or read from historical gas concentration datasets (CAMtr). Note that the latter only worked when the WRF code was compiled with the macro flag `-DCLWRFGHG`. This PR modifies the radiation schemes so that input of GHG concentration from CAMtr becomes a run-time option. The old approach of specifying a time invariant value for the GHG concentrations remains available for backward consistency. 

This PR is a reworking of "Run-time option of GHG concentration from various climate RCPs" #1611.

ISSUE: CLWRF tracer gases are not used in RRTMG shortwave code
Fixes #1597

LIST OF MODIFIED FILES:
M       Makefile
M       Registry/Registry.EM_COMMON
M       clean
M       dyn_em/module_first_rk_step_part1.F
M       dyn_em/start_em.F
M       main/depend.common
M       phys/module_physics_init.F
M       phys/module_ra_cam.F
M       phys/module_ra_cam_support.F
M       phys/module_ra_clWRF_support.F
M       phys/module_ra_rrtm.F
M       phys/module_ra_rrtmg_lw.F
M       phys/module_ra_rrtmg_lwf.F
M       phys/module_ra_rrtmg_sw.F
M       phys/module_ra_rrtmg_swf.F
M       phys/module_ra_sw.F
M       phys/module_radiation_driver.F
M       run/README.namelist
M       share/module_check_a_mundo.F
M       share/output_wrf.F

TESTS CONDUCTED:
After all of the commits, testing conducted by Ming Chen:
1. Shown below are differences in T2, LWDNB and SWDNB between RRTMG runs with GHG_INPUT=1 and 
GHG_INPUT=0 after 18 hours of integration. This is a case initialized at 00 UTC 23 February 
2017. We do see impacts caused by GHG changes.  

<img width="372" alt="T2" src="https://user-images.githubusercontent.com/17932265/149973558-4f654474-f107-4118-9ec4-132f43efd59b.png">
<img width="399" alt="LWDNB" src="https://user-images.githubusercontent.com/17932265/149973580-fa0415d0-96d5-4fad-9a5f-7c2d70e73969.png">
<img width="343" alt="SWDNB" src="https://user-images.githubusercontent.com/17932265/149973603-0f1fce93-e944-4d53-aaa4-46d3639365df.png">

2. Results here show the differences in T2 and LWDNB after 1-hour of integration between runs with specified and time-varying  greenhouse gases, respectively. This is a case using RRTMG radiation scheme. 
<img width="435" alt="t2new" src="https://user-images.githubusercontent.com/17932265/150200146-4483eb33-3e3c-452b-a3d7-4dc4e26fda24.png">
<img width="445" alt="lwdnbnew" src="https://user-images.githubusercontent.com/17932265/150200167-fb4ef228-4434-4397-9c30-e17825343b7f.png">
 

RELEASE NOTE: Climatology green house gas (GHG) concentrations from a number of RCPs and newer SSPs are now a run-time option in the WRFV4.4 (previously, they were a compile-time option). This serves two purposes: 1) Since the data files provide compiled global climatological values for co2, n2o, ch4, cfc11 and cfc12 up to 2006 for RCPs and 2014 for SSPs, they are better estimates for historical and current runs. 2) If users have values of their own, they can be easily added to the data file. The user specifies `ghg_input=1` in the physics namelist record for climatology, which is the default in v4.4, or `ghg_input=0` for constant values for backward compatibility. The default file used is CAMtr_volume_mixing_ratio.SSP245, added to the model via PR#[1553](https://github.com/wrf-model/WRF/pull/1553). A simple function for CO2 is now the default when choosing to not use the climo GHG files for RRTM - previously this function is only in RRTMG schemes. This option is only available for radiation schemes of CAM, RRTMG, RRTMGF and RRTM. 