### PR TITLE
resolve uninitialized variable issues in surface_driver

### DIFF
--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3679,7 +3679,6 @@ CONTAINS
 !save old tsk_ice
                          tsk_save(i,j)  = tsk(i,j)
                          tsk(i,j)  = ( tsk(i,j)  * XICE(i,j) ) + ( (1.0-XICE(i,j)) * TSK_SEA(i,j)  )
-                         pblh(i,j) = ( pblh(i,j) * XICE(i,j) ) + ( (1.0-XICE(i,j)) * PBLH_SEA(i,j) )
                       ENDIF
                    ENDDO
                 ENDDO
@@ -6041,6 +6040,8 @@ CONTAINS
      MOL_HOLD(its:ite,jts:jte)    = MOL(its:ite,jts:jte)
      PSIH_HOLD(its:ite,jts:jte)   = PSIH(its:ite,jts:jte)
      PSIM_HOLD(its:ite,jts:jte)   = PSIM(its:ite,jts:jte)
+     FH_HOLD(its:ite,jts:jte)     = FH(its:ite,jts:jte)
+     FM_HOLD(its:ite,jts:jte)     = FM(its:ite,jts:jte)
      QFX_HOLD(its:ite,jts:jte)    = QFX(its:ite,jts:jte)
      QGH_HOLD(its:ite,jts:jte)    = QGH(its:ite,jts:jte)
      REGIME_HOLD(its:ite,jts:jte) = REGIME(its:ite,jts:jte)
@@ -6465,6 +6466,8 @@ ITIMESTEP,TICE2TSK_IF2COLD,XICE_THRESHOLD,                         &
      MOL_HOLD(its:ite,jts:jte)    = MOL(its:ite,jts:jte)
      PSIH_HOLD(its:ite,jts:jte)   = PSIH(its:ite,jts:jte)
      PSIM_HOLD(its:ite,jts:jte)   = PSIM(its:ite,jts:jte)
+     FH_HOLD(its:ite,jts:jte)     = FH(its:ite,jts:jte)
+     FM_HOLD(its:ite,jts:jte)     = FM(its:ite,jts:jte)
      QFX_HOLD(its:ite,jts:jte)    = QFX(its:ite,jts:jte)
      QGH_HOLD(its:ite,jts:jte)    = QGH(its:ite,jts:jte)
      REGIME_HOLD(its:ite,jts:jte) = REGIME(its:ite,jts:jte)


### PR DESCRIPTION

TYPE: bug-fix
KEYWORDS: surface driver, uninitialized variables

SOURCE: internal
DESCRIPTION OF CHANGES:
Problem:
Several variables showed up as used while uninitialized
Solution:
PXLSM does not need to compute sea-ice weighted PBLH
sfclay,sfclayrev FH and FM need to be initialized for use in sea-ice weighting

ISSUE: none
LIST OF MODIFIED FILES:
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
1. compile test only - OK
2. Are the Jenkins tests all passing?

RELEASE NOTE: 