### PR TITLE
Init Henry's Law Constants for MOZART & convective wet scavenging with GF

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -649,7 +649,9 @@ module_cu_gf_sh.o: \
 module_cu_gf_ctrans.o: \
                 ../chem/module_chem_utilities.o \
                 ../share/module_HLaw.o \
-                ../frame/module_configure.o 
+                ../share/module_ctrans_aqchem.o \
+                ../frame/module_configure.o \
+                ../frame/module_state_description.o 
 module_cumulus_driver.o: \
 		module_cu_kf.o \
 		module_cu_g3.o \

--- a/main/depend.common
+++ b/main/depend.common
@@ -639,13 +639,17 @@ module_shallowcu_driver.o: \
 		../frame/module_state_description.o \
 		../share/module_model_constants.o
 
+module_cu_gf_deep.o: \
+                module_cu_gf_ctrans.o
 module_cu_gf_wrfdrv.o: \
 		module_cu_gf_deep.o \
 		module_cu_gf_sh.o
 module_cu_gf_sh.o: \
 		module_cu_gf_deep.o
-module_cu_gf_deep.o: \
-                module_cu_gf_ctrans.o
+module_cu_gf_ctrans.o: \
+                ../chem/module_chem_utilities.o \
+                ../share/module_HLaw.o \
+                ../frame/module_configure.o 
 module_cumulus_driver.o: \
 		module_cu_kf.o \
 		module_cu_g3.o \

--- a/main/depend.common
+++ b/main/depend.common
@@ -650,7 +650,6 @@ module_cu_gf_ctrans.o: \
                 ../chem/module_chem_utilities.o \
                 ../share/module_HLaw.o \
                 ../share/module_ctrans_aqchem.o \
-                ../frame/module_configure.o \
                 ../frame/module_state_description.o 
 module_cumulus_driver.o: \
 		module_cu_kf.o \

--- a/main/depend.common
+++ b/main/depend.common
@@ -644,6 +644,8 @@ module_cu_gf_wrfdrv.o: \
 		module_cu_gf_sh.o
 module_cu_gf_sh.o: \
 		module_cu_gf_deep.o
+module_cu_gf_deep.o: \
+                module_cu_gf_ctrans.o
 module_cumulus_driver.o: \
 		module_cu_kf.o \
 		module_cu_g3.o \

--- a/phys/module_cu_gf_ctrans.F
+++ b/phys/module_cu_gf_ctrans.F
@@ -1,5 +1,6 @@
 MODULE module_cu_gf_ctrans
   real, parameter::g=9.81
+  INTEGER, allocatable :: HLC_ndx(:)
 !++ GF CTRAN ++ lyy 01/2020
 #if ( WRF_CHEM == 1 )    
   contains
@@ -204,7 +205,7 @@ MODULE module_cu_gf_ctrans
              do nv=2,num_chem
                call wetscav(tr_up(i,k,nv),tr_pw(i,k,nv) &
                            ,zuo(i,k),nv,p(i,k),t(i,k),clw_all(i,k),dz  &
-                           ,chemopt,numgas)
+                           ,chemopt,numgas,num_chem)
                tot_up_pw(i,nv)=tot_up_pw(i,nv)+tr_pw(i,k,nv)*dp/g
              enddo ! nv
            endif ! scav
@@ -306,7 +307,7 @@ MODULE module_cu_gf_ctrans
 
   SUBROUTINE wetscav(tr_up1d,tr_pw1d &
                     ,zu1d,nv,p1d,t1d,clw_all1d,dz &
-                    ,chemopt,numgas)
+                    ,chemopt,numgas,num_chem)
   USE module_HLawConst, only:HLC
   USE module_state_description, ONLY: mozart_mosaic_4bin_kpp, &
                               mozart_mosaic_4bin_aq_kpp, &
@@ -323,7 +324,7 @@ MODULE module_cu_gf_ctrans
                               p_hcooh 
       IMPLICIT NONE
      integer,intent (in) ::         &
-        chemopt,nv,numgas
+        chemopt,nv,numgas,num_chem
      real,intent (in )::            &
         p1d,t1d,clw_all1d,dz,zu1d
      REAL,INTENT(INOUT)::           &
@@ -343,7 +344,6 @@ MODULE module_cu_gf_ctrans
      integer,parameter :: USE_ICE_RETENTION=1
      real::reteff
 !--
-     INTEGER, allocatable :: HLC_ndx(:)
      tfac=(HL_t0-t1d)/(t1d*HL_t0)
      aq_gas_ratio=0.0
      dens=0.1*p1d/t1d*mwdry/8.314472  !kg/m3
@@ -369,7 +369,13 @@ MODULE module_cu_gf_ctrans
      if( chemopt == MOZCART_KPP .or. chemopt == T1_MOZCART_KPP .or. &
                 chemopt == MOZART_MOSAIC_4BIN_KPP .or. &
                 chemopt == MOZART_MOSAIC_4BIN_AQ_KPP ) then
+! This setup is not ideal, as the the sub is just a duplicate version of the
+! init that occurs on the /chem side. But, it will work for now.
+       if ( .not. allocated(HLC_ndx) ) then
+           call conv_tr_wetscav_init_phys( numgas, num_chem )
+       endif
        HLndx = HLC_ndx(nv)
+
        if( HLndx /= 0 ) then
          HLCnst1 = HLC(HLndx)%hcnst(1) 
          HLCnst2 = HLC(HLndx)%hcnst(2)
@@ -454,6 +460,52 @@ MODULE module_cu_gf_ctrans
        tr_up1d = trcc+trch ! Total amount of species in updraft = conc in liq water (trcc) + conc in gas phase (trch)
      endif
   END SUBROUTINE wetscav
+
+   SUBROUTINE conv_tr_wetscav_init_phys( numgas, num_chem )
+
+   use module_state_description, only : param_first_scalar
+   use module_scalar_tables, only : chem_dname_table
+   use module_chem_utilities, only : UPCASE
+   use module_HLawConst
+
+   integer, intent(in) :: numgas, num_chem
+
+!----------------------------------------------------------------------
+!  local variables
+!----------------------------------------------------------------------
+   integer :: m, m1
+   integer :: astat
+   character(len=64) :: HL_tbl_name
+   character(len=64) :: wrf_spc_name
+
+is_allocated : &
+   if( .not. allocated(HLC_ndx) ) then
+!----------------------------------------------------------------------
+!  scan HLawConst table for match with chem_opt scheme gas phase species
+!----------------------------------------------------------------------
+     allocate( HLC_ndx(num_chem),stat=astat )
+     if( astat /= 0 ) then
+       call wrf_error_fatal("conv_tr_wetscav_init: failed to allocate HLC_ndx")
+     endif
+     HLC_ndx(:) = 0
+     do m = param_first_scalar,numgas
+       wrf_spc_name = chem_dname_table(1,m)
+       call upcase( wrf_spc_name )
+       do m1 = 1,nHLC
+         HL_tbl_name = HLC(m1)%name
+         call upcase( HL_tbl_name )
+         if( trim(HL_tbl_name) == trim(wrf_spc_name) ) then
+           HLC_ndx(m) = m1
+           exit
+         endif
+       end do
+     end do
+   endif is_allocated
+
+   END SUBROUTINE conv_tr_wetscav_init_phys
+
+
+
 
   REAL FUNCTION moz_aq_frac(T, q, heff )
    implicit none

--- a/phys/module_cu_gf_ctrans.F
+++ b/phys/module_cu_gf_ctrans.F
@@ -16,6 +16,7 @@ MODULE module_cu_gf_ctrans
                       ,xmb,ierr,edto  &
                       ,itf,ktf,its,ite,kts,kte  &
                       ,ishallow)
+  
   IMPLICIT NONE
      integer,intent (in   )                   ::            &
         itf,ktf,its,ite, kts,kte,                           &


### PR DESCRIPTION
Initialize Henry's Law Constants in phys when using MOZART and convective wet scavenging with GF

TYPE: Bug fix

KEYWORDS: MOZART, GF cumulus (3), conv_tr_wetscav
SOURCE: Dale Allen (UMD)

DESCRIPTION OF CHANGES:
Problem: https://forum.mmm.ucar.edu/phpBB3/viewtopic.php?f=91&t=11275

This fixes a bug introduced with PR #1354. When a MOZART chemistry option is used in conjuction with cu_physics = 3 and conv_tr_wetscav = 1, the Henry's Law Constants intialized in the chemistry directory are not available to the physics code resulting in a memory mapping error when attemtping to index the allocatable array. This commit adds an additional subroutine in module_cu_gf_ctrans.F that is identical to the intitialzation routine in module_ctrans_grell.F, which is the parameterized convective transport scheme disconnected from physics (i.e., cu_physics /= 3 or 10 & chem_conv_tr = 1).

ISSUE: https://forum.mmm.ucar.edu/phpBB3/viewtopic.php?f=91&t=11275

LIST OF MODIFIED FILES: 

M       main/depend.common
M       phys/module_cu_gf_ctrans.F

TESTS CONDUCTED: 
1. PENDING - user is undergoing final tests 
2. Are the Jenkins tests all passing?

RELEASE NOTE: Fixed issue when using MOZART chemistry and convective wet scavenging with GF cumulus