### PR TITLE
Fix undefined behavior in RSL_LITE

### DIFF
--- a/external/RSL_LITE/rsl_bcast.c
+++ b/external/RSL_LITE/rsl_bcast.c
@@ -80,6 +80,26 @@ static destroy_par_info ( p )
   if ( p != NULL ) RSL_FREE( p ) ;
 }
 
+static destroy_list( list, dfcn )
+     rsl_list_t ** list ;          /* pointer to pointer to list */
+     int (*dfcn)() ;               /* pointer to function for destroying
+                                      the data field of the list */
+{
+  rsl_list_t *p, *trash ;
+  if ( list == NULL ) return(0) ;
+  if ( *list == NULL ) return(0) ;
+  for ( p = *list ; p != NULL ; )
+    {
+      if ( dfcn != NULL ) (*dfcn)( p->data ) ;
+      trash = p ;
+      p = p->next ;
+      RSL_FREE( trash ) ;
+    }
+  *list = NULL ;
+  return(0) ;
+}
+
+
 static rsl_list_t *Xlist, *Xp, *Xprev ;
 static rsl_list_t *stage ;
 static int stage_len = 0 ;              /* 96/3/15 */
@@ -726,23 +746,3 @@ rsl_lite_from_peerpoint_msg ( len_p, buf )
 
 /********************************************/
 
-destroy_list( list, dfcn )
-  rsl_list_t ** list ;          /* pointer to pointer to list */
-  int (*dfcn)() ;               /* pointer to function for destroying
-                                   the data field of the list */
-{
-  rsl_list_t *p, *trash ;
-  if ( list == NULL ) return(0) ;
-  if ( *list == NULL ) return(0) ;
-  for ( p = *list ; p != NULL ; )
-  {
-    if ( dfcn != NULL ) (*dfcn)( p->data ) ;
-    trash = p ;
-    p = p->next ;
-    RSL_FREE( trash ) ;
-  }
-  *list = NULL ;
-  return(0) ;
-}
-
-/********************************************/

--- a/external/RSL_LITE/rsl_bcast.c
+++ b/external/RSL_LITE/rsl_bcast.c
@@ -89,12 +89,12 @@ static destroy_list( list, dfcn )
   if ( list == NULL ) return(0) ;
   if ( *list == NULL ) return(0) ;
   for ( p = *list ; p != NULL ; )
-    {
-      if ( dfcn != NULL ) (*dfcn)( p->data ) ;
-      trash = p ;
-      p = p->next ;
-      RSL_FREE( trash ) ;
-    }
+  {
+    if ( dfcn != NULL ) (*dfcn)( p->data ) ;
+    trash = p ;
+    p = p->next ;
+    RSL_FREE( trash ) ;
+  }
   *list = NULL ;
   return(0) ;
 }

--- a/external/RSL_LITE/rsl_lite.h
+++ b/external/RSL_LITE/rsl_lite.h
@@ -165,6 +165,7 @@
 
 char * buffer_for_proc ( int P, int size, int code ) ;
 void * rsl_malloc( char * f, int l, int s ) ;
+void rsl_free( char ** p ) ;
 typedef int * int_p ;
 
 #define INDEX_2(A,B,NB)       ( (B) + (A)*(NB) )


### PR DESCRIPTION
Fix undefined behavior in RSL_LITE 

TYPE: bug fix

KEYWORDS: RSL_LITE

SOURCE: Florian Sammüller (Universität Bayreuth, Germany)

DESCRIPTION OF CHANGES:
Problem:
RSL_LITE has undefined behavior due to implicitly declared functions.
This may lead to a crash of `wrf.exe` in the initialization of nested domains if WRF is built with link-time optimization and with recent compilers (e.g. GCC 12).

Solution:
Declare rsl_free() and destroy_list() before first use.

ISSUE:
Fixes #1764

LIST OF MODIFIED FILES:
M       external/RSL_LITE/rsl_bcast.c
M       external/RSL_LITE/rsl_lite.h

TESTS CONDUCTED: 
It passed regression tests.

RELEASE NOTE: Fixed an undefined behavior of RSL_LITE due to implicitly declared functions, which might lead to a model abort when using GCC 12.