### PR TITLE
check if USENETCDFPAR is empty first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1069,7 +1069,7 @@ fseek_test :
 
 # rule used by configure to test if this will compile with netcdf4
 nc4_test:
-	if [ $(USENETCDFPAR) -eq 0 ] ; then \
+	if [ -z "$(USENETCDFPAR)" ] || [ $(USENETCDFPAR) -eq 0 ] ; then \
 	 ( cd tools ; /bin/rm -f nc4_test.{exe,nc,o} ; $(SCC) -o nc4_test.exe nc4_test.c -I$(NETCDF)/include -L$(NETCDF)/lib -lnetcdf $(NETCDF4_DEP_LIB) ; cd .. ) ; \
 	else \
 	 ( cd tools ; /bin/rm -f nc4_test.{exe,nc,o} ; $(DM_CC) -o nc4_test.exe nc4_test.c -I$(NETCDF)/include -L$(NETCDF)/lib -lnetcdf $(NETCDF4_DEP_LIB) ; cd ..  ) ; \


### PR DESCRIPTION
Env variable USENETCDFPAR may not be set when running make.

TYPE: bug fix

KEYWORDS: USENETCDFPAR

SOURCE: Wei-keng Liao

DESCRIPTION OF CHANGES:
When env USENETCDFPAR is not set, running make spews the following error message.
```
/bin/sh: line 0: [: -eq: unary operator expected
```
Solution: Check if USENETCDFPAR  is set first, and then its value if set.

LIST OF MODIFIED FILES: Makefile

TESTS CONDUCTED:  running command make