### PR TITLE
Fix runtime error when using sf_surface_mosaic = 1 with use_wudapt_lcz = 0

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -726,6 +726,7 @@ BENCH_START(surf_driver_tim)
      &        ,urban_map_fbd = config_flags%urban_map_fbd                 & !multi-layer urban
      &        ,urban_map_zgrd = config_flags%urban_map_zgrd               & !multi-layer urban
      &        ,NUM_URBAN_HI=config_flags%num_urban_hi                     & !multi-layer urban
+     &        ,use_wudapt_lcz=config_flags%use_wudapt_lcz                 & !wudapt
      &        ,TSK_RURAL=grid%tsk_rural                                   & !multi-layer urban
      &        ,TRB_URB4D=grid%trb_urb4d,TW1_URB4D=grid%tw1_urb4d          & !multi-layer urban
      &        ,TW2_URB4D=grid%tw2_urb4d,TGB_URB4D=grid%tgb_urb4d          & !multi-layer urban

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -3713,10 +3713,14 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   IF(UTYPE_URB==10) FRC_URB2D(I,J)=0.55
                   IF(UTYPE_URB==11) FRC_URB2D(I,J)=1.
                 ELSE
-                  IF(IVGTYP(I,J)==ISURBAN) THEN
-                    UTYPE_URB=2
-                    FRC_URB2D(I,J)=0.9
-                  END IF
+                  IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
+                  IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1 ! LOW_DENSITY_RESIDENTIAL
+                  IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2 ! HIGH_DENSITY_RESIDENTIAL
+                  IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3 ! HIGH_INTENSITY_INDUSTRIAL
+
+                  IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.5
+                  IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
+                  IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.95
                 END IF
 
                   TA_URB    = SFCTMP           ! [K]

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -2392,6 +2392,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   urban_map_fbd,                                & !I multi-layer urban
                   urban_map_zgrd,                               & !I multi-layer urban
                   num_urban_hi,                                 & !I multi-layer urban
+                  use_wudapt_lcz,                               & !I wudapt
                   tsk_rural_bep,                                & !H multi-layer urban
                   trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,      & !H multi-layer urban
                   tlev_urb3d,qlev_urb3d,                        & !H multi-layer urban
@@ -2897,6 +2898,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
    INTEGER, INTENT(IN  ) ::                               urban_map_fbd
    INTEGER, INTENT(IN  ) ::                               urban_map_zgrd
    INTEGER, INTENT(IN  ) ::                               NUM_URBAN_HI
+   INTEGER, INTENT(IN  ) ::                               use_wudapt_lcz
    REAL, OPTIONAL, DIMENSION( ims:ime,                     jms:jme ), INTENT(INOUT) :: tsk_rural_bep
    REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zrd, jms:jme ), INTENT(INOUT) :: trb_urb4d
    REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw1_urb4d
@@ -3684,31 +3686,38 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
       
                 !  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
                 !  this need to be changed in the mosaic danli
-                IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=5
-                IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1
-                IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2
-                IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3
-                IF(IVGTYP(I,J)==LCZ_4) UTYPE_URB=4
-                IF(IVGTYP(I,J)==LCZ_5) UTYPE_URB=5
-                IF(IVGTYP(I,J)==LCZ_6) UTYPE_URB=6
-                IF(IVGTYP(I,J)==LCZ_7) UTYPE_URB=7
-                IF(IVGTYP(I,J)==LCZ_8) UTYPE_URB=8
-                IF(IVGTYP(I,J)==LCZ_9) UTYPE_URB=9
-                IF(IVGTYP(I,J)==LCZ_10) UTYPE_URB=10
-                IF(IVGTYP(I,J)==LCZ_11) UTYPE_URB=11
- 
-                        
-                IF(UTYPE_URB==1) FRC_URB2D(I,J)=1.
-                IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.99
-                IF(UTYPE_URB==3) FRC_URB2D(I,J)=1.00
-                IF(UTYPE_URB==4) FRC_URB2D(I,J)=0.65
-                IF(UTYPE_URB==5) FRC_URB2D(I,J)=0.7
-                IF(UTYPE_URB==6) FRC_URB2D(I,J)=0.65
-                IF(UTYPE_URB==7) FRC_URB2D(I,J)=0.3
-                IF(UTYPE_URB==8) FRC_URB2D(I,J)=0.85
-                IF(UTYPE_URB==9) FRC_URB2D(I,J)=0.3
-                IF(UTYPE_URB==10) FRC_URB2D(I,J)=0.55
-                IF(UTYPE_URB==11) FRC_URB2D(I,J)=1.
+                IF (use_wudapt_lcz == 1) THEN
+                  IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=5
+                  IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1
+                  IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2
+                  IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3
+                  IF(IVGTYP(I,J)==LCZ_4) UTYPE_URB=4
+                  IF(IVGTYP(I,J)==LCZ_5) UTYPE_URB=5
+                  IF(IVGTYP(I,J)==LCZ_6) UTYPE_URB=6
+                  IF(IVGTYP(I,J)==LCZ_7) UTYPE_URB=7
+                  IF(IVGTYP(I,J)==LCZ_8) UTYPE_URB=8
+                  IF(IVGTYP(I,J)==LCZ_9) UTYPE_URB=9
+                  IF(IVGTYP(I,J)==LCZ_10) UTYPE_URB=10
+                  IF(IVGTYP(I,J)==LCZ_11) UTYPE_URB=11
+
+
+                  IF(UTYPE_URB==1) FRC_URB2D(I,J)=1.
+                  IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.99
+                  IF(UTYPE_URB==3) FRC_URB2D(I,J)=1.00
+                  IF(UTYPE_URB==4) FRC_URB2D(I,J)=0.65
+                  IF(UTYPE_URB==5) FRC_URB2D(I,J)=0.7
+                  IF(UTYPE_URB==6) FRC_URB2D(I,J)=0.65
+                  IF(UTYPE_URB==7) FRC_URB2D(I,J)=0.3
+                  IF(UTYPE_URB==8) FRC_URB2D(I,J)=0.85
+                  IF(UTYPE_URB==9) FRC_URB2D(I,J)=0.3
+                  IF(UTYPE_URB==10) FRC_URB2D(I,J)=0.55
+                  IF(UTYPE_URB==11) FRC_URB2D(I,J)=1.
+                ELSE
+                  IF(IVGTYP(I,J)==ISURBAN) THEN
+                    UTYPE_URB=2
+                    FRC_URB2D(I,J)=0.9
+                  END IF
+                END IF
 
                   TA_URB    = SFCTMP           ! [K]
                   QA_URB    = Q2K              ! [kg/kg]

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -269,6 +269,7 @@ CONTAINS
      &          ,urban_map_fbd                                        & !multi-layer urban
      &          ,urban_map_zgrd                                       & !multi-layer urban
      &          ,num_urban_hi                                         & !multi-layer urban
+     &          ,use_wudapt_lcz                                       & !wudapt
      &          ,tsk_rural                                            & !multi-layer urban
      &          ,trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d              & !multi-layer urban
      &          ,tlev_urb3d,qlev_urb3d                                & !multi-layer urban
@@ -969,6 +970,7 @@ CONTAINS
    INTEGER , INTENT(IN)        ::     urban_map_fbd
    INTEGER , INTENT(IN)        ::     urban_map_zgrd
    INTEGER, INTENT(IN )::   NUM_URBAN_HI
+   INTEGER, INTENT(IN )::   use_wudapt_lcz
    REAL, OPTIONAL, DIMENSION( ims:ime,                     jms:jme ), INTENT(INOUT) :: tsk_rural
    REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zrd, jms:jme ), INTENT(INOUT) :: trb_urb4d
    REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw1_urb4d
@@ -2785,6 +2787,7 @@ CONTAINS
                 urban_map_fbd,                                  & !I multi-layer urban
                 urban_map_zgrd,                                 & !I multi-layer urban
                 num_urban_hi,                                   & !I multi-layer urban
+                use_wudapt_lcz,                                 & !I wudapt
                 tsk_rural,                                      & !H multi-layer urban
                 trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,        & !H multi-layer urban
                 tlev_urb3d,qlev_urb3d,                          & !H multi-layer urban


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: noah mosaic, wudapt

SOURCE: Do Ngoc Khanh (Tokyo Institute of Technology)

DESCRIPTION OF CHANGES:
Fix runtime error when using sf_surface_mosaic = 1 with use_wudapt_lcz = 0.

Problem:
Segmentation fault occurs when running the model using sf_surface_mosaic = 1 with use_wudapt_lcz = 0 as described in detail in #1633. 

Solution:
The code now checks for use_wudapt_lcz and uses different code to define urban categories in lsm_mosaic routine in module_sf_noahdrv.F.

ISSUE: 
Fixes #1633 

LIST OF MODIFIED FILES:
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_sf_noahdrv.F
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
1. When use_wudapt_lcz = 1: bit-by-bit identical output before and after modification.
2. When use_wudapt_lcz = 0: Segmentation fault is fixed.
3. The Jenkins tests are all passing.

RELEASE NOTE: Fix runtime error when using sf_surface_mosaic = 1 with use_wudapt_lcz = 0.