### PR TITLE
Urban model: fix undefined WDR and direction logic

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -686,7 +686,7 @@ use module_wrf_error
    SIGMA_ZED = stdh_urb
 
  !Calculate Wind Direction and Assign Appropriae lf_urb
-   !WDR = (180.0/PI)*ATAN2(U10,V10)
+   WDR = (180.0/PI)*ATAN2(U10,V10)
    
    IF(WDR.ge.0.0.and.WDR.lt.22.5)THEN
      lambda_f = lf_urb(1)
@@ -698,7 +698,7 @@ use module_wrf_error
      lambda_f = lf_urb(1)
    ELSEIF(WDR.gt.22.5.and.WDR.le.67.5)THEN
      lambda_f = lf_urb(2)
-   ELSEIF(WDR.ge.-67.5.and.WDR.lt.-22.5)THEN
+   ELSEIF(WDR.ge.-157.5.and.WDR.lt.-112.5)THEN
      lambda_f = lf_urb(2)
    ELSEIF(WDR.gt.67.5.and.WDR.le.112.5)THEN
      lambda_f = lf_urb(3)
@@ -706,7 +706,7 @@ use module_wrf_error
      lambda_f = lf_urb(3)
    ELSEIF(WDR.gt.112.5.and.WDR.le.157.5)THEN
      lambda_f = lf_urb(4)
-   ELSEIF(WDR.ge.-157.5.and.WDR.lt.-112.5)THEN
+   ELSEIF(WDR.ge.-67.5.and.WDR.lt.-22.5)THEN
      lambda_f = lf_urb(4)
    ELSE
      lambda_f = lf_urb(1)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: urban model WDR undefined before use
SOURCE: internal 
DESCRIPTION OF CHANGES:
Problem:
WDR was used before being defined in urban model. This is a wind direction used in computing the urban roughness length for local surface flux calculations.
Another problem was that logic for some directions was wrong in selecting the correct one of 4 frontal area directions.

Solution:
Uncomment WDR calculation (assumes grid is roughly y direction northwards).
Correct direction if-tests.

ISSUE: None
LIST OF MODIFIED FILES: 
M       phys/module_sf_urban.F

TESTS CONDUCTED: 
1. Compile only - recommend test for effect
2. The Jenkins tests are all passing.

RELEASE NOTE: minor fix for urban wind directions when using detailed urban morphology maps