### PR TITLE
Update namelist in VAR to include cloud_det change from V4.2

### DIFF
--- a/var/README.namelist
+++ b/var/README.namelist
@@ -472,7 +472,7 @@ Description of WRFDA namelist variables, defined in Registry/registry.var
                                                  ; next cycle will perform a coldstart again.
   use_clddet                      = 0            ; 0: off
                                                  ; 1:use the MMR scheme to conduct cloud detection for infrared radiance
-                                                 ; 2:use the pf scheme to conduct cloud detection for infrared radiance
+                                                 ; 2:use the pf scheme to conduct cloud detection for infrared radiance (Default)
                                                  ; 3:use the ECMWF operational scheme to conduct cloud detection for infrared radiance
   use_clddet_zz                    = false    ; .true. :use the cloud detection scheme from Zhuge X. and Zou X. JAMC,2016.
   airs_warmest_fov                    = .false.  ; .true.: uses the observation brightness temperature for 

--- a/var/README.namelist
+++ b/var/README.namelist
@@ -470,8 +470,11 @@ Description of WRFDA namelist variables, defined in Registry/registry.var
                                                  ; first assimilation cycle. If there are not enough data 
                                                  ; (according to "VARBC_NOBSMIN") on the first cycle, the 
                                                  ; next cycle will perform a coldstart again.
-  use_clddet_mmr                      = false    ; .true. :use the MMR scheme to conduct cloud detection for infrared radiance
-  use_clddet_ecmwf                    = false    ; .true. :use the ECMWF operational scheme to conduct cloud detection for infrared radiance.
+  use_clddet                      = 0            ; 0: off
+                                                 ; 1:use the MMR scheme to conduct cloud detection for infrared radiance
+                                                 ; 2:use the pf scheme to conduct cloud detection for infrared radiance
+                                                 ; 3:use the ECMWF operational scheme to conduct cloud detection for infrared radiance
+  use_clddet_zz                    = false    ; .true. :use the cloud detection scheme from Zhuge X. and Zou X. JAMC,2016.
   airs_warmest_fov                    = .false.  ; .true.: uses the observation brightness temperature for 
                                                  ;         AIRS Window channel #914 as criterion for GSI 
                                                  ;         thinning (with a higher amplitude than the distance 


### PR DESCRIPTION
Inclusion of 

TYPE: Bug

DESCRIPTION OF CHANGES:
Problem:
Since V4.2 the cloud detection seems to have changed with a change of registry values to decommission individual set mmr and ecmwf to include a single value that chooses a choice of 3 schemes to use. Also addition of a cloud detection scheme from Zhunge and Zou which has an individual place holder in the namelist. I cant find any release notes as to when this was added but from looking at the code i think it was V4.2. Noticed when looking at the code that i cant find the ecmwf scheme mentioned anywhere so not sure this option is actually working? can only find if statements in the new cloud_dect.inc file for options 1 and 2. Similarly couldnt find where the ecmwf scheme was prior to the merging of the cloud dectect inc files.

Solution:
Changed read me file in VAR to reflect the change that happened in V4.2. This may need to be also changed in the user guide if it hasnt already.

LIST OF MODIFIED FILES: var/README.namelist

TESTS CONDUCTED: 
No tests conducted with no change to model. 

RELEASE NOTE: Update to VAR namelist read me to include change of cloud_det option. Now 3 option for clouddet and a seperate one for clouddet_zz for Zhuge and Zou 2016 scheme.
