### PR TITLE
GF cumulus chem loop bug fix - reverse num_tracer and num_chem

### DIFF
--- a/phys/module_cu_gf_wrfdrv.F
+++ b/phys/module_cu_gf_wrfdrv.F
@@ -777,7 +777,7 @@ CONTAINS
                                    its,ite,kts,kte,itf)
               DO I=ibegc,iendc
               DO K=kts,ktf
-              do nv=2,num_tracer
+              do nv=2,num_chem
                 chem(I,K,J,nv)=max(epsilc,chem(i,k,j,nv)+totchemt(i,k,nv)*dt)
               enddo
               ENDDO
@@ -788,7 +788,7 @@ CONTAINS
                                    its,ite,kts,kte,itf)
               DO I=ibegc,iendc
               DO K=kts,ktf
-              do nv=2,num_chem
+              do nv=2,num_tracer
                  tracer(I,K,J,nv)=max(epsilc,tracer(i,k,j,nv)+tottracert(i,k,nv)*dt)
               enddo ! nv
               ENDDO


### PR DESCRIPTION
Fixes two loop upper bounds that were incorrectly switched for tracers and chem arrays

TYPE: bug fix

KEYWORDS: 5 to 10 words related to commit, separated by commas

SOURCE: internal

DESCRIPTION OF CHANGES: switched loop bounds

Solution:
switched loop bounds

LIST OF MODIFIED FILES:
M       phys/module_cu_gf_wrfdrv.F

TESTS CONDUCTED: 
1. Jenkins tests all passing

RELEASE NOTE: Fixes chem/tracer loop upper bounds in GF cumulus wet scavenging parameterization.
