### PR TITLE
BF firebrand array index must be integer

### DIFF
--- a/phys/module_firebrand_spotting.F
+++ b/phys/module_firebrand_spotting.F
@@ -570,7 +570,7 @@ END FUNCTION order_val
 
         ENDIF
 
-        get_fuel_cat = ksb(cat)
+        get_fuel_cat = ksb(icat)
 
     END FUNCTION get_fuel_cat
 !=============================================================


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: firebrand, Cray, HPE, cat

SOURCE: Patricia Balle (HPE), internal

DESCRIPTION OF CHANGES:
Problem:
The line
```
get_fuel_cat = ksb(cat)
```
should have an integer as the index to the `ksb` array.

Solution:
At the top of the function is the line
```
icat = INT(cat)
```
which is supposed to be used as the argument.

LIST OF MODIFIED FILES:
modified:   phys/module_firebrand_spotting.F

TESTS CONDUCTED:
1. The fix allows the HPE CCE compilation to proceed.
2. All jenkins tests are PASS.