### PR TITLE
Fix bug in module_ra_clWRF_support.F with Cray CCE Fortran compiler

### DIFF
--- a/phys/module_ra_clWRF_support.F
+++ b/phys/module_ra_clWRF_support.F
@@ -170,8 +170,10 @@ CONTAINS
 
              IF (istatus == -1) THEN
                 WRITE(message,*) "Normal ending of CAMtr_volume_mixing_ratio file"
+                CALL wrf_message( message)
              ELSE IF (istatus == -4001) THEN ! Cray CCE compiler throws -4001 rather than -1
                 WRITE(message,*) "Normal ending of CAMtr_volume_mixing_ratio file"
+                CALL wrf_message( message)
              ELSE ! if not -1 or -4001, then abort
                 WRITE(message,*) "   Not normal ending of CAMtr_volume_mixing_ratio file"
                 call wrf_error_fatal( message) 

--- a/phys/module_ra_clWRF_support.F
+++ b/phys/module_ra_clWRF_support.F
@@ -168,7 +168,11 @@ CONTAINS
                 CALL wrf_message( message) 
              ENDIF
 
-             IF (istatus /= -1) THEN
+             IF (istatus == -1) THEN
+                WRITE(message,*) "Normal ending of CAMtr_volume_mixing_ratio file"
+             ELSE IF (istatus == -4001) THEN ! Cray CCE compiler throws -4001 rather than -1
+                WRITE(message,*) "Normal ending of CAMtr_volume_mixing_ratio file"
+             ELSE ! if not -1 or -4001, then abort
                 WRITE(message,*) "   Not normal ending of CAMtr_volume_mixing_ratio file"
                 call wrf_error_fatal( message) 
              END IF


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Compiler issue, CRAY CCE 

SOURCE: Jatin Kala (J.Kala@murdoch.edu.au)

DESCRIPTION OF CHANGES:
Problem:
The Cray CCE compile returns -4001 (rather than -1) when it's finished reading the CAMtr file in module_ra_clWRF_support.F, however the code in 4.4 only checks for -1, which causes WRF to abort when one is using Cray CCE Fortran compiler. 

Solution:
modfify module_ra_clWRF_support.F to check for for -1 and -4001, before aborting.

ISSUE: For use when this PR closes an issue.
Fixes #1741

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
phys/module_ra_clWRF_support.F


TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
Yes, compiled, re-ran, and issue is fixed.
2. Are the Jenkins tests all passing? Yes. 

RELEASE NOTE: minor bug-fix when using Cray CCE Fortran compiler related to reading CAMtr file.
