### PR TITLE
BF: NETCDFPAR "Error" in build log when option not used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -921,13 +921,13 @@ framework :
 	       LIB_LOCAL="$(LIB_LOCAL)" \
                ESMF_MOD_DEPENDENCE="$(ESMF_MOD_DEPENDENCE)" AR="INTERNAL_BUILD_ERROR_SHOULD_NOT_NEED_AR"; \
           cd ../io_netcdfpar ; \
-          $(MAKE) NETCDFPARPATH="$(NETCDFPATH)" \
+          $(NETCDFPAR_BUILD) $(MAKE) NETCDFPARPATH="$(NETCDFPATH)" \
                FC="$(FC) $(FCBASEOPTS) $(PROMOTION) $(FCDEBUG) $(OMP)" RANLIB="$(RANLIB)" \
                CPP="$(CPP)" LDFLAGS="$(LDFLAGS)" TRADFLAG="$(TRADFLAG)" ESMF_IO_LIB_EXT="$(ESMF_IO_LIB_EXT)" \
                LIB_LOCAL="$(LIB_LOCAL)" \
                ESMF_MOD_DEPENDENCE="$(ESMF_MOD_DEPENDENCE)" AR="INTERNAL_BUILD_ERROR_SHOULD_NOT_NEED_AR" diffwrf; \
           cd ../io_netcdfpar ; \
-          $(MAKE) NETCDFPARPATH="$(NETCDFPATH)" \
+          $(NETCDFPAR_BUILD) $(MAKE) NETCDFPARPATH="$(NETCDFPATH)" \
                FC="$(SFC) $(FCBASEOPTS) $(PROMOTION) $(FCDEBUG) $(OMP)" RANLIB="$(RANLIB)" \
                CPP="$(CPP)" LDFLAGS="$(LDFLAGS)" TRADFLAG="$(TRADFLAG)" ESMF_IO_LIB_EXT="$(ESMF_IO_LIB_EXT)" \
 	       LIB_LOCAL="$(LIB_LOCAL)" \

--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -507,6 +507,7 @@ while ( <CONFIGURE_DEFAULTS> )
     if ( $sw_netcdfpar_path )
       { $_ =~ s/CONFIGURE_WRFIO_NFPAR/wrfio_nfpar/g ;
         $_ =~ s:CONFIGURE_NETCDFPAR_FLAG:-DNETCDFPAR: ;
+        $_ =~ s:CONFIGURE_NETCDFPAR_BUILD:: ;
         if ( $ENV{NETCDFPAR_LDFLAGS} ) {
           $_ =~ s:CONFIGURE_NETCDFPAR_LIB_PATH:\$\(WRF_SRC_ROOT_DIR\)/external/io_netcdfpar/libwrfio_nfpar.a $ENV{NETCDFPAR_LDFLAGS} : ;
         } elsif ( $sw_os eq "Interix" ) {
@@ -518,6 +519,7 @@ while ( <CONFIGURE_DEFAULTS> )
     else
       { $_ =~ s/CONFIGURE_WRFIO_NFPAR//g ;
         $_ =~ s:CONFIGURE_NETCDFPAR_FLAG::g ;
+        $_ =~ s:CONFIGURE_NETCDFPAR_BUILD:echo SKIPPING: ;
         $_ =~ s:CONFIGURE_NETCDFPAR_LIB_PATH::g ;
          }
 

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -42,7 +42,7 @@ RANLIB          =      ls
 RLFLAGS		=	
 #ranlib
 CC_TOOLS        =      cc 
-NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD 
 
 ###########################################################
 #ARCH    Linux i486 i586 i686 armv7l aarch64, gfortran compiler with gcc #serial smpar dmpar dm+sm

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -42,6 +42,7 @@ RANLIB          =      ls
 RLFLAGS		=	
 #ranlib
 CC_TOOLS        =      cc 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux i486 i586 i686 armv7l aarch64, gfortran compiler with gcc #serial smpar dmpar dm+sm
@@ -86,6 +87,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux i486 i586 i686, g95 compiler with gcc #serial dmpar
@@ -129,6 +131,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, PGI compiler with gcc # serial smpar dmpar dm+sm
@@ -172,6 +175,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le, PGI compiler with pgcc, SGI MPT # serial smpar dmpar dm+sm
@@ -215,6 +219,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le, PGI accelerator compiler with gcc # serial smpar dmpar dm+sm
@@ -257,6 +262,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
@@ -334,6 +340,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, Xeon Phi (MIC architecture) ifort compiler with icc # dm+sm
@@ -381,6 +388,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      gcc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, Xeon (SNB with AVX mods) ifort compiler with icc # serial smpar dmpar dm+sm
@@ -428,6 +436,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      gcc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, ifort compiler with icc, SGI MPT #serial smpar dmpar dm+sm
@@ -499,6 +508,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, ifort compiler with icc, IBM POE #serial smpar dmpar dm+sm
@@ -548,6 +558,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    ia64 Linux ifort compiler with icc 9.x,10.x #serial smpar dmpar dm+sm
@@ -629,6 +640,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux SGI Altix, ifort compiler with icc 9.x,10.x #serial smpar dmpar dm+sm
@@ -712,6 +724,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux i486 i586 i686 x86_64 ppc64le, PathScale compiler with pathcc #serial dmpar
@@ -755,6 +768,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le, gfortran compiler with gcc  #serial smpar dmpar dm+sm
@@ -799,6 +813,7 @@ M4              =      m4 -G
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) PGI compiler with pgcc #serial smpar dmpar dm+sm
@@ -842,6 +857,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) intel compiler with icc #serial smpar dmpar dm+sm
@@ -888,6 +904,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) intel compiler with clang EDIT FOR OPENMPI #serial smpar dmpar dm+sm
@@ -933,6 +950,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) g95 with gcc #serial dmpar
@@ -977,6 +995,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib -c
 RLFLAGS		=	-c
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) gfortran with gcc #serial smpar dmpar dm+sm
@@ -1021,6 +1040,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) gfortran with clang #serial smpar dmpar dm+sm
@@ -1065,6 +1085,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      clang
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) xlf  #serial dmpar
@@ -1110,6 +1131,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    AIX xlf compiler with xlc #serial smpar dmpar dm+sm
@@ -1158,6 +1180,7 @@ M4              =       m4 -B 20000
 RANLIB          =       ranlib
 RLFLAGS		=	
 CC_TOOLS        =       cc
+NETCDFPAR_BUILD	=       CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, xlf compiler with xlc # serial smpar dmpar dm+sm
@@ -1209,6 +1232,7 @@ M4              =       m4 -B 14000
 RANLIB          =       ranlib
 RLFLAGS		=	
 CC_TOOLS        =       cc
+NETCDFPAR_BUILD	=       CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Cray XC CLE/Linux x86_64, PGI compiler with gcc # serial dmpar smpar dm+sm
@@ -1271,6 +1295,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Cray XE and XC CLE/Linux x86_64, Cray CCE compiler # serial dmpar smpar dm+sm
@@ -1321,6 +1346,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      gcc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Cray XC CLE/Linux x86_64, Xeon ifort compiler # serial dmpar smpar dm+sm
@@ -1370,6 +1396,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      gcc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 
 ###########################################################
@@ -1422,6 +1449,8 @@ M4              =       m4 -B 14000
 RANLIB          =       ranlib
 RLFLAGS		=	
 CC_TOOLS        =       cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
+
 ###########################################################
 #ARCH    Linux ppc64 BG /P xlf compiler with xlc # smpar dmpar dm+sm
 #     developed on surveyor.alcf.anl.gov (thanks to ANL/ALCF)
@@ -1469,6 +1498,8 @@ M4              =       m4 -B 14000
 RANLIB          =       ranlib
 RLFLAGS		=	
 CC_TOOLS        =       cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
+
 ###########################################################
 #ARCH    Linux ppc64 IBM Blade Server xlf compiler with xlc # dmpar
 #    provided by Luis C. Cana Cascallar for IBM JS21 blade server, May 2009
@@ -1513,6 +1544,7 @@ M4              =       m4 -B 14000
 RANLIB          =       ranlib
 RLFLAGS		=	
 CC_TOOLS        =       xlc -q64
+NETCDFPAR_BUILD	=       CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, PGI compiler with pgcc # serial smpar dmpar dm+sm
@@ -1556,6 +1588,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    CYGWIN_NT i686, PGI compiler on Windows # serial smpar dmpar dm+sm
@@ -1599,6 +1632,7 @@ M4              =       NA
 RANLIB          =       ranlib
 RLFLAGS		=	
 CC_TOOLS        =       $(SCC) 
+NETCDFPAR_BUILD	=       CONFIGURE_NETCDFPAR_BUILD
 
 LIB_EXTERNAL    = \
                      ../external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.lib \
@@ -1656,6 +1690,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) PGI compiler with pgcc -f90= #serial smpar dmpar dm+sm
@@ -1699,6 +1734,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) intel compiler with icc #serial smpar dmpar dm+sm
@@ -1745,6 +1781,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      cc
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Darwin (MACOS) gfortran with gcc openmpi #serial smpar dmpar dm+sm
@@ -1789,6 +1826,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux x86_64 ppc64le i486 i586 i686, PGI compiler with pgcc -f90= # serial smpar dmpar dm+sm
@@ -1832,6 +1870,7 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux HSW/BDW x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
@@ -1876,6 +1915,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    Linux KNL x86_64 ppc64le i486 i586 i686, ifort compiler with icc #serial smpar dmpar dm+sm
@@ -1920,6 +1960,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC) 
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 ###########################################################
 #ARCH    CYGWIN_NT i686 x86_64 Cygwin, gfortran compiler with gcc  #serial smpar dmpar dm+sm
@@ -1964,6 +2005,7 @@ M4              =      m4 -G
 RANLIB          =      ranlib
 RLFLAGS		=	
 CC_TOOLS        =      $(SCC)
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 LIB_EXTERNAL    = \
                      $(WRF_SRC_ROOT_DIR)/external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.dll.a \
@@ -2022,6 +2064,7 @@ M4              =      m4 -G
 RANLIB          =      ranlib
 RLFLAGS         =
 CC_TOOLS        =      $(SCC)
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 #insert new stanza here
 
@@ -2067,6 +2110,7 @@ M4              =      m4
 RANLIB          =      ranlib
 RLFLAGS         =
 CC_TOOLS        =      /usr/bin/gcc -Wall
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 
 #insert new stanza before the Fujitsu block, keep Fujitsu at the end of the list
 ###########################################################

--- a/configure
+++ b/configure
@@ -158,6 +158,12 @@ if test -n "$PERL" ; then
     
 fi
 
+if [ -e $NETCDF/bin/nc-config ] ; then
+  ncversion=`nc-config --version | awk '{print $2}'` 
+else
+  ncversion=OLD
+fi
+
 PROBS=FALSE
 if [ -n "$NETCDFPAR" ] ; then
   NETCDF="$NETCDFPAR"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: netcdfpar, Error

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
With PR #1552 "Parallel netcdf-4 IO option" (SHA1 3cd4713), when then code was built without
the new parallel NetCDF4 compression, the build log had an `Error`. 
```
> grep Error compile.log
Fatal Error: Cannot open module file ‘wrf_data_ncpar.mod’ for reading at (1): No such file or directory
make[2]: [diffwrf] Error 1 (ignored)
make[2]: [diffwrf] Error 1 (ignored)
wrf_io.f:117: Error: Can't open included file 'mpif.h'
make[2]: [wrf_io.o] Error 1 (ignored)
Fatal Error: Cannot open module file ‘wrf_data_ncpar.mod’ for reading at (1): No such file or directory
make[2]: [field_routines.o] Error 1 (ignored)
make[2]: [libwrfio_nfpar.a] Error 127 (ignored)
make[2]: [libwrfio_nfpar.a] Error 1 (ignored)
```
The problem was related to constructing the object files in the io_netcdfpar directory. When the 
option is not selected at compile time, then we do not care about errors in the directory that will 
never be used.

Solution:
If the NETCDFPAR option is not selected at compile time, then SKIP going into the io_netcdfpar
directory all together.

LIST OF MODIFIED FILES:
m Makefile
m arch/Config.pl
m arch/configure.defaults
m configure

TESTS CONDUCTED:
1. Without the NETCDFPAR parameter set, the build for the io_netcdfpar directory is bypassed:
```
          cd ../io_netcdfpar ; \
          echo SKIPPING make -i -r NETCDFPARPATH="/glade/u/apps/ch/opt/netcdf/4.7.3/gnu/9.1.0" \

          cd ../io_netcdfpar ; \
          echo SKIPPING make -i -r NETCDFPARPATH="/glade/u/apps/ch/opt/netcdf/4.7.3/gnu/9.1.0" \
```

2. When the NETCDFPAR env variable is set, the build includes the io_netcdfpar directory:
          cd ../io_netcdfpar ; \
           make -i -r NETCDFPARPATH="/glade/u/apps/ch/opt/netcdf/4.8.0/gnu/9.1.0" \

          cd ../io_netcdfpar ; \
           make -i -r NETCDFPARPATH="/glade/u/apps/ch/opt/netcdf/4.8.0/gnu/9.1.0" \
```

3. Jenkins tests are all PASS.