### PR TITLE
fix WRFDA build for Parallel netcdf-4 IO

### DIFF
--- a/Registry/Registry.EM_COMMON.var
+++ b/Registry/Registry.EM_COMMON.var
@@ -404,6 +404,7 @@ package   io_zzz      io_form_restart==9                     -             -
 package   io_grib2    io_form_restart==10                    -             -
 package   io_pnetcdf  io_form_restart==11                    -             -
 package   io_pio      io_form_restart==12                    -             -
+package   io_netcdfpar io_form_restart==13                   -             -
 
 #WRF Hydro
 package   no_wrfhydro    wrf_hydro==0                -            -

--- a/Registry/Registry.EM_COMMON.var
+++ b/Registry/Registry.EM_COMMON.var
@@ -404,7 +404,7 @@ package   io_zzz      io_form_restart==9                     -             -
 package   io_grib2    io_form_restart==10                    -             -
 package   io_pnetcdf  io_form_restart==11                    -             -
 package   io_pio      io_form_restart==12                    -             -
-package   io_netcdfpar io_form_restart==13                   -             -
+package   io_netcdfpar io_form_restart==13                   -             - 
 
 #WRF Hydro
 package   no_wrfhydro    wrf_hydro==0                -            -

--- a/Registry/Registry.EM_COMMON.var
+++ b/Registry/Registry.EM_COMMON.var
@@ -404,7 +404,7 @@ package   io_zzz      io_form_restart==9                     -             -
 package   io_grib2    io_form_restart==10                    -             -
 package   io_pnetcdf  io_form_restart==11                    -             -
 package   io_pio      io_form_restart==12                    -             -
-package   io_netcdfpar io_form_restart==13                   -             - 
+package   io_netcdfpar io_form_restart==13                   -             -
 
 #WRF Hydro
 package   no_wrfhydro    wrf_hydro==0                -            -


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, IO_NETCDFPAR

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Problem:
WRFDA does not build after commit e0186240.
Registry.EM_COMMON was modified in commit e0186240, but WRFDA uses Registry.EM_COMMON.var.

Solution:
Add io_netcdfpar to Registry.EM_COMMON.var

LIST OF MODIFIED FILES:
M       Registry/Registry.EM_COMMON.var

TESTS CONDUCTED:
1. WRFDA builds after the fix
2. Jenkins is all pass (for real).