### PR TITLE
V4.4 bugfix gas omb

### DIFF
--- a/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
+++ b/var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
@@ -1,6 +1,13 @@
 subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
    !-----------------------------------------------------------------------
-   ! Purpose: TBD    
+   ! Purpose: Compute innovation vectors for surface chemical obs
+   !
+   ! Caution: chem_cv_options == 10 or 20 assumes all six species in [ug/m3]
+   !          chem_cv_options == 108 assumes pm25 and pm10 in [ug/m3], but
+   !                                         so2, no2, o3, co in [ppmv]
+   !          Thus, data QC and obs errors change with the units.
+   ! For input data format, check var/da/da_obs_io/da_read_obs_chem_sfc.inc 
+   ! (Soyoung Ha, Apr-25-2022)
    !-----------------------------------------------------------------------
 
    implicit none
@@ -21,9 +28,10 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
 !  FIXME: It would be better to put this parameter in the namelist.
    real, parameter  :: Lrepr = 3000. !2000.    ! Scaling factor for obs error [meters]
 
-!  Max thresholds of abs(o-b) in pm25,  pm10,  so2,  no2,  o3,  co
-   real,dimension(6):: maxomb = (/100., 100., 0.20, 0.20, 0.20, 20./)
-   real             :: err_o, err_r
+!  For chem_cv_options = 10 or 20, maximum thresholds is 120 except for co, which is 120*1000.
+!  For chem_cv_options = 108, max thresholds of abs(o-b) in pm25,  pm10,  so2,  no2,  o3,  co
+   real,dimension(6):: maxomb = (/100., 100., 0.20, 0.20, 0.20, 20./) ! [ug/m3, ug/m3, ppmv, ppmv, ppmv, ppmv]
+   real             :: err_o, err_r, thresh
 
    if (trace_use) call da_trace_entry("da_get_innov_vector_chem_sfc")
 
@@ -46,6 +54,7 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
       call da_interp_lin_2d (grid%xbchem%chem_ic(:,:,1,ichem),  iv%info(chemic_surf), 1, model_chemic(:,ichem))
       call da_interp_lin_2d (grid%xb    %rho    (:,:,1),        iv%info(chemic_surf), 1, model_rho   (:,ichem))
    end do
+
 
    ! [1.1] Compute prior observations at obs sites
    if (chem_cv_options == 10) then           ! gocart_test
@@ -175,15 +184,24 @@ subroutine da_get_innov_vector_chem_sfc( it, num_qcstat_conv, grid, ob, iv)
              iv % chemic_surf(n) % chem(ichem) % inv = &
              ob % chemic_surf(n) % chem(ichem) - model_chemic_surf(n,ichem)
 
-             ! Observation error specification
+             ! Observation errors ([ug/m3]) 
              err_o = 1.5 + 0.0075 * ob % chemic_surf(n) % chem(ichem)
              err_r = 0.5 * err_o * sqrt(grid%dx/Lrepr)
 
              iv % chemic_surf(n) % chem(ichem) % error = 1.0*sqrt(err_o**2 + err_r**2) ! Ha (GMD2022)
 
+             if (chem_cv_options >= 108 .and. ipm > 2) &    ! gas obs error as 10 percent of obs values
+                 iv % chemic_surf(n) % chem(ichem) % error = ob % chemic_surf(n) % chem(ichem) * 0.10
+
             ! Quality Control
             ! ----------------
-            if (abs(iv % chemic_surf(n) % chem(ichem) % inv) .ge. maxomb(ipm)) then
+            thresh = maxomb(ipm)
+            if (chem_cv_options >= 1 .and. chem_cv_options < 108) then  ! pm and gas species in [ug/m3]
+                thresh = 120.
+                if(ichem.eq.num_chemic_surf) thresh = thresh*1000. ! mg to ug for co
+            endif
+     
+            if (abs(iv % chemic_surf(n) % chem(ichem) % inv) .ge. thresh) then !maxomb(ipm)
                 iv % chemic_surf(n) % chem(ichem) % inv   = missing_r
                 iv % chemic_surf(n) % chem(ichem) % qc    = missing
                 iv % chemic_surf(n) % chem(ichem) % error = missing_r

--- a/var/da/da_chem_sfc/da_print_stats_chem_sfc.inc
+++ b/var/da/da_chem_sfc/da_print_stats_chem_sfc.inc
@@ -16,12 +16,28 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
    type (stats_chem_sfc_type), intent(in)    :: stats
    integer,  intent(in), optional    :: ichem
 
+   ! local variables (Ha)
+   integer :: ipc
+   character*64   :: str_pm2,str_pm1,str_so2,str_no2,str_o3,str_co
+   str_pm2 = 'pm25 (ug/m3)     n         k    '
+   str_pm1 = 'pm10 (ug/m3)     n         k    '
+   str_so2 = 'so2 (ug/m3)     n         k    '
+   str_no2 = 'no2 (ug/m3)     n         k    '
+   str_o3  = 'o3 (ug/m3)     n         k    '
+   str_co  = 'co (ug/m3)     n         k    '
+
+   if (chem_cv_options >= 108) then
+   str_so2 = 'so2 (ppmv)      n         k    '
+   str_no2 = 'no2 (ppmv)      n         k    '
+   str_o3  = 'o3 (ppmv)      n         k    '
+   str_co  = 'co (ppmv)      n         k    '
+   endif
+
    if (trace_use_dull) call da_trace_entry("da_print_stats_chem_sfc")
 
    if (chemicda_opt == 1 ) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'pm25 (ug/kg)     n         k    '
+      '   var             ', str_pm2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -34,8 +50,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (chemicda_opt == 2 ) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'pm10 (ug/kg)     n         k    '
+      '   var             ', str_pm1
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -49,8 +64,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
    else if (chemicda_opt == 3) then
    if (present(ichem).and.ichem == PARAM_FIRST_SCALAR) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'pm25 (ug/kg)     n         k    '
+      '   var             ', str_pm2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -63,8 +77,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+1) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'pm10 (ug/kg)     n         k    '
+      '   var             ', str_pm1
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -80,8 +93,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
    else if (chemicda_opt == 4) then
    if (present(ichem).and.ichem == PARAM_FIRST_SCALAR) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'so2 (ug/kg)     n         k    '
+      '   var             ', str_so2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -94,8 +106,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+1) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'no2 (ug/kg)     n         k    '
+      '   var             ', str_no2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -108,8 +119,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+2) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'o3 (ug/kg)     n         k    '
+      '   var             ', str_o3
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -122,8 +132,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+3) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'co (ug/kg)     n         k    '
+      '   var             ', str_co
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -139,8 +148,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
    else if (chemicda_opt == 5) then
    if (present(ichem).and.ichem == PARAM_FIRST_SCALAR) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'pm25 (ug/kg)     n         k    '
+      '   var             ', str_pm2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -153,8 +161,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+1) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'pm10 (ug/kg)     n         k    '
+      '   var             ', str_pm1
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -167,8 +174,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+2) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'so2 (ug/kg)     n         k    '
+      '   var             ', str_so2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -181,8 +187,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+3) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'no2 (ug/kg)     n         k    '
+      '   var             ', str_no2
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -195,8 +200,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+4) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'o3 (ug/kg)     n         k    '
+      '   var             ', str_o3
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1
@@ -209,8 +213,7 @@ use module_state_description, only : num_chem, PARAM_FIRST_SCALAR               
 
    else if (present(ichem).and.ichem == PARAM_FIRST_SCALAR+5) then
    write(unit=stats_unit, fmt='(2a/)') &
-      '   var             ', &
-      'co (ug/kg)     n         k    '
+      '   var             ', str_co
    write(unit=stats_unit, fmt='(a,i16)') &
       '  Number: ', nchem
    if (nchem < 1) nchem = 1

--- a/var/da/da_obs_io/da_read_obs_chem_sfc.inc
+++ b/var/da/da_obs_io/da_read_obs_chem_sfc.inc
@@ -5,6 +5,9 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
    !
    ! History: 03/2019  Creation (Wei Sun)
    !          06/2021  Add maximum thresholds for each species (Soyoung Ha)
+   ! Caution: chem_cv_options == 10 or 20 assumes all six species in [ug/m3]
+   !          chem_cv_options == 108 assumes pm25 and pm10 in [ug/m3], but 
+   !                                         so2, no2, o3, co in [ppmv]
    !-------------------------------------------------------------------------
 
    implicit none
@@ -13,9 +16,9 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
    character(len=*),  intent(in)    :: filename
    type(domain),     intent(in)     :: grid     ! first guess state.
 
-   ! Maximum thresholds for observation values - treat as missing above these values
+   ! chem_cv_options == 108: Maximum thresholds for observation values - treat as missing above these values
    ! FIXME: We may want to put these maximum thresholds in namelist later.
-   real, dimension(6)  :: max_pm = (/500.,999.,2.0, 2.0, 2.0, 50./)
+   real, dimension(6)  :: max_pm = (/500.,999.,2.0, 2.0, 2.0, 50./)  ! [ug/m3, ug/m3, ppmv, ppmv, ppmv, ppmv]
    real                :: pm25, pm10, so2, no2, o3, co
 
    character (len =   6)        :: SiteID
@@ -85,7 +88,6 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
    allocate ( platform%chem (num_chemic_surf) )
    obs_index = chemic_surf
 
-   write(*,'(A,6f7.1)') "da_read_obs_chem_sfc: pm25, pm10, so2, no2, o3, co obs are rejected if >= ", max_pm
 
    imin=0     ! minutes
 
@@ -284,6 +286,8 @@ subroutine da_read_obs_chem_sfc (iv, filename, grid)
 
          ! Sanity check
          !!!!!!!!!!!!!!!!!!!
+         write(*,'(A,6f7.1)') &
+         "da_read_obs_chem_sfc: pm25, pm10 [ug/m3], so2, no2, o3, co [ppmv] obs are rejected if >= ", max_pm
          do ichem = PARAM_FIRST_SCALAR, num_chemic_surf
             ipm = ichem - PARAM_FIRST_SCALAR + 1
             if (platform%chem(ichem)%inv<0.or.abs(platform%chem(ichem)%inv)>=max_pm(ipm)) then

--- a/var/da/da_obs_io/da_scan_obs_chem_sfc.inc
+++ b/var/da/da_obs_io/da_scan_obs_chem_sfc.inc
@@ -6,6 +6,9 @@ subroutine da_scan_obs_chem_sfc (iv, filename, grid)
    ! History: 03/2019  Creation (Wei Sun)
    !
    !          06/2021  Add maximum thresholds for each species (Soyoung Ha)
+   ! Caution: chem_cv_options == 10 or 20 assumes all six species in [ug/m3]
+   !          chem_cv_options == 108 assumes pm25 and pm10 in [ug/m3], but
+   !                                         so2, no2, o3, co in [ppmv]
    !-------------------------------------------------------------------------
 
    implicit none
@@ -14,9 +17,9 @@ subroutine da_scan_obs_chem_sfc (iv, filename, grid)
    character(len=*),  intent(in)    :: filename
    type(domain),     intent(in)     :: grid     ! first guess state.
 
-   ! Maximum thresholds for observation values - treat as missing above these values
+   ! chem_cv_options == 108: Maximum thresholds for observation values - treat as missing above these values
    ! FIXME: We may want to put these maximum thresholds in namelist later.
-   real, dimension(6)  :: max_pm = (/500.,999.,2.0, 2.0, 2.0, 50./)
+   real, dimension(6)  :: max_pm = (/500.,999.,2.0, 2.0, 2.0, 50./)  ! [ug/m3, ug/m3, ppmv, ppmv, ppmv, ppmv]
    real                         :: pm25, pm10, so2, no2, o3, co
 
    character (len =   6)        :: SiteID


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ChemDA for gas species with different units

SOURCE: Soyoung Ha (MMM/NCAR)

DESCRIPTION OF CHANGES:
Problem:
As pointed out in PR #1724, there were inconsistent data units for gas species depending on test data (meaning chem_cv_options). Thus, the codes related to observations should be treated differently: Data QC based on innovations (o-b) and observation error specification cannot be uniformly applied to all chem_cv_options.
Also, the final output ("statistics_chem") showed wrong units for all six chem species.

Solution:
Data units are clarified in the codes related to observations.
Threshold values for omb are set differently for different chem_cv_options, so are the obs errors for gas species.

LIST OF MODIFIED FILES: 
var/da/da_chem_sfc/da_get_innov_vector_chem_sfc.inc
var/da/da_obs_io/da_read_obs_chem_sfc.inc
var/da/da_obs_io/da_scan_obs_chem_sfc.inc
var/da/da_chem_sfc/da_print_stats_chem_sfc.inc

TESTS CONDUCTED: 
Tests with chem_cv_options=20 and 108 showed that statistics_chem looked good for both options.
Are the Jenkins tests all passing?

RELEASE NOTE: ChemDA can treat different units for gas species.
