### PR TITLE
check if WRF_CMAQ is empty first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1026,7 +1026,7 @@ physics :
 	@ echo '--------------------------------------'
 	if [ $(WRF_CHEM) -eq 0 ] ; then \
 		( cd phys ; $(MAKE) submodules ; $(MAKE) CF2=" " ) ; \
-		if [ $(WRF_CMAQ) -eq 1 ] ; then \
+		if [ -n "$(WRF_CMAQ)" ] && [ $(WRF_CMAQ) -eq 1 ] ; then \
 			@ echo '----------- make cmaq ----------------' ; \
 			( rm -f main/libcmaqlib.a; cd cmaq ; $(MAKE) -f Makefile.twoway ) ; \
 		fi \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Makefile, string check

SOURCE:

Problem:
When WRF_CMAQ is empty, it spews the following error message.
```
/bin/sh: line 0: [: -eq: unary operator expected
```

Solution:
Check if WRF_CMAQ is empty first.

Modified files:
M    Makefile

TESTS CONDUCTED:
- Yes, the change fixes the error.
- The Jenkins tests have passed. No effect on other code.

RELEASE NOTE: 