### PR TITLE
Fixing bug in check-a-mundo for time-varying aerosol

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2507,11 +2507,11 @@
      END DO
 
 !-----------------------------------------------------------------------
-!  Check if qna_update=0 when aer_init_opt>0 for Thompson-MP-Aero (mp_physics=28)
+!  Check if qna_update=0 when aer_init_opt>1 for Thompson-MP-Aero (mp_physics=28)
 !-----------------------------------------------------------------------
      DO i = 1, model_config_rec % max_dom
        IF ( model_config_rec%mp_physics(i) .EQ. THOMPSONAERO ) THEN
-         IF ( model_config_rec%aer_init_opt .GT. 0 .and. model_config_rec%qna_update .EQ. 0 ) THEN
+         IF ( model_config_rec%aer_init_opt .GT. 1 .and. model_config_rec%qna_update .EQ. 0 ) THEN
            wrf_err_message = '--- ERROR: Time-varying sfc aerosol emissions not set for mp_physics=28 '
            CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
            wrf_err_message = '--- ERROR: Please set qna_update=1 and control through auxinput17 options '


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Thompson aerosol-aware microphysics scheme

SOURCE: Tim Juliano and Maria Frediani (NCAR/RAL)

DESCRIPTION OF CHANGES:
Problem:
Check-a-mundo caused a model stop if `qna_update=0` when climatological aerosol option selected (`use_aero_icbc=.true.`), but `qna_update` is only intended for first guess aerosol (`use_aero_rap_icbc=.true.`)

Solution:
Modify logical statement in check-a-mundo.

LIST OF MODIFIED FILES:
M share/module_check_a_mundo.F

TESTS CONDUCTED: 
This fixes the problem as reported by Maria Frediani.

RELEASE NOTE: Minor bug fix for logical checking of time-varying aerosol option when climatological aerosol option selected.