### PR TITLE
Add missing oops for CLM plus urban check

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2404,6 +2404,7 @@
         IF ( model_config_rec%SF_SURFACE_PHYSICS(i) == CLMSCHEME .and. &
              model_config_rec%SF_URBAN_PHYSICS(i) >= 1 .and. &
              model_config_rec%SF_URBAN_PHYSICS(i) <= 3 ) THEN
+             oops = oops + 1 
         ENDIF
       ENDDO
       IF ( oops .GT. 0 ) THEN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: clm, urban cross check

SOURCE: reported by Shuhua Chen, UC Davis, internal

DESCRIPTION OF CHANGES:
Problem:
Error check variable oops is not incremented when urban options are checked against land model option CLM.

Solution:
Increment variable oops to correct the error.

LIST OF MODIFIED FILES: 
M      share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Yes. Model gracefully stops when both CLM and an urban option are selected.
2. The Jenkins tests are all passing.

RELEASE NOTE: Model will stop if both CLM and an urban physics option are selected. 
