### PR TITLE
Use FLUX method as default for 2-m diagnostics with RUC LSM.

### DIFF
--- a/phys/module_sf_sfcdiags_ruclsm.F
+++ b/phys/module_sf_sfcdiags_ruclsm.F
@@ -47,8 +47,8 @@ CONTAINS
 
       LOGICAL :: FLUX
 
-!      flux = .true.
-      flux = .false.
+      flux = .true.
+      !flux = .false.
 
       DO J=jts,jte
         DO I=its,ite


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: 2-m temperature and moisture diagnostics

SOURCE:  Tanya Smirnova, NOAA/ESRL/GSL

DESCRIPTION OF CHANGES:
Change the default diagnostic method for 2 m temperature and mixing ratio to the flux method, which is used in the operational RAPv5/HRRRv4. This change makes the method the same as the WRF code used in operational models at NCEP.

LIST OF MODIFIED FILES: 
module_sf_sfcdiags_ruclsm.F

TESTS CONDUCTED: 
1. Do mods fix problem? Yes.
2. The Jenkins tests are all passing.

RELEASE NOTE: The default method to diagnose 2 m temperature and mixing ratio is changed to the flux method in RUC LSM, the same as used in NCEP operational RAPv5/HRRRv4.
