### PR TITLE
Bug fix for ozone input option o3input = 0

### DIFF
--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -12412,7 +12412,6 @@ CONTAINS
             endif
          enddo
         else
-         print *, 'are we here in lw rad'
          do k = kts, nlayers
             o3vmr(ncol,k) = o3mmr(k) * amdo
             o31d(k) = o3vmr(ncol,k)

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11701,9 +11701,8 @@ CONTAINS
 
 !  Ozone
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
-         OPTIONAL                                               , &
-         INTENT(IN   ) :: O33D
-   INTEGER, OPTIONAL, INTENT(IN ) :: o3input
+         INTENT(INOUT) :: O33D
+   INTEGER, INTENT(IN ) :: o3input
 
       real, parameter :: thresh=1.e-9
       real slope
@@ -12011,7 +12010,7 @@ CONTAINS
             QV1D(K)=max(0.,QV1D(K))
          ENDDO
 
-         IF (PRESENT(O33D)) THEN
+         IF (o3input.eq.2) THEN
             DO K=kts,kte
                O31D(K)=O33D(I,K,J)
             ENDDO
@@ -12401,26 +12400,31 @@ CONTAINS
          call inirad (o3mmr,plev,kts,nlay-1)
 
 ! Steven Cavallo: Changed to nlayers from kte+1
-        if(present(o33d)) then
+        if(o3input.eq.2) then
          do k = kts, nlayers
             o3vmr(ncol,k) = o3mmr(k) * amdo
-            IF ( PRESENT( O33D ) ) THEN
-            if(o3input .eq. 2)then
-               if(k.le.kte)then
-                 o3vmr(ncol,k) = o31d(k)
-               else
+            if(k.le.kte)then
+               o3vmr(ncol,k) = o31d(k)
+            else
 ! apply shifted climatology profile above model top
-                 o3vmr(ncol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
-                 if(o3vmr(ncol,k) .le. 0.)o3vmr(ncol,k) = o3mmr(k)*amdo
-               endif
+               o3vmr(ncol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
+               if(o3vmr(ncol,k) .le. 0.)o3vmr(ncol,k) = o3mmr(k)*amdo
             endif
-            ENDIF
          enddo
         else
+         print *, 'are we here in lw rad'
          do k = kts, nlayers
             o3vmr(ncol,k) = o3mmr(k) * amdo
+            o31d(k) = o3vmr(ncol,k)
          enddo
         endif
+
+! output o3 for o3input=0
+        IF (o3input.ne.2) THEN
+            DO K=kts,kte
+               O33D(I,K,J)=O31D(K)
+            ENDDO
+        ENDIF
 
 ! Set surface emissivity in each RRTMG longwave band
          do nb = 1, nbndlw

--- a/phys/module_ra_rrtmg_lwf.F
+++ b/phys/module_ra_rrtmg_lwf.F
@@ -15375,8 +15375,8 @@ integer,external :: omp_get_thread_num
 !  Ozone
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
          OPTIONAL                                               , &
-         INTENT(IN   ) :: O33D
-   INTEGER, OPTIONAL, INTENT(IN ) :: o3input
+         INTENT(INOUT) :: O33D
+   INTEGER, INTENT(IN ) :: o3input
 
       real, parameter :: thresh=1.e-9
       real slope
@@ -15674,7 +15674,7 @@ integer,external :: omp_get_thread_num
             QV1D(K)=max(0.,QV1D(K))
          ENDDO
 
-         IF (PRESENT(O33D)) THEN
+         IF (o3input.eq.2) THEN
             DO K=kts,kte
                O31D(K)=O33D(I,K,J)
             ENDDO
@@ -16015,20 +16015,16 @@ integer,external :: omp_get_thread_num
          call inirad (o3mmr,plev(icol,:),kts,nlay-1)
 
 ! Steven Cavallo: Changed to nlayers from kte+1
-        if(present(o33d)) then
+        if(o3input.eq.2) then
          do k = kts, nlayers
             o3vmr(icol,k) = o3mmr(k) * amdo
-            IF ( PRESENT( O33D ) ) THEN
-            if(o3input .eq. 2)then
-               if(k.le.kte)then
-                 o3vmr(icol,k) = o31d(k)
-               else
+            if(k.le.kte)then
+               o3vmr(icol,k) = o31d(k)
+            else
 ! apply shifted climatology profile above model top
-                 o3vmr(icol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
-                 if(o3vmr(icol,k) .le. 0.)o3vmr(icol,k) = o3mmr(k)*amdo
-               endif
+               o3vmr(icol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
+               if(o3vmr(icol,k) .le. 0.)o3vmr(icol,k) = o3mmr(k)*amdo
             endif
-            ENDIF
          enddo
         else
          do k = kts, nlayers

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -10214,9 +10214,8 @@ CONTAINS
 
 !  Ozone
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
-         OPTIONAL                                               , &
-         INTENT(IN   ) :: O33D
-   INTEGER, OPTIONAL, INTENT(IN ) :: o3input
+         INTENT(INOUT) :: O33D
+   INTEGER, INTENT(IN ) :: o3input
 !  EC aerosol: no_src = naerec = 6
    INTEGER,           INTENT(IN ) :: no_src
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme, 1:no_src )       , &
@@ -10598,7 +10597,7 @@ CONTAINS
             QV1D(K)=max(0.,QV1D(K))
          ENDDO
 
-         IF (PRESENT(O33D)) THEN
+         IF (o3input.eq.2) THEN
             DO K=kts,kte
                O31D(K)=O33D(I,K,J)
             ENDDO
@@ -10919,24 +10918,22 @@ CONTAINS
 ! Get ozone profile including amount in extra layer above model top
          call inirad (o3mmr,plev,kts,kte)
 
-        if(present(o33d)) then
+        if(o3input.eq.2) then
          do k = kts, kte+1
             o3vmr(ncol,k) = o3mmr(k) * amdo
-            IF ( PRESENT( O33D ) ) THEN
-            if(o3input .eq. 2)then
-               if(k.le.kte)then
-                 o3vmr(ncol,k) = o31d(k)
-               else
+            if(k.le.kte)then
+               o3vmr(ncol,k) = o31d(k)
+            else
 ! apply shifted climatology profile above model top
-                 o3vmr(ncol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
-                 if(o3vmr(ncol,k) .le. 0.)o3vmr(ncol,k) = o3mmr(k)*amdo
-               endif
+               o3vmr(ncol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
+               if(o3vmr(ncol,k) .le. 0.)o3vmr(ncol,k) = o3mmr(k)*amdo
             endif
-            ENDIF
          enddo
         else
+         print *, 'are we here in the else part'
          do k = kts, kte+1
             o3vmr(ncol,k) = o3mmr(k) * amdo
+            o31d(k) = o3vmr(ncol,k)
          enddo
         endif
 

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -10930,7 +10930,6 @@ CONTAINS
             endif
          enddo
         else
-         print *, 'are we here in the else part'
          do k = kts, kte+1
             o3vmr(ncol,k) = o3mmr(k) * amdo
             o31d(k) = o3vmr(ncol,k)

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11386,8 +11386,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
    INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn
 !  Ozone
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
-         OPTIONAL                                               , &
-         INTENT(IN   ) :: O33D
+         INTENT(INOUT) :: O33D
    INTEGER, OPTIONAL, INTENT(IN ) :: o3input
 !  EC aerosol: no_src = naerec = 6
    INTEGER,           INTENT(IN ) :: no_src
@@ -11731,7 +11730,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
             QV1D(K)=max(0.,QV1D(K))
          ENDDO
 
-         IF (PRESENT(O33D)) THEN
+         IF (o3input.eq.2) THEN
             DO K=kts,kte
                O31D(K)=O33D(I,K,J)
             ENDDO
@@ -11992,20 +11991,16 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
 !         call inirad (o3mmr,plev,kts,kte)
          call inirad (o3mmr,plev(icol,:),kts,kte)
 
-        if(present(o33d)) then
+        if(o3input.eq.2) then
          do k = kts, kte+1
             o3vmr(icol,k) = o3mmr(k) * amdo
-            IF ( PRESENT( O33D ) ) THEN
-            if(o3input .eq. 2)then
-               if(k.le.kte)then
-                 o3vmr(icol,k) = o31d(k)
-               else
+            if(k.le.kte)then
+               o3vmr(icol,k) = o31d(k)
+            else
 ! apply shifted climatology profile above model top
-                 o3vmr(icol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
-                 if(o3vmr(icol,k) .le. 0.)o3vmr(icol,k) = o3mmr(k)*amdo
-               endif
+               o3vmr(icol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
+               if(o3vmr(icol,k) .le. 0.)o3vmr(icol,k) = o3mmr(k)*amdo
             endif
-            ENDIF
          enddo
         else
          do k = kts, kte+1


### PR DESCRIPTION
Bug fix for o3input=0

TYPE: bug fix

KEYWORDS: RRTMG radiation, o3input=0

SOURCE: reported by Mauro Morichetti of Institute of Atmospheric Sciences and Climate (ISAC), ITALY, fixed internally

DESCRIPTION OF CHANGES:
Problem:
The ozone input option 0 (o3input=0) has been broken since 3.5.1 after a different ozone input option was introduced in 3.5. The code checks the presence of the ozone array O33D, and if it is not present, then the ozone is computed using o3input option 0. But the array is always present, so that code never reaches the other branch. Note also that the default o3input option was changed to 2 since 3.7.

Solution:
This PR fixes the option by checking the ozone input option rather than the presence of the array O33D. As there is an interest to see the output from this option, code is added to pass out the data, which is based on 1-d ozone profile. 

LIST OF MODIFIED FILES: 
M       phys/module_ra_rrtmg_lw.F
M       phys/module_ra_rrtmg_lwf.F
M       phys/module_ra_rrtmg_sw.F
M       phys/module_ra_rrtmg_swf.F

TESTS CONDUCTED: 
1. Do mods fix problem? Tested and it fixed the bug.
2. The Jenkins tests have passed.

RELEASE NOTE: Fixed a bug associated with ozone input option o3input = 0. When o3input is set to 0, ozone is effectively not used in the RRTMG radiation option before this fix.
