### PR TITLE
Ingest GFS ozone, use total column in TUV photolysis

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -593,8 +593,8 @@ state   real    qaoli3            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QAOLI3"           "Ice volume-3 times aspect ratio mixing ratio" "m(3) kg(-1)"
 state   real    o3_gfs            ikjb   dyn_em        1         -    \
    i0{12}rhusdf=(bdy_interp:dt)  "o3_gfs"       "ozone from GFS"         "kg kg -1"
-state   real    o3_gfs_sf         ij     misc          1         -    \
-   irh                           "o3_gfs_sf"    "scale factor ozone from GFS"              "unitless"
+state   real    o3_gfs_du         ij     misc          1         -    \
+   i012rh                        "o3_gfs_du"    "Total ozone from GFS"              "Dobson"
 
 state   real    -              ikjftb  dfi_scalar      1         -     -   -
 state   real    dfi_qndrop     ikjftb  dfi_scalar      1         -     \
@@ -1324,7 +1324,7 @@ state  real   VOLC     idjf aerosolc    2    -   -     "VOLC"         "VOLC aero
 state  real   m_hybi    d     misc      1    -   -     "m_hybi"       "MATCH hybi"
 
 # GFS ozone variables
-package   gfsozone      gfs_ozone==1                 -             state:o3_gfs_sf,o3_gfs
+package   gfsozone      gfs_ozone==1                 -             state:o3_gfs_du,o3_gfs
 
 # new eta microphysics State Variables
 state   real    F_ICE_PHY      ikj     misc         1         -      rhdu     "F_ICE_PHY"            "FRACTION OF ICE"         ""
@@ -2404,7 +2404,6 @@ rconfig   character  path_to_files        namelist,physics      1             "~
 # GFS ozone
 rconfig   integer   num_o3_gfs_levels     namelist,physics       1              23    irh      "num_o3_gfs_levels"   ""                                            ""
 rconfig   integer   gfs_ozone             namelist,physics       max_domains    0      rh      "gfs_ozone_opt"       "GFS O3 opition, 1:on"                        ""
-rconfig   integer   scale_o3_to_gfstotal  namelist,physics       1              0     irh      "gfs_ozone_scale_opt" "GFS scale, option 1:on"                      ""
 
 
 rconfig   integer     gsfcgce_hail        namelist,physics      1              0       rh       "gsfcgce select hail/graupel"  ""      ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -171,7 +171,8 @@ state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"  
 state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
 state    real   erod           ij.      misc        1        -     i012rd  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
-
+state    real   o3_inp         i{zo3gfs}j  dyn_em   1        Z     i1  "o3_inp"     "ozone from input/forecast data" "kg kg-1"
+state    real   p_ib           i{zo3gfs}j  dyn_em   1        Z     i1  "PRES_IB" "pressure, isobaric grid" "Pq"
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               
 # Variables for Eulerian mass coordinate dynamics                                            
@@ -590,6 +591,10 @@ state   real    qvoli3            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QVOLI3"           "Ice volume-3 mixing ratio" "m(3) kg(-1)"
 state   real    qaoli3            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QAOLI3"           "Ice volume-3 times aspect ratio mixing ratio" "m(3) kg(-1)"
+state   real    o3_gfs            ikjb   dyn_em        1         -    \
+   i0{12}rhusdf=(bdy_interp:dt)  "o3_gfs"       "ozone from GFS"         "kg kg -1"
+state   real    o3_gfs_sf         ij     misc          1         -    \
+   irh                           "o3_gfs_sf"    "scale factor ozone from GFS"              "unitless"
 
 state   real    -              ikjftb  dfi_scalar      1         -     -   -
 state   real    dfi_qndrop     ikjftb  dfi_scalar      1         -     \
@@ -1317,6 +1322,9 @@ state  real   BCPHI    idjf aerosolc    2    -   -     "BCPHI"        "BCPHI aer
 state  real   BG       idjf aerosolc    2    -   -     "BG"           "BG aerosol concentration"
 state  real   VOLC     idjf aerosolc    2    -   -     "VOLC"         "VOLC aerosol concentration"
 state  real   m_hybi    d     misc      1    -   -     "m_hybi"       "MATCH hybi"
+
+# GFS ozone variables
+package   gfsozone      gfs_ozone==1                 -             state:o3_gfs_sf,o3_gfs
 
 # new eta microphysics State Variables
 state   real    F_ICE_PHY      ikj     misc         1         -      rhdu     "F_ICE_PHY"            "FRACTION OF ICE"         ""
@@ -2393,7 +2401,10 @@ rconfig   integer  nudge_light_timee      namelist,physics      max_domains   72
 rconfig   integer  nudge_light_int        namelist,physics      max_domains   600     rh       "time interval in sec of input lightning data files"  ""      ""
 rconfig   character  path_to_files        namelist,physics      1             "~/WRFV3/"    rh   "path on local machine of input lightning data files"  ""      ""
 
-
+# GFS ozone
+rconfig   integer   num_o3_gfs_levels     namelist,physics       1              23    irh      "num_o3_gfs_levels"   ""                                            ""
+rconfig   integer   gfs_ozone             namelist,physics       max_domains    0      rh      "gfs_ozone_opt"       "GFS O3 opition, 1:on"                        ""
+rconfig   integer   scale_o3_to_gfstotal  namelist,physics       1              0     irh      "gfs_ozone_scale_opt" "GFS scale, option 1:on"                      ""
 
 
 rconfig   integer     gsfcgce_hail        namelist,physics      1              0       rh       "gsfcgce select hail/graupel"  ""      ""

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -4182,6 +4182,7 @@ rconfig   logical   has_o3_exo_coldens namelist,chem  1                  .false.
 rconfig   real      du_at_grnd      namelist,chem     1                  300.     rh     "O3 at ground"          "O3 at ground"                     "o3 Dobson units"
 rconfig   logical   scale_o3_to_grnd_exo_coldens namelist,chem  1  .false.  rh     "scale o3 column to exo_coldens"   "true = scale to exo model o3 column denisties"   ""
 rconfig   logical   scale_o3_to_du_at_grnd       namelist,chem  1  .false.  rh     "scale o3 column to du_at_grnd"    "true = scale to DU at ground"   ""
+rconfig   logical   scale_o3_to_gfs_tot          namelist,chem  1  .false.   rh     "gfs_ozone_scale_opt"              "true = sacle to GFS DU at ground"               ""
 
 package  lnox_opt_none      lnox_opt==0    -   -
 package  lnox_opt_ott       lnox_opt==1    -   tracer:lnox_total

--- a/Registry/registry.dimspec
+++ b/Registry/registry.dimspec
@@ -95,6 +95,7 @@ dimspec    lake_sll  2   constant=10                       z     soil_levels_or_
 dimspec    crop    2     constant=5                        z     crop_types
 dimspec    soilc   2     constant=8                        z     soil_composition_layers
 dimspec    gecros  2     constant=60                       z     gecros
+dimspec    zo3gfs  -     namelist=num_o3_gfs_levels        z     num_o3_gfs_levels
 
 # Set up the dust erosion dimension irrespective of WRF-Chem, but namelist erosion_dim=3 mandatory when not using WRF-Chem  (gthompsn, 2017Jun23)
 dimspec    .       3     namelist=erosion_dim              z     dust_erosion_dimension

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -985,7 +985,7 @@
               grid%bscoef1,grid%bscoef2,grid%bscoef3,grid%bscoef4,                    &
               grid%l2aer,grid%l3aer,grid%l4aer,grid%l5aer,grid%l6aer,grid%l7aer,      &
               grid%pm2_5_dry,grid%pm2_5_water,grid%uvrad,grid%ivgtyp,                 &
-              grid%o3_gfs_sf,                                                         & 
+              grid%o3_gfs_du,                                                         & 
               ids,ide, jds,jde, kds,kde,                                              &
               ims,ime, jms,jme, kms,kme,                                              &
               its,ite,jts,jte,kts,kte)

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -985,6 +985,7 @@
               grid%bscoef1,grid%bscoef2,grid%bscoef3,grid%bscoef4,                    &
               grid%l2aer,grid%l3aer,grid%l4aer,grid%l5aer,grid%l6aer,grid%l7aer,      &
               grid%pm2_5_dry,grid%pm2_5_water,grid%uvrad,grid%ivgtyp,                 &
+              grid%o3_gfs_sf,                                                         & 
               ids,ide, jds,jde, kds,kde,                                              &
               ims,ime, jms,jme, kms,kme,                                              &
               its,ite,jts,jte,kts,kte)

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -86,7 +86,7 @@
                ph_glyald,ph_mek,ph_gly,                                   &
                pm2_5_dry,pm2_5_water,uvrad,                               &
                dt_cld,af_dir,af_dn,af_up,par,erythema,                    &
-               o3_gfs_sf,                                                 &
+               o3_gfs_du,                                                 &
                ids,ide, jds,jde, kds,kde,                                 &
                ims,ime, jms,jme, kms,kme,                                 &
                its,ite, jts,jte, kts,kte )
@@ -157,7 +157,7 @@
    REAL,     INTENT(IN   ) ::                        gmt
 
    REAL, DIMENSION( ims:ime, jme:jme ),                         &
-         OPTIONAL,INTENT(IN ) :: o3_gfs_sf
+         OPTIONAL,INTENT(IN ) :: o3_gfs_du
 
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 
@@ -508,11 +508,7 @@ has_daylight : &
          dens_air(ktsm1:kte) = xair_kg*rhoa(ktsm1:kte)                  ! air num.(molecules/cm^3)
          call z_interp( z_air_dens_data, air_dens_data, n_air_dens_data, &
                         tuv_z(kte+1:n_tuv_z), dens_air(kte+1:n_tuv_z) )
-         if ( config_flags%scale_o3_to_gfstotal ) then
-           o33(kts:kte) = o3_gfs_sf(i,j) * ppm2vmr * chem(i,kts:kte,j,p_o3) * dens_air(kts:kte)
-         else
-           o33(kts:kte) = ppm2vmr * chem(i,kts:kte,j,p_o3) * dens_air(kts:kte)
-         endif
+         o33(kts:kte) = ppm2vmr * chem(i,kts:kte,j,p_o3) * dens_air(kts:kte)
          o33(ktsm1)   = o33(kts)
          call z_interp( z_o3_data, o3_data, n_o3_data, &
                         tuv_z(kte+1:n_tuv_z), o33(kte+1:n_tuv_z) )
@@ -558,6 +554,9 @@ has_daylight : &
          endif
          if( config_flags%scale_o3_to_grnd_exo_coldens ) then
            dobsi = real( o3_exo_col_at_grnd(i,j),4 )/2.687e16
+         endif
+         if (config_flags%scale_o3_to_gfs_tot ) then
+           dobsi = o3_gfs_du(i,j)
          endif
 
          so2col(:) = 0.

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -86,6 +86,7 @@
                ph_glyald,ph_mek,ph_gly,                                   &
                pm2_5_dry,pm2_5_water,uvrad,                               &
                dt_cld,af_dir,af_dn,af_up,par,erythema,                    &
+               o3_gfs_sf,                                                 &
                ids,ide, jds,jde, kds,kde,                                 &
                ims,ime, jms,jme, kms,kme,                                 &
                its,ite, jts,jte, kts,kte )
@@ -154,6 +155,9 @@
    REAL,  DIMENSION( ims:ime , jms:jme )                   ,    &     
           INTENT(INOUT   ) ::                        uvrad
    REAL,     INTENT(IN   ) ::                        gmt
+
+   REAL, DIMENSION( ims:ime, jme:jme ),                         &
+         OPTIONAL,INTENT(IN ) :: o3_gfs_sf
 
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 
@@ -504,8 +508,11 @@ has_daylight : &
          dens_air(ktsm1:kte) = xair_kg*rhoa(ktsm1:kte)                  ! air num.(molecules/cm^3)
          call z_interp( z_air_dens_data, air_dens_data, n_air_dens_data, &
                         tuv_z(kte+1:n_tuv_z), dens_air(kte+1:n_tuv_z) )
-
-         o33(kts:kte) = ppm2vmr*chem(i,kts:kte,j,p_o3)*dens_air(kts:kte)
+         if ( config_flags%scale_o3_to_gfstotal ) then
+           o33(kts:kte) = o3_gfs_sf(i,j) * ppm2vmr * chem(i,kts:kte,j,p_o3) * dens_air(kts:kte)
+         else
+           o33(kts:kte) = ppm2vmr * chem(i,kts:kte,j,p_o3) * dens_air(kts:kte)
+         endif
          o33(ktsm1)   = o33(kts)
          call z_interp( z_o3_data, o3_data, n_o3_data, &
                         tuv_z(kte+1:n_tuv_z), o33(kte+1:n_tuv_z) )

--- a/chem/photolysis_driver.F
+++ b/chem/photolysis_driver.F
@@ -28,7 +28,7 @@
                bscoef1,bscoef2,bscoef3,bscoef4,                          &
                l2aer,l3aer,l4aer,l5aer,l6aer,l7aer,                      &
                pm2_5_dry,pm2_5_water,uvrad,ivgtyp,                       &
-               o3_gfs_sf,                                                &
+               o3_gfs_du,                                                &
                ids,ide, jds,jde, kds,kde,                                &
                ims,ime, jms,jme, kms,kme,                                &
                its,ite, jts,jte, kts,kte                                 )
@@ -135,7 +135,7 @@
                                                      xlat,             &
                                                      xlong
    REAL,  DIMENSION( ims:ime, jms:jme ),                                & 
-          OPTIONAL, INTENT(IN ) :: o3_gfs_sf
+          OPTIONAL, INTENT(IN ) :: o3_gfs_du
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 
    LOGICAL, INTENT(IN)  :: haveaer
@@ -239,7 +239,7 @@
                ph_glyald,ph_mek,ph_gly,                                &
                pm2_5_dry, pm2_5_water, uvrad,                          &
                dt_cld,af_dir,af_dn,af_up,par,erythema,                 &
-               o3_gfs_sf,                                              &
+               o3_gfs_du,                                              &
                ids,ide, jds,jde, kds,kde,                              &
                ims,ime, jms,jme, kms,kme,                              &
                its,ite, jts,jte, kts,kte                               )

--- a/chem/photolysis_driver.F
+++ b/chem/photolysis_driver.F
@@ -28,6 +28,7 @@
                bscoef1,bscoef2,bscoef3,bscoef4,                          &
                l2aer,l3aer,l4aer,l5aer,l6aer,l7aer,                      &
                pm2_5_dry,pm2_5_water,uvrad,ivgtyp,                       &
+               o3_gfs_sf,                                                &
                ids,ide, jds,jde, kds,kde,                                &
                ims,ime, jms,jme, kms,kme,                                &
                its,ite, jts,jte, kts,kte                                 )
@@ -133,6 +134,8 @@
           INTENT(IN   ) ::                                             &
                                                      xlat,             &
                                                      xlong
+   REAL,  DIMENSION( ims:ime, jms:jme ),                                & 
+          OPTIONAL, INTENT(IN ) :: o3_gfs_sf
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 
    LOGICAL, INTENT(IN)  :: haveaer
@@ -236,6 +239,7 @@
                ph_glyald,ph_mek,ph_gly,                                &
                pm2_5_dry, pm2_5_water, uvrad,                          &
                dt_cld,af_dir,af_dn,af_up,par,erythema,                 &
+               o3_gfs_sf,                                              &
                ids,ide, jds,jde, kds,kde,                              &
                ims,ime, jms,jme, kms,kme,                              &
                its,ite, jts,jte, kts,kte                               )

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2425,16 +2425,8 @@ integer::oops1,oops2
                                ids , ide , jds , jde , kds , kde , &
                                ims , ime , jms , jme , kms , kme , &
                                its , ite , jts , jte , kts , kte )
-! Create scaling factor for total GFS column vs. total column interpolated to WRF grid
-           if ( config_flags%scale_o3_to_gfstotal .gt. 0 ) then
-             do j = jts, jte
-               do i = its, ite
-                 grid%o3_gfs_sf(i,j) = sum(grid%o3_inp(i,:,j))/sum(grid%o3_gfs(i,:,j))
-               enddo
-             enddo
-           endif
 ! Convert to mixing ratio
-           grid%o3_inp = grid%o3_inp * 1.e6 * mw_air / mw_o3
+           grid%o3_gfs = grid%o3_gfs * 1.e6 * mw_air / mw_o3
 
          ENDIF
          !  Do we have the old data that came in on the same vertical levels as the other

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -119,7 +119,7 @@ CONTAINS
       INTEGER :: IICOUNT, icount
 
       REAL :: p_top_requested , temp
-      INTEGER :: num_metgrid_levels
+      INTEGER :: num_metgrid_levels,num_o3_gfs_levels
       REAL , DIMENSION(max_eta) :: eta_levels
 
       INTEGER :: auto_levels_opt
@@ -164,6 +164,18 @@ integer::oops1,oops2
       !  Vert interpolation in WRF
 
       INTEGER :: k_max_p , k_min_p
+      REAL, PARAMETER :: mw_o3  = 48.0
+      REAL, PARAMETER :: mw_air = 28.966
+      REAL, PARAMETER, DIMENSION(24) :: p_o3gfs_old = (/0.1000E+06, 0.8500E+05, 0.7000E+05, &
+              0.5000E+05, 0.4000E+05, 0.3500E+05, 0.3000E+05, 0.2500E+05, 0.2000E+05, &
+              0.1500E+05, 0.1000E+05, 7000., 5000., 4000., 3000., 2000., 1500., &
+              1000., 700., 500., 300., 200., 100., 40./)
+      REAL, PARAMETER, DIMENSION(41) :: p_o3gfs_new = (/0.1000E+06, 0.9750E+05, 0.9500E+05, &
+              0.9250E+05, 0.9000E+05, 0.8500E+05, 0.8000E+05, 0.7500E+05, 0.7000E+05, &
+              0.6500E+05, 0.6000E+05, 0.5500E+05, 0.5000E+05, 0.4500E+05, 0.4000E+05, &
+              0.3500E+05, 0.3000E+05, 0.2500E+05, 0.2000E+05, 0.1500E+05, 0.1000E+05, &
+              7000., 5000., 4000., 3000., 2000., 1500., &
+              1000., 700., 500., 300., 200., 100., 70., 40., 20., 10., 7., 4., 2.,1. /)
 
 !-- Carsel and Parrish [1988]
         REAL , DIMENSION(100) :: lqmi
@@ -580,6 +592,7 @@ integer::oops1,oops2
       IF ( flag_metgrid .EQ. 1 ) THEN  !   <----- START OF VERTICAL INTERPOLATION PART ---->
 
          num_metgrid_levels = grid%num_metgrid_levels
+         IF ( config_flags%gfs_ozone .GT. 0 ) num_o3_gfs_levels  = grid%num_o3_gfs_levels
 
          IF ( config_flags%nest_interp_coord .EQ. 1 ) THEN
 
@@ -2385,6 +2398,45 @@ integer::oops1,oops2
          END IF
 #endif
 
+         IF ( config_flags%gfs_ozone .GT. 0 ) THEN
+! GFS Ozone, first fill isobaric grid with pressure depending on number of levels / GFS version
+            DO j=jts,jte
+             DO k = 1,num_o3_gfs_levels
+               DO i=its,ite
+                  if ( num_o3_gfs_levels .lt. 30 ) then
+                    grid%p_ib(i,k,j) = p_o3gfs_old(k)
+                  else
+                    grid%p_ib(i,k,j) = p_o3gfs_new(k)
+                  endif
+               ENDDO
+             ENDDO
+            ENDDO
+
+            CALL vert_interp ( grid%o3_inp , grid%p_ib, grid%o3_gfs , grid%pb , &
+                               grid%hgtmaxw , grid%hgttrop , grid%pmaxw , grid%ptrop ,&
+                               grid%pmaxwnn , grid%ptropnn , &
+                               0 , 0 , &
+                               config_flags%maxw_horiz_pres_diff ,config_flags%trop_horiz_pres_diff , &
+                               config_flags%maxw_above_this_level , &
+                               num_o3_gfs_levels , 'Q' , &
+                               interp_type , linear_interp , extrap_type , &
+                               .false., use_levels_below_ground , use_surface , &
+                               zap_close_levels, force_sfc_in_vinterp , grid%id , &     ! RAR: I set zap_* option =10. for smoke interpolation
+                               ids , ide , jds , jde , kds , kde , &
+                               ims , ime , jms , jme , kms , kme , &
+                               its , ite , jts , jte , kts , kte )
+! Create scaling factor for total GFS column vs. total column interpolated to WRF grid
+           if ( config_flags%scale_o3_to_gfstotal .gt. 0 ) then
+             do j = jts, jte
+               do i = its, ite
+                 grid%o3_gfs_sf(i,j) = sum(grid%o3_inp(i,:,j))/sum(grid%o3_gfs(i,:,j))
+               enddo
+             enddo
+           endif
+! Convert to mixing ratio
+           grid%o3_inp = grid%o3_inp * 1.e6 * mw_air / mw_o3
+
+         ENDIF
          !  Do we have the old data that came in on the same vertical levels as the other
          !  met variables? If so, we can skip all of this interpolation, as the pressure field
          !  is allocated, but all zeros.

--- a/main/real_em.F
+++ b/main/real_em.F
@@ -707,6 +707,7 @@ character *24 :: temp24 , temp24b
    REAL , DIMENSION(:,:,:) , ALLOCATABLE , SAVE :: ubdy3dtemp2 , vbdy3dtemp2 , tbdy3dtemp2 , pbdy3dtemp2 , qbdy3dtemp2
    REAL , DIMENSION(:,:,:) , ALLOCATABLE , SAVE :: mbdy2dtemp2
    REAL , DIMENSION(:,:,:) , ALLOCATABLE , SAVE :: qn1bdy3dtemp1, qn1bdy3dtemp2, qn2bdy3dtemp1, qn2bdy3dtemp2
+   REAL , DIMENSION(:,:,:) , ALLOCATABLE , SAVE :: o3gfsbdy3dtemp1, o3gfsbdy3dtemp2
 real::t1,t2
 
    INTEGER                                :: open_status
@@ -808,6 +809,15 @@ real::t1,t2
             ALLOCATE ( qn2bdy3dtemp2(ims:ime,kms:kme,jms:jme) )
          END IF
 
+         IF (config_flags%gfs_ozone .eq. 1) THEN ! or set o3input (RRTMG only)
+!         IF ( config_flags%o3input .eq. 3 .and. config_flags%ra_lw_physics .eq.       &
+!              RRTMG_LWSCHEME .and. config_flags%ra_sw_physics .eq. RRTMG_SWSCHEME ) THEN 
+            IF ( ALLOCATED ( o3gfsbdy3dtemp1 ) ) DEALLOCATE ( o3gfsbdy3dtemp1 )
+            IF ( ALLOCATED ( o3gfsbdy3dtemp2 ) ) DEALLOCATE ( o3gfsbdy3dtemp2 )
+            ALLOCATE ( o3gfsbdy3dtemp1(ims:ime,kms:kme,jms:jme) )
+            ALLOCATE ( o3gfsbdy3dtemp2(ims:ime,kms:kme,jms:jme) )
+         END IF
+
       END IF
 
       !  Open the wrfinput file.  From this program, this is an *output* file.
@@ -873,6 +883,12 @@ real::t1,t2
                        grid%c1h, grid%c2h, grid%c1h, grid%c2h, &
                        ids, ide, jds, jde, kds, kde, ims, ime, jms, jme, kms, kme, ips, ipe, jps, jpe, kps, kpe )
          END IF
+
+         IF (config_flags%gfs_ozone==1) THEN ! JLS
+            CALL couple ( grid%mu_2 , grid%mub , o3gfsbdy3dtemp1 , grid%o3_gfs, 'c' , grid%msfty , &
+                          grid%c1h, grid%c2h, grid%c1h, grid%c2h, &
+                          ids, ide, jds, jde, kds, kde, ims, ime, jms, jme, kms, kme, ips, ipe, jps, jpe, kps, kpe )
+         ENDIF
 
       END IF
 
@@ -954,6 +970,14 @@ real::t1,t2
                                                                     ims , ime , jms , jme , kms , kme , &
                                                                     ips , ipe , jps , jpe , kps , kpe )
          END IF
+        IF (config_flags%gfs_ozone==1) THEN ! JLS
+        CALL stuff_bdy ( o3gfsbdy3dtemp1, grid%o3_gfs_bxs, grid%o3_gfs_bxe,   &
+                         grid%o3_gfs_bys, grid%o3_gfs_bye,                    &
+                         'T' , spec_bdy_width      , &
+                         ids , ide , jds , jde , kds , kde , &
+                         ims , ime , jms , jme , kms , kme , &
+                         ips , ipe , jps , jpe , kps , kpe )
+        ENDIF
       END IF
 
 
@@ -1041,6 +1065,12 @@ real::t1,t2
             CALL couple ( grid%mu_2 , grid%mub , qn2bdy3dtemp2 , grid%scalar(:,:,:,P_QNIFA)      , 't' , grid%msfty , &
                        grid%c1h, grid%c2h, grid%c1h, grid%c2h, &
                        ids, ide, jds, jde, kds, kde, ims, ime, jms, jme, kms, kme, ips, ipe, jps, jpe, kps, kpe )
+         END IF
+
+         IF (config_flags%gfs_ozone==1) THEN ! JLS
+            CALL couple ( grid%mu_2 , grid%mub , o3gfsbdy3dtemp2 , grid%o3_gfs , 'c' , grid%msfty , &
+                          grid%c1h, grid%c2h, grid%c1h, grid%c2h, &
+                          ids, ide, jds, jde, kds, kde, ims, ime, jms, jme, kms, kme, ips, ipe, jps, jpe, kps, kpe )
          END IF
 
       END IF
@@ -1144,6 +1174,17 @@ real::t1,t2
                                                                ims , ime , jms , jme , kms , kme , &
                                                                ips , ipe , jps , jpe , kps , kpe )
          END IF
+
+        IF (config_flags%gfs_ozone==1) THEN ! JLS
+        CALL stuff_bdytend (o3gfsbdy3dtemp2 , o3gfsbdy3dtemp1 , REAL(interval_seconds) ,      &
+                            grid%o3_gfs_btxs, grid%o3_gfs_btxe, &
+                            grid%o3_gfs_btys, grid%o3_gfs_btye, &
+                            'T' , &
+                            spec_bdy_width      , &
+                            ids , ide , jds , jde , kds , kde , &
+                            ims , ime , jms , jme , kms , kme , &
+                            ips , ipe , jps , jpe , kps , kpe )
+        ENDIF
       END IF
 
       !  Both pieces of the boundary data are now available to be written (initial time and tendency).
@@ -1265,6 +1306,16 @@ real::t1,t2
                END DO
             END IF
 
+            IF (config_flags%gfs_ozone==1) THEN ! JLS
+               DO j = jps , jpe
+                  DO k = kps , kpe
+                     DO i = ips , ipe
+                        o3gfsbdy3dtemp1(i,k,j) = o3gfsbdy3dtemp2(i,k,j)
+                     END DO
+                  END DO
+               END DO
+            END IF
+
          END IF
 
          IF(grid_fdda .GE. 1)THEN
@@ -1345,6 +1396,15 @@ real::t1,t2
                                                                        ims , ime , jms , jme , kms , kme , &
                                                                        ips , ipe , jps , jpe , kps , kpe )
             END IF
+
+            IF (config_flags%gfs_ozone==1) THEN ! JLS
+                CALL stuff_bdy    ( o3gfsbdy3dtemp1 , grid%o3_gfs_bxs, grid%o3_gfs_bxe,     &
+                                    grid%o3_gfs_bys,grid%o3_gfs_bye,     &
+                                    'T' , spec_bdy_width      ,               &
+                                    ids , ide , jds , jde , kds , kde , &
+                                    ims , ime , jms , jme , kms , kme , &
+                                    ips , ipe , jps , jpe , kps , kpe )
+            ENDIF
    
          END IF
 


### PR DESCRIPTION
Ingest GFS Ozone - 3D and total column - option to use GFS total column in TUV photolysis 

TYPE: enhancement 

KEYWORDS: GFS ozone, TUV photolysis, boundary conditions, total ozone column

SOURCE: internal

DESCRIPTION OF CHANGES:
This allows GFS ozone to be ingested into WRF and WRF-Chem. The current code puts GFS ozone into the boundary files (O3_GFS_B*), but a user will need to manually place them in the actual O3 boundary variables (i.e., O3_B*) using an outside program (e.g., ncks)

LIST OF MODIFIED FILES:

M       Registry/Registry.EM_COMMON
M       Registry/registry.chem
M       Registry/registry.dimspec
M       chem/Makefile
M       chem/chem_driver.F
M       chem/module_input_chem_data.F
M       chem/module_phot_tuv.F
M       chem/photolysis_driver.F
M       dyn_em/module_initialize_real.F
M       main/real_em.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Ingest GFS ozone for use in boundary conditions and photolysis option 4 (TUV)
