### PR TITLE
Stop the model if mp_physics is set to 32 for the time being

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2556,6 +2556,21 @@
      END DO
 
 !-----------------------------------------------------------------------
+! Stop the model if full_khain_lynn or mp_physics = 32 is selected
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec%mp_physics(i) .eq. full_khain_lynn) THEN
+              oops = oops + 1
+         wrf_err_message = '--- ERROR: full bin spectral microphysics should not be used '
+         CALL wrf_message ( wrf_err_message )
+         wrf_err_message = '--- ERROR: use fast version instead (mp_physics=30)'
+         CALL wrf_message ( wrf_err_message )
+         count_fatal_error = count_fatal_error + 1
+         END IF
+      ENDDO      ! Loop over domains
+
+!-----------------------------------------------------------------------
 !  DJW Check that we're not using ndown and vertical nesting.
 !-----------------------------------------------------------------------
      DO i=1,model_config_rec%max_dom


### PR DESCRIPTION
TYPE: bug fix, feature removed

KEYWORDS: Full SBM scheme, do not use

SOURCE: internal, Koby Shpund of PNNL

DESCRIPTION OF CHANGES:
Problem:
The developers of full spectral bin microphysics scheme requested not to use this full SBM scheme for the time being site 'degraded' results.

Solution:
A check is put into check_a_mundo to stop the model if this scheme is selected.

LIST OF MODIFIED FILES: 
M    share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. The code stops when mp_physics is set to 32.
2. Are the Jenkins tests all passing?

RELEASE NOTE: Due to degraded performance, the full spectral bin microphysics should not be used for the time being.
