### PR TITLE
Add gocart_dust dependency to mosaic_addemiss, necessary for source_du

### DIFF
--- a/chem/depend.chem
+++ b/chem/depend.chem
@@ -229,7 +229,7 @@ module_mosaic_sect_intr.o: module_mosaic_coag1d.o module_mosaic_coag3d.o module_
 
 module_mosaic_aerdynam_intr.o: module_mosaic_sect_intr.o module_mosaic_aerchem_intr.o
 
-module_mosaic_addemiss.o: module_data_mosaic_asect.o module_data_sorgam.o
+module_mosaic_addemiss.o: module_data_mosaic_asect.o module_data_sorgam.o module_gocart_dust.o
 
 module_dep_simple.o: module_data_sorgam.o module_aerosols_soa_vbs.o
 


### PR DESCRIPTION
Add necessary dependency for gocart dust emissions from mosaic

TYPE: bug fix

KEYWORDS:gocart, mosaic_addemiss, dependency

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem: Would not compile, missing dependency

Solution:
added module_gocart_dust to depend.chem for module_mosaic_addemiss

ISSUE: https://forum.mmm.ucar.edu/phpBB3/viewtopic.php?f=83&t=11458&p=25494#p25494

LIST OF MODIFIED FILES: 

M    chem/depend.com

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: add missing dependency
