### PR TITLE
BF: WRF-Solar EPS broke DA build

### DIFF
--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -496,9 +496,9 @@ SUBROUTINE microphysics_driver(                                          &
                                                                  rliq      !Vertically-integrated reserved cloud condensate(m/s)
 
 ! WRF-Solar EPS
-   integer, intent (in) :: multi_perturb 
-   logical, intent (in) :: pert_thom
-   real, intent (in) :: pert_thom_qv, pert_thom_qc, pert_thom_qi, pert_thom_qs, pert_thom_ni
+   integer, intent (in), optional :: multi_perturb 
+   logical, intent (in), optional :: pert_thom
+   real, intent (in), optional :: pert_thom_qv, pert_thom_qc, pert_thom_qi, pert_thom_qs, pert_thom_ni
    real, dimension(ims:ime, kms:kme, jms:jme ), intent (in), optional :: perts_qvapor, perts_qcloud, perts_qice, &
        perts_qsnow, perts_ni 
   real, dimension(:, :, :), allocatable :: qv_tmp, qc_tmp, qi_tmp, qs_tmp, qni_tmp


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: EPS, DA

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The WRF-Solar EPS mods (PR #1547, SHA1 fed10f4ba9) modified the solve_em.F file, with
arguments to the microphysics driver. The solver_em.F file is one of the special files
that has a _ad and a _tl version. Any changes to solve_em.F need to be reflected in the
other two DA-related files.

Solution:
In this case, since only Thompson MP uses the EPS fields, the new args were made optional in
the MP driver.

LIST OF MODIFIED FILES:
M phys/module_microphysics_driver.F

TESTS CONDUCTED:
1. Yes, code compiles and passes regtests.