### PR TITLE
WRfv4.4_bugfix_pm10_wrfda_chem108

### DIFF
--- a/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
+++ b/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
@@ -180,7 +180,6 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
    ! Innovations and obs errors for chemic_surf (e.g., surfce concentration)
 
    do ichem = PARAM_FIRST_SCALAR, num_chemic_surf
-
       ipm = ichem - PARAM_FIRST_SCALAR + 1
  
       do n=iv%info(chemic_surf)%n1,iv%info(chemic_surf)%n2

--- a/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
+++ b/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
@@ -17,11 +17,13 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
    real, allocatable :: model_chemic(:,:)
    real, allocatable :: model_rho(:,:)
 
-   real, parameter  :: scaleL = 3000.         ! scaling factor for obs error [meters]
+!  Raidus of influence of ground observations at urban sites (Table 3. in Elbernet al. 2007)
+!  FIXME: It would be better to put this parameter in the namelist.
+   real, parameter  :: Lrepr = 3000. !2000.    ! Scaling factor for obs error [meters]
 
- ! max thresholds of abs(o-b) in pm25,  pm10,  so2,  no2,  o3,  co
+!  Max thresholds of abs(o-b) in pm25,  pm10,  so2,  no2,  o3,  co
    real,dimension(6):: maxomb = (/100., 100., 0.20, 0.20, 0.20, 20./)
-   real             :: err_o, err_r
+   real             :: err_o1, err_o2, err_r1, err_r2
 
    if (trace_use) call da_trace_entry("da_get_innov_vector_chem_sfc")
 
@@ -46,14 +48,14 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
    end do
 
    ! [1.1] Compute prior observations at obs sites
-   if (chem_cv_options == 10) then
+   if (chem_cv_options == 10) then           ! gocart_test
        model_chemic_surf(:,p_chemsi_pm25)=model_rho(:,p_chem_ic_p25)*(model_chemic(:,p_chem_ic_p25)                                       + &
            1.375*(96.06/28.964*1000)*model_chemic(:,p_chem_ic_sulf)                                                                       + &
 	   model_chemic(:,p_chem_ic_bc1)+model_chemic(:,p_chem_ic_bc2)+1.8*(model_chemic(:,p_chem_ic_oc1)+model_chemic(:,p_chem_ic_oc2))  + &
            model_chemic(:,p_chem_ic_dust_1)+0.286*model_chemic(:,p_chem_ic_dust_2)+model_chemic(:,p_chem_ic_seas_1)                       + &
            0.942*model_chemic(:,p_chem_ic_seas_2))
 
-   else if (chem_cv_options == 20) then
+   else if (chem_cv_options == 20) then      ! mosaic_test
 
       if (chemicda_opt == 1 ) then
       model_chemic_surf(:,p_chemsi_pm25)=model_rho(:,p_chem_ic_bc_a01)*(model_chemic(:,p_chem_ic_bc_a01)+model_chemic(:,p_chem_ic_bc_a02)        + &
@@ -109,7 +111,7 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
 
       end if
 
-   else if (chem_cv_options == 108) then   ! racm_soa_vbs_da
+   else if (chem_cv_options >= 108) then   ! racm_soa_vbs_da or racm_soa_vbs_aqchem_da
 
       if (chemicda_opt == 1 .or. chemicda_opt == 3 .or. chemicda_opt == 5) then   ! pm2.5
 
@@ -118,6 +120,13 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
             model_chemic_surf(:,p_chemsi_pm25) = model_chemic_surf(:,p_chemsi_pm25) + &
                                                  model_rho(:,ichem)  * model_chemic(:,ichem)
          end do
+
+         if( (p_chem_ic_p25cwi .gt. p_chem_ic_p25i) .and. chem_cv_options == 109 ) then   ! aqueous chemistry
+         do ichem = p_chem_ic_so4cwj,p_chem_ic_p25cwi
+            model_chemic_surf(:,p_chemsi_pm25) = model_chemic_surf(:,p_chemsi_pm25) + &
+                                                 model_rho(:,ichem)  * model_chemic(:,ichem)
+         enddo
+         endif
 
       end if
 
@@ -128,6 +137,13 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
             model_chemic_surf(:,p_chemsi_pm10) = model_chemic_surf(:,p_chemsi_pm10) + &
                                                  model_rho(:,ichem) * model_chemic(:,ichem)
          end do
+
+         if( (p_chem_ic_p25cwi .gt. p_chem_ic_p25i) .and. chem_cv_options == 109 ) then   ! aqueous chemistry
+         do ichem = p_chem_ic_so4cwj,p_chem_ic_soilcw
+            model_chemic_surf(:,p_chemsi_pm10) = model_chemic_surf(:,p_chemsi_pm10) + &
+                                                 model_rho(:,ichem)  * model_chemic(:,ichem)
+         end do
+         endif
 
       end if !(chemicda_opt == 2) then
 
@@ -140,6 +156,13 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
                                                      model_rho(:,ichem) * model_chemic(:,ichem)
          end do
 
+         if( (p_chem_ic_p25cwi .gt. p_chem_ic_p25i) .and. chem_cv_options == 109 ) then   ! aqueous chemistry
+         do ichem = p_chem_ic_anthcw,p_chem_ic_soilcw
+            model_chemic_surf(:,p_chemsi_pm10) = model_chemic_surf(:,p_chemsi_pm10) + &
+                                                     model_rho(:,ichem) * model_chemic(:,ichem)
+         end do
+         endif
+
       end if !(chemicda_opt == 3 .or. chemicda_opt == 5)
 
       if (chemicda_opt >= 4) then
@@ -151,10 +174,13 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
 
       end if !(chemicda_opt >= 4 ) then
 
-   end if   !  (chem_cv_options == 108)
+   end if   !  (chem_cv_options >= 108)
 
-   ! Loop over chemic_surf (e.g., surfce concentration)
+
+   ! Innovations and obs errors for chemic_surf (e.g., surfce concentration)
+
    do ichem = PARAM_FIRST_SCALAR, num_chemic_surf
+
       ipm = ichem - PARAM_FIRST_SCALAR + 1
  
       do n=iv%info(chemic_surf)%n1,iv%info(chemic_surf)%n2
@@ -170,22 +196,22 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
              iv % chemic_surf(n) % chem(ichem) % inv = &
              ob % chemic_surf(n) % chem(ichem) - model_chemic_surf(n,ichem)
 
-             if ( ichem <= PARAM_FIRST_SCALAR+1 ) then     ! PM2.5 and PM10
+             ! Observation error specification
+              err_o1 = 1.0 + 0.0075 * ob % chemic_surf(n) % chem(ichem)
+              err_o2 = 1.5 + 0.0075 * ob % chemic_surf(n) % chem(ichem)
+              err_r1 = 0.5 * err_o1 * sqrt(grid%dx/Lrepr)
+              err_r2 = 0.5 * err_o2 * sqrt(grid%dx/Lrepr)
 
-               err_o = 1.5 + 0.0075 * ob % chemic_surf(n) % chem(ichem)
-               err_r = 0.5 * err_o * sqrt(grid % dx / scaleL)
-               iv % chemic_surf(n) % chem(ichem) % error = sqrt(err_o**2 + err_r**2)
-
-             else  ! gas species (so2, no2, o3, co)
-
-               err_o = 0.10 * ob % chemic_surf(n) % chem(ichem)    ! obs error as 10% of the observation value
-               iv % chemic_surf(n) % chem(ichem) % error = err_o
-
-               !err_o = 1.0 + 0.0075 * ob % chemic_surf(n) % chem(ichem)   ! Wei Sun
-               !err_r = 0.5 * err_o * sqrt(grid % dx / 2000.)
-               !iv % chemic_surf(n) % chem(ichem) % error = 1.5*sqrt(err_o**2 + err_r**2)
-
-             end if !( ichem <= PARAM_FIRST_SCALAR+1 )
+              if (chemicda_opt == 3 .or. chemicda_opt == 5 ) then   ! PM10 is treated as (PM10 - PM2.5) residual.
+               if (ichem  == PARAM_FIRST_SCALAR+1 ) then
+                   iv % chemic_surf(n) % chem(ichem) % error = 1.0*sqrt(err_o1**2 + err_r1**2) ! reduced error for PM10
+               else   ! PM2.5 and gas species (so2, no2, o3, co)
+                   iv % chemic_surf(n) % chem(ichem) % error = 1.0*sqrt(err_o2**2 + err_r2**2) ! Ha (GMD2022)
+               end if
+              else     ! PM10 is not a residual.
+                   iv % chemic_surf(n) % chem(ichem) % error = 1.0*sqrt(err_o2**2 + err_r2**2) ! Ha (GMD2022)
+                  !iv % chemic_surf(n) % chem(ichem) % error = 1.5*sqrt(err_o1**2 + err_r1**2) ! Wei's error
+              end if
 
             ! Quality Control
             ! ----------------

--- a/var/da/da_obs_io/da_read_obs_chem_sfc.inc
+++ b/var/da/da_obs_io/da_read_obs_chem_sfc.inc
@@ -235,41 +235,41 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
 
       else if (chem_cv_options == 108) then
 
-      read (iunit, fmt='(A6,F10.6,1X,F10.6,1X,I4,3I2,2F9.1,4F9.3)', iostat=iost)  &
-            SiteID,                                   &
-            platform%info%lat,                        &
-            platform%info%lon,                        &
-            iyear, imonth, iday, ihour,               &
-            pm25,  pm10,   so2,  no2,   o3, co
+         read (iunit, fmt='(A6,F10.6,1X,F10.6,1X,I4,3I2,2F9.1,4F9.3)', iostat=iost)  &
+               SiteID,                                   &
+               platform%info%lat,                        &
+               platform%info%lon,                        &
+               iyear, imonth, iday, ihour,               &
+               pm25,  pm10,   so2,  no2,   o3, co
 
-      platform%info%id = trim(SiteID)
-      read(SiteID,'(I6)') isite
-      write (platform%info%date_char,'(i4,3(i2.2))')  iyear, imonth, iday, ihour
+         platform%info%id = trim(SiteID)
+         read(SiteID,'(I6)') isite
+         write (platform%info%date_char,'(i4,3(i2.2))')  iyear, imonth, iday, ihour
 
-      !!!!!!!!!!!!!!!!!!!
-      ! Caution: Observations are assumed to have the same unit of ppmv.
-      ! Unit conversion (to ppmv) must have been done in the preprocessing.
-      ! (ex. The original chinese data had ug/m3 for gas species.)
-      !!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!
+         ! Caution: Observations are assumed to have the same unit of ppmv.
+         ! Unit conversion (to ppmv) must have been done in the preprocessing.
+         ! (ex. The original chinese data had ug/m3 for gas species.)
+         !!!!!!!!!!!!!!!!!!!
 
-      select case ( chemicda_opt )
-      case ( 1 )
+         select case ( chemicda_opt )
+         case ( 1 )
             platform%chem(PARAM_FIRST_SCALAR  )%inv = pm25
             platform%info%name                      = "pm25"
-      case ( 2 )
+         case ( 2 )
             platform%chem(PARAM_FIRST_SCALAR  )%inv = pm10
             platform%info%name                      = "pm10"
-      case ( 3 )
+         case ( 3 )
             platform%chem(PARAM_FIRST_SCALAR  )%inv = pm25
             platform%chem(PARAM_FIRST_SCALAR+1)%inv = pm10
             platform%info%name                      = "all_pm"
-      case ( 4 )
+         case ( 4 )
             platform%chem(PARAM_FIRST_SCALAR  )%inv = so2
             platform%chem(PARAM_FIRST_SCALAR+1)%inv = no2
             platform%chem(PARAM_FIRST_SCALAR+2)%inv = o3
             platform%chem(PARAM_FIRST_SCALAR+3)%inv = co
             platform%info%name                      = "gas"
-      case ( 5 )
+         case ( 5 )
             platform%chem(PARAM_FIRST_SCALAR  )%inv = pm25
             platform%chem(PARAM_FIRST_SCALAR+1)%inv = pm10
             platform%chem(PARAM_FIRST_SCALAR+2)%inv = so2
@@ -277,23 +277,35 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
             platform%chem(PARAM_FIRST_SCALAR+4)%inv = o3
             platform%chem(PARAM_FIRST_SCALAR+5)%inv = co
             platform%info%name                      = "all"
-      case default
+         case default
             platform%chem(PARAM_FIRST_SCALAR  )%inv = pm25
             platform%info%name                      = ""
-      end select
+         end select
 
-      ! Sanity check
-      !!!!!!!!!!!!!!!!!!!
-      do ichem = PARAM_FIRST_SCALAR, num_chemic_surf
-         ipm = ichem - PARAM_FIRST_SCALAR + 1
-         if (platform%chem(ichem)%inv<0.or.abs(platform%chem(ichem)%inv)>=max_pm(ipm)) then
-             platform%chem(ichem)%inv=missing_r
-         else
-             platform%chem(ichem)%qc = 0
-         endif
-      end do
+         ! Sanity check
+         !!!!!!!!!!!!!!!!!!!
+         do ichem = PARAM_FIRST_SCALAR, num_chemic_surf
+            ipm = ichem - PARAM_FIRST_SCALAR + 1
+            if (platform%chem(ichem)%inv<0.or.abs(platform%chem(ichem)%inv)>=max_pm(ipm)) then
+                platform%chem(ichem)%inv=missing_r
+            else
+                platform%chem(ichem)%qc = 0
+            endif
+         end do
 
-      end if ! (chem_cv_options == 10) then
+         if ((chemicda_opt == 3) .or. (chemicda_opt == 5)) then
+          if ((platform%chem(PARAM_FIRST_SCALAR+1)%inv.lt.platform%chem(PARAM_FIRST_SCALAR)%inv) .or. &
+              (platform%chem(PARAM_FIRST_SCALAR+1)%inv<0).or.(platform%chem(PARAM_FIRST_SCALAR)%inv<0)) then ! Feb-27-2022
+              platform%chem(PARAM_FIRST_SCALAR+1)%inv = missing_r
+              platform%chem(PARAM_FIRST_SCALAR+1)%qc  = missing
+          else
+              ! pm10 <= pm10 - pm25 residual
+              platform%chem(PARAM_FIRST_SCALAR+1)%inv = platform%chem(PARAM_FIRST_SCALAR+1)%inv - &
+                                                        platform%chem(PARAM_FIRST_SCALAR)%inv
+          endif
+         end if ! ((chemicda_opt == 3) .or. (chemicda_opt == 5)) then
+
+      end if !  if (chem_cv_options == 108)
 
       if (iost /= 0) then
          ! FIX? This is expected, but its unclear how we handle failure

--- a/var/da/da_obs_io/da_read_omb_tmp.inc
+++ b/var/da/da_obs_io/da_read_omb_tmp.inc
@@ -361,8 +361,10 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
          if (num_obs > 0) then
             do n = 1, num_obs    
                read(unit_in,'(2i8)') levels, ifgat
-               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
-               num = num + 1
+               if (if_write) then
+                  write(omb_unit,'(2i8)')levels, ifgat
+                  num = num + 1
+               end if
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
                      kk,l, stn_id, &          ! Station
@@ -385,8 +387,10 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
          if (num_obs > 0) then
             do n = 1, num_obs    
                read(unit_in,'(2i8)') levels, ifgat
-               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
-               num = num + 1
+               if (if_write) then
+                  write(omb_unit,'(2i8)')levels, ifgat
+                  num = num + 1
+               end if
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
                      kk,l, stn_id, &          ! Station
@@ -429,8 +433,10 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
          if (num_obs > 0) then
             do n = 1, num_obs    
                read(unit_in,'(2i8)') levels, ifgat
-               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
-               num = num + 1
+               if (if_write) then
+                  write(omb_unit,'(2i8)')levels, ifgat
+                  num = num + 1
+               end if
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
                      kk,l, stn_id, &          ! Station

--- a/var/da/da_obs_io/da_read_omb_tmp.inc
+++ b/var/da/da_obs_io/da_read_omb_tmp.inc
@@ -361,10 +361,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
          if (num_obs > 0) then
             do n = 1, num_obs    
                read(unit_in,'(2i8)') levels, ifgat
-               if (if_write) then
-                  write(omb_unit,'(2i8)')levels, ifgat
-                  num = num + 1
-               end if
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
+               num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
                      kk,l, stn_id, &          ! Station
@@ -387,10 +385,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
          if (num_obs > 0) then
             do n = 1, num_obs    
                read(unit_in,'(2i8)') levels, ifgat
-               if (if_write) then
-                  write(omb_unit,'(2i8)')levels, ifgat
-                  num = num + 1
-               end if
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
+               num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
                      kk,l, stn_id, &          ! Station
@@ -433,10 +429,8 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
          if (num_obs > 0) then
             do n = 1, num_obs    
                read(unit_in,'(2i8)') levels, ifgat
-               if (if_write) then
-                  write(omb_unit,'(2i8)')levels, ifgat
-                  num = num + 1
-               end if
+               if (if_write) write(omb_unit,'(2i8)')levels, ifgat
+               num = num + 1
                do k = 1, levels
                   read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
                      kk,l, stn_id, &          ! Station


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Fix compilation errors due to aqueous variables in da_get_innov_vector_chem_sfc.inc 

SOURCE: Soyoung Ha

DESCRIPTION OF CHANGES:
Problem:
racm_soa_vbs_aqchem_kpp variables are incorrectly introduced in da_get_innov_vector_chem_sfc.inc.

Solution:
AQchem variables are now removed. Also, the obs error formula is back to the original form for pm10 residuals to avoid overfitting issues.

ISSUE: For use when this PR closes an issue.
Fixes #1688 

LIST OF MODIFIED FILES: 
var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc

TESTS CONDUCTED: 
1. Do mods fix problem? Yes
2. Are the Jenkins tests all passing? Yes
