### PR TITLE
Update HONO, TERP, and CO2 emissions

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -4034,7 +4034,7 @@ package   cri_mosaic_4bin_aq_kpp  chem_opt==611          -             chem:dms,
 #emission package definitions
 #
 package   eradm           emiss_opt==2                   -             emis_ant:e_iso,e_so2,e_no,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3
-package   eradmsorg       emiss_opt==3                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_ch4,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_pm25i,e_pm25j,e_pm_10,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_naaj,e_naai,e_orgi_a,e_orgj_a,e_orgi_bb,e_orgj_bb,e_hcl,e_cli,e_clj,e_ch3cl
+package   eradmsorg       emiss_opt==3                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_ch4,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_terp,e_hono,e_co2,e_pm25i,e_pm25j,e_pm_10,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_naaj,e_naai,e_orgi_a,e_orgj_a,e_orgi_bb,e_orgj_bb,e_hcl,e_cli,e_clj,e_ch3cl
 package   ecbmz_mosaic    emiss_opt==4                   -             emis_ant:e_iso,e_so2,e_no,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_no2,e_ch3oh,e_c2h5oh,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_so4c,e_no3c,e_orgc,e_ecc
 package   ecptec          emiss_opt==5                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_pm_25,e_pm_10,e_oc,e_sulf,e_bc
 package   gocart_ecptec   emiss_opt==6                   -             emis_ant:e_so2,e_sulf,e_bc,e_oc,e_pm_25,e_pm_10

--- a/chem/module_emissions_anthropogenics.F
+++ b/chem/module_emissions_anthropogenics.F
@@ -227,6 +227,16 @@ is_mozart:if( is_moz_chm ) then
             if(p_ete >= param_first_scalar) then
               chem(its:ite,k,j,p_ete) = chem(its:ite,k,j,p_ete) + emis_ant(its:ite,k,j,p_e_ol2)*conv_rho(its:ite)
             end if
+            if(p_e_hono >= param_first_scalar .and. p_hono >= param_first_scalar) then
+              chem(its:ite,k,j,p_hono) = chem(its:ite,k,j,p_hono) + emis_ant(its:ite,k,j,p_e_hono)*conv_rho(its:ite)
+            end if
+            if(p_e_terp >= param_first_scalar .and. p_api >= param_first_scalar .and. p_lim >= param_first_scalar) then
+              chem(its:ite,k,j,p_api) = chem(its:ite,k,j,p_api) + 0.5*emis_ant(its:ite,k,j,p_e_terp)*conv_rho(its:ite)
+              chem(its:ite,k,j,p_lim) = chem(its:ite,k,j,p_lim) + 0.5*emis_ant(its:ite,k,j,p_e_terp)*conv_rho(its:ite)
+            end if
+            if(p_e_co2 >= param_first_scalar .and. p_co2 >= param_first_scalar) then
+              chem(its:ite,k,j,p_co2) = chem(its:ite,k,j,p_co2) + emis_ant(its:ite,k,j,p_e_co2)*conv_rho(its:ite)
+            end if
             if( config_flags%chem_opt == GOCARTRACM_KPP .or. config_flags%chem_opt == GOCARTRADM2 ) then
               chem(its:ite,k,j,p_p10) = chem(its:ite,k,j,p_p10) + conv_rho_aer(its:ite)*emis_ant(its:ite,k,j,p_e_pm_10)
               chem(its:ite,k,j,p_p25) = chem(its:ite,k,j,p_p25) + conv_rho_aer(its:ite)*emis_ant(its:ite,k,j,p_e_pm_25)


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: anthropogenic emissions

SOURCE: Rebecca Schwantes (CIRES/NOAA CSL)

DESCRIPTION OF CHANGES:
Update code to add HONO, TERP, and CO2 anthropogenic emissions for RACM mechanisms.

Problem:
HONO, TERP, and CO2 anthropogenic emissions were not automatically pulled into the RACM mechanisms.

Solution:
Added some if statements such that if HONO, TERP, and CO2 are in the anthropogenic emission file and hono, 
api, lim, and co2 are chemical species in the selected RACM mechanism, then the HONO, TERP, and CO2 
anthropogenic emissions would be included in the simulation.

LIST OF MODIFIED FILES: 
M Registry/registry.chem
M chem/module_emissions_anthropogenics.F

TESTS CONDUCTED: 
1. The modifications fix the problem of missing (but available) anthropogenic emissions.
2.  jenkins tests are all passing.
3. Attached are some plots that show that with the updates HONO, CO2, API, and LIM now all increase in regions impacted by anthropogenic emissions (namely you can clearly see increases in cities) compared to the default case.

[anthropogenic_emission_quick_QC.pdf](https://github.com/wrf-model/WRF/files/7900930/anthropogenic_emission_quick_QC.pdf)


RELEASE NOTE: Previously, HONO, TERP, and CO2 were not automatically pulled into the RACM mechanisms even when they were in the anthropogenic emissions file. This has been fixed.