### PR TITLE
Reduce memory increase from PRs 1567 and 1616

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2988,7 +2988,7 @@ package   nssl_1momlfo    mp_physics==21               -             moist:qv,qc
 package   nssl_2momg      mp_physics==22               -             moist:qv,qc,qr,qi,qs,qg;scalar:qndrop,qnr,qni,qns,qng,qvolg;state:re_cloud,re_ice,re_snow
 package   wsm7scheme      mp_physics==24               -             moist:qv,qc,qr,qi,qs,qg,qh;state:re_cloud,re_ice,re_snow
 package   wdm7scheme      mp_physics==26               -             moist:qv,qc,qr,qi,qs,qg,qh;scalar:qnn,qnc,qnr;state:re_cloud,re_ice,re_snow
-package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa;state:re_cloud,re_ice,re_snow,qnwfa2d,qnifa2d,taod5503d,taod5502d
+package   thompsonaero    mp_physics==28               -             moist:qv,qc,qr,qi,qs,qg;scalar:qni,qnr,qnc,qnwfa,qnifa,qnbca;state:re_cloud,re_ice,re_snow,qnwfa2d,qnifa2d,taod5503d,taod5502d
 package   p3_1category    mp_physics==50               -             moist:qv,qc,qr,qi;scalar:qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
 package   p3_1category_nc mp_physics==51               -             moist:qv,qc,qr,qi;scalar:qnc,qni,qnr,qir,qib;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,refl_10cm,th_old,qv_old
 package   p3_2category    mp_physics==52               -             moist:qv,qc,qr,qi,qi2;scalar:qnc,qni,qnr,qir,qib,qni2,qir2,qib2;state:re_cloud,re_ice,vmi3d,rhopo3d,di3d,vmi3d_2,rhopo3d_2,di3d_2,refl_10cm,th_old,qv_old
@@ -3029,7 +3029,7 @@ package   nssl_1mom_dfi     mp_physics_dfi==19       -             dfi_moist:dfi
 package   nssl_1momlfo_dfi  mp_physics_dfi==21       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg
 package   wsm7scheme_dfi    mp_physics_dfi==24       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   wdm7scheme_dfi    mp_physics_dfi==26       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg,dfi_qh;dfi_scalar:dfi_qnn,dfi_qnc,dfi_qnr;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
-package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
+package   thompsonaero_dfi  mp_physics_dfi==28       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qs,dfi_qg;dfi_scalar:dfi_qni,dfi_qnr,dfi_qnc,dfi_qnwfa,dfi_qnifa,dfi_qnbca;state:dfi_re_cloud,dfi_re_ice,dfi_re_snow
 package   p3_1category_dfi  mp_physics_dfi==50       -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
 package   p3_1category_nc_dfi  mp_physics_dfi==51    -             dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib;state:dfi_re_cloud,dfi_re_ice
 package   p3_2category_dfi  mp_physics_dfi==52    -                dfi_moist:dfi_qv,dfi_qc,dfi_qr,dfi_qi,dfi_qi2;dfi_scalar:dfi_qnc,dfi_qni,dfi_qnr,dfi_qir,dfi_qib,dfi_qni2,dfi_qir2,dfi_qib2;state:dfi_re_cloud,dfi_re_ice

--- a/Registry/registry.new3d_wif
+++ b/Registry/registry.new3d_wif
@@ -9,7 +9,7 @@
 #		The output from real is placed into the scalar arrays.
 ###############################################################################
 
-###   Thompson Water Ice Friendly Aerosols WIF
+###   Thompson Water Ice Black-Carbon Friendly Aerosols WIF (updated in 4.4)
 
 dimspec  wif    2     namelist=num_wif_levels          z     num_wif_levels
 

--- a/Registry/registry.new3d_wif
+++ b/Registry/registry.new3d_wif
@@ -14,7 +14,7 @@
 dimspec  wif    2     namelist=num_wif_levels          z     num_wif_levels
 
 rconfig   integer num_wif_levels    namelist,domains	   1              30      irh    "num_wif_levels" "number of levels in the Thompson Water Ice Friendly Aerosols" ""
-rconfig   integer wif_input_opt     namelist,domains       1              1       irh    "wif_input_opt"  "0=do not process the Water Ice Friendly Aerosol input from metgrid"
+rconfig   integer wif_input_opt     namelist,domains       1              0       irh    "wif_input_opt"  "0=do not process the Water Ice Friendly Aerosol input from metgrid"
 
 state    real       qnwfa_gc       i{wif}j      dyn_em      1        Z     i1         "QNWFA"   "water-friendly aerosol  num concentration"   "# kg-1"
 state    real       qnifa_gc       i{wif}j      dyn_em      1        Z     i1         "QNIFA"   "water-friendly aerosol  num concentration"   "# kg-1"

--- a/Registry/registry.new3d_wif
+++ b/Registry/registry.new3d_wif
@@ -1,4 +1,4 @@
-/##############################################################################
+###############################################################################
 #	This is an example registry.  
 #	It has the necessary pieces to allow a set of input fields to come
 #	into the real program from metgrid.  These fields are assumed to

--- a/Registry/registry.new3d_wif
+++ b/Registry/registry.new3d_wif
@@ -14,7 +14,7 @@
 dimspec  wif    2     namelist=num_wif_levels          z     num_wif_levels
 
 rconfig   integer num_wif_levels    namelist,domains	   1              30      irh    "num_wif_levels" "number of levels in the Thompson Water Ice Friendly Aerosols" ""
-rconfig   integer wif_input_opt     namelist,domains       1              0       irh    "wif_input_opt"  "0=do not process the Water Ice Friendly Aerosol input from metgrid"
+rconfig   integer wif_input_opt     namelist,domains       1              1       irh    "wif_input_opt"  "0=do not process the Water Ice Friendly Aerosol input from metgrid"
 
 state    real       qnwfa_gc       i{wif}j      dyn_em      1        Z     i1         "QNWFA"   "water-friendly aerosol  num concentration"   "# kg-1"
 state    real       qnifa_gc       i{wif}j      dyn_em      1        Z     i1         "QNIFA"   "water-friendly aerosol  num concentration"   "# kg-1"


### PR DESCRIPTION
Reduce memory used by the model from two previous PRs

TYPE: bug fix

KEYWORDS: qnbca, wif_input_opt, package

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR1567 changed default wif_input_opt from 0 to 1, which increased memory use by about 12%. PR1616 added new variable qnbca, but it is not packaged.

Solution:
Change default wif_input_opt option back to 0, and add qnbca to package for mp_physics=28 and its dfi counterpart. Testing the latest release 4.4 code shows a memory reduction (when mp_physics=28 is not used) is down by 11%.

LIST OF MODIFIED FILES: 
M    Registry/Registry.EM_COMMON
M    Registry/registry.new3d_wif

TESTS CONDUCTED: 
1. Do mods fix problem? The fix reduces memory use in the model.
2. The Jenkins tests are all passing.

RELEASE NOTE: 
