### PR TITLE
bug fix for Noah urban driver for longwave & shorwave input variables

### DIFF
--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -3387,8 +3387,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
       !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
       ! the "NATURAL" category in the VEGPARM.TBL
       	
-      	!   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
-                       
+      	!   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN                 
       
            !           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
            !            IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -965,6 +965,9 @@ CONTAINS
                  ALBEDOK =0.2         !  0.2
                  ALBBRD  =0.2         !0.2
                  EMISSI = 0.98                                 !for VEGTYP=5
+                 LWDN   = GLW(I,J) * EMISSI
+                 SOLNET = SOLDN * (1.0 - ALBEDOK)
+
 		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
                    if(sf_urban_physics.eq.1)then
                      T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
@@ -3440,7 +3443,9 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                        ALBEDOK =0.2         !  0.2
                        ALBBRD  =0.2         !  0.2
                        EMISSI = 0.98        !  for VEGTYP=5       
-                       
+                       LWDN   = GLW(I,J) * EMISSI
+                       SOLNET = SOLDN * (1.0 - ALBEDOK)
+ 
       		      T1= TS_RUL2D_mosaic(I,mosaic_i,J)
                        
                  ENDIF
@@ -4360,6 +4365,9 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                        ALBEDOK =0.2         !  0.2
                        ALBBRD  =0.2         !0.2
                        EMISSI = 0.98                                 !for VEGTYP=5
+                       LWDN   = GLW(I,J) * EMISSI
+                       SOLNET = SOLDN * (1.0 - ALBEDOK)
+
       		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
                    if(sf_urban_physics.eq.1)then
                      T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))


### PR DESCRIPTION
Bug fix for the LWDN and SOLNET input variables for urban simulation in Noah LSM driver

TYPE: bug fix

KEYWORDS: Noah, urban, LWDN, SOLNET

SOURCE: Cenlin He (NCAR)

DESCRIPTION OF CHANGES:
Problem:
The variables SOLNET and LWDN in module_sf_noahdrv.F, that are, respectively, the net shortwave radiation and the absorbed longwave radiation, are computed by using the whole-grid albedo and emissivity from last time step. However, these two variables (LWDN and SOLNET) are the input forcing variables for non-urban fraction of the grid in SFLX subroutine calculations. So to be consistent, LWDN and SOLNET should be computed based on non-urban (instead of whole-grid) albedo and emissivity for the use in SFLX.

Solution:
add the following two lines to re-calculate using non-urban albedo and emissivity:
      LWDN=GLW(I,J) x EMISSI
      SOLNET=SOLDN x (1.0-ALBEDOK)

LIST OF MODIFIED FILES:
phys/module_sf_noahdrv.F

RELEASE NOTE:
Corrected input variables of absorbed longwave radiation LWDN and net shortwave radiation SOLNET for non-urban fraction of the LSM call. 