### PR TITLE
Fix PBL + LES logic initialization - redux

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -411,10 +411,11 @@
 ! Check that LES PBL is only paired with acceptable other PBL options.
 ! Currently, problems occur with any CG PBL option that has a packaged 
 ! scalar component: MYNN2, MYNN3, EEPS. This test is also if a user 
-! chooses to not run a PBL scheme on a finer domain, wbut use a PBL 
+! chooses to not run a PBL scheme on a finer domain, but use a PBL 
 ! parameterized scheme on a coarser domain (obviously, just for testing 
 ! purposes).
 !-----------------------------------------------------------------------
+      exists = .FALSE.
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % bl_pbl_physics(i) .EQ. LESscheme ) THEN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: PBL, LES, exists

SOURCE: Tim Juliano (NCAR)

DESCRIPTION OF CHANGES:
Original: "Fix PBL + LES logic initialization" #1615

Problem:
A logical test relied on the existence of condition, but the logical was a re-used, multi-purpose
variable. Depending on the namelist settings, this flag could be .TRUE. even when failing the
logical tests.

Solution:
Initialize the variable to .FALSE. before running through the existence test.

LIST OF MODIFIED FILES:
modified:   share/module_check_a_mundo.F

TESTS CONDUCTED:
1. With this modification, the testing is as it should be.
2. Jenkins tests are all passing.

RELEASE NOTE: The v4.3.2 release contained an error in the commit that addressed the situation of segmentation faults when running a PBL on a coarse grid and no PBL on the fine grid. If a user is running the option to get the time series output, then the model will always report that there are PBL + LES issues if the user is choosing the MYNN or EEPS PBL schemes. This bug is fixed in the v4.3.3 release.