### PR TITLE
Remove duplicate use module_dm in module_stoch prevenging compilation with intel

### DIFF
--- a/dyn_em/module_stoch.F
+++ b/dyn_em/module_stoch.F
@@ -108,7 +108,6 @@ contains
                           ipsy, ipey, jpsy, jpey, kpsy, kpey )
 
 
-    USE module_dm
     USE module_configure
     USE module_domain, ONLY : domain
     USE module_wrf_error


### PR DESCRIPTION
Remove a duplicate 'use module_dm' in module_stoch.F, preventing compilation with older versions of the intel compiler

TYPE: bug fix

KEYWORDS: compilation, intel, module_stoch

SOURCE: Louis Marelle (LATMOS, CNRS; Paris, France)

DESCRIPTION OF CHANGES:
Problem: When compiling with ifort+dmpar (15), or ifort+serial(13) with an older version (12.1.3) of the intel compiler, the compilation of WRF4.4 fails in module_stoch.f90, giving the following error message:
> module_stoch.f90(117): error #7837: Two or more accessible entities, other than generic interfaces, may have the same name only if the name is not used to refer to an entity in the scoping unit. [WRF_DM_MAXVAL]
> wrf_dm_maxval, wrf_err_message, local_communicator_x, local_communicator_y, data_order_xzy
> --------------------------^
> compilation aborted for module_stoch.f90 (code 1)

Solution:
The issue is due to a duplicate USE module_dm in module_stoch.F.
line 111:
`USE module_dm`
line 115:
```
#ifdef DM_PARALLEL
USE module_dm, ONLY : …
```
The first reference to 'use module_dm' was added in v4.4 and is not needed. Removing the first reference fixes the issue.

ISSUE: Fixes #1751

LIST OF MODIFIED FILES:
> M       dyn_em/module_stoch.F

TESTS CONDUCTED: 
1. Recompiled WRF without error with both options (13) or (15). 
2. The Jenkins tests have passed.

RELEASE NOTE: Remove duplicate reference to use module_dm in module_stoch.F (which is added in v4.4), which causes a compilation error when using an older version of Intel compiler (12.1.3).