### PR TITLE
Fix quality control issue of chemical DA

### DIFF
--- a/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
+++ b/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
@@ -183,11 +183,13 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
 
             ! Quality Control
             ! ----------------
+           if (chem_cv_options >= 108) then
             if (abs(iv % chemic_surf(n) % chem(ichem) % inv) .ge. maxomb(ipm)) then
                 iv % chemic_surf(n) % chem(ichem) % inv   = missing_r
                 iv % chemic_surf(n) % chem(ichem) % qc    = missing
                 iv % chemic_surf(n) % chem(ichem) % error = missing_r
             end if
+           end if
 
          end if    ! good obs
 

--- a/var/da/da_obs_io/da_read_obs_chem_sfc.inc
+++ b/var/da/da_obs_io/da_read_obs_chem_sfc.inc
@@ -85,6 +85,7 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
    allocate ( platform%chem (num_chemic_surf) )
    obs_index = chemic_surf
 
+   if (chem_cv_options >= 108) &
    write(*,'(A,6f7.1)') "da_read_obs_chem_sfc: pm25, pm10, so2, no2, o3, co obs are rejected if >= ", max_pm
 
    imin=0     ! minutes


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Quality control, chemical DA

SOURCE: Jake Liu (NCAR/MMM)

DESCRIPTION OF CHANGES:
Problem:
PR #1575 introduced a new chemical DA option for the MADE-VBS aerosol scheme (chem_cv_options=108).
Ideally this should not change the observation part of the chemical DA code. However, current implementation also modified observation part along with the new option (e.g., obs file format, obs units, quality control).  The New QC check for rejecting obs with omb>maxomb leads to too many obs rejected for the obs file format for other chemical DA options originally implemented in v4.3. 

Solution:
Restrict the new maxomb QC check only for chem_cv_options=108. Also limit a print statement only for chem_cv_options=108. This does not recover exactly the v43 QC for other options, but it is close.

LIST OF MODIFIED FILES:
M       var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
M       var/da/da_obs_io/da_read_obs_chem_sfc.inc

TESTS CONDUCTED: 
The statistic_chem file now has the similar number of good obs for chem_cv_options=20 (case provided in the user's guide) with the fixed code. 

RELEASE NOTE: None.
