### PR TITLE
Remove unnecessary EM_CORE checks

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -3366,13 +3366,11 @@
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % mp_physics(i) .EQ. MILBRANDT2MOM ) .OR. &
-#if (EM_CORE == 1)
               ( model_config_rec % mp_physics(i) .EQ. NSSL_2MOM     ) .OR. &
               ( model_config_rec % mp_physics(i) .EQ. NSSL_2MOMG    ) .OR. &
               ( model_config_rec % mp_physics(i) .EQ. NSSL_2MOMCCN  ) .OR. &
               ( model_config_rec % mp_physics(i) .EQ. NSSL_1MOM     ) .OR. &
               ( model_config_rec % mp_physics(i) .EQ. NSSL_1MOMLFO  ) .OR. &
-#endif
               ( model_config_rec % do_radar_ref  .EQ. 1             ) ) THEN
             model_config_rec % compute_radar_ref = 1
          END IF
@@ -3405,7 +3403,6 @@
 ! additional output 
 !-----------------------------------------------------------------------
 
-#if (EM_CORE == 1)
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME2 ) .AND. &
@@ -3413,7 +3410,6 @@
             model_config_rec % bl_mynn_edmf = 0
          END IF
       ENDDO
-#endif
 
 !-----------------------------------------------------------------------
 ! Set the namelist parameters for the RRTMG radiation scheme if either
@@ -3441,7 +3437,6 @@
 ! sf_surface_physics
 !-----------------------------------------------------------------------
 
-#if (EM_CORE == 1)
       IF      (   model_config_rec % sf_surface_physics(1) .EQ. NOLSMSCHEME  ) THEN
          model_config_rec % num_soil_layers = 5
       ELSE IF (   model_config_rec % sf_surface_physics(1) .EQ. SLABSCHEME   ) THEN
@@ -3472,7 +3467,6 @@
          WRITE (wrf_err_message, FMT='(A,I6)') '--- ERROR: sf_surface_physics = ' , model_config_rec % sf_surface_physics(1)
          CALL wrf_error_fatal ( TRIM(wrf_err_message) )
       END IF 
-#endif
 
       WRITE (wrf_err_message, FMT='(A,I6)') '--- NOTE: num_soil_layers has been set to ', &
                                              model_config_rec % num_soil_layers

--- a/tools/data.h
+++ b/tools/data.h
@@ -75,7 +75,7 @@ typedef struct node_struct {
   char pkg_4dscalars[NAMELEN_LONG] ;
 
 /* fields used by Comm (halo, period, xpose)  nodes */
-  char comm_define[2*8192] ;
+  char comm_define[4*8192] ;
 
 /* marker */
   int mark ;

--- a/tools/data.h
+++ b/tools/data.h
@@ -75,7 +75,7 @@ typedef struct node_struct {
   char pkg_4dscalars[NAMELEN_LONG] ;
 
 /* fields used by Comm (halo, period, xpose)  nodes */
-  char comm_define[4*8192] ;
+  char comm_define[3*8192] ;
 
 /* marker */
   int mark ;

--- a/tools/data.h
+++ b/tools/data.h
@@ -75,7 +75,7 @@ typedef struct node_struct {
   char pkg_4dscalars[NAMELEN_LONG] ;
 
 /* fields used by Comm (halo, period, xpose)  nodes */
-  char comm_define[3*8192] ;
+  char comm_define[4*8192] ;
 
 /* marker */
   int mark ;


### PR DESCRIPTION
Remove a few unnecessary EM_CORE checks

TYPE: no impact, code clean up

KEYWORDS: EM_CORE,  clean up, check_a_mundo

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Some EM_CORE checks in the routine are no longer needed.

Solution:
They are removed.

LIST OF MODIFIED FILES: 
M      share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Should have no impact. 
2. Are the Jenkins tests all passing?

RELEASE NOTE: 
