### PR TITLE
Bug fix for chem DA omb/oma output

### DIFF
--- a/var/da/da_obs_io/da_final_write_obs_gas_sfc.inc
+++ b/var/da/da_obs_io/da_final_write_obs_gas_sfc.inc
@@ -17,8 +17,7 @@ subroutine da_final_write_obs_gas_sfc(it,iv)
 
    !local
    character(len=4) :: typestr
-   typestr = 'chem'
-   if (chem_cv_options >= 108) typestr = 'gas'
+   typestr = 'gas'
 
    if (trace_use) call da_trace_entry("da_final_write_obs_gas_sfc")
 

--- a/var/da/da_obs_io/da_read_omb_tmp.inc
+++ b/var/da/da_obs_io/da_read_omb_tmp.inc
@@ -456,7 +456,6 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
 #if (WRF_CHEM == 1)
       case ('chem' )
          if (num_obs > 0) then
-          !if (chem_cv_options > 1 .and. chem_cv_options < 100) then
             do n = 1, num_obs
                read(unit_in,'(2i8)')levels, ifgat
                if (if_write) then
@@ -519,7 +518,6 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
                end do
             end do
 
-          !endif !(chem_cv_options >= 100) then
          end if !  if (num_obs > 0) then
 
          if (if_write) exit reports
@@ -527,7 +525,6 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
 
       case ('gas' )
          if (num_obs > 0) then
-          !if (chem_cv_options >= 108) then
            do n = 1, num_obs
               read(unit_in,'(2i8)')levels, ifgat
               if (if_write) then
@@ -551,7 +548,6 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
                        chem_obs4, chem_inv4, chem_qc4, chem_err4, chem_inc4
               end if
            end do   !  do n = 1, num_obs
-          !endif     !  if (chem_cv_options >= 108) then
          end if     !  if (num_obs > 0) then
 
          if (if_write) exit reports

--- a/var/da/da_obs_io/da_read_omb_tmp.inc
+++ b/var/da/da_obs_io/da_read_omb_tmp.inc
@@ -456,7 +456,7 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
 #if (WRF_CHEM == 1)
       case ('chem' )
          if (num_obs > 0) then
-          if (chem_cv_options > 1 .and. chem_cv_options < 100) then
+          !if (chem_cv_options > 1 .and. chem_cv_options < 100) then
             do n = 1, num_obs
                read(unit_in,'(2i8)')levels, ifgat
                if (if_write) then
@@ -465,96 +465,61 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
                end if
                do k = 1, levels
                  if (chemicda_opt == 1 .or. chemicda_opt ==2 ) then
-                  read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
-                     kk,l, stn_id, &          ! Station
-                     lat, lon, dummy, &       ! Lat/lon, dummy
+                  read(unit_in,fmt=fmt_chem1, err= 1000)&
+                     kk, stn_id, &       ! Station
+                     lat, lon,   &       ! Lat/lon
                      chem_obs, chem_inv, chem_qc, chem_err, chem_inc
                   if (if_write) &
-                     write(omb_unit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
-                        num, k, stn_id,  &       ! Station
-                        lat, lon, dummy, &       ! Lat/lon, dummy
+                     write(omb_unit,fmt=wrt_chem1, err= 1000)&
+                        stn_id,  &       ! Station
+                        lat, lon,  &          ! Lat/lon
                         chem_obs, chem_inv, chem_qc, chem_err, chem_inc
                  else if (chemicda_opt == 3) then
-                  read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
-                     kk,l, stn_id, &          ! Station
-                     lat, lon, dummy, &       ! Lat/lon, dummy
+                  read(unit_in,fmt=fmt_chem2, err= 1000)&
+                     kk, stn_id, &          ! Station
+                     lat, lon,  &       ! Lat/lon
                      chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
                      chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2
                   if (if_write) &
-                     write(omb_unit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
-                        num, k, stn_id,  &       ! Station
-                        lat, lon, dummy, &       ! Lat/lon, dummy
+                     write(omb_unit,fmt=wrt_chem2, err= 1000)&
+                        stn_id,  &       ! Station
+                        lat, lon, &       ! Lat/lon
                         chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
                         chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2
                  else if (chemicda_opt == 4) then
-                  read(unit_in,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
-                     kk,l, stn_id, &          ! Station
-                     lat, lon, dummy, &       ! Lat/lon, dummy
+                  read(unit_in,fmt=fmt_chem4, err= 1000)&
+                     kk, stn_id, &          ! Station
+                     lat, lon,  &       ! Lat/lon
                      chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
                      chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2, &
                      chem_obs3, chem_inv3, chem_qc3, chem_err3, chem_inc3, &
                      chem_obs4, chem_inv4, chem_qc4, chem_err4, chem_inc4
                   if (if_write) &
-                     write(omb_unit,'(2i8,a5,2f9.2,f17.7,5(2f17.7,i8,2f17.7))', err= 1000)&
-                        num, k, stn_id,  &       ! Station
-                        lat, lon, dummy, &       ! Lat/lon, dummy
+                     write(omb_unit,fmt=wrt_chem4, err= 1000)&
+                        stn_id,  &       ! Station
+                        lat, lon,  &       ! Lat/lon, dummy
                         chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
                         chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2, &
                         chem_obs3, chem_inv3, chem_qc3, chem_err3, chem_inc3, &
                         chem_obs4, chem_inv4, chem_qc4, chem_err4, chem_inc4
                  else if (chemicda_opt == 5) then
-                  read(unit_in,'(2i8,a5,2f9.2,f17.7,6(2f17.7,i8,2f17.7))', err= 1000)&
-                     kk,l, stn_id, &          ! Station
-                     lat, lon, dummy, &       ! Lat/lon, dummy
+                  read(unit_in,fmt=fmt_chem2, err= 1000)&
+                     kk, stn_id, &          ! Station
+                     lat, lon,  &       ! Lat/lon
                      chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
-                     chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2, &
-                     chem_obs3, chem_inv3, chem_qc3, chem_err3, chem_inc3, &
-                     chem_obs4, chem_inv4, chem_qc4, chem_err4, chem_inc4, &
-                     chem_obs5, chem_inv5, chem_qc5, chem_err5, chem_inc5, &
-                     chem_obs6, chem_inv6, chem_qc6, chem_err6, chem_inc6
+                     chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2
                   if (if_write) &
-                     write(omb_unit,'(2i8,a5,2f9.2,f17.7,6(2f17.7,i8,2f17.7))', err= 1000)&
-                        num, k, stn_id,  &       ! Station
-                        lat, lon, dummy, &       ! Lat/lon, dummy
+                     write(omb_unit,fmt=wrt_chem2, err= 1000)&
+                        stn_id,  &       ! Station
+                        lat, lon, &       ! Lat/lon
                         chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
-                        chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2, &
-                        chem_obs3, chem_inv3, chem_qc3, chem_err3, chem_inc3, &
-                        chem_obs4, chem_inv4, chem_qc4, chem_err4, chem_inc4, &
-                        chem_obs5, chem_inv5, chem_qc5, chem_err5, chem_inc5, &
-                        chem_obs6, chem_inv6, chem_qc6, chem_err6, chem_inc6
+                        chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2
 
                  end if
                end do
             end do
 
-          else if (chem_cv_options >= 108) then
-
-           do n = 1, num_obs
-              if (chemicda_opt <= 2) then
-                  read(unit_in, fmt = fmt_chem1, err= 1000)&
-                       kk,  stn_id, &       ! Station
-                       lat, lon,    &       ! Lat/lon
-                       chem_obs, chem_inv, chem_qc, chem_err, chem_inc
-                  if (if_write) &
-                  write(omb_unit, fmt = wrt_chem1, err= 1000)&
-                       stn_id,  lat, lon,     &       ! station, lat/lon
-                       chem_obs, chem_inv, chem_qc, chem_err, chem_inc
-              else if (chemicda_opt == 3 .or. chemicda_opt == 5) then
-                  read(unit_in, fmt = fmt_chem2, err= 1000)&
-                       kk,  stn_id, &       ! Station
-                       lat, lon,    &       ! Lat/lon
-                       chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
-                       chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2
-                  if (if_write) &
-                  write(omb_unit, fmt = wrt_chem2, err= 1000)&
-                       stn_id,  lat, lon,     &       ! station, lat/lon
-                       chem_obs, chem_inv, chem_qc, chem_err, chem_inc, &
-                       chem_obs2, chem_inv2, chem_qc2, chem_err2, chem_inc2
-              end if
-
-           end do ! n = 1, num_obs
-
-          endif !(chem_cv_options >= 100) then
+          !endif !(chem_cv_options >= 100) then
          end if !  if (num_obs > 0) then
 
          if (if_write) exit reports
@@ -562,8 +527,13 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
 
       case ('gas' )
          if (num_obs > 0) then
-          if (chem_cv_options >= 108) then
+          !if (chem_cv_options >= 108) then
            do n = 1, num_obs
+              read(unit_in,'(2i8)')levels, ifgat
+              if (if_write) then
+                 write(omb_unit,'(2i8)')levels, ifgat
+                 num = num + 1
+              end if
               if (chemicda_opt == 4 .or. chemicda_opt == 5) then
                   read(unit_in, fmt = fmt_chem4, err= 1000)&
                        kk,  stn_id, &       ! Station
@@ -581,7 +551,7 @@ subroutine da_read_omb_tmp(filename,unit_in,num,obs_type_in,nc,if_wind_sd)
                        chem_obs4, chem_inv4, chem_qc4, chem_err4, chem_inc4
               end if
            end do   !  do n = 1, num_obs
-          endif     !  if (chem_cv_options >= 108) then
+          !endif     !  if (chem_cv_options >= 108) then
          end if     !  if (num_obs > 0) then
 
          if (if_write) exit reports

--- a/var/da/da_obs_io/da_write_obs_chem_sfc.inc
+++ b/var/da/da_obs_io/da_write_obs_chem_sfc.inc
@@ -98,12 +98,10 @@ subroutine da_write_obs_chem_sfc(it,ob, iv, re)
 
          if (iv%info(chemic_surf)%proc_domain(1,n)) then
             num_obs = num_obs + 1
-            if (chem_cv_options > 1 .and. chem_cv_options < 108) then
              write(ounit,'(2i8)') 1, ifgat
              if (chemicda_opt == 5) then
                write(ounit2,'(2i8)') 1, ifgat
              end if
-            end if !  if (chem_cv_options > 1 .and. chem_cv_options < 108)
 
             ipcc = p_chemsi_pm25
             jpcc = p_chemsi_pm10


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Chem DA, OMB/OMA

SOURCE: Jake Liu (NCAR/MMM)

DESCRIPTION OF CHANGES:
Problem:
PR #1575 breaks ChemDA's omb/oma output.

Solution:
Make write/read omb/oma format consistent

LIST OF MODIFIED FILES:
M       var/da/da_obs_io/da_final_write_obs_gas_sfc.inc
M       var/da/da_obs_io/da_read_omb_tmp.inc
M.      var/da/da_obs_io/da_write_obs_chem_sfc.inc

TESTS CONDUCTED: 
Tested mosaic scheme with chemicda_opt = 1,2,3,4, or 5.

RELEASE NOTE: None.
