### PR TITLE
Modification to address Intel compile issue for moving nests

### DIFF
--- a/tools/data.h
+++ b/tools/data.h
@@ -75,7 +75,7 @@ typedef struct node_struct {
   char pkg_4dscalars[NAMELEN_LONG] ;
 
 /* fields used by Comm (halo, period, xpose)  nodes */
-  char comm_define[2*8192] ;
+  char comm_define[4*8192] ;
 
 /* marker */
   int mark ;

--- a/tools/data.h
+++ b/tools/data.h
@@ -75,7 +75,7 @@ typedef struct node_struct {
   char pkg_4dscalars[NAMELEN_LONG] ;
 
 /* fields used by Comm (halo, period, xpose)  nodes */
-  char comm_define[4*8192] ;
+  char comm_define[3*8192] ;
 
 /* marker */
   int mark ;

--- a/tools/data.h
+++ b/tools/data.h
@@ -75,7 +75,7 @@ typedef struct node_struct {
   char pkg_4dscalars[NAMELEN_LONG] ;
 
 /* fields used by Comm (halo, period, xpose)  nodes */
-  char comm_define[3*8192] ;
+  char comm_define[4*8192] ;
 
 /* marker */
   int mark ;


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: moving nest, vortex-following, compile, intel, ifort, C

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
Beginning with V4.4, neither the specified move (option 2) or vortex-following (option 3) moving nest options were able to compile with an Intel compiler. The error message given was 
`module_comm_dm_4.G:30:0: fatal error: REGISTRY_COMM_DM_PERIOD_subs.inc: No such file or directory`
 `#include "REGISTRY_COMM_DM_PERIOD_subs.inc"`
 `^`
`compilation terminated.`
`make[2]: [module_comm_dm_4.o] Error 1 (ignored)`

The issue was narrowed down to commit [#fed10f4b](https://github.com/wrf-model/WRF/commit/fed10f4b), and this change caused the file external/RSL_LITE/gen_comms.c to not create the REGISTRY_COMM_DM_PERIOD_subs.inc file when building a moving nest. The newly added 4D array, pert3d, apparently pushed the number of communication variables to exceed a preset limit. 

Solution:
The solution was to modify the tools/data.h file line
`char comm_define[2*8192] ;`
to
`char comm_define[4*8192] ;`

LIST OF MODIFIED FILES: 
M   tools/data.h

TESTS CONDUCTED: 
1. The modification allows both the specified move and vortex-following nesting options to be compiled when using an Intel compiler. 
2. Jenkins tests pass.

RELEASE NOTE: A modification addresses an issue that prevented WRF from compiling when choosing either the specified move (option 2) or vortex-following (option 3) nesting options, while using an Intel compiler.  This issue began with WRFV4.4.
