### PR TITLE
Modify configure to address hires option compile issue

### DIFF
--- a/configure
+++ b/configure
@@ -1033,10 +1033,10 @@ fi
 
 # testing for location of rpc/types.h file, used in landuse
 if [ -f /usr/include/rpc/types.h ] ; then
-  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=1/' configure.wrf > configure.wrf.edit
+  sed -e '/^ARCH_LOCAL/s/#/-DRPC_TYPES=1 &/' configure.wrf > configure.wrf.edit
   mv configure.wrf.edit configure.wrf
 elif [ -f /usr/include/tirpc/rpc/types.h ] ; then
-  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=2/' configure.wrf > configure.wrf.edit
+  sed -e '/^ARCH_LOCAL/s/#/-DRPC_TYPES=2 &/' configure.wrf > configure.wrf.edit
   mv configure.wrf.edit configure.wrf
 else
   echo "************************** W A R N I N G ************************************"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: hires, configure, ARCH_LOCAL, CFLAGS_LOCAL, -DRPC_TYPES, landread.o

SOURCE: Mathieu (forum user - requesting full name and affiliation)

DESCRIPTION OF CHANGES:
Problem: When compiling with the vortex-following "hires" option, often a compiling error occurred regarding the landuse.o file. 
`mpiicc -DFSEEKO64_OK  -o landread.o -c -w -O3 -ip  -DDM_PARALLEL -DTERRAIN_AND_LANDUSE -DMAX_HISTORY=25 -DNMM_CORE=0  landread.c
landread.c(130): error: identifier "XDR" is undefined
  static XDR  *xdrs;
         ^

landread.c(410): error: identifier "XDR" is undefined
    xdrs = (XDR *) malloc(sizeof(XDR));
            ^

landread.c(410): error: expected an expression
    xdrs = (XDR *) malloc(sizeof(XDR));
                 ^

landread.c(410): error: expected a ";"
    xdrs = (XDR *) malloc(sizeof(XDR));
                   ^

landread.c(411): error: identifier "XDR_DECODE" is undefined
    xdrstdio_create(xdrs, fp, XDR_DECODE);
                              ^

../configure.wrf:404: recipe for target 'landread.o' failed
make[2]: [landread.o] Error 2 (ignored)
`

A similar error was addressed previously in #1072, but didn't fully correct the issue. 

Solution:
A modification to the configure file (specifically the section added in #1072), to place -DRPC_TYPES in the CFLAGS_LOCAL line, instead of ARCH_LOCAL corrects the issue. 

LIST OF MODIFIED FILES: 
M   configure

TESTS CONDUCTED: 
1. Modifications fix the problem. Configure, compile, and simulation tested - all successful.
2. Are the Jenkins tests all passing? (pending)
