### PR TITLE
Make the print for submodule conditionally appearing in log file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ framework_only : configcheck
 
 wrf : framework_only
 	$(MAKE) MODULE_DIRS="$(ALL_MODULES)" physics
-	if [ \( ! -f run/MPTABLE.TBL \) -o \
+	@if [ \( ! -f run/MPTABLE.TBL \) -o \
 	     \( ! -f phys/module_sf_noahmpdrv.F \) -o \
 	     \( ! -f phys/module_sf_noahmp_glacier.F \) -o \
 	     \( ! -f phys/module_sf_noahmp_groundwater.F \) -o \


### PR DESCRIPTION
TYPE: no impact, text only

KEYWORDS: print, submodule status

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Currently when we compile, this section of the submodule status check from top-level Makefile always appears in the log file, which can be confusing to users:

        if [ \( ! -f run/MPTABLE.TBL \) -o \
             \( ! -f phys/module_sf_noahmpdrv.F \) -o \
             \( ! -f phys/module_sf_noahmp_glacier.F \) -o \
             \( ! -f phys/module_sf_noahmp_groundwater.F \) -o \
             \( ! -f phys/module_sf_noahmplsm.F \) ] ; then \
           echo " " ; \
           echo "------------------------------------------------------------------------------" ; \
           echo "Error Error Error NoahMP submodule files not populating WRF directories" ; \
           echo "------------------------------------------------------------------------------" ; \
           echo " " ; \
           exit 31 ; \
        else \
           echo "------------------------------------------------------------------------------" ; \
           echo "NoahMP submodule files populating WRF directories" ; \
           echo "------------------------------------------------------------------------------" ; \
        fi

After that the actual status report print would appear. For example, you may find this in the log file:

     ------------------------------------------------------------------------------
     NoahMP submodule files populating WRF directories
     -----------------------------------------------------------------------------

Solution:
Add @ in front of 'if', and this will stop the entire section to be printed, and depending on the actual status of the submodule, this would appear if there is no trouble getting the files from the noahmp submodule:

     ------------------------------------------------------------------------------
     NoahMP submodule files populating WRF directories
     ------------------------------------------------------------------------------

LIST OF MODIFIED FILES: 
M     Makefile

TESTS CONDUCTED: 
1. Do mods fix problem? Yes, on a test compilation on Cheyenne.
2. The Jenkins tests are all passing.
