### PR TITLE
Bug fix for emissivity in Noah urban code

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -1709,7 +1709,7 @@ CONTAINS
 !           emiss(i,j)=(1.-frc_urb2d(i,j))*emiss_rural(i,j)+frc_urb2d(i,j)*emiss_urb(i,j)
 ! using the emissivity and the total longwave upward radiation estimate the averaged skin temperature
            IF (FRC_URB2D(I,J).GT.0.) THEN
-              rl_up_rural=-emiss_rural(i,j)*sigma_sb*(tsk_rural(i,j)**4.)-(1.-emissi)*glw(i,j)
+              rl_up_rural=-emiss_rural(i,j)*sigma_sb*(tsk_rural(i,j)**4.)-(1.-emiss_rural(i,j))*glw(i,j)
               rl_up_tot=(1.-frc_urb2d(i,j))*rl_up_rural+frc_urb2d(i,j)*rl_up_urb(i,j)   
               emiss(i,j)=(1.-frc_urb2d(i,j))*emiss_rural(i,j)+frc_urb2d(i,j)*emiss_urb(i,j)
               ts_urb2d(i,j)=(max(0.,(-rl_up_urb(i,j)-(1.-emiss_urb(i,j))*glw(i,j))/emiss_urb(i,j)/sigma_sb))**0.25


### PR DESCRIPTION
Bug fix for emissivity variable of urban code in Noah driver

TYPE: bug fix

KEYWORDS: Noah, urban, emissivity

SOURCE: Cenlin He (NCAR)

DESCRIPTION OF CHANGES:
Problem:
The rural area emissivity variable is not initialized in module_sf_noahdrv.F before it is used. See Issue #1676 for details.

Solution:
Replace the un-initialized emissivity variable by the correct rural emissivity variable.

ISSUE: #1676

LIST OF MODIFIED FILES:
M       phys/module_sf_noahdrv.F

TESTS CONDUCTED: 
1. The proposed modification fixes the problem.
2. Jenkins tests are all passing.