### PR TITLE
Fix for Intel: HSW/BDW config option

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1834,7 +1834,7 @@ RLFLAGS		=
 CC_TOOLS        =      $(SCC) 
 
 ###########################################################
-#ARCH    Linux x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
+#ARCH    Linux HSW/BDW x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       INTEL ($SFC/$SCC): HSW/BDW
 DMPARALLEL      =       # 1


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Intel, ifort, HWS, BDW, bug

SOURCE: GitHub user jw500

DESCRIPTION OF CHANGES:
Problem: When a user chooses one of the following configuration options for the Intel (HWS/BDW) compiler,
`64. (serial)  65. (smpar)  66. (dmpar)  67. (dm+sm)   INTEL (ifort/icc): HSW/BDW`
they will instead be given a configuration for the corresponding option for basic Intel.
`13. (serial)  14. (smpar)  15. (dmpar)  16. (dm+sm)   INTEL (ifort/icc)`

The configure.wrf file will read
```
#### Architecture specific settings ####

# Settings for    Linux x86_64 ppc64le i486 i586 i686, ifort compiler with icc  (serial)

DESCRIPTION     =       INTEL ($SFC/$SCC)
```

This is the result of "Add missing compiler name for two Intel config stanzas" #1326, hash [commit 0a9c2eb](https://github.com/wrf-model/WRF/commit/0a9c2eb2dc8d81246dd6a4f2d739396c84043fef)

Solution:
Modified configure.defaults to ensure the "#ARCH" lines were not identical between HSW/BDW Intel and basic Intel options.

LIST OF MODIFIED FILES: 
M    arch/configure.defaults

TESTS CONDUCTED: 
1. Mods fix the issue. A configuration was done to test this.
2. Jenkins tests are all passing.

RELEASE NOTE: Beginning with V4.2.2 a bug was introduced that prevented users from configuring the model with the  "INTEL (ifort/icc): HSW/BDW" option. This is now resolved.
