### PR TITLE
Stop users from using full SBM for the time being

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2556,6 +2556,21 @@
      END DO
 
 !-----------------------------------------------------------------------
+! Stop the model if full_khain_lynn or mp_physics = 32 is selected
+!-----------------------------------------------------------------------
+      DO i = 1, model_config_rec % max_dom
+         IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
+         IF ( model_config_rec%mp_physics(i) .eq. full_khain_lynn) THEN
+              oops = oops + 1
+         wrf_err_message = '--- ERROR: full bin spectral microphysics should not be used '
+         CALL wrf_message ( wrf_err_message )
+         wrf_err_message = '--- ERROR: use fast version instead (mp_physics=30)'
+         CALL wrf_message ( wrf_err_message )
+         count_fatal_error = count_fatal_error + 1
+         END IF
+      ENDDO      ! Loop over domains
+
+!-----------------------------------------------------------------------
 !  DJW Check that we're not using ndown and vertical nesting.
 !-----------------------------------------------------------------------
      DO i=1,model_config_rec%max_dom


### PR DESCRIPTION
TYPE: bug fix, text only

KEYWORDS: full spectral bin microphysics, disable its use

SOURCE: J. Shpund, PNNL

DESCRIPTION OF CHANGES:
Problem:
The full spectral bin microphysics (mp_physics = 32) appears to be out of date, and it has significantly degraded performance.

Solution:
The contributors hence recommended not to use the full SBM for the time being. Use the fast version instead (mp_physics=30). A stop is added if the model detects the use of the full SBM.

LIST OF MODIFIED FILES: 
M     share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. The model will stop if mp_physics is set to 32
2. Are the Jenkins tests all passing?

RELEASE NOTE: It is recommended not to use the full spectral bin microphysics until it is updated. Use the fast version instead.
