### PR TITLE
Fix 4dvar build failure after commit 8b5bfe59

### DIFF
--- a/var/build/da_name_space.pl
+++ b/var/build/da_name_space.pl
@@ -195,4 +195,5 @@ set_tiles
 wrf_get_dom_ti_integer
 is_this_data_ok_to_use
 check_which_switch
+med_read_qna_emissions
 ###########################################################################################

--- a/var/build/da_name_space.pl
+++ b/var/build/da_name_space.pl
@@ -33,7 +33,7 @@ exit;
 
 __DATA__
 ###########################################################################################
-# The following subroutines will be add pre-fix da
+# The following subroutines will be add prefix da
 all_sub_
 call_pkg_and_dist
 collect_generic_and_call_pkg


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: WRFDA, 4DVAR, compile

SOURCE: Jamie Bresch (NCAR)

DESCRIPTION OF CHANGES:
Following commit 8b5bfe593, PR #1616, a new subroutine name (med_read_qna_emissions) needs to be 
added in da_name_space.pl to avoid name conflict for 4DVAR build with the error message:
```
duplicate symbol '_med_read_qna_emissions_' in:
    /Users/hclin/code/WRFPLUS/develop/main/libwrflib.a(mediation_integrate.o)
    ./libwrfvar.a(mediation_integrate.o)
ld: 1 duplicate symbol for architecture x86_64
collect2: error: ld returned 1 exit status
```

LIST OF MODIFIED FILES:
M var/build/da_name_space.pl

TESTS CONDUCTED:
1. 4DVAR builds after the fix.
2. Jenkins tests now pass again.