### PR TITLE
Changes to derive snow height from snow water equivalent

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -538,9 +538,9 @@ integer::oops1,oops2
       ELSE IF ( ( flag_snow .EQ. 1 ) .AND. ( flag_snowh .EQ. 0 ) ) THEN
          DO j=jts,MIN(jde-1,jte)
             DO i=its,MIN(ide-1,ite)
-!              ( kg/m^2 -> m)  & ( liquid to snow depth, 5:1 ratio )
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
-               grid%snowh(i,j) = grid%snow(i,j) / 1000. * 5.
+               ! Hill et al 2019, Cryosphere         
+               grid%snowh(i,j) = (10.**(((log10(grid%snow(i,j))-log10(0.146))/1.102)))/1000.
             END DO
          END DO
 


### PR DESCRIPTION
Changing the conversion from snow water equivalent to physical snow depth using ECMWF data

TYPE: enhancement 

KEYWORDS: snow water equivalent, snow height, real.exe

SOURCE: Thomas Schwitalla (UHOH)

DESCRIPTION OF CHANGES:
Problem: When calculating physical snow height from ECMWF snow water equivalent, very high values of 50 m occur over glaciers (e.g, over Iceland or the Alps).

Solution:
Changed the conversion from snow water equivalent to snow height following Hill et al., (2019) (https://tc.copernicus.org/articles/13/1767/2019/; eq. 2) when only snow water equivalent is present. This reduces the maximum snow height to approx. 24 m and the other values by about a 40 %.

LIST OF MODIFIED FILES: 
M       dyn_em/module_initialize_real.F

TESTS CONDUCTED: 

RELEASE NOTE: Changed the conversion from snow water equivalent to physical snow depth in case only snow water equivalent is available.
