### PR TITLE
VEGPARM.TBL update for NLCD40 Landuse crash

### DIFF
--- a/run/VEGPARM.TBL
+++ b/run/VEGPARM.TBL
@@ -181,11 +181,27 @@ NATURAL
 CROP
 12
 LCZ_1
-24
+31
 LCZ_2
-26
+32
 LCZ_3
-99
+33
+LCZ_4
+34
+LCZ_5
+35
+LCZ_6
+36
+LCZ_7
+37
+LCZ_8
+38
+LCZ_9
+39
+LCZ_10
+40
+LCZ_11
+41
 Vegetation Parameters
 USGS-RUC
 28,1, 'ALBEDO    Z0   LEMI     PC   SHDFAC IFOR   RS      RGL      HS      SNUP    LAI    MAXALB'


### PR DESCRIPTION
WRFv4.4 crashes upon LSM initialization when NLCD40 landuse dataset is used because of the VEGPARM tables settings.

TYPE: bug fix

KEYWORDS: VEGPARM.TBL, NLCD40, LCZ_1, NUDAP

SOURCE: Robert Gilliam, US EPA

DESCRIPTION OF CHANGES:
Problem:
WRFv4.4 crashes when reading the VEGPARM.TBL file because of the the LCZ_* specs at the end of the main NLCD40 table entries.

Solution:
We just copied the values used for MODIS since the NLCD40 is a blend of US NLCD and MODIS.

ISSUE: For use when this PR closes an issue.
Fixes https://github.com/wrf-model/WRF/pull/123

LIST OF MODIFIED FILES: VEGPARM.TBL

TESTS CONDUCTED:

Does the mode fix the problem: Yes. We ran a full 2018 simulation at 12 km CONUS and 108 km N. Hemisphere scales and verified this works.
The Jenkins tests have passed.

RELEASE NOTE: VEGPARM.TBL updated for NLCD40 landuse case to work with recent updates of the LSM initialization that reads the file.