### PR TITLE
configure: check nc-config and nf-config

### DIFF
--- a/configure
+++ b/configure
@@ -220,29 +220,28 @@ export NETCDF
 export NETCDF4
 export USENETCDFPAR
 
+# Check NetCDF C libaray files
+if [ -f "$NETCDF/lib/libnetcdf.a" ] || [ -f "$NETCDF/lib/libnetcdf.so" ] || [ -f "$NETCDF/lib/libnetcdf.dll.a" ] ; then
+    USENETCDF="-lnetcdf"
+else
+    USENETCDF=""
+fi
+export USENETCDF=$USENETCDF
+
+# Check NetCDF Fortran library files, assuming both C and Fortran libraries
+# are installed in the same location set in environment variable NETCDF.
+echo "Checking NetCDF Fortran library under dir: $NETCDF"
+if [ -f "$NETCDF/lib/libnetcdff.a" ] ||  [ -f "$NETCDF/lib/libnetcdff.so" ] || [ -f "$NETCDF/lib/libnetcdff.dll.a" ] ; then
+   USENETCDFF="-lnetcdff"
+else
+   USENETCDFF=""
+fi
+export USENETCDFF=$USENETCDFF
+
 if  test -z "$NETCDF_classic"  ; then
   export NETCDF4=1
 else
   unset NETCDF4
-fi
-
-USENETCDFF=""
-USENETCDF=""
-if [ -n "$NETCDF" ] ; then
-  echo "Will use NETCDF in dir: $NETCDF"
-# Oh UNIDATA, why make it so hard ...
-  if [ -f "$NETCDF/lib/libnetcdff.a" -o -f "$NETCDF/lib/libnetcdff.so" -o -f "$NETCDF/lib/libnetcdff.dll.a" ] ; then
-    USENETCDFF="-lnetcdff"
-  else
-    USENETCDFF=" "
-  fi
-  if [ -f "$NETCDF/lib/libnetcdf.a" -o -f "$NETCDF/lib/libnetcdf.so" -o -f "$NETCDF/lib/libnetcdf.dll.a" ] ; then
-    USENETCDF="-lnetcdf"
-  else
-    USENETCDF=" "
-  fi
-  export USENETCDF=$USENETCDF
-  export USENETCDFF=$USENETCDFF
 fi
 
 # If the user asked for classic netcdf, acquiesce to the request.

--- a/configure
+++ b/configure
@@ -238,36 +238,34 @@ else
 fi
 export USENETCDFF=$USENETCDFF
 
-if  test -z "$NETCDF_classic"  ; then
-  export NETCDF4=1
-else
-  unset NETCDF4
+nf_config="$NETCDF/bin/nf-config"
+if ! [ -x $nf_config ] ; then
+   echo
+   echo "A valid NetCDF command 'nf-confg' could not be found under"
+   echo "  $NETCDF"
+   echo "Please set a valid install path of NetCDF library in environment"
+   echo "variable NETCDF. Abort."
+   echo
+   exit
 fi
 
 # If the user asked for classic netcdf, acquiesce to the request.
-
-ans="`which nf-config`"
-status="$?"
-if [ "$ans" = "nf-config:" -o "$ans" = "" -o "$status" != "0" ] ; then
-    export NETCDF_classic=1
-    unset NETCDF4
-else
-  if [ -n "$NETCDF_classic" ] ; then
-    if [ $NETCDF_classic -eq 1 ] ; then
+if [ -n "$NETCDF_classic" ] ; then
+   if [ $NETCDF_classic -eq 1 ] ; then
       unset  NETCDF4
-    else
+   else
       unset  NETCDF_classic
       export NETCDF4=1
-    fi
-  else
-    if [ "`nf-config --has-nc4`" = "yes" ] ; then
+   fi
+else
+   has_nc4=`$nf_config --has-nc4`
+   if test "x$has_nc4" = xyes ; then
       unset  NETCDF_classic
       export NETCDF4=1
-    else
+   else
       export NETCDF_classic=1
       unset  NETCDF4
-    fi
-  fi
+   fi
 fi
 
 if [ -z "$HDF5_PATH" ] ; then HDF5_PATH=''; fi
@@ -278,8 +276,8 @@ if [ -z "$CURL_PATH" ] ; then CURL_PATH=''; fi
 if [ -n "$NETCDF4" ] ; then
   if [ $NETCDF4 -eq 1 ] ; then
     DEP_LIB_PATH=''
-    if [ -f $NETCDF/bin/nf-config ] ; then
-      nx_config="$NETCDF/bin/nf-config --flibs"
+    if [ -f $nf_config ] ; then
+      nx_config="$nf_config --flibs"
       DEP_LIB_PATH="`$nx_config | awk '{for(i=1;i<=NF;i++){if(match($i, /-L.*/)) {print $i} } }'`"
       CURL="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lcurl") {print $i} } }'`"
       GPFS="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lgpfs") {print $i} } }'`"

--- a/configure
+++ b/configure
@@ -171,6 +171,11 @@ if [ -z "$NETCDF" ] ; then
   exit 5
 fi
 
+# supersede env NETCDFPAR over NETCDF
+if [ -n "$NETCDFPAR" ] ; then
+   NETCDF="$NETCDFPAR"
+fi
+
 nc_config="$NETCDF/bin/nc-config"
 if ! [ -x $nc_config ] ; then
    echo
@@ -183,7 +188,6 @@ fi
 
 PROBS=FALSE
 if [ -n "$NETCDFPAR" ] ; then
-  NETCDF="$NETCDFPAR"
   if [ ! -e $nc_config ] ; then
     PROBS=TRUE
   else

--- a/configure
+++ b/configure
@@ -179,9 +179,9 @@ fi
 nc_config="$NETCDF/bin/nc-config"
 if ! [ -x $nc_config ] ; then
    echo
-   echo A valid NetCDF command 'nc-confg' could not be found. Please set a
-   echo valid installation path of NetCDF libraries in environment variable
-   echo NETCDF. Abort.
+   echo "A valid NetCDF command 'nc-confg' could not be found. Please set a"
+   echo "valid installation path of NetCDF libraries in environment variable"
+   echo "NETCDF. Abort."
    echo
    exit
 fi
@@ -192,8 +192,10 @@ if [ -n "$NETCDFPAR" ] ; then
    nc_has_parallel4=`$nc_config --has-parallel4`
    if test "x$nc_has_parallel4" != xyes ; then
       echo
-      echo NETCDFPAR is set but the NetCDF library under $NETCDFPAR is not
-      echo built with parallel NetCDF-4 I/O feature enabled. Abort.
+      echo "NETCDFPAR is set but the NetCDF library under"
+      echo "   $NETCDFPAR"
+      echo "is not built with parallel NetCDF-4 I/O feature enabled."
+      echo "Abort."
       echo
       exit
    fi
@@ -242,9 +244,10 @@ nf_config="$NETCDF/bin/nf-config"
 if ! [ -x $nf_config ] ; then
    echo
    echo "A valid NetCDF command 'nf-confg' could not be found under"
-   echo "  $NETCDF"
-   echo "Please set a valid install path of NetCDF library in environment"
-   echo "variable NETCDF. Abort."
+   echo "   $NETCDF"
+   echo "Please set a valid installation path of NetCDF library in"
+   echo "environment variable NETCDF. Note both NetCDF-C and NetCDF-Fortran"
+   echo "libraries must be installed in the same location. Abort."
    echo
    exit
 fi

--- a/configure
+++ b/configure
@@ -159,6 +159,18 @@ if test -n "$PERL" ; then
     
 fi
 
+# WRF requires env variable NETCDF to be set by users
+if [ -z "$NETCDF" ] ; then
+  echo ' '
+  echo '**********************************************************************'
+  echo ' Environment variable NETCDF is not set or empty.'
+  echo ' Please set NETCDF to the installation path of NetCDF libraries.'
+  echo ' Stopping'
+  echo '**********************************************************************'
+  echo ' '
+  exit 5
+fi
+
 if [ -e $NETCDF/bin/nc-config ] ; then
   ncversion=`nc-config --version | awk '{print $2}'` 
 else
@@ -198,16 +210,6 @@ if [ -n "$NETCDFPAR" ] ; then
   export USENETCDFPAR
 fi
 
-if  test -z "$NETCDF"  ; then
-  echo ' '
-  echo '*****************************************************************************'
-  echo 'No environment variable NETCDF set.'
-  echo 'Stopping'
-  echo '*****************************************************************************'
-  echo ' '
-  exit 5
-fi
-
 if  test -z "$NETCDF_classic"  ; then
   export NETCDF4=1
 else
@@ -231,14 +233,6 @@ if [ -n "$NETCDF" ] ; then
   fi
   export USENETCDF=$USENETCDF
   export USENETCDFF=$USENETCDFF
-else
-  echo ' '
-  echo '*****************************************************************************'
-  echo 'No environment variable NETCDF set.'
-  echo 'Stopping'
-  echo '*****************************************************************************'
-  echo ' '
-  exit 6
 fi
 
 # If the user asked for classic netcdf, acquiesce to the request.

--- a/configure
+++ b/configure
@@ -171,19 +171,23 @@ if [ -z "$NETCDF" ] ; then
   exit 5
 fi
 
-if [ -e $NETCDF/bin/nc-config ] ; then
-  ncversion=`nc-config --version | awk '{print $2}'` 
-else
-  ncversion=OLD
+nc_config="$NETCDF/bin/nc-config"
+if ! [ -x $nc_config ] ; then
+   echo
+   echo A valid NetCDF command 'nc-confg' could not be found. Please set a
+   echo valid installation path of NetCDF libraries in environment variable
+   echo NETCDF. Abort.
+   echo
+   exit
 fi
 
 PROBS=FALSE
 if [ -n "$NETCDFPAR" ] ; then
   NETCDF="$NETCDFPAR"
-  if [ ! -e $NETCDF/bin/nc-config ] ; then
+  if [ ! -e $nc_config ] ; then
     PROBS=TRUE
   else
-    ncversion=`nc-config --version | awk '{print $2}'`
+    ncversion=`$nc_config --version | awk '{print $2}'`
     ncversiona=`echo $ncversion | cut -c 1`
     ncversionb=`echo $ncversion | cut -c 3`
     ncversionc=`echo $ncversion | cut -c 5`
@@ -276,8 +280,8 @@ if [ -n "$NETCDF4" ] ; then
       GPFS="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lgpfs") {print $i} } }'`"
     fi
     if [ "$DEP_LIB_PATH" = '' ] ; then
-      if [ -f $NETCDF/bin/nc-config ] ; then
-        nx_config="$NETCDF/bin/nc-config --libs"
+      if [ -f $nc_config ] ; then
+        nx_config="$nc_config --libs"
         DEP_LIB_PATH="`$nx_config | awk '{for(i=1;i<=NF;i++){if(match($i, /-L.*/)) {print $i} } }'`"
         CURL="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lcurl") {print $i} } }'`"
         GPFS="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lgpfs") {print $i} } }'`"
@@ -906,10 +910,10 @@ EOF
       echo "           Fortran compiler is $SFC_arch"
       echo "              It will build in $netcdf_arch"
       echo " "
-      if [ -e $NETCDF/bin/nc-config ] ; then
+      if [ -e $nc_config ] ; then
         echo "NetCDF version: ${ncversion}"
-        echo "Enabled NetCDF-4/HDF-5: `nc-config --has-nc4`"
-        echo "NetCDF built with PnetCDF: `nc-config --has-pnetcdf`"
+        echo "Enabled NetCDF-4/HDF-5: `$nc_config --has-nc4`"
+        echo "NetCDF built with PnetCDF: `$nc_config --has-pnetcdf`"
         if [ "$USENETCDFPAR" == "1" ] ; then
           echo "Using parallel NetCDF via NETCDFPAR option"
         fi

--- a/configure
+++ b/configure
@@ -275,14 +275,11 @@ if [ -z "$CURL_PATH" ] ; then CURL_PATH=''; fi
 
 if [ -n "$NETCDF4" ] && [ $NETCDF4 -eq 1 ] ; then
     DEP_LIB_PATH=''
-    if [ -f $nf_config ] ; then
-      nx_config="$nf_config --flibs"
-      DEP_LIB_PATH="`$nx_config | awk '{for(i=1;i<=NF;i++){if(match($i, /-L.*/)) {print $i} } }'`"
-      CURL="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lcurl") {print $i} } }'`"
-      GPFS="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lgpfs") {print $i} } }'`"
-    fi
+    nx_config="$nf_config --flibs"
+    DEP_LIB_PATH="`$nx_config | awk '{for(i=1;i<=NF;i++){if(match($i, /-L.*/)) {print $i} } }'`"
+    CURL="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lcurl") {print $i} } }'`"
+    GPFS="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lgpfs") {print $i} } }'`"
     if [ "$DEP_LIB_PATH" = '' ] ; then
-      if [ -f $nc_config ] ; then
         nx_config="$nc_config --libs"
         DEP_LIB_PATH="`$nx_config | awk '{for(i=1;i<=NF;i++){if(match($i, /-L.*/)) {print $i} } }'`"
         CURL="`$nx_config | awk '{for(i=1;i<=NF;i++){if($i == "-lcurl") {print $i} } }'`"
@@ -293,7 +290,6 @@ if [ -n "$NETCDF4" ] && [ $NETCDF4 -eq 1 ] ; then
         if [ "$GPFS" != '' -a  "$GPFS_PATH" = '' ] ; then
            GPFS_PATH="DEFAULT"
         fi
-      fi
     fi
     for P in "$HDF5_PATH" "$ZLIB_PATH" "$GPFS_PATH" "$CURL_PATH"
     do
@@ -911,15 +907,13 @@ EOF
       echo "           Fortran compiler is $SFC_arch"
       echo "              It will build in $netcdf_arch"
       echo " "
-      if [ -e $nc_config ] ; then
-        echo "NetCDF version: ${ncversion}"
-        echo "Enabled NetCDF-4/HDF-5: `$nc_config --has-nc4`"
-        echo "NetCDF built with PnetCDF: `$nc_config --has-pnetcdf`"
-        if [ "$USENETCDFPAR" == "1" ] ; then
-          echo "Using parallel NetCDF via NETCDFPAR option"
-        fi
-        echo " "
+      echo "NetCDF version: ${ncversion}"
+      echo "Enabled NetCDF-4/HDF-5: `$nc_config --has-nc4`"
+      echo "NetCDF built with PnetCDF: `$nc_config --has-pnetcdf`"
+      if [ "$USENETCDFPAR" == "1" ] ; then
+         echo "Using parallel NetCDF via NETCDFPAR option"
       fi
+      echo " "
     fi
     echo
   fi

--- a/configure
+++ b/configure
@@ -314,7 +314,7 @@ if [ -n "$NETCDF4" ] && [ $NETCDF4 -eq 1 ] ; then
       n=`echo $buff | wc -w`
       lastword=`echo "$buff" | cut -d' ' -f$n | sed 's/\/$//'`
       c="`echo $lastword | cut -c1`"
-      if [ "$c" == "/" ] ; then
+      if [ "$c" = "/" ] ; then
          NETCDF=$lastword
       else
         c="`echo $lastword | cut -c1-2`"
@@ -913,7 +913,7 @@ EOF
       echo "NetCDF version: ${ncversion}"
       echo "Enabled NetCDF-4/HDF-5: `$nc_config --has-nc4`"
       echo "NetCDF built with PnetCDF: `$nc_config --has-pnetcdf`"
-      if [ "$USENETCDFPAR" == "1" ] ; then
+      if [ "$USENETCDFPAR" = "1" ] ; then
          echo "Using parallel NetCDF via NETCDFPAR option"
       fi
       echo " "

--- a/configure
+++ b/configure
@@ -186,37 +186,39 @@ if ! [ -x $nc_config ] ; then
    exit
 fi
 
-PROBS=FALSE
+ncversion=`$nc_config --version | cut -d' ' -f2`
+# check if parallel I/O feature is enabled in NetCDF library
 if [ -n "$NETCDFPAR" ] ; then
-  if [ ! -e $nc_config ] ; then
-    PROBS=TRUE
-  else
-    ncversion=`$nc_config --version | awk '{print $2}'`
-    ncversiona=`echo $ncversion | cut -c 1`
-    ncversionb=`echo $ncversion | cut -c 3`
-    ncversionc=`echo $ncversion | cut -c 5`
-    ncversiona=`expr $ncversiona \* 100`
-    ncversionb=`expr $ncversionb \* 10`
-    ncversionabc=`expr $ncversiona   + $ncversionb`
-    ncversionabc=`expr $ncversionabc + $ncversionc`
-    if [ $ncversionabc -lt 474 ] ; then
-      PROBS=TRUE
-    fi
-  fi
-  if [ "$PROBS" == "TRUE" ] ; then
-    echo
-    echo Cannot activate NETCDFPAR with this version of NetCDF: $ncversion
-    echo You need NetCDF version 4.7.4 or newer
-    echo Use a newer version of NetCDF, or unset the env variable NETCDFPAR
-    echo
-    exit
-  fi
-  NETCDF4="1"
-  USENETCDFPAR="1"
-  export NETCDF
-  export NETCDF4
-  export USENETCDFPAR
+   nc_has_parallel4=`$nc_config --has-parallel4`
+   if test "x$nc_has_parallel4" != xyes ; then
+      echo
+      echo NETCDFPAR is set but the NetCDF library under $NETCDFPAR is not
+      echo built with parallel NetCDF-4 I/O feature enabled. Abort.
+      echo
+      exit
+   fi
+   # WRF requires NetCDF version 4.7.4 when using parallel NetCDF-4 feature
+   ncversiona=`echo $ncversion | cut -c 1`
+   ncversionb=`echo $ncversion | cut -c 3`
+   ncversionc=`echo $ncversion | cut -c 5`
+   ncversiona=`expr $ncversiona \* 100`
+   ncversionb=`expr $ncversionb \* 10`
+   ncversionabc=`expr $ncversiona   + $ncversionb`
+   ncversionabc=`expr $ncversionabc + $ncversionc`
+   if [ $ncversionabc -lt 474 ] ; then
+      echo
+      echo Cannot activate NETCDFPAR with this version of NetCDF: $ncversion
+      echo You need NetCDF version 4.7.4 or newer
+      echo Use a newer version of NetCDF, or unset the env variable NETCDFPAR
+      echo
+      exit
+   fi
+   USENETCDFPAR="1"
 fi
+NETCDF4="1"
+export NETCDF
+export NETCDF4
+export USENETCDFPAR
 
 if  test -z "$NETCDF_classic"  ; then
   export NETCDF4=1

--- a/configure
+++ b/configure
@@ -273,8 +273,7 @@ if [ -z "$ZLIB_PATH" ] ; then ZLIB_PATH=''; fi
 if [ -z "$GPFS_PATH" ] ; then GPFS_PATH=''; fi
 if [ -z "$CURL_PATH" ] ; then CURL_PATH=''; fi
 
-if [ -n "$NETCDF4" ] ; then
-  if [ $NETCDF4 -eq 1 ] ; then
+if [ -n "$NETCDF4" ] && [ $NETCDF4 -eq 1 ] ; then
     DEP_LIB_PATH=''
     if [ -f $nf_config ] ; then
       nx_config="$nf_config --flibs"
@@ -345,7 +344,6 @@ if [ -n "$NETCDF4" ] ; then
       DEP_LIB_PATH=`echo $DEP_LIB_PATH | sed 's/\/$//'`
     fi
     DEP_LIB_PATH="`echo $DEP_LIB_PATH | awk -v VAR=-L$NETCDF/lib '{for(i=1;i<=NF;i++){if ($i != VAR ) {print $i} } }'`"
-  fi
 fi
 
 if [ -n "$PNETCDF" ] ; then


### PR DESCRIPTION
Fix the use of nc-config and nf-config.

TYPE: bug fix

KEYWORDS: nc-config, nf-config

SOURCE: Wei-keng Liao

DESCRIPTION OF CHANGES:
Problem: Sometimes $NETCDF/bin/nc-config  is used and others nc-config. The same for nf-config. Error messages below appear when the folder of `nc-config` and `nf-config` is not in the user's env PATH.
```
configure: line 163: nc-config: command not found
configure: line 174: nc-config: command not found
expr: syntax error: unexpected argument ‘100’
expr: syntax error: unexpected argument ‘10’
expr: syntax error: missing argument after ‘+’
expr: syntax error: missing argument after ‘+’
configure: line 182: [: -lt: unary operator expected
...
NetCDF version: 
configure: line 917: nc-config: command not found
Enabled NetCDF-4/HDF-5: 
configure: line 918: nc-config: command not found
```

Solution:
* Use 2 variables nc_config and nf_config
* Requires both NetCDF C and Fortran libraries installed in the same location set in env variable NETCDF.
* Add a check for whether NetCDF is built with parallel I/O enabled by calling `nc-config --has-parallel4`
* Improve error messages

LIST OF MODIFIED FILES: configure

TESTS CONDUCTED: 
* NETCDF env variable is set, but its bin folder does not appear in env PATH
