### PR TITLE
Update da_read_obs_bufrseviri.inc to fix meteosat 11 error messages

### DIFF
--- a/var/da/da_radiance/da_read_obs_bufrseviri.inc
+++ b/var/da/da_radiance/da_read_obs_bufrseviri.inc
@@ -294,7 +294,8 @@ subroutine da_read_obs_bufrseviri (obstype,iv,infile)
         ! SAID 55 is meteosat-8  or msg-1
         ! SAID 56 is meteosat-9  or msg-2
         ! SAID 57 is meteosat-10 or msg-3
-        if ( ( kidsat > 57) .or. ( kidsat < 55) ) then 
+	! SAID 70 is meteosat-11 or msg-4
+        if ( ( kidsat > 70) .or. ( kidsat < 55) ) then 
            write(unit=message(1),fmt='(A,I6)') 'Unknown platform: ', kidsat
            call da_warning(__FILE__,__LINE__,message(1:1))
         end if
@@ -305,6 +306,8 @@ subroutine da_read_obs_bufrseviri (obstype,iv,infile)
             satellite_id = 2
         else if ( kidsat == 57 ) then
             satellite_id = 3
+	else if ( kidsat == 70 ) then
+            satellite_id = 4
         end if
 
         if (clrsky) then     ! asr bufr has no sza


### PR DESCRIPTION
TYPE: Bug fix

DESCRIPTION OF CHANGES:
Problem:
Meteosat 11 was added to the GFS bufr files in Feb 2018 meaning when the seviri bufr read was turned on in the namelist it would throw out an error message for each data point in the log file making it very large. The change to the error loop removes this message but also prepares the bufr read file to ingest meteosat 11 data into wrf. Dont think a crtm currently supports meteosat 11 but i can change the VARBC.in file to include data for this sat number and add a msg-4-seviri.info file to the radiance_info folder in another commit if this might be desirable for people to use.

Solution:
Added identifier for meteosat 11 and then changed the upper limit of the identifier error if with the new identifier significantly higher than previous

RELEASE NOTE: Updated bufrseviri.inc so that if seviri turned on in WRFDA after Feb 2018 it suppresses many error messages in log file.
