### PR TITLE
Update Noahmp for unary operation bug fix #2

### DIFF
--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -1,4 +1,4 @@
-!WRF:MEDIATION_LAYER:SOLVER
+! WRF:MEDIATION_LAYER:SOLVER
 
 SUBROUTINE solve_em ( grid , config_flags  &
 ! Arguments generated from Registry

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -1,4 +1,4 @@
-! WRF:MEDIATION_LAYER:SOLVER
+!WRF:MEDIATION_LAYER:SOLVER
 
 SUBROUTINE solve_em ( grid , config_flags  &
 ! Arguments generated from Registry


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: unary operator, Noahmp

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
Found more occurrences of `a* -b` in Noahmp. A space is in between `*` and `-1`. OK even for Cray, but it is still non-standard.

Solution:
The same solution is applied: add parentheses: `a * (-b)`.

ASSOCIATED REPOSITORY CHANGE:
NCAR/noahmp#33

LIST OF MODIFIED FILES:
modified: phys/noahmp

TESTS CONDUCTED: 
1. More code is fixed.
2. Jenkins tests are all passing.