### PR TITLE
MYNN-EDMF Update from CCPP to WRF

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2425,7 +2425,7 @@ rconfig   integer     irr_ph              namelist,physics      max_domains    0
 
 rconfig   integer     sf_surface_physics  namelist,physics	max_domains    -1      rh       "sf_surface_physics"            ""      ""
 rconfig   integer     bl_pbl_physics      namelist,physics	max_domains    -1      rh       "bl_pbl_physics"                ""      ""
-rconfig   logical     tke_budget          namelist,physics      max_domains    .false. rh       "tke_budget"                    ""      ""
+rconfig   integer     tke_budget          namelist,physics      max_domains    0       rh       "tke_budget"                    ""      ""
 rconfig   integer     ysu_topdown_pblmix  namelist,physics      1              1       rh       "ysu_topdown_pblmix"            ""      ""
 rconfig   integer     shinhong_tke_diag   namelist,physics      max_domains    0       rh       "shinhong_tke_diag"             ""      ""
 rconfig   logical     bl_mynn_tkeadvect   namelist,physics      max_domains    .false.  rh      "bl_mynn_tkeadvect"             ""      ""
@@ -3119,7 +3119,7 @@ package   gbmpblscheme   bl_pbl_physics==12          -             state:exch_tk
 package   eepsscheme     bl_pbl_physics==16          -             scalar:pek_adv,pep_adv;state:tke_pbl,pep_pbl
 package   mrfscheme      bl_pbl_physics==99          -             -
 
-package   tkebudget      tke_budget==.true.          -             state:qSHEAR,qBUOY,qDISS,qWT,dqke
+package   tkebudget      tke_budget==1               -             state:qSHEAR,qBUOY,qDISS,qWT,dqke
 package   mynn_dmp_edmf  bl_mynn_edmf==1             -             state:ktop_plume,maxmf,nupdraft
 package   mynn_3Doutput  bl_mynn_output==1           -             state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl,qi_bl

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1106,6 +1106,7 @@ state   real   tsq             ikj     misc        1         -      r        "ts
 state   real   qsq             ikj     misc        1         -      r        "qsq"               "total water variance"      "(kg/kg)**2"
 state   real   cov             ikj     misc        1         -      r        "cov"               "total water-liquid water pottemp covariance"   "K kg/kg"
 state   real   Sh3d            ikj     misc        1         -      r        "Sh3d"              "Stability function for heat"   ""
+state   real   Sm3d            ikj     misc        1         -      r        "Sm3d"              "Stability function for momentum"   ""
 state   real   ch               ij     misc        1         -      -        "ch"                "surface exchange coeff for heat"    "m s-1"
 #state   real   K_m             ikj     misc        1         -     -          "K_m"               "EXCHANGE COEFFICIENT for momentum "
 #state   real   K_h             ikj     misc        1         -     -          "K_h"               "EXCHANGE COEFFICIENT for heat "
@@ -2424,7 +2425,7 @@ rconfig   integer     irr_ph              namelist,physics      max_domains    0
 
 rconfig   integer     sf_surface_physics  namelist,physics	max_domains    -1      rh       "sf_surface_physics"            ""      ""
 rconfig   integer     bl_pbl_physics      namelist,physics	max_domains    -1      rh       "bl_pbl_physics"                ""      ""
-rconfig   integer     bl_mynn_tkebudget   namelist,physics      max_domains    0       rh       "bl_mynn_tkebudget"             ""      ""
+rconfig   logical     tke_budget          namelist,physics      max_domains    .false. rh       "tke_budget"                    ""      ""
 rconfig   integer     ysu_topdown_pblmix  namelist,physics      1              1       rh       "ysu_topdown_pblmix"            ""      ""
 rconfig   integer     shinhong_tke_diag   namelist,physics      max_domains    0       rh       "shinhong_tke_diag"             ""      ""
 rconfig   logical     bl_mynn_tkeadvect   namelist,physics      max_domains    .false.  rh      "bl_mynn_tkeadvect"             ""      ""
@@ -2438,6 +2439,7 @@ rconfig   integer     bl_mynn_output      namelist,physics      max_domains    0
 rconfig   integer     bl_mynn_cloudmix    namelist,physics      max_domains    1       irh      "bl_mynn_cloudmix"              "0:off,1:activate mixing of all cloud species"          ""
 rconfig   integer     bl_mynn_mixqt       namelist,physics      max_domains    0       irh      "bl_mynn_mixqt"                 "0:mix moisture species separate,1: mix total water"    ""
 rconfig   integer     icloud_bl           namelist,physics      1              1       irh      "icloud_bl"                     "0:no subgrid cloud-radiation coupling,1:activated"     ""
+rconfig   real        bl_mynn_closure     namelist,physics      1              2.6     irh      "bl_mynn_closure"               "2.5: level2.5, 2.6: level 2.6, 3.0: level 3.0"         ""
 rconfig   integer     mfshconv            namelist,physics      max_domains    1       rh       "mfshconv"         "To activate mass flux scheme with qnse, 1=true or 0=false"      ""
 rconfig   integer     sf_urban_physics    namelist,physics      max_domains    0       rh       "sf_urban_physics"     "activate urban model  0=no, 1=Noah_UCM 2=BEP_UCM"   ""
 rconfig   real    BLDT                    namelist,physics      max_domains    0       h    "BLDT"          ""      ""
@@ -3107,8 +3109,7 @@ package   ysuscheme      bl_pbl_physics==1           -             -
 package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
 package   gfsscheme      bl_pbl_physics==3           -             -
 package   qnsepblscheme  bl_pbl_physics==4           -             state:tke_pbl,el_pbl,massflux_EDKF,entr_EDKF,detr_EDKF,thl_up,thv_up,rv_up,rt_up,rc_up,u_up,v_up,frac_up,rc_mf
-package   mynnpblscheme2 bl_pbl_physics==5           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
-package   mynnpblscheme3 bl_pbl_physics==6           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,tsq,qsq,cov,el_pbl
+package   mynnpblscheme  bl_pbl_physics==5           -             scalar:qke_adv;state:qke,tke_pbl,sh3d,sm3d,tsq,qsq,cov,el_pbl
 package   acmpblscheme   bl_pbl_physics==7           -             -
 package   boulacscheme   bl_pbl_physics==8           -             state:el_pbl,tke_pbl,wu_tur,wv_tur,wt_tur,wq_tur
 package   camuwpblscheme bl_pbl_physics==9           -             state:tauresx2d,tauresy2d,tpert2d,qpert2d,wpert2d,tke_pbl,smaw3d,wsedl3d,turbtype3d
@@ -3118,7 +3119,7 @@ package   gbmpblscheme   bl_pbl_physics==12          -             state:exch_tk
 package   eepsscheme     bl_pbl_physics==16          -             scalar:pek_adv,pep_adv;state:tke_pbl,pep_pbl
 package   mrfscheme      bl_pbl_physics==99          -             -
 
-package   mynn_tkebudget bl_mynn_tkebudget==1        -             state:qSHEAR,qBUOY,qDISS,qWT,dqke
+package   tkebudget      tke_budget==.true.          -             state:qSHEAR,qBUOY,qDISS,qWT,dqke
 package   mynn_dmp_edmf  bl_mynn_edmf==1             -             state:ktop_plume,maxmf,nupdraft
 package   mynn_3Doutput  bl_mynn_output==1           -             state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl,qi_bl
@@ -3126,8 +3127,7 @@ package   pbl_cloud      icloud_bl==1                -             state:cldfra_
 package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_diss,elmin,xkmv_meso
 
 # dfi
-package   mynnpblscheme2_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv
-package   mynnpblscheme3_dfi bl_pbl_physics_dfi==6   -             dfi_scalar:dfi_qke_adv
+package   mynnpblscheme_dfi bl_pbl_physics_dfi==5   -             dfi_scalar:dfi_qke_adv
 
 package   nocuscheme     cu_physics==0               -             -
 package   kfetascheme    cu_physics==1               -             state:w0avg

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -3779,6 +3779,7 @@ rconfig   integer cam_mam_mode             namelist,chem        1              3
 rconfig   integer cam_mam_nspec            namelist,chem        1              85      irh     "cam_mam_nspec"                   ""    ""
 rconfig   logical CAM_MP_MAM_cpled         namelist,chem        1            .true.    irh     "CAM_MP_MAM_cpled"                   ""    ""
 rconfig   integer mozart_ph_diag           namelist,chem        1              0       rh      "mozart_ph_diag"                  ""    ""
+rconfig   logical mynn_chem_vertmx         namelist,chem        1            .false.   rh      "mynn_chem_vertmx"                  ""    ""
 
 # CLM inputs
 rconfig   character  megan_specifier      namelist,physics     max_mgnspc      " "        -     "map from Megan2.1 to WRF species" "" ""

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -612,14 +612,18 @@ end if
 
 ! Set the num_vert_mix variable if using ACM
     num_vert_mix = 0
-    IF ( config_flags%bl_pbl_physics == ACMPBLSCHEME ) THEN
+    IF ( config_flags%bl_pbl_physics == ACMPBLSCHEME .or. config_flags%bl_pbl_physics == MYNNPBLSCHEME) THEN
          mix_select: SELECT CASE(config_flags%chem_opt)
          CASE (RADM2SORG_AQ, RADM2SORG_AQCHEM, RACMSORG_AQ, RACMSORG_AQCHEM_KPP, CBMZ_MOSAIC_4BIN_AQ, CBMZ_MOSAIC_8BIN_AQ, CBMZSORG_AQ, &
               CBMZ_MOSAIC_DMS_4BIN, CBMZ_MOSAIC_DMS_8BIN, CBMZ_MOSAIC_DMS_4BIN_AQ, CBMZ_MOSAIC_DMS_8BIN_AQ, &
               CRI_MOSAIC_8BIN_AQ_KPP, CRI_MOSAIC_4BIN_AQ_KPP)
             num_vert_mix = numgas
          CASE DEFAULT
-            num_vert_mix = num_chem
+            IF (config_flags%mynn_chem_vertmx) THEN
+               num_vert_mix = num_chem
+            ELSE
+               num_vert_mix = 0
+            ENDIF
          END SELECT mix_select
         if(num_vert_mix .gt. config_flags%ndepvel) then
          write(message_txt,'(A30,2(I8,2x))') 'chem_init: num_vert_mix and ndepvel ',num_vert_mix,config_flags%ndepvel

--- a/chem/dry_dep_driver.F
+++ b/chem/dry_dep_driver.F
@@ -740,18 +740,20 @@ CONTAINS
               SAPRC99_MOSAIC_8BIN_VBS2_AQ_KPP,                                             &
               CB05_SORG_AQ_KPP, CB05_SORG_VBS_AQ_KPP)
             if(.not.is_aerosol(nv))then ! mix gases not aerosol
-               call vertmx(dtstep,pblst,ekmfull,dryrho_1d, &
+               if (.not.config_flags%mynn_chem_vertmx) then
+                  call vertmx(dtstep,pblst,ekmfull,dryrho_1d, &
                            zzfull,zz,ddvel(i,j,nv),kts,kte)
-
+               endif
             endif
 !The default case below does turbulent mixing for all gas and aerosol species
 !If aqueous phase is not activated
 !It requires ddvel array as a boundary condition near surface for flux of species 
 !The top boundary condition for eddy diffusivity is zero
          CASE DEFAULT
-            call vertmx(dtstep,pblst,ekmfull,dryrho_1d, &
+            if (.not.config_flags%mynn_chem_vertmx) then
+               call vertmx(dtstep,pblst,ekmfull,dryrho_1d, &
                         zzfull,zz,ddvel(i,j,nv),kts,kte)
-
+            endif
          END SELECT mix_select
 
          ! chem is in ppmv
@@ -1026,17 +1028,18 @@ CONTAINS
 !
        CASE (TRACER_SMOKE,TRACER_TEST1,TRACER_TEST2)
         CALL wrf_debug(15,'DOING TRACER MIXING, 1 SPECIE ONLY')
-        do nv=2,num_tracer
-         do k=kts,kte
-            pblst(k)=max(epsilc,tracer(i,k,j,nv))
-         enddo
-
+         do nv=2,num_tracer
+            do k=kts,kte
+               pblst(k)=max(epsilc,tracer(i,k,j,nv))
+            enddo
+            if (.not.config_flags%mynn_chem_vertmx) then
                call vertmx(dtstep,pblst,ekmfull,dryrho_1d, &
                            zzfull,zz,0.,kts,kte)
-         do k=kts,kte-1
-            tracer(i,k,j,nv)=max(epsilc,pblst(k))
+            endif
+            do k=kts,kte-1
+               tracer(i,k,j,nv)=max(epsilc,pblst(k))
+            enddo
          enddo
-        enddo
        CASE DEFAULT
 !        CALL wrf_debug(15,'NOT YET DEFINED')
        END SELECT tracer_select

--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -5707,7 +5707,7 @@ END SUBROUTINE phy_prep_part2
           mpten=max(-config_flags%mp_tend_lim*dt, mpten)
 
 #if ( WRF_DFI_RADAR == 1 )
-compiler error, not handled yet
+!compiler error, not handled yet
        if(k < k_end ) then
          if(dfi_tten_max < dfi_tten_rad(i,k,j) ) dfi_tten_max = dfi_tten_rad(i,k,j)
          if(old_max < (th_phy(i,k,j)-h_diabatic(i,k,j)) ) old_max=th_phy(i,k,j)-h_diabatic(i,k,j)

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1276,7 +1276,7 @@ BENCH_START(pbl_driver_tim)
      &        ,pert_mynn_qke=config_flags%pert_mynn_qke                   &
 !Variables required for camuwpbl scheme
      &        ,Z_AT_W=grid%z_at_w,CLDFRA_OLD_MP=grid%cldfra_old_mp        &
-     &        ,CLDFRA=grid%cldfra                                        &
+     &        ,CLDFRA=grid%cldfra                                         &
      &        ,RTHRATENLW=grid%rthratenlw,TAURESX2D=grid%tauresx2d        &
      &        ,TAURESY2D=grid%tauresy2d                                   &
      &        ,TPERT2D=grid%tpert2d,QPERT2D=grid%qpert2d                  &
@@ -1292,15 +1292,16 @@ BENCH_START(pbl_driver_tim)
 ! for pbl mixing of scalars and tracers
      &        ,SCALAR=scalar,SCALAR_TEND=scalar_tend,NUM_SCALAR=num_scalar&
      &        ,TRACER=tracer,TRACER_TEND=tracer_tend,NUM_TRACER=num_tracer&
-     &        ,SCALAR_PBLMIX=config_flags%scalar_pblmix                  &
-     &        ,TRACER_PBLMIX=config_flags%tracer_pblmix                  &
+     &        ,SCALAR_PBLMIX=config_flags%scalar_pblmix                   &
+     &        ,TRACER_PBLMIX=config_flags%tracer_pblmix                   &
 #if (WRF_CHEM == 1)
-     &        ,CHEM=chem,VD=grid%dep_vel                                 &
-     &        ,NCHEM=num_chem,kdvel=config_flags%kdepvel                 &
-     &        ,ndvel=config_flags%ndepvel                                &
-     &        ,NUM_VERT_MIX=grid%num_vert_mix                            &
+     &        ,mynn_chem_vertmx=config_flags%mynn_chem_vertmx             &
+     &        ,CHEM=chem,VD=grid%dep_vel                                  &
+     &        ,NCHEM=num_chem,kdvel=config_flags%kdepvel                  &
+     &        ,ndvel=config_flags%ndepvel                                 &
+     &        ,NUM_VERT_MIX=grid%num_vert_mix                             &
 #endif
-     &        ,QNORM=grid%QNORM, fasdas=config_flags%fasdas              & !fasdas
+     &        ,QNORM=grid%QNORM, fasdas=config_flags%fasdas               & !fasdas
      &        )
 
 #if (WRF_CHEM == 1)

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1192,13 +1192,13 @@ BENCH_START(pbl_driver_tim)
      &        ,QNBCA_CURR=scalar(ims,kms,jms,P_QNBCA),F_QNBCA=F_QNBCA     &
      &        ,HOL=HOL, MOL=grid%mol, REGIME=grid%REGIME                  &
 !mynn mp@
-     &        ,QKE=grid%qke, Sh3d=grid%sh3d                               &
+     &        ,QKE=grid%qke, Sh3d=grid%sh3d, Sm3d=grid%sm3d               &
      &        ,QKE_ADV=scalar(ims,kms,jms,P_qke_adv)                      & !ACF-QKE advection
      &        ,bl_mynn_tkeadvect=config_flags%bl_mynn_tkeadvect           & !ACF-QKE advection
      &        ,tsq=grid%tsq, qsq=grid%qsq, cov=grid%cov                   &
      &        ,DQKE=grid%dqke,QWT=grid%qWT                                &
      &        ,QSHEAR=grid%qSHEAR,QBUOY=grid%qBUOY,QDISS=grid%qDISS       &
-     &        ,bl_mynn_tkebudget=config_flags%bl_mynn_tkebudget           &
+     &        ,tke_budget=config_flags%tke_budget                         &
      &        ,bl_mynn_cloudpdf=config_flags%bl_mynn_cloudpdf             &
      &        ,bl_mynn_mixlength=config_flags%bl_mynn_mixlength           &
      &        ,icloud_bl=config_flags%icloud_bl                           &
@@ -1210,6 +1210,7 @@ BENCH_START(pbl_driver_tim)
      &        ,bl_mynn_output=config_flags%bl_mynn_output                 &
      &        ,bl_mynn_cloudmix=config_flags%bl_mynn_cloudmix             &
      &        ,bl_mynn_mixqt=config_flags%bl_mynn_mixqt                   &
+     &        ,bl_mynn_closure=config_flags%bl_mynn_closure               &
      &        ,edmf_a=grid%edmf_a,edmf_w=grid%edmf_w                      &
      &        ,edmf_thl=grid%edmf_thl,edmf_qt=grid%edmf_qt                &
      &        ,edmf_ent=grid%edmf_ent,edmf_qc=grid%edmf_qc                &
@@ -1305,7 +1306,7 @@ BENCH_START(pbl_driver_tim)
 #if (WRF_CHEM == 1)
 #ifdef DM_PARALLEL
      IF ( num_chem >= PARAM_FIRST_SCALAR .AND. (config_flags%bl_pbl_physics == &
-     & mynnpblscheme2 .OR. config_flags%bl_pbl_physics == mynnpblscheme3)  ) then
+     & mynnpblscheme)  ) then
          CALL wrf_debug ( 200 , ' call HALO CHEM AFTER PBL' )
          IF      ( config_flags%h_sca_adv_order <= 4 ) THEN
 #      include "HALO_EM_CHEM_E_3.inc"

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -832,8 +832,7 @@ BENCH_START(calc_p_rho_tim)
                             )
 
 #ifdef DM_PARALLEL
-       IF ( config_flags%bl_pbl_physics == MYNNPBLSCHEME2 .OR. &
-            config_flags%bl_pbl_physics == MYNNPBLSCHEME3 ) THEN
+       IF ( config_flags%bl_pbl_physics == MYNNPBLSCHEME ) THEN
 #        include "HALO_EM_SCALAR_E_5.inc"
        ENDIF
 #endif

--- a/main/depend.common
+++ b/main/depend.common
@@ -179,7 +179,10 @@ module_bl_gfs.o: module_gfs_machine.o \
 module_bl_gfsedmf.o: module_gfs_machine.o \
 		 module_gfs_physcons.o
 
-module_bl_mynn.o: ../share/module_model_constants.o
+module_bl_mynn.o: module_bl_mynn_common.o
+
+module_bl_mynn_wrapper.o: module_bl_mynn.o \
+		  module_bl_mynn_common.o
 
 module_cam_upper_bc.o: module_cam_shr_kind_mod.o \
 		module_cam_support.o
@@ -225,11 +228,9 @@ module_sf_mynn.o: module_sf_sfclay.o module_bl_mynn.o \
                 ../share/module_model_constants.o \
                 ../frame/module_wrf_error.o
 
-module_sf_fogdes.o: ../share/module_model_constants.o \
-                module_bl_mynn.o
+module_sf_fogdes.o: ../share/module_model_constants.o
 
-module_bl_fogdes.o: ../share/module_model_constants.o \
-                module_bl_mynn.o
+module_bl_fogdes.o: ../share/module_model_constants.o
 
 module_sf_gfdl.o : \
 		module_gfs_machine.o \
@@ -551,10 +552,11 @@ module_physics_init.o : \
 		module_bl_myjpbl.o		\
 		module_bl_qnsepbl.o		\
 		module_bl_mynn.o                \
+                module_bl_mynn_wrapper.o        \
 		module_bl_myjurb.o              \
 		module_bl_boulac.o              \
 		module_bl_camuwpbl_driver.o     \
-		module_bl_temf.o              \
+		module_bl_temf.o                \
 		module_bl_mfshconvpbl.o         \
 		module_cu_kf.o			\
 	        module_cu_g3.o                  \
@@ -691,6 +693,7 @@ module_pbl_driver.o:  \
 		module_bl_gfs.o \
 		module_bl_gfsedmf.o \
 		module_bl_mynn.o \
+                module_bl_mynn_wrapper.o \
 		module_bl_fogdes.o \
 		module_bl_gwdo.o \
 		module_bl_gwdo_gsl.o \

--- a/phys/Makefile
+++ b/phys/Makefile
@@ -42,7 +42,9 @@ MODULES = \
 	module_bl_myjpbl.o \
 	module_bl_qnsepbl.o \
 	module_bl_acm.o \
-	module_bl_mynn.o \
+        module_bl_mynn_common.o \
+        module_bl_mynn.o \
+        module_bl_mynn_wrapper.o \
 	module_bl_fogdes.o \
 	module_bl_gwdo.o \
 	module_bl_gwdo_gsl.o \

--- a/phys/module_bl_fogdes.F
+++ b/phys/module_bl_fogdes.F
@@ -1,11 +1,12 @@
 MODULE module_bl_fogdes
 
   USE module_model_constants
-  USE module_bl_mynn, only: qcgmin, gno, gpw
 
 !-------------------------------------------------------------------
   IMPLICIT NONE
 !-------------------------------------------------------------------
+  REAL, PARAMETER :: gno=1.0  !original value seems too aggressive: 4.64158883361278196
+  REAL, PARAMETER :: gpw=5./3., qcgmin=1.e-8
 
 CONTAINS
 

--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -223,7 +223,7 @@
 !            New option for stability function: (Puhales, 2020-12)
 !                bl_mynn_stfunc = 0 (original, Kansas-type function, Paulson, 1970 )
 !                bl_mynn_stfunc = 1 (expanded range, same as used for Jimenez et al (MWR)
-!                see the Technical Note for this implementation.
+!                see the Technical Note for this implementation (small impact).
 !            Improved conservation of momentum and higher-order moments.
 !            Important bug fixes for mixing of chemical species.
 !            Addition of pressure-gradient effects on updraft momentum transport.
@@ -386,7 +386,7 @@ CONTAINS
        &nchem,kdvel,ndvel,              & !smoke/chem variables
        &chem3d,vdep,                    &
        &frp,emis_ant_no,                &
-       &mix_chem,enh_mix,               &
+       &mix_chem,enh_mix,               & !note: these arrays/flags are still under development
        &rrfs_sd,smoke_dbg,              & !end smoke/chem variables
        &tsq,qsq,cov,                    &
        &rublten,rvblten,rthblten,       &
@@ -812,8 +812,7 @@ CONTAINS
              zw(kte+1)=zw(kte)+dz(i,kte)
 
 !>  - Call get_pblh() to calculate hybrid (\f$\theta_{vli}-TKE\f$) PBL height.
-!             CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
-             CALL GET_PBLH(KTS,KTE,PBLH(i),thvl,  &
+             CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
                &  Qke1,zw,dz1,xland(i),KPBL(i))
              
 !>  - Call scale_aware() to calculate similarity functions for scale-adaptive control
@@ -831,7 +830,7 @@ CONTAINS
 !! obtaining prerequisite variables by calling the following subroutines from 
 !! within mym_initialize(): mym_level2() and mym_length().
              CALL mym_initialize (                & 
-                  &kts,kte,                       &
+                  &kts,kte,xland(i),              &
                   &dz1, dx(i), zw,                &
                   &u1, v1, thl, sqv,              &
                   &thlsg, sqwsg,                  &
@@ -840,7 +839,7 @@ CONTAINS
                   &el, Qke1, Tsq1, Qsq1, Cov1,    &
                   &Psig_bl(i), cldfra_bl1D,       &
                   &bl_mynn_mixlength,             &
-                  &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
+                  &edmf_w1,edmf_a1,               &
                   &INITIALIZE_QKE,                &
                   &spp_pbl,rstoch_col )
 
@@ -1116,8 +1115,7 @@ CONTAINS
 
 !>  - Call get_pblh() to calculate the hybrid \f$\theta_{vli}-TKE\f$
 !! PBL height diagnostic.
-!          CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
-          CALL GET_PBLH(KTS,KTE,PBLH(i),thvl,&
+          CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
           & Qke1,zw,dz1,xland(i),KPBL(i))
 
 !>  - Call scale_aware() to calculate the similarity functions,
@@ -1179,7 +1177,7 @@ CONTAINS
 !! selected by use of the namelist parameter \p bl_mynn_cloudpdf.
 
           CALL  mym_condensation ( kts,kte,      &
-               &dx(i),dz1,zw,u1,v1,xland(i),     &
+               &dx(i),dz1,zw,xland(i),           &
                &thl,sqw,sqv,sqc,sqi,             &
                &p1,ex1,tsq1,qsq1,cov1,           &
                &Sh,el,bl_mynn_cloudpdf,          &
@@ -1267,7 +1265,7 @@ CONTAINS
           delt2 = delt !*0.5    !only works if topdown=0
 
           CALL mym_turbulence (                  & 
-               &kts,kte,closure,                 &
+               &kts,kte,xland(i),closure,        &
                &dz1, DX(i), zw,                  &
                &u1, v1, thl, thetav, sqc, sqw,   &
                &thlsg, sqwsg,                    &
@@ -1283,7 +1281,7 @@ CONTAINS
                &tke_budget,                      &
                &Psig_bl(i),Psig_shcu(i),         &
                &cldfra_bl1D,bl_mynn_mixlength,   &
-               &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
+               &edmf_w1,edmf_a1,                 &
                &TKEprodTD,                       &
                &spp_pbl,rstoch_col)
 
@@ -1416,7 +1414,7 @@ CONTAINS
                if (present(qnifa) .and. flag_qnifa) rqnifablten(i,k)=0.
                if (present(qnbca) .and. flag_qnbca) rqnbcablten(i,k)=0.
              endif
-             DOZONE(i,k)=DOZONE1(k)
+             dozone(i,k)=dozone1(k)
 
              if (icloud_bl > 0) then
                 qc_bl(i,k)=qc_bl1D(k)
@@ -1605,7 +1603,7 @@ CONTAINS
 !!\section gen_mym_ini GSD MYNN-EDMF mym_initialize General Algorithm 
 !> @{
   SUBROUTINE  mym_initialize (                                & 
-       &            kts,kte,                                  &
+       &            kts,kte,xland,                            &
        &            dz, dx, zw,                               &
        &            u, v, thl, qw,                            &
        &            thlsg, qwsg,                              &
@@ -1614,21 +1612,21 @@ CONTAINS
        &            ust, rmo, el,                             &
        &            Qke, Tsq, Qsq, Cov, Psig_bl, cldfra_bl1D, &
        &            bl_mynn_mixlength,                        &
-       &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,    &
+       &            edmf_w1,edmf_a1,                          &
        &            INITIALIZE_QKE,                           &
        &            spp_pbl,rstoch_col)
 !
 !-------------------------------------------------------------------
     
     INTEGER, INTENT(IN)   :: kts,kte
-    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength
     LOGICAL, INTENT(IN)   :: INITIALIZE_QKE
 !    REAL, INTENT(IN)   :: ust, rmo, pmz, phh, flt, flq
-    REAL, INTENT(IN)   :: ust, rmo, Psig_bl, dx
+    REAL, INTENT(IN)   :: ust, rmo, Psig_bl, dx, xland
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
     REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,cldfra_bl1D,&
-                                          edmf_w1,edmf_a1,edmf_qc1
+                                          edmf_w1,edmf_a1
     REAL, DIMENSION(kts:kte), INTENT(out) :: tsq,qsq,cov
     REAL, DIMENSION(kts:kte), INTENT(inout) :: el,qke
     REAL, DIMENSION(kts:kte) :: &
@@ -1637,7 +1635,7 @@ CONTAINS
     INTEGER :: k,l,lmax
     REAL :: phm,vkz,elq,elv,b1l,b2l,pmz=1.,phh=1.,flt=0.,flq=0.,tmpq
     REAL :: zi
-      REAL, DIMENSION(kts:kte) :: theta,thetav,thlsg,qwsg
+    REAL, DIMENSION(kts:kte) :: theta,thetav,thlsg,qwsg
 
     REAL, DIMENSION(kts:kte) :: rstoch_col
     INTEGER ::spp_pbl
@@ -1692,17 +1690,18 @@ CONTAINS
     DO l = 1,lmax
 !
 !> - call mym_length() to calculate the master length scale.
-       CALL mym_length (                     &
-            &            kts,kte,            &
-            &            dz, dx, zw,         &
-            &            rmo, flt, flq,      &
-            &            vt, vq,             &
-            &            u, v, qke,          &
-            &            dtv,                &
-            &            el,                 &
-            &            zi,theta,           &
-            &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength,&
-            &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf)
+       CALL mym_length (                          &
+            &            kts,kte,xland,           &
+            &            dz, dx, zw,              &
+            &            rmo, flt, flq,           &
+            &            vt, vq,                  &
+            &            u, v, qke,               &
+            &            dtv,                     &
+            &            el,                      &
+            &            zi,theta,                &
+            &            qkw,Psig_bl,cldfra_bl1D, &
+            &            bl_mynn_mixlength,       &
+            &            edmf_w1,edmf_a1          )
 !
        DO k = kts+1,kte
           elq = el(k)*qkw(k)
@@ -1945,16 +1944,17 @@ CONTAINS
 !>\ingroup gsd_mynn_edmf
 !! This subroutine calculates the mixing lengths.
   SUBROUTINE  mym_length (                     & 
-    &            kts,kte,                      &
+    &            kts,kte,xland,                &
     &            dz, dx, zw,                   &
     &            rmo, flt, flq,                &
     &            vt, vq,                       &
     &            u1, v1, qke,                  &
     &            dtv,                          &
     &            el,                           &
-    &            zi,theta,                     &
-    &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength,&
-    &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf)
+    &            zi, theta, qkw,               &
+    &            Psig_bl, cldfra_bl1D,         &
+    &            bl_mynn_mixlength,            &
+    &            edmf_w1,edmf_a1               )
     
 !-------------------------------------------------------------------
 
@@ -1965,12 +1965,12 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength
     REAL, DIMENSION(kts:kte), INTENT(in)   :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,dx
+    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,dx,xland
     REAL, DIMENSION(kts:kte), INTENT(IN)   :: u1,v1,qke,vt,vq,cldfra_bl1D,&
-                                          edmf_w1,edmf_a1,edmf_qc1
+                                          edmf_w1,edmf_a1
     REAL, DIMENSION(kts:kte), INTENT(out)  :: qkw, el
     REAL, DIMENSION(kts:kte), INTENT(in)   :: dtv
 
@@ -2003,12 +2003,11 @@ CONTAINS
     !SURFACE LAYER LENGTH SCALE MODS TO REDUCE IMPACT IN UPPER BOUNDARY LAYER
     REAL, PARAMETER :: ZSLH = 100. !< Max height correlated to surface conditions (m)
     REAL, PARAMETER :: CSL = 2.    !< CSL = constant of proportionality to L O(1)
-    REAL :: z_m
 
 
     INTEGER :: i,j,k
     REAL :: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,wstar,elb,els, &
-            & els1,elf,el_stab,el_unstab,el_mf,el_stab_mf,elb_mf,     &
+            & elf,el_stab,el_mf,el_stab_mf,elb_mf,                    &
             & PBLH_PLUS_ENT,Uonset,Ugrid,wt_u,el_les
     REAL, PARAMETER :: ctau = 1000. !constant for tau_cloud
 
@@ -2078,15 +2077,11 @@ CONTAINS
               elf = elb
            ENDIF
 
-           z_m = MAX(0.,zwk - 4.)
-
            !   **  Length scale in the surface layer  **
            IF ( rmo .GT. 0.0 ) THEN
               els  = karman*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-              els1 = karman*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
            ELSE
               els  =  karman*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-              els1 =  karman*z_m*( 1.0 - alp4* zwk*rmo )**0.2
            END IF
 
            !   ** HARMONC AVERGING OF MIXING LENGTH SCALES:
@@ -2146,7 +2141,9 @@ CONTAINS
         END DO
 
         elt = MIN( MAX( alp1*elt/vsc, 10.), 400.)
-        vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        !avoid use of buoyancy flux functions which are ill-defined at the surface
+        !vflx = ( vt(kts)+1.0 )*flt + ( vq(kts)+tv0 )*flq
+        vflx = flt
         vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
 
         !   **  Strictly, el(i,j,1) is not zero.  **
@@ -2173,15 +2170,11 @@ CONTAINS
               elf = elb
            ENDIF
 
-           z_m = MAX(0.,zwk - 4.)
-
            !   **  Length scale in the surface layer  **
            IF ( rmo .GT. 0.0 ) THEN
               els  = karman*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-              els1 = karman*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
            ELSE
               els  =  karman*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-              els1 =  karman*z_m*( 1.0 - alp4* zwk*rmo )**0.2
            END IF
 
            !   ** NOW BLEND THE MIXING LENGTH SCALES:
@@ -2191,8 +2184,6 @@ CONTAINS
            !defined relative to the PBLH (zi) + transition layer (h1)
            !el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
            !try squared-blending
-           !el_unstab = SQRT( els**2/(1. + (els1**2/elt**2) ))
-   !        el(k) = SQRT( els**2/(1. + (els1**2/elt**2) +(els1**2/elb**2)))
            el(k) = SQRT( els**2/(1. + (els**2/elt**2) +(els**2/elb**2)))
            el(k) = MIN (el(k), elf)
            el(k) = el(k)*(1.-wt) + alp5*elBLavg(k)*wt
@@ -2250,7 +2241,9 @@ CONTAINS
         END DO
 
         elt = MIN( MAX(alp1*elt/vsc, 10.), 400.)
-        vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        !avoid use of buoyancy flux functions which are ill-defined at the surface
+        !vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        vflx = flt
         vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
 
         !   **  Strictly, el(i,j,1) is not zero.  **
@@ -2313,33 +2306,24 @@ CONTAINS
               elb_mf = elb
          END IF
          elf    = elf/(1. + (elf/800.))  !bound free-atmos mixing length to < 800 m.
-!         elb_mf = elb_mf/(1. + (elb_mf/800.))  !bound buoyancy mixing length to < 800 m.
          elb_mf = MAX(elb_mf, 0.01) !to avoid divide-by-zero below
-
-         z_m = MAX(0.,zwk - 4.)
 
          !   **  Length scale in the surface layer  **
          IF ( rmo .GT. 0.0 ) THEN
             els  = karman*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-            els1 = karman*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
          ELSE
             els  =  karman*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-            els1 =  karman*z_m*( 1.0 - alp4* zwk*rmo )**0.2
          END IF
 
          !   ** NOW BLEND THE MIXING LENGTH SCALES:
          wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
 
-         ! "el_unstab" = blended els-elt
-         !el_unstab = els/(1. + (els1/elt))
          !try squared-blending
-         !el(k) = SQRT( els**2/(1. + (els1**2/elt**2) ))
-         el(k) = SQRT( els**2/(1. + (els1**2/elt**2) +(els1**2/elb_mf**2)))
-         !el(k) = MIN(el_unstab, elb_mf)
+         el(k) = SQRT( els**2/(1. + (els**2/elt**2) +(els**2/elb_mf**2)))
          el(k) = el(k)*(1.-wt) + elf*wt
 
-         ! include scale-awareness. For now, use simple asymptotic kz -> 12 m.
-         el_les= MIN(els/(1. + (els1/12.)), elb_mf)
+         ! include scale-awareness. For now, use simple asymptotic kz -> 12 m (should be ~dz).
+         el_les= MIN(els/(1. + (els/12.)), elb_mf)
          el(k) = el(k)*Psig_bl + (1.-Psig_bl)*el_les
 
        END DO
@@ -2729,7 +2713,7 @@ CONTAINS
 !! is set to True)
   SUBROUTINE  mym_turbulence (                                &
     &            kts,kte,                                     &
-    &            closure,                                     &
+    &            xland,closure,                               &
     &            dz, dx, zw,                                  &
     &            u, v, thl, thetav, ql, qw,                   &
     &            thlsg, qwsg,                                 &
@@ -2742,8 +2726,9 @@ CONTAINS
     &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
     &		 qWT1D,qSHEAR1D,qBUOY1D,qDISS1D,              &
     &            tke_budget,                                  &
-    &            Psig_bl,Psig_shcu,cldfra_bl1D,bl_mynn_mixlength,&
-    &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,       &
+    &            Psig_bl,Psig_shcu,cldfra_bl1D,               &
+    &            bl_mynn_mixlength,                           &
+    &            edmf_w1,edmf_a1,                             &
     &            TKEprodTD,                                   &
     &            spp_pbl,rstoch_col)
 
@@ -2756,13 +2741,13 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf,tke_budget
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,tke_budget
     REAL, INTENT(IN)      :: closure
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu,dx
+    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu,dx,xland,zi
     REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,thetav,qw,& 
-         &ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1D,edmf_w1,edmf_a1,edmf_qc1,&
+         &ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1D,edmf_w1,edmf_a1,&
          &TKEprodTD,thlsg,qwsg
 
     REAL, DIMENSION(kts:kte), INTENT(out) :: dfm,dfh,dfq,&
@@ -2781,7 +2766,7 @@ CONTAINS
     REAL :: e6c,dzk,afk,abk,vtt,vqq,&
          &cw25,clow,cupp,gamt,gamq,smd,gamv,elq,elh
 
-    REAL :: zi, cldavg
+    REAL :: cldavg
     REAL, DIMENSION(kts:kte), INTENT(in) :: theta
 
     REAL ::  a2fac, duz, ri !JOE-Canuto/Kitamura mod
@@ -2822,7 +2807,7 @@ CONTAINS
     &            dtl, dqw, dtv, gm, gh, sm, sh  )
 !
     CALL mym_length (                           &
-    &            kts,kte,                       &
+    &            kts,kte,xland,                 &
     &            dz, dx, zw,                    &
     &            rmo, flt, flq,                 &
     &            vt, vq,                        &
@@ -2830,8 +2815,9 @@ CONTAINS
     &            dtv,                           &
     &            el,                            &
     &            zi,theta,                      &
-    &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength, &
-    &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf )
+    &            qkw,Psig_bl,cldfra_bl1D,       &
+    &            bl_mynn_mixlength,             &
+    &            edmf_w1,edmf_a1                )
 !
 
     DO k = kts+1,kte
@@ -3158,11 +3144,6 @@ CONTAINS
 !      with active plumes and clouds.
        cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
        IF (edmf_a1(k) > 0.001 .OR. cldavg > 0.02) THEN
-           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
-           !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
-           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
-           !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
-
            ! for mass-flux columns
            sm(k) = MAX(sm(k), 0.03*MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
            sh(k) = MAX(sh(k), 0.03*MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
@@ -3176,14 +3157,14 @@ CONTAINS
 
        ! Production of TKE (pdk), T-variance (pdt),
        ! q-variance (pdq), and covariance (pdc)
-       pdk(k) = elq*( sm(k)*gm(k) &
-            &                    +sh(k)*gh(k)+gamv ) + &
+       pdk(k) = elq*( sm(k)*gm(k)                &
+            &        +sh(k)*gh(k)+gamv ) +       &
             &   TKEprodTD(k)
        pdt(k) = elh*( sh(k)*dtl(k)+gamt )*dtl(k)
        pdq(k) = elh*( sh(k)*dqw(k)+gamq )*dqw(k)
-       pdc(k) = elh*( sh(k)*dtl(k)+gamt )&
-            &*dqw(k)*0.5 &
-                  &+elh*( sh(k)*dqw(k)+gamq )*dtl(k)*0.5
+       pdc(k) = elh*( sh(k)*dtl(k)+gamt )        &
+            &   *dqw(k)*0.5                      &
+            & + elh*( sh(k)*dqw(k)+gamq )*dtl(k)*0.5
 
        ! Contergradient terms
        tcd(k) = elq*gamt
@@ -3227,7 +3208,7 @@ CONTAINS
        !!!Dissipation Term (now it evaluated on mym_predict)
        !qDISS1D(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.)) !! ORIGINAL CODE
        
-       !! >> EOB  
+       !! >> EOB
     ENDIF
 
     END DO
@@ -3719,7 +3700,7 @@ CONTAINS
 !! calculate the buoyancy flux. Different cloud PDFs can be selected by
 !! use of the namelist parameter \p bl_mynn_cloudpdf .
   SUBROUTINE  mym_condensation (kts,kte,   &
-    &            dx, dz, zw, u1, v1, xland,&
+    &            dx, dz, zw, xland,        &
     &            thl, qw, qv, qc, qi,      &
     &            p,exner,                  &
     &            tsq, qsq, cov,            &
@@ -3743,7 +3724,7 @@ CONTAINS
     REAL, DIMENSION(kts:kte), INTENT(IN) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(IN) :: zw
     REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner,thl,qw,qv,qc,qi, &
-         &tsq, qsq, cov, th, u1, v1
+         &tsq, qsq, cov, th
 
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: vt,vq,sgm
 
@@ -3755,7 +3736,7 @@ CONTAINS
     REAL :: qsl,esat,qsat,dqsl,cld0,q1k,qlk,eq1,qll,&
          &q2p,pt,rac,qt,t,xl,rsl,cpm,Fng,qww,alpha,beta,bb,&
          &ls,wt,cld_factor,fac_damp,liq_frac,ql_ice,ql_water,&
-         &qmq,qsat_tk,wsp,wspfac
+         &qmq,qsat_tk
     INTEGER :: i,j,k
 
     REAL :: erf
@@ -3767,7 +3748,6 @@ CONTAINS
     !variables for SGS BL clouds
     REAL            :: zagl,damp,PBLH2
     REAL            :: cfmax
-    INTEGER, PARAMETER :: pdf_opt=1   ! 0: traditional SD77, 1: CB02,CB05
 
     !JAYMES:  variables for tropopause-height estimation
     REAL            :: theta1, theta2, ht1, ht2
@@ -3977,16 +3957,10 @@ CONTAINS
            ! Specify cloud fraction
            !Original C-B cloud fraction, allows cloud fractions out to q1 = -3.5
            !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.55*q1(k)))) ! Eq. 7 in CB02
-           !wayne's  - over-diffuse, when limits removed from vt & vq & fng
+           !Waynes LES fit  - over-diffuse, when limits removed from vt & vq & fng
            !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.2*(q1(k)+0.4))))
-           !effort to reduce rh-dependency
-           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(2.9*(q1(k)+0.4))))
-           cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.8*(q1(k)+0.4))))
-           !moderate - best compromise??
-           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.55*(q1(k)+0.2))))
-           !closer to original for Q1 < -1, best for holding onto stratus, not good flowers
-           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.9*(q1(k)+0.4))))
-
+           !Best compromise: Improves marine stratus without adding much cold bias.
+           cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.8*(q1(k)+0.2))))
 
            ! Specify hydrometeors
            ! JAYMES- this option added 8 May 2015
@@ -4003,8 +3977,10 @@ CONTAINS
            ENDIF
 
            !In saturated grid cells, use average of SGS and resolved values
-           if ( qc(k) > 1.e-7 ) ql_water = 0.5 * ( ql_water + qc(k) )
-           if ( qi(k) > 1.e-9 ) ql_ice = 0.5 * ( ql_ice + qi(k) )
+           if ( qc(k) > 1.e-6 ) ql_water = 0.5 * ( ql_water + qc(k) ) 
+           !since ql_ice is actually the total frozen condensate (snow+ice),
+           !do not average with grid-scale ice alone 
+           !if ( qi(k) > 1.e-9 ) ql_ice = 0.5 * ( ql_ice + qi(k) )
 
            if (cldfra_bl1D(k) < 0.01) then
               ql_ice   = 0.0
@@ -4012,7 +3988,8 @@ CONTAINS
               cldfra_bl1D(k) = 0.0
            endif
 
-           !PHASE PARTITIONING:  Make some inferences about the relative amounts of 
+           !PHASE PARTITIONING: currently commented out since we are moving towards prognostic sgs clouds
+           !Make some inferences about the relative amounts of
            !subgrid cloud water vs. ice based on collocated explicit clouds.  Otherise, 
            !use a simple temperature-dependent partitioning.
            ! IF ( qc(k) + qi(k) > 0.0 ) THEN ! explicit condensate exists, retain its phase partitioning
@@ -4045,11 +4022,8 @@ CONTAINS
 
            !Buoyancy-flux-related calculations follow...
            !limiting Q1 to avoid too much diffusion in cloud layers
-           if ((xland-1.5).GE.0) then   ! water
-              q1k=max(Q1(k),-2.5)
-           else                         ! land
-              q1k=max(Q1(k),-2.0)
-           endif
+           q1k=max(Q1(k),-2.0)
+
            ! "Fng" represents the non-Gaussian transport factor
            ! (non-dimensional) from Bechtold et al. 1995 
            ! (hereafter BCMT95), section 3(c).  Their suggested 
@@ -4072,63 +4046,29 @@ CONTAINS
               Fng = MIN(23.9 + EXP(-1.6*(q1k+2.5)), 60.)
            ENDIF
 
-           if (pdf_opt .eq. 1) then
-              cfmax= min(cldfra_bl1D(K), 0.6)
-              bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
-                                ! "b" in CB02 (i.e., b(k) above) by a factor 
-                                ! of T/theta.  Strictly, b(k) above is formulated in
-                                ! terms of sat. mixing ratio, but bb in BCMT95 is
-                                ! cast in terms of sat. specific humidity.  The
-                                ! conversion is neglected here. 
-              qww   = 1.+0.61*qw(k)
-              alpha = 0.61*th(k)
-              beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
-              vt(k) = qww   - cfmax*beta*bb*Fng   - 1.
-              vq(k) = alpha + cfmax*beta*a(k)*Fng - tv0
-              ! vt and vq correspond to beta-theta and beta-q, respectively,  
-              ! in NN09, Eq. B8.  They also correspond to the bracketed
-              ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
-              ! The "-1" and "-tv0" terms are included for consistency with 
-              ! the legacy vt and vq formulations (above).
-           else
+           cfmax= min(cldfra_bl1D(k), 0.5)
+           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
+                             ! "b" in CB02 (i.e., b(k) above) by a factor 
+                             ! of T/theta.  Strictly, b(k) above is formulated in
+                             ! terms of sat. mixing ratio, but bb in BCMT95 is
+                             ! cast in terms of sat. specific humidity.  The
+                             ! conversion is neglected here. 
+           qww   = 1.+0.61*qw(k)
+           alpha = 0.61*th(k)
+           beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
+           vt(k) = qww   - cfmax*beta*bb*Fng   - 1.
+           vq(k) = alpha + cfmax*beta*a(k)*Fng - tv0
+           ! vt and vq correspond to beta-theta and beta-q, respectively,  
+           ! in NN09, Eq. B8.  They also correspond to the bracketed
+           ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
+           ! The "-1" and "-tv0" terms are included for consistency with 
+           ! the legacy vt and vq formulations (above).
 
-              !original buoyancy flux functions from SD77
-              eq1  = rrp*exp( -0.5*q1k*q1k )
-              qll  = max( cldfra_bl1D(k)*q1k + eq1, 0.0 )
-              q2p = xl/cp/exner(k)
-
-              !qt is a THETA-V CONVERSION FOR TOTAL WATER
-              cfmax= min(cldfra_bl1D(K), 0.6)
-              qt   = 1.0 +p608*qw(k) -(1.+p608)*(qc_bl1D(k)+qi_bl1D(k))*cfmax
-              rac  = alp(k)*( cfmax-qll*eq1 )*( q2p*qt-(1.+p608)*th(k) )
-
-              !BUOYANCY FACTORS: wherever vt and vq are used, there is a
-              !"+1" and "+tv0", respectively, so these are subtracted out here.
-              !vt is unitless and vq has units of K.
-              vt(k) =         qt-1.0 -rac*bet(k)
-              vq(k) = p608*th(k)-tv0 +rac
-           endif
-
-           ! dampen the amplification factor (cld_factor) with height in order
-           ! to limit excessively large cloud fractions aloft
-           !fac_damp = 1.! -MIN(MAX( zagl-(PBLH2+1000.),0.0)/ &
-                        !      MAX((zw(k_tropo)-(PBLH2+1000.)),500.), 1.)
-           !fac_damp = min(zagl * 0.01, 1.0)
-           wsp      =sqrt(u1(k)**2 + v1(k)**2)
-           wspfac   = 1.0 - min(max(0.,wsp-15),10.)/10. ! reduce as winds go from 15 to 25 m/s.
-           fac_damp = min(zagl * 0.0025, 1.0)*wspfac
-           !cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.5 ) / 0.51 )**3.3
+           ! dampen amplification factor where need be
+           fac_damp = min(zagl * 0.0025, 1.0)
            !cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.75 ) / 0.26 )**1.9 !HRRRv4
-           !cld_factor = 1.0 + fac_damp*(MAX(0.0, ( RH(k) - 0.80 )) / 0.22 )**2
-           !cld_factor = 1.0 + fac_damp*(MAX(0.0, ( RH(k) - 0.90 )) / 0.11 )**2
-           !cld_factor = 1.0 + fac_damp*1.8*(max(0.0, q1k + 0.2 ))**2 !too low of albedo
-           !cld_factor = 1.0 + fac_damp*1.8*(max(0.0, q1k + 0.2 ))**2
-           !make this enhancement over water only?
-           !if ((xland-1.5).GE.0) then   ! water
-              cld_factor = 1.0 + fac_damp*min((max(0.0, ( RH(k) - 0.92 )) / 0.25 )**2, 0.3)
-           !else
-           !   cld_factor = 1.0
-           !endif
+           !cld_factor = 1.0 + fac_damp*min((max(0.0, ( RH(k) - 0.92 )) / 0.25 )**2, 0.3)
+           cld_factor = 1.0 + fac_damp*min((max(0.0, ( RH(k) - 0.92 )) / 0.145)**2, 0.4)
            cldfra_bl1D(K) = MIN( 1., cld_factor*cldfra_bl1D(K) )
         enddo
 
@@ -5357,9 +5297,9 @@ ENDIF
 
     REAL, DIMENSION(kts:kte) :: rhoinv
     REAL, DIMENSION(kts:kte+1) :: rhoz,khdz
-    REAL, PARAMETER :: NO_threshold    = 0.1      ! For anthropogenic sources
+    REAL, PARAMETER :: NO_threshold    = 10.0     ! For anthropogenic sources
     REAL, PARAMETER :: frp_threshold   = 10.0     ! RAR 02/11/22: I increased the frp threshold to enhance mixing over big fires
-    REAL, PARAMETER :: pblh_threshold  = 250.0
+    REAL, PARAMETER :: pblh_threshold  = 100.0
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
@@ -6622,9 +6562,9 @@ ENDIF
 
     !smoke/chem
     IF ( mix_chem ) THEN
-      DO k=KTS,KTE-1
+      DO k=kts,kte-1
         IF(k > KTOP) exit
-        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
+        rho_int     = (rho(k)*dz(k+1)+rho(k+1)*dz(k))/(dz(k+1)+dz(k))
         DO I=1,NUP !NUP2
           IF(I > NUP2) exit
           do ic = 1,nchem
@@ -6641,14 +6581,14 @@ ENDIF
     ENDIF
 
     !Calculate the effects environmental subsidence.
-     !All envi_*variables are valid at the interfaces, like the edmf_* variables
+    !All envi_*variables are valid at the interfaces, like the edmf_* variables
     IF (env_subs) THEN
-       DO k=KTS+1,KTE-1
+       DO k=kts+1,kte-1
           !First, smooth the profiles of w & a, since sharp vertical gradients
           !in plume variables are not likely extended to env variables
           !Note1: w is treated as negative further below
           !Note2: both w & a will be transformed into env variables further below
-          envi_w(k) = onethird*(edmf_w(K-1)+edmf_w(K)+edmf_w(K+1))
+          envi_w(k) = onethird*(edmf_w(k-1)+edmf_w(k)+edmf_w(k+1))
           envi_a(k) = onethird*(edmf_a(k-1)+edmf_a(k)+edmf_a(k+1))*adjustment
        ENDDO
        !define env variables at k=1 (top of first model layer)
@@ -6669,22 +6609,26 @@ ENDIF
           sublim = 1.0
        ENDIF
        !Transform w & a into env variables
-       DO k=KTS,KTE
+       DO k=kts,kte
           temp=envi_a(k)
           envi_a(k)=1.0-temp
           envi_w(k)=csub*sublim*envi_w(k)*temp/(1.-temp)
        ENDDO
        !calculate tendencies from subsidence and detrainment valid at the middle of
-       !each model layer
-       dzi(kts)    = 0.5*(DZ(kts)+DZ(kts+1))
-       sub_thl(kts)=0.5*envi_w(kts)*envi_a(kts)*(thl(kts+1)-thl(kts))/dzi(kts)
-       sub_sqv(kts)=0.5*envi_w(kts)*envi_a(kts)*(qv(kts+1)-qv(kts))/dzi(kts)
-       DO k=KTS+1,KTE-1
-          dzi(k)    = 0.5*(DZ(k)+DZ(k+1))
-          sub_thl(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
-                      (thl(k+1)-thl(k))/dzi(k)
-          sub_sqv(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
-                      (qv(k+1)-qv(k))/dzi(k) 
+       !each model layer. The lowest model layer uses an assumes w=0 at the surface.
+       dzi(kts)    = 0.5*(dz(kts)+dz(kts+1))
+       rho_int     = (rho(kts)*dz(kts+1)+rho(kts+1)*dz(kts))/(dz(kts+1)+dz(kts))
+       sub_thl(kts)= 0.5*envi_w(kts)*envi_a(kts)*                               &
+                     (rho(kts+1)*thl(kts+1)-rho(kts)*thl(kts))/dzi(kts)/rho_int
+       sub_sqv(kts)= 0.5*envi_w(kts)*envi_a(kts)*                               &
+                     (rho(kts+1)*qv(kts+1)-rho(kts)*qv(kts))/dzi(kts)/rho_int
+       DO k=kts+1,kte-1
+          dzi(k)    = 0.5*(dz(k)+dz(k+1))
+          rho_int   = (rho(k)*dz(k+1)+rho(k+1)*dz(k))/(dz(k+1)+dz(k))
+          sub_thl(k)= 0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
+                      (rho(k+1)*thl(k+1)-rho(k)*thl(k))/dzi(k)/rho_int
+          sub_sqv(k)= 0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
+                      (rho(k+1)*qv(k+1)-rho(k)*qv(k))/dzi(k)/rho_int
        ENDDO
 
        DO k=KTS,KTE-1
@@ -6694,13 +6638,17 @@ ENDIF
        ENDDO
 
        IF (momentum_opt > 0) THEN
-         sub_u(kts)=0.5*envi_w(kts)*envi_a(kts)*(u(kts+1)-u(kts))/dzi(kts)
-         sub_v(kts)=0.5*envi_w(kts)*envi_a(kts)*(v(kts+1)-v(kts))/dzi(kts)
-         DO k=KTS+1,KTE-1
+         rho_int     = (rho(kts)*dz(kts+1)+rho(kts+1)*dz(kts))/(dz(kts+1)+dz(kts))
+         sub_u(kts)=0.5*envi_w(kts)*envi_a(kts)*                               &
+                    (rho(kts+1)*u(kts+1)-rho(kts)*u(kts))/dzi(kts)/rho_int
+         sub_v(kts)=0.5*envi_w(kts)*envi_a(kts)*                               &
+                    (rho(kts+1)*v(kts+1)-rho(kts)*v(kts))/dzi(kts)/rho_int
+         DO k=kts+1,kte-1
+            rho_int   = (rho(k)*dz(k+1)+rho(k+1)*dz(k))/(dz(k+1)+dz(k))
             sub_u(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
-                      (u(k+1)-u(k))/dzi(k)
+                      (rho(k+1)*u(k+1)-rho(k)*u(k))/dzi(k)/rho_int
             sub_v(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
-                      (v(k+1)-v(k))/dzi(k)
+                      (rho(k+1)*v(k+1)-rho(k)*v(k))/dzi(k)/rho_int
          ENDDO
 
          DO k=KTS,KTE-1
@@ -6721,7 +6669,7 @@ ENDIF
 
 !JOE: ADD CLDFRA_bl1d, qc_bl1d. Note that they have already been defined in
 !     mym_condensation. Here, a shallow-cu component is added, but no cumulus
-!     clouds can be added at k=1 (start loop at k=2).  
+!     clouds can be added at k=1 (start loop at k=2).
     DO K=KTS+1,KTE-2
        IF(k > KTOP) exit
          IF(0.5*(edmf_qc(k)+edmf_qc(k-1))>0.0)THEN
@@ -6776,7 +6724,6 @@ ENDIF
             !CB form:
             !sigq = 3.5E-3 * Aup * 0.5*(edmf_w(k)+edmf_w(k-1)) * f  ! convective component of sigma (CB2005)
             !sigq = SQRT(sigq**2 + sgm(k)**2)    ! combined conv + stratus components
-
             !Per S.DeRoode 2009?
             !sigq = 4. * Aup * (QTp - qt(k))
             sigq = 10. * Aup * (QTp - qt(k)) 
@@ -6788,7 +6735,7 @@ ENDIF
             Q1  = qmq/sigq                        !   the numerator of Q1
 
             if ((landsea-1.5).GE.0) then      ! WATER
-               !LES with adjustment
+               !modified form from LES
                !mf_cf = min(max(0.5 + 0.36 * atan(1.20*(Q1+0.2)),0.01),0.6)
                !Original CB
                mf_cf = min(max(0.5 + 0.36 * atan(1.55*Q1),0.01),0.6)

--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -1,19 +1,118 @@
-!WRF:MODEL_LAYER:PHYSICS
-!
-! translated from NN f77 to F90 and put into WRF by Mariusz Pagowski
-! NOAA/GSD & CIRA/CSU, Feb 2008
+!>\file module_bl_mynn.F90
+!! This file contains the entity of MYNN-EDMF PBL scheme.
+! **********************************************************************
+! *   An improved Mellor-Yamada turbulence closure model               *
+! *                                                                    *
+! *      Original author: M. Nakanishi (N.D.A), naka@nda.ac.jp         *
+! *      Translated into F90 and implemented in WRF-ARW by:            *
+! *                       Mariusz Pagowski (NOAA-GSL)                  *
+! *      Subsequently developed by:                                    *
+! *                 Joseph Olson, Jaymes Kenyon (NOAA/GSL),            *
+! *                 Wayne Angevine (NOAA/CSL), Kay Suselj (NASA/JPL),  *
+! *                 Franciano Puhales (UFSM), Laura Fowler (NCAR),     *
+! *                 Elynn Wu (UCSD), and Jordan Schnell (NOAA/GSL)     *
+! *                                                                    *
+! *   Contents:                                                        *
+! *                                                                    *
+! *   mynn_bl_driver - main subroutine which calls all other routines  *
+! *   --------------                                                   *
+! *     1. mym_initialize  (to be called once initially)               *
+! *        gives the closure constants and initializes the turbulent   *
+! *        quantities.                                                 *
+! *     2. get_pblh                                                    *
+! *        Calculates the boundary layer height                        *
+! *     3. scale_aware                                                 *
+! *        Calculates scale-adaptive tapering functions                *
+! *     4. mym_condensation                                            *
+! *        determines the liquid water content and the cloud fraction  *
+! *        diagnostically.                                             *
+! *     5. dmp_mf                                                      *
+! *        Calls the (nonlocal) mass-flux component                    *
+! *     6. ddmf_jpl                                                    *
+! *        Calls the downdraft mass-flux component                     *
+! *    (-) mym_level2      (called in the other subroutines)           *
+! *        calculates the stability functions at Level 2.              *
+! *    (-) mym_length      (called in the other subroutines)           *
+! *        calculates the master length scale.                         *
+! *     7. mym_turbulence                                              *
+! *        calculates the vertical diffusivity coefficients and the    *
+! *        production terms for the turbulent quantities.              *
+! *     8. mym_predict                                                 *
+! *        predicts the turbulent quantities at the next step.         *
+! *                                                                    *
+! *             call mym_initialize                                    *
+! *                  |                                                 *
+! *                  |<----------------+                               *
+! *                  |                 |                               *
+! *             call get_pblh          |                               *
+! *             call scale_aware       |                               *
+! *             call mym_condensation  |                               *
+! *             call dmp_mf            |                               *
+! *             call ddmf_jpl          |                               *
+! *             call mym_turbulence    |                               *
+! *             call mym_predict       |                               *
+! *                  |                 |                               *
+! *                  |-----------------+                               *
+! *                  |                                                 *
+! *                 end                                                *
+! *                                                                    *
+! *   Variables worthy of special mention:                             *
+! *     tref   : Reference temperature                                 *
+! *     thl    : Liquid water potential temperature                    *
+! *     qw     : Total water (water vapor+liquid water) content        *
+! *     ql     : Liquid water content                                  *
+! *     vt, vq : Functions for computing the buoyancy flux             *
+! *     qke    : 2 * TKE                                               *
+! *     el     : mixing length                                         *
+! *                                                                    *
+! *     If the water contents are unnecessary, e.g., in the case of    *
+! *     ocean models, thl is the potential temperature and qw, ql, vt  *
+! *     and vq are all zero.                                           *
+! *                                                                    *
+! *   Grid arrangement:                                                *
+! *             k+1 +---------+                                        *
+! *                 |         |     i = 1 - nx                         *
+! *             (k) |    *    |     k = 1 - nz                         *
+! *                 |         |                                        *
+! *              k  +---------+                                        *
+! *                 i   (i)  i+1                                       *
+! *                                                                    *
+! *     All the predicted variables are defined at the center (*) of   *
+! *     the grid boxes. The diffusivity coefficients and two of their  *
+! *     components (el and stability functions sh & sm) are, however,  *
+! *     defined on the walls of the grid boxes.                        *
+! *     # Upper boundary values are given at k=nz.                     *
+! *                                                                    *
+! *   References:                                                      *
+! *     1. Nakanishi, M., 2001:                                        *
+! *        Boundary-Layer Meteor., 99, 349-378.                        *
+! *     2. Nakanishi, M. and H. Niino, 2004:                           *
+! *        Boundary-Layer Meteor., 112, 1-31.                          *
+! *     3. Nakanishi, M. and H. Niino, 2006:                           *
+! *        Boundary-Layer Meteor., 119, 397-407.                       *
+! *     4. Nakanishi, M. and H. Niino, 2009:                           *
+! *        Jour. Meteor. Soc. Japan, 87, 895-912.                      *
+! *     5. Olson J. and coauthors, 2019: A description of the          *
+! *        MYNN-EDMF scheme and coupling to other components in        *
+! *        WRF-ARW. NOAA Tech. Memo. OAR GSD, 61, 37 pp.,              *
+! *        https://doi.org/10.25923/n9wm-be49.                         * 
+! *     6. Puhales, Franciano S. and coauthors, 2020: Turbulent        *
+! *        Kinetic Energy Budget for MYNN-EDMF PBL Scheme in WRF model.*
+! *        Universidade Federal de Santa Maria Technical Note. 9 pp.   *
+! **********************************************************************
+! ==================================================================
+! Notes on original implementation into WRF-ARW
 ! changes to original code:
 ! 1. code is 1D (in z)
-! 2. no advection of TKE, covariances and variances 
+! 2. option to advect TKE, but not the covariances and variances
 ! 3. Cranck-Nicholson replaced with the implicit scheme
-! 4. removed terrain dependent grid since input in WRF in actual
+! 4. removed terrain-dependent grid since input in WRF in actual
 !    distances in z[m]
-! 5. cosmetic changes to adhere to WRF standard (remove common blocks, 
+! 5. cosmetic changes to adhere to WRF standard (remove common blocks,
 !            intent etc)
 !-------------------------------------------------------------------
-!Modifications implemented by Joseph Olson and Jaymes Kenyon NOAA/GSD/MDB - CU/CIRES
+! Further modifications post-implementation
 !
-! Departures from original MYNN (Nakanish & Niino 2009)
 ! 1. Addition of BouLac mixing length in the free atmosphere.
 ! 2. Changed the turbulent mixing length to be integrated from the
 !    surface to the top of the BL + a transition layer depth.
@@ -117,89 +216,59 @@
 !            Misc small-impact bugfixes:
 !                1) dz was incorrectly indexed in mym_condensation
 !                2) configurations with icloud_bl = 0 were using uninitialized arrays
+! v4.5 / CCPP
+!            This version includes many modifications that proved valuable in the global
+!            framework and removes some key lingering bugs in the mixing of chemical species.
+!            TKE Budget output fixed (Puhales, 2020-12)
+!            New option for stability function: (Puhales, 2020-12)
+!                bl_mynn_stfunc = 0 (original, Kansas-type function, Paulson, 1970 )
+!                bl_mynn_stfunc = 1 (expanded range, same as used for Jimenez et al (MWR)
+!                see the Technical Note for this implementation.
+!            Improved conservation of momentum and higher-order moments.
+!            Important bug fixes for mixing of chemical species.
+!            Addition of pressure-gradient effects on updraft momentum transport.
+!            Addition of bl_mynn_closure option = 2.5, 2.6, or 3.0
+!            Addition of higher-order moments for sigma when using 
+!                bl_mynn_cloudpdf = 2 (Chab-Becht).
+!            Removed WRF_CHEM dependencies.
+!            Many miscellaneous tweaks.
 !
-!            Many of these changes are now documented in Olson et al. (2019,
-!                NOAA Technical Memorandum)
-!
-! For more explanation of some configuration options, see "JOE's mods" below:
-!-------------------------------------------------------------------
+! Many of these changes are now documented in references listed above.
+!====================================================================
 
 MODULE module_bl_mynn
 
-!==================================================================
-!FV3 CONSTANTS
-!       use physcons, only : cp     => con_cp,              &
-!      &                     g      => con_g,               &
-!      &                     r_d    => con_rd,              &
-!      &                     r_v    => con_rv,              &
-!      &                     cpv    => con_cvap,            &
-!      &                     cliq   => con_cliq,            &
-!      &                     Cice   => con_csol,            &
-!      &                     rcp    => con_rocp,            &
-!      &                     XLV    => con_hvap,            &
-!      &                     XLF    => con_hfus,            &
-!      &                     EP_1   => con_fvirt,           &
-!      &                     EP_2   => con_eps
-!
-!  IMPLICIT NONE
-!
-!   REAL    , PARAMETER :: karman       = 0.4
-!   REAL    , PARAMETER :: XLS          = 2.85E6
-!   REAL    , PARAMETER :: p1000mb      = 100000.
-!   REAL    , PARAMETER :: rvovrd       = r_v/r_d
-!   REAL    , PARAMETER :: SVP1         = 0.6112
-!   REAL    , PARAMETER :: SVP2         = 17.67
-!   REAL    , PARAMETER :: SVP3         = 29.65
-!   REAL    , PARAMETER :: SVPT0        = 273.15
-!
-!   INTEGER , PARAMETER :: param_first_scalar = 1, &
-!       &                  p_qc = 2, &
-!       &                  p_qr = 0, &
-!       &                  p_qi = 2, &
-!       &                  p_qs = 0, &
-!       &                  p_qg = 0, &
-!       &                  p_qnc= 0, &
-!       &                  p_qni= 0
-!
-!END FV3 CONSTANTS
-!====================================================================
-!WRF CONSTANTS
-  USE module_model_constants, only: &
-       &karman, g, p1000mb, &
-       &cp, r_d, r_v, rcp, xlv, xlf, xls, &
-       &svp1, svp2, svp3, svpt0, ep_1, ep_2, rvovrd, &
-       &cpv, cliq, cice
+  use module_bl_mynn_common,only: &
+        cp        , cpv       , cliq       , cice      , &
+        p608      , ep_2      , ep_3       , gtr       , &
+        grav      , g_inv     , karman     , p1000mb   , &
+        rcp       , r_d       , r_v        , rk        , &
+        rvovrd    , svp1      , svp2       , svp3      , &
+        xlf       , xlv       , xls        , xlscp     , &
+        xlvcp     , tv0       , tv1        , tref      , &
+        zero      , half      , one        , two       , &
+        onethird  , twothirds , tkmin      , t0c       , &
+        tice      , kind_phys
 
-  USE module_state_description, only: param_first_scalar, &
-       &p_qc, p_qr, p_qi, p_qs, p_qg, p_qnc, p_qni 
 
   IMPLICIT NONE
 
-!END WRF CONSTANTS
 !===================================================================
-! From here on, these are used for any model
+! From here on, these are MYNN-specific parameters:
 ! The parameters below depend on stability functions of module_sf_mynn.
   REAL, PARAMETER :: cphm_st=5.0, cphm_unst=16.0, &
                      cphh_st=5.0, cphh_unst=16.0
 
-  REAL, PARAMETER :: xlvcp=xlv/cp, xlscp=(xlv+xlf)/cp, ev=xlv, rd=r_d, &
-       &rk=cp/rd, svp11=svp1*1.e3, p608=ep_1, ep_3=1.-ep_2
-
-  REAL, PARAMETER :: tref=300.0     ! reference temperature (K)
-  REAL, PARAMETER :: TKmin=253.0    ! for total water conversion, Tripoli and Cotton (1981)
-  REAL, PARAMETER :: tv0=p608*tref, tv1=(1.+p608)*tref, gtr=g/tref
-
 ! Closure constants
-  REAL, PARAMETER :: &
-       &vk  = karman, &
+  REAL, PARAMETER ::  &
        &pr  =  0.74,  &
        &g1  =  0.235, &  ! NN2009 = 0.235
-       &b1  = 24.0, &
-       &b2  = 15.0, &    ! CKmod     NN2009
+       &b1  = 24.0,   &
+       &b2  = 15.0,   &  ! CKmod     NN2009
        &c2  =  0.729, &  ! 0.729, & !0.75, &
        &c3  =  0.340, &  ! 0.340, & !0.352, &
-       &c4  =  0.0, &
-       &c5  =  0.2, &
+       &c4  =  0.0,   &
+       &c5  =  0.2,   &
        &a1  = b1*( 1.0-3.0*g1 )/6.0, &
 !       &c1  = g1 -1.0/( 3.0*a1*b1**(1.0/3.0) ), &
        &c1  = g1 -1.0/( 3.0*a1*2.88449914061481660), &
@@ -219,55 +288,54 @@ MODULE module_bl_mynn
 ! and factor for eddy viscosity for TKE (Kq = Sqfac*Km):
   REAL, PARAMETER :: qmin=0.0, zmax=1.0, Sqfac=3.0
 ! Note that the following mixing-length constants are now specified in mym_length
-!      &cns=3.5, alp1=0.23, alp2=0.3, alp3=3.0, alp4=10.0, alp5=0.4
+!      &cns=3.5, alp1=0.23, alp2=0.3, alp3=3.0, alp4=10.0, alp5=0.2
 
-! Constants for gravitational settling
-!  REAL, PARAMETER :: gno=1.e6/(1.e8)**(2./3.), gpw=5./3., qcgmin=1.e-8
-  REAL, PARAMETER :: gno=1.0  !original value seems too agressive: 4.64158883361278196
   REAL, PARAMETER :: gpw=5./3., qcgmin=1.e-8, qkemin=1.e-12
+  REAL, PARAMETER :: tliq = 269. !all hydrometeors are liquid when T > tliq
 
 ! Constants for cloud PDF (mym_condensation)
   REAL, PARAMETER :: rr2=0.7071068, rrp=0.3989423
 
-! 'parameters' for Poisson distribution (EDMF scheme)
-  REAL, PARAMETER  :: zero = 0.0, half = 0.5, one = 1.0, two = 2.0, &
-                      onethird = 1./3., twothirds = 2./3.
-
-  !Use Canuto/Kitamura mod (remove Ric and negative TKE) (1:yes, 0:no)
-  !For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the 
-  !Meteorological Society of Japan, Vol. 88, No. 5, pp. 857-864, 2010).
-  !Note that this change required further modification of other parameters
-  !above (c2, c3). If you want to remove this option, set c2 and c3 constants 
-  !(above) back to NN2009 values (see commented out lines next to the
-  !parameters above). This only removes the negative TKE problem
-  !but does not necessarily improve performance - neutral impact.
+  !>Use Canuto/Kitamura mod (remove Ric and negative TKE) (1:yes, 0:no)
+  !!For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the 
+  !!Meteorological Society of Japan, Vol. 88, No. 5, pp. 857-864, 2010).
+  !!Note that this change required further modification of other parameters
+  !!above (c2, c3). If you want to remove this option, set c2 and c3 constants 
+  !!(above) back to NN2009 values (see commented out lines next to the
+  !!parameters above). This only removes the negative TKE problem
+  !!but does not necessarily improve performance - neutral impact.
   REAL, PARAMETER :: CKmod=1.
 
-  !Use Ito et al. (2015, BLM) scale-aware (0: no, 1: yes). Note that this also has impacts
-  !on the cloud PDF and mass-flux scheme, using Honnert et al. (2011) similarity function
-  !for TKE in the upper PBL/cloud layer.
+  !>Use Ito et al. (2015, BLM) scale-aware (0: no, 1: yes). Note that this also has impacts
+  !!on the cloud PDF and mass-flux scheme, using Honnert et al. (2011) similarity function
+  !!for TKE in the upper PBL/cloud layer.
   REAL, PARAMETER :: scaleaware=1.
 
-  !Temporary switch to deactivate the mixing of chemical species (already done when WRF_CHEM = 1)
-  INTEGER, PARAMETER :: bl_mynn_mixchem = 0
+  !>Of the following the options, use one OR the other, not both.
+  !>Adding top-down diffusion driven by cloud-top radiative cooling
+  INTEGER, PARAMETER :: bl_mynn_topdown = 0
+  !>Option to activate downdrafts, from Elynn Wu (0: deactive, 1: active)
+  INTEGER, PARAMETER :: bl_mynn_edmf_dd = 0
 
-  !Adding top-down diffusion driven by cloud-top radiative cooling
-  INTEGER, PARAMETER :: bl_mynn_topdown = 1
-
-  !Option to activate heating due to dissipation of TKE (to activate, set to 1.0)
-  REAL, PARAMETER :: dheat_opt = 1.
+  !>Option to activate heating due to dissipation of TKE (to activate, set to 1.0)
+  INTEGER, PARAMETER :: dheat_opt = 1
 
   !Option to activate environmental subsidence in mass-flux scheme
-  LOGICAL, PARAMETER :: env_subs = .true.
+  LOGICAL, PARAMETER :: env_subs = .false.
+
+  !Option to switch flux-profile relationship for surface (from Puhales et al. 2020)
+  !0: use original Dyer-Hicks, 1: use Cheng-Brustaert and Blended COARE
+  INTEGER, PARAMETER :: bl_mynn_stfunc = 1
 
   !option to print out more stuff for debugging purposes
   LOGICAL, PARAMETER :: debug_code = .false.
+  INTEGER, PARAMETER :: idbg = 23 !specific i-point to write out
 
 ! JAYMES-
-! Constants used for empirical calculations of saturation
-! vapor pressures (in function "esat") and saturation mixing ratios
-! (in function "qsat"), reproduced from module_mp_thompson.F, 
-! v3.6 
+!> Constants used for empirical calculations of saturation
+!! vapor pressures (in function "esat") and saturation mixing ratios
+!! (in function "qsat"), reproduced from module_mp_thompson.F, 
+!! v3.6 
   REAL, PARAMETER:: J0= .611583699E03
   REAL, PARAMETER:: J1= .444606896E02
   REAL, PARAMETER:: J2= .143177157E01
@@ -289,155 +357,1239 @@ MODULE module_bl_mynn
   REAL, PARAMETER:: K8= .161444444E-12
 ! end-
 
-!JOE & JAYMES'S mods
-!
-! Mixing Length Options 
-!   specifed through namelist:  bl_mynn_mixlength
-!   added:  16 Apr 2015
-!
-! 0: Uses original MYNN mixing length formulation (except elt is calculated from 
-!    a 10-km vertical integration).  No scale-awareness is applied to the master
-!    mixing length (el), regardless of "scaleaware" setting. 
-!
-! 1 (*DEFAULT*): Instead of (0), uses BouLac mixing length in free atmosphere.  
-!    This helps remove excessively large mixing in unstable layers aloft.  Scale-
-!    awareness in dx is available via the "scaleaware" setting.  As of Apr 2015, 
-!    this mixing length formulation option is used in the ESRL RAP/HRRR configuration.
-!
-! 2: As in (1), but elb is lengthened using separate cloud mixing length functions 
-!    for statically stable and unstable regimes.  This elb adjustment is only 
-!    possible for nonzero cloud fractions, such that cloud-free cells are treated 
-!    as in (1), but BouLac calculation is used more sparingly - when elb > 500 m. 
-!    This is to reduce the computational expense that comes with the BouLac calculation.
-!    Also, This option is  scale-aware in dx if "scaleaware" = 1. (Following Ito et al. 2015). 
-!
-!JOE & JAYMES- end
-
-
-
+  ! Used in WRF-ARW module_physics_init.F
   INTEGER :: mynn_level
 
-  CHARACTER*128 :: mynn_message
-
-  INTEGER, PARAMETER :: kdebug=27
 
 CONTAINS
 
-! **********************************************************************
-! *   An improved Mellor-Yamada turbulence closure model               *
-! *                                                                    *
-! *                                   Aug/2005  M. Nakanishi (N.D.A)   *
-! *                        Modified:  Dec/2005  M. Nakanishi (N.D.A)   *
-! *                                             naka@nda.ac.jp         *
-! *                                                                    *
-! *   Contents:                                                        *
-! *     1. mym_initialize  (to be called once initially)               *
-! *        gives the closure constants and initializes the turbulent   *
-! *        quantities.                                                 *
-! *    (2) mym_level2      (called in the other subroutines)           *
-! *        calculates the stability functions at Level 2.              *
-! *    (3) mym_length      (called in the other subroutines)           *
-! *        calculates the master length scale.                         *
-! *     4. mym_turbulence                                              *
-! *        calculates the vertical diffusivity coefficients and the    *
-! *        production terms for the turbulent quantities.              *
-! *     5. mym_predict                                                 *
-! *        predicts the turbulent quantities at the next step.         *
-! *     6. mym_condensation                                            *
-! *        determines the liquid water content and the cloud fraction  *
-! *        diagnostically.                                             *
-! *                                                                    *
-! *             call mym_initialize                                    *
-! *                  |                                                 *
-! *                  |<----------------+                               *
-! *                  |                 |                               *
-! *             call mym_condensation  |                               *
-! *             call mym_turbulence    |                               *
-! *             call mym_predict       |                               *
-! *                  |                 |                               *
-! *                  |-----------------+                               *
-! *                  |                                                 *
-! *                 end                                                *
-! *                                                                    *
-! *   Variables worthy of special mention:                             *
-! *     tref   : Reference temperature                                 *
-! *     thl    : Liquid water potential temperature                    *
-! *     qw     : Total water (water vapor+liquid water) content        *
-! *     ql     : Liquid water content                                  *
-! *     vt, vq : Functions for computing the buoyancy flux             *
-! *                                                                    *
-! *     If the water contents are unnecessary, e.g., in the case of    *
-! *     ocean models, thl is the potential temperature and qw, ql, vt  *
-! *     and vq are all zero.                                           *
-! *                                                                    *
-! *   Grid arrangement:                                                *
-! *             k+1 +---------+                                        *
-! *                 |         |     i = 1 - nx                         *
-! *             (k) |    *    |     j = 1 - ny                         *
-! *                 |         |     k = 1 - nz                         *
-! *              k  +---------+                                        *
-! *                 i   (i)  i+1                                       *
-! *                                                                    *
-! *     All the predicted variables are defined at the center (*) of   *
-! *     the grid boxes. The diffusivity coefficients are, however,     *
-! *     defined on the walls of the grid boxes.                        *
-! *     # Upper boundary values are given at k=nz.                     *
-! *                                                                    *
-! *   References:                                                      *
-! *     1. Nakanishi, M., 2001:                                        *
-! *        Boundary-Layer Meteor., 99, 349-378.                        *
-! *     2. Nakanishi, M. and H. Niino, 2004:                           *
-! *        Boundary-Layer Meteor., 112, 1-31.                          *
-! *     3. Nakanishi, M. and H. Niino, 2006:                           *
-! *        Boundary-Layer Meteor., (in press).                         *
-! *     4. Nakanishi, M. and H. Niino, 2009:                           *
-! *        Jour. Meteor. Soc. Japan, 87, 895-912.                      *
-! **********************************************************************
-!
+! ==================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine is the GSD MYNN-EDNF PBL driver routine,which
+!! encompassed the majority of the subroutines that comprise the 
+!! procedures that ultimately solve for tendencies of 
+!! \f$U, V, \theta, q_v, q_c, and q_i\f$.
+!!\section gen_mynn_bl_driver GSD mynn_bl_driver General Algorithm
+!> @{
+  SUBROUTINE mynn_bl_driver(            &
+       &initflag,restart,cycling,       &
+       &delt,dz,dx,znt,                 &
+       &u,v,w,th,sqv3d,sqc3d,sqi3d,     &
+       &qnc,qni,                        &
+       &qnwfa,qnifa,qnbca,ozone,        &
+       &p,exner,rho,t3d,                &
+       &xland,ts,qsfc,ps,               &
+       &ust,ch,hfx,qfx,rmol,wspd,       &
+       &uoce,voce,                      & !ocean current
+       &qke,qke_adv,                    &
+       &sh3d,sm3d,                      &
+       &nchem,kdvel,ndvel,              & !smoke/chem variables
+       &chem3d,vdep,                    &
+       &frp,emis_ant_no,                &
+       &mix_chem,enh_mix,               &
+       &rrfs_sd,smoke_dbg,              & !end smoke/chem variables
+       &tsq,qsq,cov,                    &
+       &rublten,rvblten,rthblten,       &
+       &rqvblten,rqcblten,rqiblten,     &
+       &rqncblten,rqniblten,            &
+       &rqnwfablten,rqnifablten,        &
+       &rqnbcablten,dozone,             &
+       &exch_h,exch_m,                  &
+       &pblh,kpbl,                      & 
+       &el_pbl,                         &
+       &dqke,qwt,qshear,qbuoy,qdiss,    &
+       &qc_bl,qi_bl,cldfra_bl,          &
+       &bl_mynn_tkeadvect,              &
+       &bl_mynn_tkebudget,              &
+       &bl_mynn_cloudpdf,               &
+       &bl_mynn_mixlength,              &
+       &icloud_bl,                      &
+       &closure,                        &
+       &bl_mynn_edmf,                   &
+       &bl_mynn_edmf_mom,               &
+       &bl_mynn_edmf_tke,               &
+       &bl_mynn_mixscalars,             &
+       &bl_mynn_output,                 &
+       &bl_mynn_cloudmix,bl_mynn_mixqt, &
+       &edmf_a,edmf_w,edmf_qt,          &
+       &edmf_thl,edmf_ent,edmf_qc,      &
+       &sub_thl3D,sub_sqv3D,            &
+       &det_thl3D,det_sqv3D,            &
+       &nupdraft,maxMF,ktop_plume,      &
+       &spp_pbl,pattern_spp_pbl,        &
+       &rthraten,                       &
+       &FLAG_QC,FLAG_QI,FLAG_QNC,       &
+       &FLAG_QNI,FLAG_QNWFA,FLAG_QNIFA, &
+       &FLAG_QNBCA,                     &
+       &IDS,IDE,JDS,JDE,KDS,KDE,        &
+       &IMS,IME,JMS,JME,KMS,KME,        &
+       &ITS,ITE,JTS,JTE,KTS,KTE         )
+    
+!-------------------------------------------------------------------
+
+    INTEGER, INTENT(in) :: initflag
+    !INPUT NAMELIST OPTIONS:
+    LOGICAL, INTENT(IN) :: restart,cycling
+    LOGICAL, INTENT(in) :: bl_mynn_tkebudget
+    INTEGER, INTENT(in) :: bl_mynn_cloudpdf
+    INTEGER, INTENT(in) :: bl_mynn_mixlength
+    INTEGER, INTENT(in) :: bl_mynn_edmf
+    LOGICAL, INTENT(in) :: bl_mynn_tkeadvect
+    INTEGER, INTENT(in) :: bl_mynn_edmf_mom
+    INTEGER, INTENT(in) :: bl_mynn_edmf_tke
+    INTEGER, INTENT(in) :: bl_mynn_mixscalars
+    INTEGER, INTENT(in) :: bl_mynn_output
+    INTEGER, INTENT(in) :: bl_mynn_cloudmix
+    INTEGER, INTENT(in) :: bl_mynn_mixqt
+    INTEGER, INTENT(in) :: icloud_bl
+    REAL,    INTENT(in) :: closure
+
+    LOGICAL, INTENT(in) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
+                           FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA
+
+    LOGICAL, INTENT(IN) :: mix_chem,enh_mix,rrfs_sd,smoke_dbg
+
+    INTEGER, INTENT(in) :: &
+         & IDS,IDE,JDS,JDE,KDS,KDE &
+         &,IMS,IME,JMS,JME,KMS,KME &
+         &,ITS,ITE,JTS,JTE,KTS,KTE
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+! initflag > 0  for TRUE
+! else        for FALSE
+!       closure       : <= 2.5;  Level 2.5
+!                  2.5< and <3;  Level 2.6
+!                        =   3;  Level 3
+    
+    REAL, INTENT(in) :: delt
+    REAL, DIMENSION(IMS:IME), INTENT(in) :: dx
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(in) :: dz,      &
+         &u,v,w,th,sqv3D,p,exner,rho,t3d
+    REAL, DIMENSION(IMS:IME,KMS:KME), OPTIONAL, INTENT(in):: &
+         &sqc3D,sqi3D,qni,qnc,qnwfa,qnifa,qnbca
+    REAL, DIMENSION(IMS:IME,KMS:KME), OPTIONAL, INTENT(in):: ozone
+    REAL, DIMENSION(IMS:IME), INTENT(in) :: xland,ust,       &
+         &ch,ts,qsfc,ps,hfx,qfx,wspd,uoce,voce,znt
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) ::       &
+         &qke,tsq,qsq,cov,qke_adv
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) ::       &
+         &rublten,rvblten,rthblten,rqvblten,rqcblten,        &
+         &rqiblten,rqniblten,rqncblten,                      &
+         &rqnwfablten,rqnifablten,rqnbcablten
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) :: dozone
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(in)    :: rthraten
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(out)   ::       &
+         &exch_h,exch_m
+
+   !These 10 arrays are only allocated when bl_mynn_output > 0
+   REAL, DIMENSION(IMS:IME,KMS:KME), OPTIONAL, INTENT(inout) :: &
+         & edmf_a,edmf_w,edmf_qt,edmf_thl,edmf_ent,edmf_qc,  &
+         & sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
+
+!   REAL, DIMENSION(IMS:IME,KMS:KME)   :: &
+!         & edmf_a_dd,edmf_w_dd,edmf_qt_dd,edmf_thl_dd,edmf_ent_dd,edmf_qc_dd
+
+    REAL, DIMENSION(IMS:IME), INTENT(inout) :: pblh,rmol
+
+    REAL, DIMENSION(IMS:IME) :: psig_bl,psig_shcu
+
+    INTEGER,DIMENSION(IMS:IME),INTENT(INOUT) ::             &
+         &kpbl,nupdraft,ktop_plume
+
+    REAL, DIMENSION(IMS:IME), INTENT(OUT) ::                &
+         &maxmf
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) ::      &
+         &el_pbl
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), optional, INTENT(out) :: &
+         &qwt,qshear,qbuoy,qdiss,dqke
+    ! 3D budget arrays are not allocated when bl_mynn_tkebudget == .false.
+    ! 1D (local) budget arrays are used for passing between subroutines.
+    REAL, DIMENSION(kts:kte) :: qwt1,qshear1,qbuoy1,qdiss1, &
+         &dqke1,diss_heat
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), intent(out) :: Sh3D,Sm3D
+
+    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) ::      &
+         &qc_bl,qi_bl,cldfra_bl
+    REAL, DIMENSION(KTS:KTE) :: qc_bl1D,qi_bl1D,cldfra_bl1D,&
+                    qc_bl1D_old,qi_bl1D_old,cldfra_bl1D_old
+
+! smoke/chemical arrays
+    INTEGER, INTENT(IN   ) ::   nchem, kdvel, ndvel
+!    REAL,    DIMENSION( ims:ime, kms:kme, nchem ), INTENT(INOUT), optional :: chem3d
+!    REAL,    DIMENSION( ims:ime, kdvel, ndvel ), INTENT(IN), optional :: vdep
+    REAL,    DIMENSION(ims:ime, kms:kme, nchem), INTENT(INOUT), optional :: chem3d
+    REAL,    DIMENSION(ims:ime, ndvel),   INTENT(IN),    optional :: vdep
+    REAL,    DIMENSION(ims:ime),     INTENT(IN),    optional :: frp,EMIS_ANT_NO
+    !local
+    REAL,    DIMENSION(kts:kte  ,nchem) :: chem1
+    REAL,    DIMENSION(kts:kte+1,nchem) :: s_awchem1
+    REAL,    DIMENSION(ndvel)           :: vd1
+    INTEGER :: ic
+
+!local vars
+    INTEGER :: ITF,JTF,KTF, IMD,JMD
+    INTEGER :: i,j,k,kproblem
+    REAL, DIMENSION(KTS:KTE) :: thl,thvl,tl,qv1,qc1,qi1,sqw,&
+         &el, dfm, dfh, dfq, tcd, qcd, pdk, pdt, pdq, pdc,  &
+         &vt, vq, sgm, thlsg, sqwsg
+    REAL, DIMENSION(KTS:KTE) :: thetav,sh,sm,u1,v1,w1,p1,   &
+         &ex1,dz1,th1,tk1,rho1,qke1,tsq1,qsq1,cov1,         &
+         &sqv,sqi,sqc,du1,dv1,dth1,dqv1,dqc1,dqi1,ozone1,   &
+         &k_m1,k_h1,qni1,dqni1,qnc1,dqnc1,qnwfa1,qnifa1,    &
+         &qnbca1,dqnwfa1,dqnifa1,dqnbca1,dozone1
+
+    !mass-flux variables
+    REAL, DIMENSION(KTS:KTE) :: dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf
+    REAL, DIMENSION(KTS:KTE) :: edmf_a1,edmf_w1,edmf_qt1,   &
+         &edmf_thl1,edmf_ent1,edmf_qc1
+    REAL, DIMENSION(KTS:KTE) :: edmf_a_dd1,edmf_w_dd1,      &
+         &edmf_qt_dd1,edmf_thl_dd1,                         &
+         &edmf_ent_dd1,edmf_qc_dd1
+    REAL, DIMENSION(KTS:KTE) :: sub_thl,sub_sqv,sub_u,sub_v,&
+                        det_thl,det_sqv,det_sqc,det_u,det_v
+    REAL,DIMENSION(KTS:KTE+1) :: s_aw1,s_awthl1,s_awqt1,    &
+                  s_awqv1,s_awqc1,s_awu1,s_awv1,s_awqke1,   &
+                  s_awqnc1,s_awqni1,s_awqnwfa1,s_awqnifa1,  &
+                  s_awqnbca1
+    REAL,DIMENSION(KTS:KTE+1) :: sd_aw1,sd_awthl1,sd_awqt1, &
+                  sd_awqv1,sd_awqc1,sd_awu1,sd_awv1,sd_awqke1
+
+    REAL, DIMENSION(KTS:KTE+1) :: zw
+    REAL :: cpm,sqcg,flt,fltv,flq,flqv,flqc,pmz,phh,exnerg,zet,phi_m,&
+          & afk,abk,ts_decay, qc_bl2, qi_bl2,                        &
+          & th_sfc,ztop_plume,sqc9,sqi9,wsp
+
+    !top-down diffusion
+    REAL, DIMENSION(ITS:ITE) :: maxKHtopdown
+    REAL, DIMENSION(KTS:KTE) :: KHtopdown,TKEprodTD
+
+    LOGICAL :: INITIALIZE_QKE,problem
+
+    ! Stochastic fields 
+    INTEGER,  INTENT(IN)                                     ::spp_pbl
+    REAL, DIMENSION( ims:ime, kms:kme), INTENT(IN),OPTIONAL  ::pattern_spp_pbl
+    REAL, DIMENSION(KTS:KTE)                                 ::rstoch_col
+
+    ! Substepping TKE
+    INTEGER :: nsub
+    real    :: delt2
+
+
+    if (debug_code) then !check incoming values
+      do i=its,ite
+        problem = .false.
+        do k=kts,kte
+          wsp  = sqrt(u(i,k)**2 + v(i,k)**2)
+          if (abs(hfx(i)) > 1200. .or. abs(qfx(i)) > 0.001 .or.         &
+              wsp > 200. .or. t3d(i,k) > 360. .or. t3d(i,k) < 160. .or. &
+              sqv3d(i,k)< 0.0 .or. sqc3d(i,k)< 0.0 ) then
+             kproblem = k
+             problem = .true.
+             print*,"Incoming problem at: i=",i," k=1"
+             print*," QFX=",qfx(i)," HFX=",hfx(i)
+             print*," wsp=",wsp," T=",t3d(i,k)
+             print*," qv=",sqv3d(i,k)," qc=",sqc3d(i,k)
+             print*," u*=",ust(i)," wspd=",wspd(i)
+             print*," xland=",xland(i)," ts=",ts(i)
+             print*," z/L=",0.5*dz(i,1)*rmol(i)," ps=",ps(i)
+             print*," znt=",znt(i)," dx=",dx(i)
+          endif
+        enddo
+        if (problem) then
+          print*,"===tk:",t3d(i,max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qv:",sqv3d(i,max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qc:",sqc3d(i,max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qi:",sqi3d(i,max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====u:",u(i,max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====v:",v(i,max(kproblem-3,1):min(kproblem+3,kte))
+        endif
+      enddo
+    endif
+
+!***  Begin debugging
+    IMD=(IMS+IME)/2
+    JMD=(JMS+JME)/2
+!***  End debugging 
+
+    JTF=JTE
+    ITF=ITE
+    KTF=KTE
+
+    IF (bl_mynn_output > 0) THEN !research mode
+       edmf_a(its:ite,kts:kte)=0.
+       edmf_w(its:ite,kts:kte)=0.
+       edmf_qt(its:ite,kts:kte)=0.
+       edmf_thl(its:ite,kts:kte)=0.
+       edmf_ent(its:ite,kts:kte)=0.
+       edmf_qc(its:ite,kts:kte)=0.
+       sub_thl3D(its:ite,kts:kte)=0.
+       sub_sqv3D(its:ite,kts:kte)=0.
+       det_thl3D(its:ite,kts:kte)=0.
+       det_sqv3D(its:ite,kts:kte)=0.
+
+       !edmf_a_dd(its:ite,kts:kte)=0.
+       !edmf_w_dd(its:ite,kts:kte)=0.
+       !edmf_qt_dd(its:ite,kts:kte)=0.
+       !edmf_thl_dd(its:ite,kts:kte)=0.
+       !edmf_ent_dd(its:ite,kts:kte)=0.
+       !edmf_qc_dd(its:ite,kts:kte)=0.
+    ENDIF
+    ktop_plume(its:ite)=0   !int
+    nupdraft(its:ite)=0     !int
+    maxmf(its:ite)=0.
+    maxKHtopdown(its:ite)=0.
+
+    ! DH* CHECK HOW MUCH OF THIS INIT IF-BLOCK IS ACTUALLY NEEDED FOR RESTARTS
+!> - Within the MYNN-EDMF, there is a dependecy check for the first time step,
+!! If true, a three-dimensional initialization loop is entered. Within this loop,
+!! several arrays are initialized and k-oriented (vertical) subroutines are called 
+!! at every i and j point, corresponding to the x- and y- directions, respectively.  
+    IF (initflag > 0 .and. .not.restart) THEN
+
+       !Test to see if we want to initialize qke
+       IF ( (restart .or. cycling)) THEN
+          IF (MAXVAL(QKE(its:ite,kts)) < 0.0002) THEN
+             INITIALIZE_QKE = .TRUE.
+             !print*,"QKE is too small, must initialize"
+          ELSE
+             INITIALIZE_QKE = .FALSE.
+             !print*,"Using background QKE, will not initialize"
+          ENDIF
+       ELSE ! not cycling or restarting:
+          INITIALIZE_QKE = .TRUE.
+          !print*,"not restart nor cycling, must initialize QKE"
+       ENDIF
+ 
+       if (.not.restart .or. .not.cycling) THEN
+         Sh3D(its:ite,kts:kte)=0.
+         Sm3D(its:ite,kts:kte)=0.
+         el_pbl(its:ite,kts:kte)=0.
+         tsq(its:ite,kts:kte)=0.
+         qsq(its:ite,kts:kte)=0.
+         cov(its:ite,kts:kte)=0.
+         cldfra_bl(its:ite,kts:kte)=0.
+         qc_bl(its:ite,kts:kte)=0.
+         qke(its:ite,kts:kte)=0.
+       else
+         qc_bl1D(kts:kte)=0.0
+         qi_bl1D(kts:kte)=0.0
+         cldfra_bl1D(kts:kte)=0.0
+       end if
+       dqc1(kts:kte)=0.0
+       dqi1(kts:kte)=0.0
+       dqni1(kts:kte)=0.0
+       dqnc1(kts:kte)=0.0
+       dqnwfa1(kts:kte)=0.0
+       dqnifa1(kts:kte)=0.0
+       dqnbca1(kts:kte)=0.0
+       dozone1(kts:kte)=0.0
+       qc_bl1D_old(kts:kte)=0.0
+       cldfra_bl1D_old(kts:kte)=0.0
+       edmf_a1(kts:kte)=0.0
+       edmf_w1(kts:kte)=0.0
+       edmf_qc1(kts:kte)=0.0
+       edmf_a_dd1(kts:kte)=0.0
+       edmf_w_dd1(kts:kte)=0.0
+       edmf_qc_dd1(kts:kte)=0.0
+       sgm(kts:kte)=0.0
+       vt(kts:kte)=0.0
+       vq(kts:kte)=0.0
+
+       DO k=KTS,KTE
+          DO i=ITS,ITF
+             exch_m(i,k)=0.
+             exch_h(i,k)=0.
+          ENDDO
+       ENDDO
+
+       IF ( bl_mynn_tkebudget ) THEN
+          DO k=KTS,KTE
+             DO i=ITS,ITF
+                qWT(i,k)=0.
+                qSHEAR(i,k)=0.
+                qBUOY(i,k)=0.
+                qDISS(i,k)=0.
+                dqke(i,k)=0.
+             ENDDO
+          ENDDO
+       ENDIF
+
+       DO i=ITS,ITF
+          DO k=KTS,KTE !KTF
+                dz1(k)=dz(i,k)
+                u1(k) = u(i,k)
+                v1(k) = v(i,k)
+                w1(k) = w(i,k)
+                th1(k)=th(i,k)
+                tk1(k)=T3D(i,k)
+                ex1(k)=exner(i,k)
+                rho1(k)=rho(i,k)
+                sqc(k)=sqc3D(i,k) !/(1.+qv(i,k))
+                sqv(k)=sqv3D(i,k) !/(1.+qv(i,k))
+                thetav(k)=th(i,k)*(1.+0.608*sqv(k))
+                IF (icloud_bl > 0) THEN
+                   CLDFRA_BL1D(k)=CLDFRA_BL(i,k)
+                   QC_BL1D(k)=QC_BL(i,k)
+                   QI_BL1D(k)=QI_BL(i,k)
+                ENDIF
+                IF (FLAG_QI ) THEN
+                   sqi(k)=sqi3D(i,k) !/(1.+qv(i,k))
+                   sqw(k)=sqv(k)+sqc(k)+sqi(k)
+                   thl(k)=th1(k) - xlvcp/ex1(k)*sqc(k) &
+                       &         - xlscp/ex1(k)*sqi(k)
+                   !Use form from Tripoli and Cotton (1981) with their
+                   !suggested min temperature to improve accuracy.
+                   !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
+                   !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
+                   !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
+                   IF(sqc(k)<1e-6 .and. sqi(k)<1e-8 .and. CLDFRA_BL1D(k)>0.001)THEN
+                      sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
+                      sqi9=QI_BL1D(k)*CLDFRA_BL1D(k)
+                   ELSE
+                      sqc9=sqc(k)
+                      sqi9=sqi(k)
+                   ENDIF
+                   thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
+                         &         - xlscp/ex1(k)*sqi9
+                   sqwsg(k)=sqv(k)+sqc9+sqi9
+                ELSE
+                   sqi(k)=0.0
+                   sqw(k)=sqv(k)+sqc(k)
+                   thl(k)=th1(k)-xlvcp/ex1(k)*sqc(k)
+                   !Use form from Tripoli and Cotton (1981) with their 
+                   !suggested min temperature to improve accuracy.      
+                   !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
+                   !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
+                   IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
+                            sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
+                      sqi9=0.0
+                   ELSE
+                      sqc9=sqc(k)
+                      sqi9=0.0
+                   ENDIF
+                   thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
+                         &         - xlscp/ex1(k)*sqi9
+                   sqwsg(k)=sqv(k)+sqc9+sqi9
+                ENDIF
+                thvl(k)=thlsg(k)*(1.+0.61*sqv(k))
+
+                IF (k==kts) THEN
+                   zw(k)=0.
+                ELSE
+                   zw(k)=zw(k-1)+dz(i,k-1)
+                ENDIF
+                IF (INITIALIZE_QKE) THEN
+                   !Initialize tke for initial PBLH calc only - using 
+                   !simple PBLH form of Koracin and Berkowicz (1988, BLM)
+                   !to linearly taper off tke towards top of PBL.
+                   qke1(k)=5.*ust(i) * MAX((ust(i)*700. - zw(k))/(MAX(ust(i),0.01)*700.), 0.01)
+                ELSE
+                   qke1(k)=qke(i,k)
+                ENDIF
+                el(k)=el_pbl(i,k)
+                sh(k)=Sh3D(i,k)
+                sm(k)=Sm3D(i,k)
+                tsq1(k)=tsq(i,k)
+                qsq1(k)=qsq(i,k)
+                cov1(k)=cov(i,k)
+                if (spp_pbl==1) then
+                    rstoch_col(k)=pattern_spp_pbl(i,k)
+                else
+                    rstoch_col(k)=0.0
+                endif
+
+             ENDDO
+
+             zw(kte+1)=zw(kte)+dz(i,kte)
+
+!>  - Call get_pblh() to calculate hybrid (\f$\theta_{vli}-TKE\f$) PBL height.
+!             CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
+             CALL GET_PBLH(KTS,KTE,PBLH(i),thvl,  &
+               &  Qke1,zw,dz1,xland(i),KPBL(i))
+             
+!>  - Call scale_aware() to calculate similarity functions for scale-adaptive control
+!! (\f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$).
+             IF (scaleaware > 0.) THEN
+                CALL SCALE_AWARE(dx(i),PBLH(i),Psig_bl(i),Psig_shcu(i))
+             ELSE
+                Psig_bl(i)=1.0
+                Psig_shcu(i)=1.0
+             ENDIF
+
+             ! DH* CHECK IF WE CAN DO WITHOUT CALLING THIS ROUTINE FOR RESTARTS
+!>  - Call mym_initialize() to initializes the mixing length, TKE, \f$\theta^{'2}\f$,
+!! \f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$. These variables are calculated after 
+!! obtaining prerequisite variables by calling the following subroutines from 
+!! within mym_initialize(): mym_level2() and mym_length().
+             CALL mym_initialize (                & 
+                  &kts,kte,                       &
+                  &dz1, dx(i), zw,                &
+                  &u1, v1, thl, sqv,              &
+                  &thlsg, sqwsg,                  &
+                  &PBLH(i), th1, thetav, sh, sm,  &
+                  &ust(i), rmol(i),               &
+                  &el, Qke1, Tsq1, Qsq1, Cov1,    &
+                  &Psig_bl(i), cldfra_bl1D,       &
+                  &bl_mynn_mixlength,             &
+                  &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
+                  &INITIALIZE_QKE,                &
+                  &spp_pbl,rstoch_col )
+
+             IF (.not.restart) THEN
+                !UPDATE 3D VARIABLES
+                DO k=KTS,KTE !KTF
+                   el_pbl(i,k)=el(k)
+                   sh3d(i,k)=sh(k)
+                   sm3d(i,k)=sm(k)
+                   qke(i,k)=qke1(k)
+                   tsq(i,k)=tsq1(k)
+                   qsq(i,k)=qsq1(k)
+                   cov(i,k)=cov1(k)
+                ENDDO
+                !initialize qke_adv array if using advection
+                IF (bl_mynn_tkeadvect) THEN
+                   DO k=KTS,KTE
+                      qke_adv(i,k)=qke1(k)
+                   ENDDO
+                ENDIF
+             ENDIF
+
+!***  Begin debugging
+!             IF(I==IMD .AND. J==JMD)THEN
+!               PRINT*,"MYNN DRIVER INIT: k=",1," sh=",sh(k)
+!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",exch_m(i,k)
+!               PRINT*," xland=",xland(i)," rmol=",rmol(i)," ust=",ust(i)
+!               PRINT*," qke=",qke(i,k)," el=",el_pbl(i,k)," tsq=",Tsq(i,k)
+!               PRINT*," PBLH=",PBLH(i)," u=",u(i,k)," v=",v(i,k)
+!             ENDIF
+!***  End debugging
+
+       ENDDO !end i-loop
+
+    ENDIF ! end initflag
+
+!> - After initializing all required variables, the regular procedures 
+!! performed at every time step are ready for execution.
+    !ACF- copy qke_adv array into qke if using advection
+    IF (bl_mynn_tkeadvect) THEN
+       qke=qke_adv
+    ENDIF
+
+    DO i=ITS,ITF
+       DO k=KTS,KTE !KTF
+            !JOE-TKE BUDGET
+             IF ( bl_mynn_tkebudget ) THEN
+                dqke(i,k)=qke(i,k)
+             END IF
+             IF (icloud_bl > 0) THEN
+                CLDFRA_BL1D(k)=CLDFRA_BL(i,k)
+                QC_BL1D(k)=QC_BL(i,k)
+                QI_BL1D(k)=QI_BL(i,k)
+                cldfra_bl1D_old(k)=cldfra_bl(i,k)
+                qc_bl1D_old(k)=qc_bl(i,k)
+                qi_bl1D_old(k)=qi_bl(i,k)
+             else
+                CLDFRA_BL1D(k)=0.0
+                QC_BL1D(k)=0.0
+                QI_BL1D(k)=0.0
+                cldfra_bl1D_old(k)=0.0
+                qc_bl1D_old(k)=0.0
+                qi_bl1D_old(k)=0.0
+             ENDIF
+             dz1(k)= dz(i,k)
+             u1(k) = u(i,k)
+             v1(k) = v(i,k)
+             w1(k) = w(i,k)
+             th1(k)= th(i,k)
+             tk1(k)=T3D(i,k)
+             p1(k) = p(i,k)
+             ex1(k)= exner(i,k)
+             rho1(k)=rho(i,k)
+             sqv(k)= sqv3D(i,k) !/(1.+qv(i,k))
+             sqc(k)= sqc3D(i,k) !/(1.+qv(i,k))
+             qv1(k)= sqv(k)/(1.-sqv(k))
+             qc1(k)= sqc(k)/(1.-sqv(k))
+             dqc1(k)=0.0
+             dqi1(k)=0.0
+             dqni1(k)=0.0
+             dqnc1(k)=0.0
+             dqnwfa1(k)=0.0
+             dqnifa1(k)=0.0
+             dqnbca1(k)=0.0
+             dozone1(k)=0.0
+             IF(FLAG_QI)THEN
+                sqi(k)= sqi3D(i,k) !/(1.+qv(i,k))
+                qi1(k)= sqi(k)/(1.-sqv(k))
+                sqw(k)= sqv(k)+sqc(k)+sqi(k)
+                thl(k)= th1(k) - xlvcp/ex1(k)*sqc(k) &
+                     &         - xlscp/ex1(k)*sqi(k)
+                !Use form from Tripoli and Cotton (1981) with their
+                !suggested min temperature to improve accuracy.    
+                !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
+                !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
+                !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
+                IF(sqc(k)<1e-6 .and. sqi(k)<1e-8 .and. CLDFRA_BL1D(k)>0.001)THEN
+                   sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
+                   sqi9=QI_BL1D(k)*CLDFRA_BL1D(k)
+                ELSE
+                   sqc9=sqc(k)
+                   sqi9=sqi(k)
+                ENDIF
+                thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
+                      &         - xlscp/ex1(k)*sqi9
+                sqwsg(k)=sqv(k)+sqc9+sqi9
+             ELSE
+                qi1(k)=0.0
+                sqi(k)=0.0
+                sqw(k)= sqv(k)+sqc(k)
+                thl(k)= th1(k)-xlvcp/ex1(k)*sqc(k)
+                !Use form from Tripoli and Cotton (1981) with their
+                !suggested min temperature to improve accuracy.    
+                !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
+                !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
+                IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
+                   sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
+                   sqi9=QI_BL1D(k)*CLDFRA_BL1D(k)
+                ELSE
+                   sqc9=sqc(k)
+                   sqi9=0.0
+                ENDIF
+                thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
+                      &         - xlscp/ex1(k)*sqi9 
+            ENDIF
+            thetav(k)=th1(k)*(1.+0.608*sqv(k))
+            thvl(k)  =thlsg(k) *(1.+0.608*sqv(k))
+
+             IF (FLAG_QNI ) THEN
+                qni1(k)=qni(i,k)
+             ELSE
+                qni1(k)=0.0
+             ENDIF
+             IF (FLAG_QNC ) THEN
+                qnc1(k)=qnc(i,k)
+             ELSE
+                qnc1(k)=0.0
+             ENDIF
+             IF (FLAG_QNWFA ) THEN
+                qnwfa1(k)=qnwfa(i,k)
+             ELSE
+                qnwfa1(k)=0.0
+             ENDIF
+             IF (FLAG_QNIFA ) THEN
+                qnifa1(k)=qnifa(i,k)
+             ELSE
+                qnifa1(k)=0.0
+             ENDIF
+             IF (FLAG_QNBCA .and. PRESENT(qnbca)) THEN
+                qnbca1(k)=qnbca(i,k)
+             ELSE
+                qnbca1(k)=0.0
+             ENDIF
+             IF (PRESENT(ozone)) THEN
+                ozone1(k)=ozone(i,k)
+             ELSE
+                ozone1(k)=0.0
+             ENDIF
+             el(k) = el_pbl(i,k)
+             qke1(k)=qke(i,k)
+             sh(k)  =sh3d(i,k)
+             sm(k)  =sm3d(i,k)
+             tsq1(k)=tsq(i,k)
+             qsq1(k)=qsq(i,k)
+             cov1(k)=cov(i,k)
+             if (spp_pbl==1) then
+                rstoch_col(k)=pattern_spp_pbl(i,k)
+             else
+                rstoch_col(k)=0.0
+             endif
+
+             !edmf
+             edmf_a1(k)=0.0
+             edmf_w1(k)=0.0
+             edmf_qc1(k)=0.0
+             s_aw1(k)=0.
+             s_awthl1(k)=0.
+             s_awqt1(k)=0.
+             s_awqv1(k)=0.
+             s_awqc1(k)=0.
+             s_awu1(k)=0.
+             s_awv1(k)=0.
+             s_awqke1(k)=0.
+             s_awqnc1(k)=0.
+             s_awqni1(k)=0.
+             s_awqnwfa1(k)=0.
+             s_awqnifa1(k)=0.
+             s_awqnbca1(k)=0.
+             ![EWDD]
+             edmf_a_dd1(k)=0.0
+             edmf_w_dd1(k)=0.0
+             edmf_qc_dd1(k)=0.0
+             sd_aw1(k)=0.
+             sd_awthl1(k)=0.
+             sd_awqt1(k)=0.
+             sd_awqv1(k)=0.
+             sd_awqc1(k)=0.
+             sd_awu1(k)=0.
+             sd_awv1(k)=0.
+             sd_awqke1(k)=0.
+             sub_thl(k)=0.
+             sub_sqv(k)=0.
+             sub_u(k)=0.
+             sub_v(k)=0.
+             det_thl(k)=0.
+             det_sqv(k)=0.
+             det_sqc(k)=0.
+             det_u(k)=0.
+             det_v(k)=0.
+
+             IF (k==kts) THEN
+                zw(k)=0.
+             ELSE
+                zw(k)=zw(k-1)+dz(i,k-1)
+             ENDIF
+          ENDDO ! end k
+
+          !initialize smoke/chem arrays (if used):
+             if  ( mix_chem ) then
+                do ic = 1,ndvel
+                   vd1(ic) = vdep(i,ic) ! dry deposition velocity
+                   chem1(kts,ic) = chem3d(i,kts,ic)
+                   s_awchem1(kts,ic)=0.
+                enddo
+                do k = kts+1,kte
+                   do ic = 1,nchem
+                      chem1(k,ic) = chem3d(i,k,ic)
+                      s_awchem1(k,ic)=0.
+                   enddo
+                enddo
+             else
+                do ic = 1,ndvel
+                   vd1(ic) = 0. ! dry deposition velocity
+                   chem1(kts,ic) = 0.
+                   s_awchem1(kts,ic)=0.
+                enddo
+                do k = kts+1,kte
+                   do ic = 1,nchem
+                      chem1(k,ic) = 0.
+                      s_awchem1(k,ic)=0.
+                   enddo
+                enddo
+             endif
+
+          zw(kte+1)=zw(kte)+dz(i,kte)
+          !EDMF
+          s_aw1(kte+1)=0.
+          s_awthl1(kte+1)=0.
+          s_awqt1(kte+1)=0.
+          s_awqv1(kte+1)=0.
+          s_awqc1(kte+1)=0.
+          s_awu1(kte+1)=0.
+          s_awv1(kte+1)=0.
+          s_awqke1(kte+1)=0.
+          s_awqnc1(kte+1)=0.
+          s_awqni1(kte+1)=0.
+          s_awqnwfa1(kte+1)=0.
+          s_awqnifa1(kte+1)=0.
+          s_awqnbca1(kte+1)=0.
+          sd_aw1(kte+1)=0.
+          sd_awthl1(kte+1)=0.
+          sd_awqt1(kte+1)=0.
+          sd_awqv1(kte+1)=0.
+          sd_awqc1(kte+1)=0.
+          sd_awu1(kte+1)=0.
+          sd_awv1(kte+1)=0.
+          sd_awqke1(kte+1)=0.
+          IF ( mix_chem ) THEN
+             DO ic = 1,nchem
+                s_awchem1(kte+1,ic)=0.
+             ENDDO
+          ENDIF
+
+!>  - Call get_pblh() to calculate the hybrid \f$\theta_{vli}-TKE\f$
+!! PBL height diagnostic.
+!          CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
+          CALL GET_PBLH(KTS,KTE,PBLH(i),thvl,&
+          & Qke1,zw,dz1,xland(i),KPBL(i))
+
+!>  - Call scale_aware() to calculate the similarity functions,
+!! \f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$, to control 
+!! the scale-adaptive behaviour for the local and nonlocal 
+!! components, respectively.
+          IF (scaleaware > 0.) THEN
+             CALL SCALE_AWARE(dx(i),PBLH(i),Psig_bl(i),Psig_shcu(i))
+          ELSE
+             Psig_bl(i)=1.0
+             Psig_shcu(i)=1.0
+          ENDIF
+
+          sqcg= 0.0   !ill-defined variable; qcg has been removed
+          cpm=cp*(1.+0.84*qv1(kts))
+          exnerg=(ps(i)/p1000mb)**rcp
+
+          !-----------------------------------------------------
+          !ORIGINAL CODE
+          !flt = hfx(i)/( rho(i,kts)*cpm ) &
+          ! +xlvcp*ch(i)*(sqc(kts)/exner(i,kts) -sqcg/exnerg)
+          !flq = qfx(i)/  rho(i,kts)       &
+          !    -ch(i)*(sqc(kts)   -sqcg )
+          !-----------------------------------------------------
+          flqv   = qfx(i)/rho1(kts)
+          flqc   = 0.0 !currently no sea-spray fluxes, fog settling hangled elsewhere
+          th_sfc = ts(i)/ex1(kts)
+
+          ! TURBULENT FLUX FOR TKE BOUNDARY CONDITIONS
+          flq =flqv+flqc                  !! LATENT
+          flt =hfx(i)/(rho1(kts)*cpm )-xlvcp*flqc/ex1(kts)  !! Temperature flux
+          fltv=flt + flqv*p608*th_sfc     !! Virtual temperature flux
+
+          ! Update 1/L using updated sfc heat flux and friction velocity
+          rmol(i) = -karman*gtr*fltv/max(ust(i)**3,1.0e-6)
+          zet = 0.5*dz(i,kts)*rmol(i)
+          zet = MAX(zet, -20.)
+          zet = MIN(zet,  20.)
+          !if(i.eq.idbg)print*,"updated z/L=",zet
+          if (bl_mynn_stfunc == 0) then
+             !Original Kansas-type stability functions
+             if ( zet >= 0.0 ) then
+                pmz = 1.0 + (cphm_st-1.0) * zet
+                phh = 1.0 +  cphh_st      * zet
+             else
+                pmz = 1.0/    (1.0-cphm_unst*zet)**0.25 - zet
+                phh = 1.0/SQRT(1.0-cphh_unst*zet)
+             end if
+          else
+             !Updated stability functions (Puhales, 2020)
+             phi_m = phim(zet)
+             pmz   = phi_m - zet
+             phh   = phih(zet)
+          end if
+
+!>  - Call mym_condensation() to calculate the nonconvective component
+!! of the subgrid cloud fraction and mixing ratio as well as the functions
+!! used to calculate the buoyancy flux. Different cloud PDFs can be
+!! selected by use of the namelist parameter \p bl_mynn_cloudpdf.
+
+          CALL  mym_condensation ( kts,kte,      &
+               &dx(i),dz1,zw,u1,v1,xland(i),     &
+               &thl,sqw,sqv,sqc,sqi,             &
+               &p1,ex1,tsq1,qsq1,cov1,           &
+               &Sh,el,bl_mynn_cloudpdf,          &
+               &qc_bl1D,qi_bl1D,cldfra_bl1D,     &
+               &PBLH(i),HFX(i),                  &
+               &Vt, Vq, th1, sgm, rmol(i),       &
+               &spp_pbl, rstoch_col              )
+
+!>  - Add TKE source driven by cloud top cooling
+!!  Calculate the buoyancy production of TKE from cloud-top cooling when
+!! \p bl_mynn_topdown =1.
+          IF (bl_mynn_topdown.eq.1)then
+             CALL topdown_cloudrad(kts,kte,dz1,zw,          &
+                &xland(i),kpbl(i),PBLH(i),                  &
+                &sqc,sqi,sqw,thl,th1,ex1,p1,rho1,thetav,    &
+                &cldfra_bl1D,rthraten(i,:),                 &
+                &maxKHtopdown(i),KHtopdown,TKEprodTD        )
+          ELSE
+             maxKHtopdown(i)  = 0.0
+             KHtopdown(kts:kte) = 0.0
+             TKEprodTD(kts:kte) = 0.0
+          ENDIF
+
+          IF (bl_mynn_edmf > 0) THEN
+            !PRINT*,"Calling DMP Mass-Flux: i= ",i
+            CALL DMP_mf(                          &
+               &kts,kte,delt,zw,dz1,p1,rho1,      &
+               &bl_mynn_edmf_mom,                 &
+               &bl_mynn_edmf_tke,                 &
+               &bl_mynn_mixscalars,               &
+               &u1,v1,w1,th1,thl,thetav,tk1,      &
+               &sqw,sqv,sqc,qke1,                 &
+               &qnc1,qni1,qnwfa1,qnifa1,qnbca1,   &
+               &ex1,Vt,Vq,sgm,                    &
+               &ust(i),flt,fltv,flq,flqv,         &
+               &PBLH(i),KPBL(i),DX(i),            &
+               &xland(i),th_sfc,                  &
+            ! now outputs - tendencies
+            ! &,dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf  &
+            ! outputs - updraft properties
+               & edmf_a1,edmf_w1,edmf_qt1,        &
+               & edmf_thl1,edmf_ent1,edmf_qc1,    &
+            ! for the solver
+               & s_aw1,s_awthl1,s_awqt1,          &
+               & s_awqv1,s_awqc1,                 &
+               & s_awu1,s_awv1,s_awqke1,          &
+               & s_awqnc1,s_awqni1,               &
+               & s_awqnwfa1,s_awqnifa1,s_awqnbca1,&
+               & sub_thl,sub_sqv,                 &
+               & sub_u,sub_v,                     &
+               & det_thl,det_sqv,det_sqc,         &
+               & det_u,det_v,                     &
+            ! chem/smoke mixing
+               & nchem,chem1,s_awchem1,           &
+               & mix_chem,                        &
+               & qc_bl1D,cldfra_bl1D,             &
+               & qc_bl1D_old,cldfra_bl1D_old,     &
+               & FLAG_QC,FLAG_QI,                 &
+               & FLAG_QNC,FLAG_QNI,               &
+               & FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA,&
+               & Psig_shcu(i),                    &
+               & nupdraft(i),ktop_plume(i),       &
+               & maxmf(i),ztop_plume,             &
+               & spp_pbl,rstoch_col               )
+          ENDIF
+
+          IF (bl_mynn_edmf_dd == 1) THEN
+            CALL DDMF_JPL(kts,kte,delt,zw,dz1,p1, &
+              &u1,v1,th1,thl,thetav,tk1,          &
+              sqw,sqv,sqc,rho1,ex1,               &
+              &ust(i),flt,flq,                    &
+              &PBLH(i),KPBL(i),                   &
+              &edmf_a_dd1,edmf_w_dd1,edmf_qt_dd1, &
+              &edmf_thl_dd1,edmf_ent_dd1,         &
+              &edmf_qc_dd1,                       &
+              &sd_aw1,sd_awthl1,sd_awqt1,         &
+              &sd_awqv1,sd_awqc1,sd_awu1,sd_awv1, &
+              &sd_awqke1,                         &
+              &qc_bl1d,cldfra_bl1d,               &
+              &rthraten(i,:)                      )
+          ENDIF
+
+          !Capability to substep the eddy-diffusivity portion
+          !do nsub = 1,2
+          delt2 = delt !*0.5    !only works if topdown=0
+
+          CALL mym_turbulence (                  & 
+               &kts,kte,closure,                 &
+               &dz1, DX(i), zw,                  &
+               &u1, v1, thl, thetav, sqc, sqw,   &
+               &thlsg, sqwsg,                    &
+               &qke1, tsq1, qsq1, cov1,          &
+               &vt, vq,                          &
+               &rmol(i), flt, flq,               &
+               &PBLH(i),th1,                     &
+               &Sh,Sm,el,                        &
+               &Dfm,Dfh,Dfq,                     &
+               &Tcd,Qcd,Pdk,                     &
+               &Pdt,Pdq,Pdc,                     &
+               &qWT1,qSHEAR1,qBUOY1,qDISS1,      &
+               &bl_mynn_tkebudget,               &
+               &Psig_bl(i),Psig_shcu(i),         &
+               &cldfra_bl1D,bl_mynn_mixlength,   &
+               &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
+               &TKEprodTD,                       &
+               &spp_pbl,rstoch_col)
+
+!>  - Call mym_predict() to solve TKE and 
+!! \f$\theta^{'2}, q^{'2}, and \theta^{'}q^{'}\f$
+!! for the following time step.
+          CALL mym_predict (kts,kte,closure,     &
+               &delt2, dz1,                      &
+               &ust(i), flt, flq, pmz, phh,      &
+               &el, dfq, rho1, pdk, pdt, pdq, pdc,&
+               &Qke1, Tsq1, Qsq1, Cov1,          &
+               &s_aw1, s_awqke1, bl_mynn_edmf_tke,&
+               &qWT1, qDISS1,bl_mynn_tkebudget) !! TKE budget  (Puhales, 2020)
+
+          if (dheat_opt > 0) then
+             DO k=kts,kte-1
+                ! Set max dissipative heating rate to 7.2 K per hour
+                diss_heat(k) = MIN(MAX(1.0*(qke1(k)**1.5)/(b1*MAX(0.5*(el(k)+el(k+1)),1.))/cp, 0.0),0.002)
+                ! Limit heating above 100 mb:
+                diss_heat(k) = diss_heat(k) * exp(-10000./MAX(p1(k),1.)) 
+             ENDDO
+             diss_heat(kte) = 0.
+          else
+             diss_heat(1:kte) = 0.
+          endif
+
+!>  - Call mynn_tendencies() to solve for tendencies of 
+!! \f$U, V, \theta, q_{v}, q_{c}, and q_{i}\f$.
+          CALL mynn_tendencies(kts,kte,i,        &
+               &delt, dz1, rho1,                 &
+               &u1, v1, th1, tk1, qv1,           &
+               &qc1, qi1, qnc1, qni1,            &
+               &ps(i), p1, ex1, thl,             &
+               &sqv, sqc, sqi, sqw,              &
+               &qnwfa1, qnifa1, qnbca1, ozone1,  &
+               &ust(i),flt,flq,flqv,flqc,        &
+               &wspd(i),uoce(i),voce(i),         &
+               &tsq1, qsq1, cov1,                &
+               &tcd, qcd,                        &
+               &dfm, dfh, dfq,                   &
+               &Du1, Dv1, Dth1, Dqv1,            &
+               &Dqc1, Dqi1, Dqnc1, Dqni1,        &
+               &Dqnwfa1, Dqnifa1, Dqnbca1,       &
+               &Dozone1,                         &
+               &diss_heat,                       &
+               ! mass flux components
+               &s_aw1,s_awthl1,s_awqt1,          &
+               &s_awqv1,s_awqc1,s_awu1,s_awv1,   &
+               &s_awqnc1,s_awqni1,               &
+               &s_awqnwfa1,s_awqnifa1,s_awqnbca1,&
+               &sd_aw1,sd_awthl1,sd_awqt1,       &
+               &sd_awqv1,sd_awqc1,               &
+               sd_awu1,sd_awv1,                  &
+               &sub_thl,sub_sqv,                 &
+               &sub_u,sub_v,                     &
+               &det_thl,det_sqv,det_sqc,         &
+               &det_u,det_v,                     &
+               &FLAG_QC,FLAG_QI,FLAG_QNC,        &
+               &FLAG_QNI,FLAG_QNWFA,FLAG_QNIFA,  &
+               &FLAG_QNBCA,                      &
+               &cldfra_bl1d,                     &
+               &bl_mynn_cloudmix,                &
+               &bl_mynn_mixqt,                   &
+               &bl_mynn_edmf,                    &
+               &bl_mynn_edmf_mom,                &
+               &bl_mynn_mixscalars               )
+
+
+          IF ( mix_chem ) THEN
+            IF ( rrfs_sd ) THEN 
+             CALL mynn_mix_chem(kts,kte,i,       &
+                  &delt, dz1, pblh(i),           &
+                  &nchem, kdvel, ndvel,          &
+                  &chem1, vd1,                   &
+                  &rho1,flt,                     &
+                  &tcd, qcd,                     &
+                  &dfh,                          &
+                  &s_aw1,s_awchem1,              &
+                  &emis_ant_no(i),               &
+                  &frp(i), rrfs_sd,              &
+                  &enh_mix, smoke_dbg            )
+             ELSE
+              CALL mynn_mix_chem(kts,kte,i,       &
+                   &delt, dz1, pblh(i),           &
+                   &nchem, kdvel, ndvel,          &
+                   &chem1, vd1,                   &
+                   &rho1,flt,                     &
+                   &tcd, qcd,                     &
+                   &dfh,                          &
+                   &s_aw1,s_awchem1,              &
+                   &zero,                         &
+                   &zero, rrfs_sd,                &
+                   &enh_mix, smoke_dbg            )
+             ENDIF
+             DO ic = 1,nchem
+                DO k = kts,kte
+                   chem3d(i,k,ic) = max(1.e-12, chem1(k,ic))
+                ENDDO
+             ENDDO
+          ENDIF
+ 
+          CALL retrieve_exchange_coeffs(kts,kte,&
+               &dfm, dfh, dz1, K_m1, K_h1)
+
+          !UPDATE 3D ARRAYS
+          do k=kts,kte
+             exch_m(i,k)=K_m1(k)
+             exch_h(i,k)=K_h1(k)
+             rublten(i,k)=du1(k)
+             rvblten(i,k)=dv1(k)
+             rthblten(i,k)=dth1(k)
+             rqvblten(i,k)=dqv1(k)
+             if (bl_mynn_cloudmix > 0) then
+               if (present(sqc3D) .and. flag_qc) rqcblten(i,k)=dqc1(k)
+               if (present(sqi3D) .and. flag_qi) rqiblten(i,k)=dqi1(k)
+             else
+               if (present(sqc3D) .and. flag_qc) rqcblten(i,k)=0.
+               if (present(sqi3D) .and. flag_qi) rqiblten(i,k)=0.
+             endif
+             if (bl_mynn_cloudmix > 0 .and. bl_mynn_mixscalars > 0) then
+               if (present(qnc) .and. flag_qnc) rqncblten(i,k)=dqnc1(k)
+               if (present(qni) .and. flag_qni) rqniblten(i,k)=dqni1(k)
+               if (present(qnwfa) .and. flag_qnwfa) rqnwfablten(i,k)=dqnwfa1(k)
+               if (present(qnifa) .and. flag_qnifa) rqnifablten(i,k)=dqnifa1(k)
+               if (present(qnbca) .and. flag_qnbca) rqnbcablten(i,k)=dqnbca1(k)
+             else
+               if (present(qnc) .and. flag_qnc) rqncblten(i,k)=0.
+               if (present(qni) .and. flag_qni) rqniblten(i,k)=0.
+               if (present(qnwfa) .and. flag_qnwfa) rqnwfablten(i,k)=0.
+               if (present(qnifa) .and. flag_qnifa) rqnifablten(i,k)=0.
+               if (present(qnbca) .and. flag_qnbca) rqnbcablten(i,k)=0.
+             endif
+             DOZONE(i,k)=DOZONE1(k)
+
+             if (icloud_bl > 0) then
+                qc_bl(i,k)=qc_bl1D(k)
+                qi_bl(i,k)=qi_bl1D(k)
+                cldfra_bl(i,k)=cldfra_bl1D(k)
+             endif
+
+             el_pbl(i,k)=el(k)
+             qke(i,k)=qke1(k)
+             tsq(i,k)=tsq1(k)
+             qsq(i,k)=qsq1(k)
+             cov(i,k)=cov1(k)
+             sh3d(i,k)=sh(k)
+             sm3d(i,k)=sm(k)
+          enddo !end-k
+
+          if ( bl_mynn_tkebudget ) then
+             !! TKE budget is now given in m**2/s**-3 (Puhales, 2020)
+             !! Lower boundary condtions (using similarity relationships such as the prognostic equation for Qke)
+             k=kts
+             qSHEAR1(k)=4.*(ust(i)**3*phi_m/(karman*dz(i,k)))-qSHEAR1(k+1) !! staggered
+             qBUOY1(k)=4.*(-ust(i)**3*zet/(karman*dz(i,k)))-qBUOY1(k+1) !! staggered
+             !! unstaggering SHEAR and BUOY and trasfering all TKE budget to 3D array               
+             do k = kts,kte-1
+                qSHEAR(i,k)=0.5*(qSHEAR1(k)+qSHEAR1(k+1)) !!! unstaggering in z
+                qBUOY(i,k)=0.5*(qBUOY1(k)+qBUOY1(k+1)) !!! unstaggering in z
+                qWT(i,k)=qWT1(k)
+                qDISS(i,k)=qDISS1(k)
+                dqke(i,k)=(qke1(k)-dqke(i,k))*0.5/delt
+             enddo
+             !! Upper boundary conditions               
+             k=kte
+             qSHEAR(i,k)=0.
+             qBUOY(i,k)=0.
+             qWT(i,k)=0.
+             qDISS(i,k)=0.
+             dqke(i,k)=0.
+          endif
+
+          !update updraft/downdraft properties
+          if (bl_mynn_output > 0) THEN !research mode == 1
+             if (bl_mynn_edmf > 0) THEN
+                DO k = kts,kte
+                   edmf_a(i,k)=edmf_a1(k)
+                   edmf_w(i,k)=edmf_w1(k)
+                   edmf_qt(i,k)=edmf_qt1(k)
+                   edmf_thl(i,k)=edmf_thl1(k)
+                   edmf_ent(i,k)=edmf_ent1(k)
+                   edmf_qc(i,k)=edmf_qc1(k)
+                   sub_thl3D(i,k)=sub_thl(k)
+                   sub_sqv3D(i,k)=sub_sqv(k)
+                   det_thl3D(i,k)=det_thl(k)
+                   det_sqv3D(i,k)=det_sqv(k)
+                ENDDO
+             endif
+!             if (bl_mynn_edmf_dd > 0) THEN
+!                DO k = kts,kte
+!                   edmf_a_dd(i,k)=edmf_a_dd1(k)
+!                   edmf_w_dd(i,k)=edmf_w_dd1(k)
+!                   edmf_qt_dd(i,k)=edmf_qt_dd1(k)
+!                   edmf_thl_dd(i,k)=edmf_thl_dd1(k)
+!                   edmf_ent_dd(i,k)=edmf_ent_dd1(k)
+!                   edmf_qc_dd(i,k)=edmf_qc_dd1(k)
+!                ENDDO
+!             ENDIF
+          ENDIF
+
+          !***  Begin debug prints
+          IF ( debug_code .and. (i .eq. idbg)) THEN
+             IF ( ABS(QFX(i))>.001)print*,&
+                "SUSPICIOUS VALUES AT: i=",i," QFX=",QFX(i)
+             IF ( ABS(HFX(i))>1100.)print*,&
+                "SUSPICIOUS VALUES AT: i=",i," HFX=",HFX(i)
+             DO k = kts,kte
+               IF ( sh(k) < 0. .OR. sh(k)> 200.)print*,&
+                  "SUSPICIOUS VALUES AT: i,k=",i,k," sh=",sh(k)
+               IF ( ABS(vt(k)) > 2.0 )print*,&
+                  "SUSPICIOUS VALUES AT: i,k=",i,k," vt=",vt(k)
+               IF ( ABS(vq(k)) > 7000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,k=",i,k," vq=",vq(k)
+               IF ( qke(i,k) < -1. .OR. qke(i,k)> 200.)print*,&
+                  "SUSPICIOUS VALUES AT: i,k=",i,k," qke=",qke(i,k)
+               IF ( el_pbl(i,k) < 0. .OR. el_pbl(i,k)> 1500.)print*,&
+                  "SUSPICIOUS VALUES AT: i,k=",i,k," el_pbl=",el_pbl(i,k)
+               IF ( exch_m(i,k) < 0. .OR. exch_m(i,k)> 2000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,k=",i,k," exxch_m=",exch_m(i,k)
+               IF (icloud_bl > 0) then
+                  IF( cldfra_bl(i,k) < 0.0 .OR. cldfra_bl(i,k)> 1.)THEN
+                  PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl(i,k)," qc_bl=",QC_BL(i,k)
+                  ENDIF
+               ENDIF
+
+               !IF (I==IMD .AND. J==JMD) THEN
+               !   PRINT*,"MYNN DRIVER END: k=",k," sh=",sh(k)
+               !   PRINT*," sqw=",sqw(k)," thl=",thl(k)," exch_m=",exch_m(i,k)
+               !   PRINT*," xland=",xland(i)," rmol=",rmol(i)," ust=",ust(i)
+               !   PRINT*," qke=",qke(i,k)," el=",el_pbl(i,k)," tsq=",tsq(i,k)
+               !   PRINT*," PBLH=",PBLH(i)," u=",u(i,k)," v=",v(i,k)
+               !   PRINT*," vq=",vq(k)," vt=",vt(k)
+               !ENDIF
+             ENDDO !end-k
+          ENDIF
+          !***  End debug prints
+
+          !JOE-add tke_pbl for coupling w/shallow-cu schemes (TKE_PBL = QKE/2.)
+          !    TKE_PBL is defined on interfaces, while QKE is at middle of layer.
+          !tke_pbl(i,kts) = 0.5*MAX(qke(i,kts),1.0e-10)
+          !DO k = kts+1,kte
+          !   afk = dz1(k)/( dz1(k)+dz1(k-1) )
+          !   abk = 1.0 -afk
+          !   tke_pbl(i,k) = 0.5*MAX(qke(i,k)*abk+qke(i,k-1)*afk,1.0e-3)
+          !ENDDO
+
+    ENDDO !end i-loop
+
+!ACF copy qke into qke_adv if using advection
+    IF (bl_mynn_tkeadvect) THEN
+       qke_adv=qke
+    ENDIF
+!ACF-end
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
+  END SUBROUTINE mynn_bl_driver
+!> @}
+
+!=======================================================================
 !     SUBROUTINE  mym_initialize:
 !
 !     Input variables:
 !       iniflag         : <>0; turbulent quantities will be initialized
 !                         = 0; turbulent quantities have been already
 !                              given, i.e., they will not be initialized
-!       nx, ny, nz      : Dimension sizes of the
-!                         x, y and z directions, respectively
+!       nx, nz          : Dimension sizes of the
+!                         x and z directions, respectively
 !       tref            : Reference temperature                      (K)
-!       dz(nz)        : Vertical grid spacings                     (m)
+!       dz(nz)          : Vertical grid spacings                     (m)
 !                         # dz(nz)=dz(nz-1)
 !       zw(nz+1)        : Heights of the walls of the grid boxes     (m)
 !                         # zw(1)=0.0 and zw(k)=zw(k-1)+dz(k-1)
-!       h(nx,ny)        : G^(1/2) in the terrain-following coordinate
-!                         # h=1-zg/zt, where zg is the height of the
-!                           terrain and zt the top of the model domain
-!       pi0(nx,my,nz) : Exner function at zw*h+zg             (J/kg K)
+!       exner(nx,nz)    : Exner function at zw*h+zg             (J/kg K)
 !                         defined by c_p*( p_basic/1000hPa )^kappa
 !                         This is usually computed by integrating
 !                         d(pi0)/dz = -h*g/tref.
-!       rmo(nx,ny)      : Inverse of the Obukhov length         (m^(-1))
-!       flt, flq(nx,ny) : Turbulent fluxes of sensible and latent heat,
-!                         respectively, e.g., flt=-u_*Theta_* (K m/s)
-!! flt - liquid water potential temperature surface flux
-!! flq - total water flux surface flux
-!       ust(nx,ny)      : Friction velocity                        (m/s)
-!       pmz(nx,ny)      : phi_m-zeta at z1*h+z0, where z1 (=0.5*dz(1))
+!       rmo(nx)         : Inverse of the Obukhov length         (m^(-1))
+!       flt, flq(nx)    : Turbulent fluxes of potential temperature and
+!                         total water, respectively:
+!                                    flt=-u_*Theta_*             (K m/s)
+!                                    flq=-u_*qw_*            (kg/kg m/s)
+!       ust(nx)         : Friction velocity                        (m/s)
+!       pmz(nx)         : phi_m-zeta at z1*h+z0, where z1 (=0.5*dz(1))
 !                         is the first grid point above the surafce, z0
 !                         the roughness length and zeta=(z1*h+z0)*rmo
-!       phh(nx,ny)      : phi_h at z1*h+z0
-!       u, v(nx,nz,ny): Components of the horizontal wind        (m/s)
-!       thl(nx,nz,ny)  : Liquid water potential temperature
+!       phh(nx)         : phi_h at z1*h+z0
+!       u, v(nx,nz)     : Components of the horizontal wind        (m/s)
+!       thl(nx,nz)      : Liquid water potential temperature
 !                                                                    (K)
-!       qw(nx,nz,ny)  : Total water content Q_w                (kg/kg)
+!       qw(nx,nz)       : Total water content Q_w                (kg/kg)
 !
 !     Output variables:
-!       ql(nx,nz,ny)  : Liquid water content                   (kg/kg)
-!       v?(nx,nz,ny)  : Functions for computing the buoyancy flux
-!       qke(nx,nz,ny) : Twice the turbulent kinetic energy q^2
+!       ql(nx,nz)       : Liquid water content                   (kg/kg)
+!       vt, vq(nx,nz)   : Functions for computing the buoyancy flux
+!       qke(nx,nz)      : Twice the turbulent kinetic energy q^2
 !                                                              (m^2/s^2)
-!       tsq(nx,nz,ny) : Variance of Theta_l                      (K^2)
-!       qsq(nx,nz,ny) : Variance of Q_w
-!       cov(nx,nz,ny) : Covariance of Theta_l and Q_w              (K)
-!       el(nx,nz,ny)  : Master length scale L                      (m)
+!       tsq(nx,nz)      : Variance of Theta_l                      (K^2)
+!       qsq(nx,nz)      : Variance of Q_w
+!       cov(nx,nz)      : Covariance of Theta_l and Q_w              (K)
+!       el(nx,nz)       : Master length scale L                      (m)
 !                         defined on the walls of the grid boxes
 !
 !     Work arrays:        see subroutine mym_level2
@@ -448,12 +1600,19 @@ CONTAINS
 !     # As to dtl, ...gh, see subroutine mym_turbulence.
 !
 !-------------------------------------------------------------------
+
+!>\ingroup gsd_mynn_edmf
+!! This subroutine initializes the mixing length, TKE, \f$\theta^{'2}\f$,
+!! \f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$.
+!!\section gen_mym_ini GSD MYNN-EDMF mym_initialize General Algorithm 
+!> @{
   SUBROUTINE  mym_initialize (                                & 
        &            kts,kte,                                  &
-       &            dz, zw,                                   &
+       &            dz, dx, zw,                               &
        &            u, v, thl, qw,                            &
+       &            thlsg, qwsg,                              &
 !       &            ust, rmo, pmz, phh, flt, flq,             &
-       &            zi, theta, sh,                            &
+       &            zi, theta, thetav, sh, sm,                &
        &            ust, rmo, el,                             &
        &            Qke, Tsq, Qsq, Cov, Psig_bl, cldfra_bl1D, &
        &            bl_mynn_mixlength,                        &
@@ -467,36 +1626,37 @@ CONTAINS
     INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
     LOGICAL, INTENT(IN)   :: INITIALIZE_QKE
 !    REAL, INTENT(IN)   :: ust, rmo, pmz, phh, flt, flq
-    REAL, INTENT(IN)   :: ust, rmo, Psig_bl
+    REAL, INTENT(IN)   :: ust, rmo, Psig_bl, dx
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
     REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,cldfra_bl1D,&
                                           edmf_w1,edmf_a1,edmf_qc1
     REAL, DIMENSION(kts:kte), INTENT(out) :: tsq,qsq,cov
     REAL, DIMENSION(kts:kte), INTENT(inout) :: el,qke
-
     REAL, DIMENSION(kts:kte) :: &
          &ql,pdk,pdt,pdq,pdc,dtl,dqw,dtv,&
          &gm,gh,sm,sh,qkw,vt,vq
     INTEGER :: k,l,lmax
     REAL :: phm,vkz,elq,elv,b1l,b2l,pmz=1.,phh=1.,flt=0.,flq=0.,tmpq
     REAL :: zi
-    REAL, DIMENSION(kts:kte) :: theta
+      REAL, DIMENSION(kts:kte) :: theta,thetav,thlsg,qwsg
 
     REAL, DIMENSION(kts:kte) :: rstoch_col
     INTEGER ::spp_pbl
 
-!   **  At first ql, vt and vq are set to zero.  **
+!> - At first ql, vt and vq are set to zero.
     DO k = kts,kte
        ql(k) = 0.0
        vt(k) = 0.0
        vq(k) = 0.0
     END DO
 !
-    CALL mym_level2 ( kts,kte,&
-         &            dz,  &
-         &            u, v, thl, qw, &
-         &            ql, vt, vq, &
+!> - Call mym_level2() to calculate the stability functions at level 2.
+    CALL mym_level2 ( kts,kte,                      &
+         &            dz,                           &
+         &            u, v, thl, thetav, qw,        &
+         &            thlsg, qwsg,                  &
+         &            ql, vt, vq,                   &
          &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
 !   **  Preliminary setting  **
@@ -518,7 +1678,7 @@ CONTAINS
     cov(kts) = phm*( flt/ust )*( flq/ust )
 !
     DO k = kts+1,kte
-       vkz = vk*zw(k)
+       vkz = karman*zw(k)
        el (k) = vkz/( 1.0 + vkz/100.0 )
 !       qke(k) = 0.0
 !
@@ -533,9 +1693,10 @@ CONTAINS
 !
     DO l = 1,lmax
 !
+!> - call mym_length() to calculate the master length scale.
        CALL mym_length (                     &
             &            kts,kte,            &
-            &            dz, zw,             &
+            &            dz, dx, zw,         &
             &            rmo, flt, flq,      &
             &            vt, vq,             &
             &            u, v, qke,          &
@@ -547,15 +1708,15 @@ CONTAINS
 !
        DO k = kts+1,kte
           elq = el(k)*qkw(k)
-          pdk(k) = elq*( sm(k)*gm (k)+&
-               &sh(k)*gh (k) )
+          pdk(k) = elq*( sm(k)*gm(k) + &
+               &         sh(k)*gh(k) )
           pdt(k) = elq*  sh(k)*dtl(k)**2
           pdq(k) = elq*  sh(k)*dqw(k)**2
           pdc(k) = elq*  sh(k)*dtl(k)*dqw(k)
        END DO
 !
-!   **  Strictly, vkz*h(i,j) -> vk*( 0.5*dz(1)*h(i,j)+z0 )  **
-       vkz = vk*0.5*dz(kts)
+!   **  Strictly, vkz*h(i,j) -> karman*( 0.5*dz(1)*h(i,j)+z0 )  **
+       vkz = karman*0.5*dz(kts)
        elv = 0.5*( el(kts+1)+el(kts) ) /  vkz
        IF (INITIALIZE_QKE)THEN 
           !qke(kts) = ust**2 * ( b1*pmz*elv    )**(2.0/3.0)
@@ -574,7 +1735,7 @@ CONTAINS
           tmpq=MIN(MAX(b1l*( pdk(k+1)+pdk(k) ),qkemin),125.)
 !          PRINT *,'tmpqqqqq',tmpq,pdk(k+1),pdk(k)
           IF (INITIALIZE_QKE)THEN
-             qke(k) = tmpq**0.666666666
+             qke(k) = tmpq**twothirds
           ENDIF
 
           IF ( qke(k) .LE. 0.0 ) THEN
@@ -607,6 +1768,7 @@ CONTAINS
 !    RETURN
 
   END SUBROUTINE mym_initialize
+!> @}
   
 !
 ! ==================================================================
@@ -625,10 +1787,35 @@ CONTAINS
 !
 !       These are defined on the walls of the grid boxes.
 !
-  SUBROUTINE  mym_level2 (kts,kte,&
-       &            dz, &
-       &            u, v, thl, qw, &
-       &            ql, vt, vq, &
+
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the level 2, non-dimensional wind shear
+!! \f$G_M\f$ and vertical temperature gradient \f$G_H\f$ as well as 
+!! the level 2 stability funcitons \f$S_h\f$ and \f$S_m\f$.
+!!\param kts    horizontal dimension
+!!\param kte    vertical dimension
+!!\param dz     vertical grid spacings (\f$m\f$)
+!!\param u      west-east component of the horizontal wind (\f$m s^{-1}\f$)
+!!\param v      south-north component of the horizontal wind (\f$m s^{-1}\f$)
+!!\param thl    liquid water potential temperature
+!!\param qw     total water content \f$Q_w\f$
+!!\param ql     liquid water content (\f$kg kg^{-1}\f$)
+!!\param vt
+!!\param vq
+!!\param dtl     vertical gradient of \f$\theta_l\f$ (\f$K m^{-1}\f$)
+!!\param dqw     vertical gradient of \f$Q_w\f$
+!!\param dtv     vertical gradient of \f$\theta_V\f$ (\f$K m^{-1}\f$)
+!!\param gm      \f$G_M\f$ divided by \f$L^{2}/q^{2}\f$ (\f$s^{-2}\f$)
+!!\param gh      \f$G_H\f$ divided by \f$L^{2}/q^{2}\f$ (\f$s^{-2}\f$)
+!!\param sm      stability function for momentum, at Level 2
+!!\param sh      stability function for heat, at Level 2
+!!\section gen_mym_level2 GSD MYNN-EDMF mym_level2 General Algorithm
+!! @ {
+  SUBROUTINE  mym_level2 (kts,kte,                &
+       &            dz,                           &
+       &            u, v, thl, thetav, qw,        &
+       &            thlsg, qwsg,                  &
+       &            ql, vt, vq,                   &
        &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
 !-------------------------------------------------------------------
@@ -641,8 +1828,8 @@ CONTAINS
 #endif
 
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,ql,vt,vq
-
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,ql,vt,vq,&
+                                            thetav,thlsg,qwsg
     REAL, DIMENSION(kts:kte), INTENT(out) :: &
          &dtl,dqw,dtv,gm,gh,sm,sh
 
@@ -651,7 +1838,7 @@ CONTAINS
     REAL :: rfc,f1,f2,rf1,rf2,smc,shc,&
          &ri1,ri2,ri3,ri4,duz,dtz,dqz,vtt,vqq,dtq,dzk,afk,abk,ri,rf
 
-    REAL ::   a2den
+    REAL ::   a2fac
 
 !    ev  = 2.5e6
 !    tv0 = 0.61*tref
@@ -679,17 +1866,23 @@ CONTAINS
        duz = ( u(k)-u(k-1) )**2 +( v(k)-v(k-1) )**2
        duz =   duz                    /dzk**2
        dtz = ( thl(k)-thl(k-1) )/( dzk )
+       !Alternatively, use SGS clouds for thl
+       !dtz = ( thlsg(k)-thlsg(k-1) )/( dzk )
        dqz = ( qw(k)-qw(k-1) )/( dzk )
+       !Alternatively, use SGS clouds for qw
+       !dqz = ( qwsg(k)-qwsg(k-1) )/( dzk )
 !
        vtt =  1.0 +vt(k)*abk +vt(k-1)*afk  ! Beta-theta in NN09, Eq. 39
        vqq =  tv0 +vq(k)*abk +vq(k-1)*afk  ! Beta-q
        dtq =  vtt*dtz +vqq*dqz
+       !Alternatively, use theta-v without the SGS clouds
+       !dtq = ( thetav(k)-thetav(k-1) )/( dzk )
 !
        dtl(k) =  dtz
        dqw(k) =  dqz
        dtv(k) =  dtq
 !?      dtv(i,j,k) =  dtz +tv0*dqz
-!?   :              +( ev/pi0(i,j,k)-tv1 )
+!?   :              +( xlv/pi0(i,j,k)-tv1 )
 !?   :              *( ql(i,j,k)-ql(i,j,k-1) )/( dzk*h(i,j) )
 !
        gm (k) =  duz
@@ -698,21 +1891,21 @@ CONTAINS
 !   **  Gradient Richardson number  **
        ri = -gh(k)/MAX( duz, 1.0e-10 )
 
-    !a2den is needed for the Canuto/Kitamura mod
+    !a2fac is needed for the Canuto/Kitamura mod
     IF (CKmod .eq. 1) THEN
-       a2den = 1. + MAX(ri,0.0)
+       a2fac = 1./(1. + MAX(ri,0.0))
     ELSE
-       a2den = 1. + 0.0
+       a2fac = 1.
     ENDIF
 
        rfc = g1/( g1+g2 )
-       f1  = b1*( g1-c1 ) +3.0*(a2/a2den)*( 1.0    -c2 )*( 1.0-c5 ) &
+       f1  = b1*( g1-c1 ) +3.0*a2*a2fac *( 1.0    -c2 )*( 1.0-c5 ) &
     &                     +2.0*a1*( 3.0-2.0*c2 )
        f2  = b1*( g1+g2 ) -3.0*a1*( 1.0    -c2 )
        rf1 = b1*( g1-c1 )/f1
        rf2 = b1*  g1     /f2
-       smc = a1 /(a2/a2den)*  f1/f2
-       shc = 3.0*(a2/a2den)*( g1+g2 )
+       smc = a1 /(a2*a2fac)*  f1/f2
+       shc = 3.0*(a2*a2fac)*( g1+g2 )
 
        ri1 = 0.5/smc
        ri2 = rf1*smc
@@ -720,7 +1913,7 @@ CONTAINS
        ri4 = ri2**2
 
 !   **  Flux Richardson number  **
-       rf = MIN( ri1*( ri+ri2-SQRT(ri**2-ri3*ri+ri4) ), rfc )
+       rf = MIN( ri1*( ri + ri2-SQRT(ri**2 - ri3*ri + ri4) ), rfc )
 !
        sh (k) = shc*( rfc-rf )/( 1.0-rf )
        sm (k) = smc*( rf1-rf )/( rf2-rf ) * sh(k)
@@ -734,6 +1927,7 @@ CONTAINS
 #endif
 
   END SUBROUTINE mym_level2
+!! @}
 
 ! ==================================================================
 !     SUBROUTINE  mym_length:
@@ -750,9 +1944,11 @@ CONTAINS
 !     NOTE: the mixing lengths are meant to be calculated at the full-
 !           sigmal levels (or interfaces beween the model layers).
 !
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the mixing lengths.
   SUBROUTINE  mym_length (                     & 
     &            kts,kte,                      &
-    &            dz, zw,                       &
+    &            dz, dx, zw,                   &
     &            rmo, flt, flq,                &
     &            vt, vq,                       &
     &            u1, v1, qke,                  &
@@ -774,7 +1970,7 @@ CONTAINS
     INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
     REAL, DIMENSION(kts:kte), INTENT(in)   :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl
+    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,dx
     REAL, DIMENSION(kts:kte), INTENT(IN)   :: u1,v1,qke,vt,vq,cldfra_bl1D,&
                                           edmf_w1,edmf_a1,edmf_qc1
     REAL, DIMENSION(kts:kte), INTENT(out)  :: qkw, el
@@ -788,48 +1984,49 @@ CONTAINS
 
     ! THE FOLLOWING CONSTANTS ARE IMPORTANT FOR REGULATING THE
     ! MIXING LENGTHS:
-    REAL :: cns,   &   ! for surface layer (els) in stable conditions
-            alp1,  &   ! for turbulent length scale (elt)
-            alp2,  &   ! for buoyancy length scale (elb)
-            alp3,  &   ! for buoyancy enhancement factor of elb
-            alp4,  &   ! for surface layer (els) in unstable conditions
-            alp5,  &   ! for BouLac mixing length or above PBLH
-            alp6       ! for mass-flux/
+    REAL :: cns,   &   !< for surface layer (els) in stable conditions
+            alp1,  &   !< for turbulent length scale (elt)
+            alp2,  &   !< for buoyancy length scale (elb)
+            alp3,  &   !< for buoyancy enhancement factor of elb
+            alp4,  &   !< for surface layer (els) in unstable conditions
+            alp5,  &   !< for BouLac mixing length or above PBLH
+            alp6       !< for mass-flux/
 
     !THE FOLLOWING LIMITS DO NOT DIRECTLY AFFECT THE ACTUAL PBLH.
     !THEY ONLY IMPOSE LIMITS ON THE CALCULATION OF THE MIXING LENGTH 
     !SCALES SO THAT THE BOULAC MIXING LENGTH (IN FREE ATMOS) DOES
     !NOT ENCROACH UPON THE BOUNDARY LAYER MIXING LENGTH (els, elb & elt).
-    REAL, PARAMETER :: minzi = 300.  !min mixed-layer height
-    REAL, PARAMETER :: maxdz = 750.  !max (half) transition layer depth
-                                     !=0.3*2500 m PBLH, so the transition
-                                     !layer stops growing for PBLHs > 2.5 km.
-    REAL, PARAMETER :: mindz = 300.  !300  !min (half) transition layer depth
+    REAL, PARAMETER :: minzi = 300.  !< min mixed-layer height
+    REAL, PARAMETER :: maxdz = 750.  !< max (half) transition layer depth
+                                     !! =0.3*2500 m PBLH, so the transition
+                                     !! layer stops growing for PBLHs > 2.5 km.
+    REAL, PARAMETER :: mindz = 300.  !< 300  !min (half) transition layer depth
 
     !SURFACE LAYER LENGTH SCALE MODS TO REDUCE IMPACT IN UPPER BOUNDARY LAYER
-    REAL, PARAMETER :: ZSLH = 100. ! Max height correlated to surface conditions (m)
-    REAL, PARAMETER :: CSL = 2.    ! CSL = constant of proportionality to L O(1)
+    REAL, PARAMETER :: ZSLH = 100. !< Max height correlated to surface conditions (m)
+    REAL, PARAMETER :: CSL = 2.    !< CSL = constant of proportionality to L O(1)
     REAL :: z_m
 
 
     INTEGER :: i,j,k
-    REAL :: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,elb,els,els1,elf, &
-            & el_stab,el_unstab,el_mf,el_stab_mf,elb_mf,PBLH_PLUS_ENT,   &
-            & Uonset,Ugrid,el_les
+    REAL :: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,wstar,elb,els, &
+            & els1,elf,el_stab,el_unstab,el_mf,el_stab_mf,elb_mf,     &
+            & PBLH_PLUS_ENT,Uonset,Ugrid,wt_u,el_les
+    REAL, PARAMETER :: ctau = 1000. !constant for tau_cloud
 
 !    tv0 = 0.61*tref
 !    gtr = 9.81/tref
 
     SELECT CASE(bl_mynn_mixlength)
 
-      CASE (0) ! ORIGINAL MYNN MIXING LENGTH
+      CASE (0) ! ORIGINAL MYNN MIXING LENGTH + BouLac
 
         cns  = 2.7
         alp1 = 0.23
         alp2 = 1.0
         alp3 = 5.0
         alp4 = 100.
-        alp5 = 0.4
+        alp5 = 0.3
 
         ! Impose limits on the height integration for elt and the transition layer depth
         zi2  = MIN(10000.,zw(kte-2))  !originally integrated to model top, not just 10 km.
@@ -863,7 +2060,7 @@ CONTAINS
         vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
         vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
 
-        !   **  Strictly, el(i,j,1) is not zero.  **
+        !   **  Strictly, el(i,k=1) is not zero.  **
         el(kts) = 0.0
         zwk1    = zw(kts+1)
 
@@ -887,11 +2084,11 @@ CONTAINS
 
            !   **  Length scale in the surface layer  **
            IF ( rmo .GT. 0.0 ) THEN
-              els  = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-              els1 = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
+              els  = karman*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
+              els1 = karman*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
            ELSE
-              els  =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-              els1 =  vk*z_m*( 1.0 - alp4* zwk*rmo )**0.2
+              els  =  karman*zwk*( 1.0 - alp4* zwk*rmo )**0.2
+              els1 =  karman*z_m*( 1.0 - alp4* zwk*rmo )**0.2
            END IF
 
            !   ** HARMONC AVERGING OF MIXING LENGTH SCALES:
@@ -904,30 +2101,34 @@ CONTAINS
 
         END DO
 
-      CASE (1) !OPERATIONAL FORM OF MIXING LENGTH
+      CASE (1) !NONLOCAL (using BouLac) FORM OF MIXING LENGTH
 
-        cns  = 2.3
-        alp1 = 0.23
-        alp2 = 0.65
-        alp3 = 3.0
-        alp4 = 20.
-        alp5 = 0.4
+        ugrid = sqrt(u1(kts)**2 + v1(kts)**2)
+        uonset= 15. 
+        wt_u = (1.0 - min(max(ugrid - uonset, 0.0)/30.0, 0.5)) 
+        cns  = 3.5
+        alp1 = 0.22 !was 0.21
+        alp2 = 0.25 !was 0.3
+        alp3 = 2.0 * wt_u !taper off bouyancy enhancement in shear-driven pbls
+        alp4 = 5.0
+        alp5 = 0.3
+        alp6 = 50.
 
         ! Impose limits on the height integration for elt and the transition layer depth
-        zi2=MAX(zi,minzi)
-        h1=MAX(0.3*zi2,mindz)
-        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        zi2=MAX(zi,200.) !minzi)
+        h1=MAX(0.3*zi2,200.)
+        h1=MIN(h1,500.)          ! 1/2 transition layer depth
         h2=h1/2.0                ! 1/4 transition layer depth
 
-        qtke(kts)=MAX(qke(kts)/2.,0.01) !tke at full sigma levels
-        thetaw(kts)=theta(kts)          !theta at full-sigma levels
+        qtke(kts)=MAX(0.5*qke(kts), 0.01) !tke at full sigma levels
+        thetaw(kts)=theta(kts)            !theta at full-sigma levels
         qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
 
         DO k = kts+1,kte
            afk = dz(k)/( dz(k)+dz(k-1) )
            abk = 1.0 -afk
            qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
-           qtke(k) = (qkw(k)**2.)/2.    ! q -> TKE
+           qtke(k) = 0.5*(qkw(k)**2)     ! q -> TKE
            thetaw(k)= theta(k)*abk + theta(k-1)*afk
         END DO
 
@@ -939,16 +2140,16 @@ CONTAINS
         zwk = zw(k)
         DO WHILE (zwk .LE. zi2+h1)
            dzk = 0.5*( dz(k)+dz(k-1) )
-           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
+           qdz = min(max( qkw(k)-qmin, 0.03 ), 30.0)*dzk
            elt = elt +qdz*zwk
            vsc = vsc +qdz
            k   = k+1
            zwk = zw(k)
         END DO
 
-        elt =  alp1*elt/vsc
+        elt = MIN( MAX( alp1*elt/vsc, 10.), 400.)
         vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
-        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
 
         !   **  Strictly, el(i,j,1) is not zero.  **
         el(kts) = 0.0
@@ -962,12 +2163,13 @@ CONTAINS
 
            !   **  Length scale limited by the buoyancy effect  **
            IF ( dtv(k) .GT. 0.0 ) THEN
-              bv  = SQRT( gtr*dtv(k) ) 
-              elb = alp2*qkw(k) / bv &                ! formulation,
-                  &       *( 1.0 + alp3/alp2*&       ! except keep
-                  &SQRT( vsc/( bv*elt ) ) )          ! elb bounded by
-              elb = MIN(elb, zwk)                     ! zwk
-              elf = alp2 * qkw(k)/bv
+              bv  = max( sqrt( gtr*dtv(k) ), 0.001)
+              elb = MAX(alp2*qkw(k),                          &
+                  &    alp6*edmf_a1(k-1)*edmf_w1(k-1)) / bv   &
+                  &  *( 1.0 + alp3*SQRT( vsc/(bv*elt) ) )
+              elb = MIN(elb, zwk)
+              elf = 0.65 * qkw(k)/bv
+              elBLavg(k) = MAX(elBLavg(k), alp6*edmf_a1(k-1)*edmf_w1(k-1)/bv)
            ELSE
               elb = 1.0e10
               elf = elb
@@ -977,11 +2179,11 @@ CONTAINS
 
            !   **  Length scale in the surface layer  **
            IF ( rmo .GT. 0.0 ) THEN
-              els  = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-              els1 = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
+              els  = karman*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
+              els1 = karman*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
            ELSE
-              els  =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-              els1 =  vk*z_m*( 1.0 - alp4* zwk*rmo )**0.2
+              els  =  karman*zwk*( 1.0 - alp4* zwk*rmo )**0.2
+              els1 =  karman*z_m*( 1.0 - alp4* zwk*rmo )**0.2
            END IF
 
            !   ** NOW BLEND THE MIXING LENGTH SCALES:
@@ -989,41 +2191,48 @@ CONTAINS
 
            !add blending to use BouLac mixing length in free atmos;
            !defined relative to the PBLH (zi) + transition layer (h1)
-           el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-           el(k) = el(k)*(1.-wt) + alp5*elBLmin(k)*wt
+           !el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+           !try squared-blending
+           !el_unstab = SQRT( els**2/(1. + (els1**2/elt**2) ))
+   !        el(k) = SQRT( els**2/(1. + (els1**2/elt**2) +(els1**2/elb**2)))
+           el(k) = SQRT( els**2/(1. + (els**2/elt**2) +(els**2/elb**2)))
+           el(k) = MIN (el(k), elf)
+           el(k) = el(k)*(1.-wt) + alp5*elBLavg(k)*wt
 
            ! include scale-awareness, except for original MYNN
            el(k) = el(k)*Psig_bl
 
          END DO
 
-      CASE (2) !Experimental mixing length formulation
+      CASE (2) !Local (mostly) mixing length formulation
 
-        Uonset = 2.5 + dz(kts)*0.1
+        Uonset = 3.5 + dz(kts)*0.1
         Ugrid  = sqrt(u1(kts)**2 + v1(kts)**2)
-        cns  = 3.5 * (1.0 - MIN(MAX(Ugrid - Uonset, 0.0)/10.0, 1.0))
-        alp1 = 0.23
-        alp2 = 0.30
-        alp3 = 2.0
-        alp4 = 20.  !10.
+        cns  = 3.5 !JOE-test  * (1.0 - MIN(MAX(Ugrid - Uonset, 0.0)/10.0, 1.0))
+        alp1 = 0.22 !0.21
+        alp2 = 0.25 !0.30
+        alp3 = 2.0  !1.5
+        alp4 = 5.0
         alp5 = alp2 !like alp2, but for free atmosphere
         alp6 = 50.0 !used for MF mixing length
 
         ! Impose limits on the height integration for elt and the transition layer depth
         !zi2=MAX(zi,minzi)
-        zi2=MAX(zi,    100.)
-        h1=MAX(0.3*zi2,mindz)
-        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        zi2=MAX(zi,    200.)
+        !h1=MAX(0.3*zi2,mindz)
+        !h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        h1=MAX(0.3*zi2,200.)
+        h1=MIN(h1,500.)
         h2=h1*0.5                ! 1/4 transition layer depth
 
         qtke(kts)=MAX(0.5*qke(kts),0.01) !tke at full sigma levels
-        qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
+        qkw(kts) = SQRT(MAX(qke(kts),1.0e-4))
 
         DO k = kts+1,kte
            afk = dz(k)/( dz(k)+dz(k-1) )
            abk = 1.0 -afk
            qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
-           qtke(k) = 0.5*qkw(k)  ! qkw -> TKE
+           qtke(k) = 0.5*qkw(k)**2  ! qkw -> TKE
         END DO
 
         elt = 1.0e-5
@@ -1035,16 +2244,16 @@ CONTAINS
         zwk = zw(k)
         DO WHILE (zwk .LE. PBLH_PLUS_ENT)
            dzk = 0.5*( dz(k)+dz(k-1) )
-           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk  !consider reducing 0.3
+           qdz = min(max( qkw(k)-qmin, 0.03 ), 30.0)*dzk
            elt = elt +qdz*zwk
            vsc = vsc +qdz
            k   = k+1
            zwk = zw(k)
         END DO
 
-        elt =  MAX(alp1*elt/vsc, 10.)
+        elt = MIN( MAX(alp1*elt/vsc, 10.), 400.)
         vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
-        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(0.33333)
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
 
         !   **  Strictly, el(i,j,1) is not zero.  **
         el(kts) = 0.0
@@ -1052,18 +2261,28 @@ CONTAINS
 
         DO k = kts+1,kte
            zwk = zw(k)              !full-sigma levels
+           dzk = 0.5*( dz(k)+dz(k-1) )
            cldavg = 0.5*(cldfra_bl1D(k-1)+cldfra_bl1D(k))
 
            !   **  Length scale limited by the buoyancy effect  **
            IF ( dtv(k) .GT. 0.0 ) THEN
-              bv  = SQRT( gtr*dtv(k) )
+              !impose min value on bv
+              bv  = MAX( SQRT( gtr*dtv(k) ), 0.001)  
               !elb_mf = alp2*qkw(k) / bv  &
-              elb_mf = MAX(alp2*qkw(k),  &
-!                  &MAX(1.-0.5*cldavg,0.0)**0.5 * alp6*edmf_a1(k)*edmf_w1(k)) / bv  &
-                  & alp6*edmf_a1(k)*edmf_w1(k)) / bv  &
+              elb_mf = MAX(alp2*qkw(k),                    &
+                  &    alp6*edmf_a1(k-1)*edmf_w1(k-1)) / bv    &
                   &  *( 1.0 + alp3*SQRT( vsc/( bv*elt ) ) )
-              elb = MIN(alp5*qkw(k)/bv, zwk)
-              elf = elb/(1. + (elb/600.))  !bound free-atmos mixing length to < 600 m.
+              elb = MIN(MAX(alp5*qkw(k), alp6*edmf_a1(k)*edmf_w1(k))/bv, zwk)
+
+              !tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(vflx,1.0e-4))**onethird),30.),150.)
+              wstar = 1.25*(gtr*zi*MAX(vflx,1.0e-4))**onethird
+              tau_cloud = MIN(MAX(ctau * wstar/grav, 30.), 150.)
+              !minimize influence of surface heat flux on tau far away from the PBLH.
+              wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
+              tau_cloud = tau_cloud*(1.-wt) + 50.*wt
+              elf = MIN(MAX(tau_cloud*SQRT(MIN(qtke(k),40.)), &
+                  &         alp6*edmf_a1(k)*edmf_w1(k)/bv), zwk)
+
               !IF (zwk > zi .AND. elf > 400.) THEN
               !   ! COMPUTE BouLac mixing length
               !   !CALL boulac_length0(k,kts,kte,zw,dz,qtke,thetaw,elBLmin0,elBLavg0)
@@ -1082,33 +2301,43 @@ CONTAINS
               ! velocity scale), except that elt is relpaced
               ! by zi, and zero is replaced by 1.0e-4 to
               ! prevent division by zero.
-              tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(flt,1.0e-4))**(0.3333)),50.),150.)
+              !tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(vflx,1.0e-4))**onethird),50.),150.)
+              wstar = 1.25*(gtr*zi*MAX(vflx,1.0e-4))**onethird
+              tau_cloud = MIN(MAX(ctau * wstar/grav, 50.), 200.)
               !minimize influence of surface heat flux on tau far away from the PBLH.
               wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
-              tau_cloud = tau_cloud*(1.-wt) + 50.*wt
+              !tau_cloud = tau_cloud*(1.-wt) + 50.*wt
+              tau_cloud = tau_cloud*(1.-wt) + MAX(100.,dzk*0.25)*wt
 
-              elb = MIN(tau_cloud*SQRT(MIN(qtke(k),30.)), zwk)
-              elf = elb
+              elb = MIN(tau_cloud*SQRT(MIN(qtke(k),40.)), zwk)
+              !elf = elb
+              elf = elb !/(1. + (elb/800.))  !bound free-atmos mixing length to < 800 m.
               elb_mf = elb
          END IF
+         elf    = elf/(1. + (elf/800.))  !bound free-atmos mixing length to < 800 m.
+!         elb_mf = elb_mf/(1. + (elb_mf/800.))  !bound buoyancy mixing length to < 800 m.
+         elb_mf = MAX(elb_mf, 0.01) !to avoid divide-by-zero below
 
          z_m = MAX(0.,zwk - 4.)
 
          !   **  Length scale in the surface layer  **
          IF ( rmo .GT. 0.0 ) THEN
-            els  = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-            els1 = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
+            els  = karman*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
+            els1 = karman*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
          ELSE
-            els  =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-            els1 =  vk*z_m*( 1.0 - alp4* zwk*rmo )**0.2
+            els  =  karman*zwk*( 1.0 - alp4* zwk*rmo )**0.2
+            els1 =  karman*z_m*( 1.0 - alp4* zwk*rmo )**0.2
          END IF
 
          !   ** NOW BLEND THE MIXING LENGTH SCALES:
          wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
 
          ! "el_unstab" = blended els-elt
-         el_unstab = els/(1. + (els1/elt))
-         el(k) = MIN(el_unstab, elb_mf)
+         !el_unstab = els/(1. + (els1/elt))
+         !try squared-blending
+         !el(k) = SQRT( els**2/(1. + (els1**2/elt**2) ))
+         el(k) = SQRT( els**2/(1. + (els1**2/elt**2) +(els1**2/elb_mf**2)))
+         !el(k) = MIN(el_unstab, elb_mf)
          el(k) = el(k)*(1.-wt) + elf*wt
 
          ! include scale-awareness. For now, use simple asymptotic kz -> 12 m.
@@ -1128,6 +2357,18 @@ CONTAINS
   END SUBROUTINE mym_length
 
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine was taken from the BouLac scheme in WRF-ARW and modified for
+!! integration into the MYNN PBL scheme. WHILE loops were added to reduce the
+!! computational expense. This subroutine computes the length scales up and down
+!! and then computes the min, average of the up/down length scales, and also
+!! considers the distance to the surface.
+!\param dlu  the distance a parcel can be lifted upwards give a finite
+!  amount of TKE.
+!\param dld  the distance a parcel can be displaced downwards given a
+!  finite amount of TKE.
+!\param lb1  the minimum of the length up and length down
+!\param lb2  the average of the length up and length down
   SUBROUTINE boulac_length0(k,kts,kte,zw,dz,qtke,theta,lb1,lb2)
 !
 !    NOTE: This subroutine was taken from the BouLac scheme in WRF-ARW
@@ -1161,10 +2402,10 @@ CONTAINS
      ! FIND DISTANCE UPWARD             
      !----------------------------------
      zup=0.
-     dlu=zw(kte+1)-zw(k)-dz(k)/2.
+     dlu=zw(kte+1)-zw(k)-dz(k)*0.5
      zzz=0.
      zup_inf=0.
-     beta=g/theta(k)           !Buoyancy coefficient
+     beta=gtr           !Buoyancy coefficient (g/tref)
 
      !print*,"FINDING Dup, k=",k," zw=",zw(k)
 
@@ -1174,10 +2415,10 @@ CONTAINS
         DO WHILE (found .EQ. 0)
 
            if (izz .lt. kte) then
-              dzt=dz(izz)                    ! layer depth above
+              dzt=dz(izz)                   ! layer depth above
               zup=zup-beta*theta(k)*dzt     ! initial PE the parcel has at k
               !print*,"  ",k,izz,theta(izz),dz(izz)
-              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt/2. ! PE gained by lifting a parcel to izz+1
+              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt*0.5 ! PE gained by lifting a parcel to izz+1
               zzz=zzz+dzt                   ! depth of layer k to izz+1
               !print*,"  PE=",zup," TKE=",qtke(k)," z=",zw(izz)
               if (qtke(k).lt.zup .and. qtke(k).ge.zup_inf) then
@@ -1185,7 +2426,7 @@ CONTAINS
                  if (bbb .ne. 0.) then
                     !fractional distance up into the layer where TKE becomes < PE
                     tl=(-beta*(theta(izz)-theta(k)) + &
-                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2. + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2 + &
                       &       2.*bbb*beta*(qtke(k)-zup_inf))))/bbb/beta
                  else
                     if (theta(izz) .ne. theta(k))then
@@ -1227,14 +2468,14 @@ CONTAINS
               dzt=dz(izz-1)
               zdo=zdo+beta*theta(k)*dzt
               !print*,"  ",k,izz,theta(izz),dz(izz-1)
-              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt/2.
+              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt*0.5
               zzz=zzz+dzt
               !print*,"  PE=",zdo," TKE=",qtke(k)," z=",zw(izz)
               if (qtke(k).lt.zdo .and. qtke(k).ge.zdo_sup) then
                  bbb=(theta(izz)-theta(izz-1))/dzt
                  if (bbb .ne. 0.) then
                     tl=(beta*(theta(izz)-theta(k))+ &
-                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2. + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2 + &
                       &       2.*bbb*beta*(qtke(k)-zdo_sup))))/bbb/beta
                  else
                     if (theta(izz) .ne. theta(k)) then
@@ -1279,16 +2520,15 @@ CONTAINS
   END SUBROUTINE boulac_length0
 
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine was taken from the BouLac scheme in WRF-ARW
+!! and modified for integration into the MYNN PBL scheme.
+!! WHILE loops were added to reduce the computational expense.
+!! This subroutine computes the length scales up and down
+!! and then computes the min, average of the up/down
+!! length scales, and also considers the distance to the
+!! surface.
   SUBROUTINE boulac_length(kts,kte,zw,dz,qtke,theta,lb1,lb2)
-!
-!    NOTE: This subroutine was taken from the BouLac scheme in WRF-ARW
-!          and modified for integration into the MYNN PBL scheme.
-!          WHILE loops were added to reduce the computational expense.
-!          This subroutine computes the length scales up and down
-!          and then computes the min, average of the up/down
-!          length scales, and also considers the distance to the
-!          surface.
-!
 !      dlu = the distance a parcel can be lifted upwards give a finite 
 !            amount of TKE.
 !      dld = the distance a parcel can be displaced downwards given a
@@ -1316,24 +2556,24 @@ CONTAINS
         ! FIND DISTANCE UPWARD
         !----------------------------------
         zup=0.
-        dlu(iz)=zw(kte+1)-zw(iz)-dz(iz)/2.
+        dlu(iz)=zw(kte+1)-zw(iz)-dz(iz)*0.5
         zzz=0.
         zup_inf=0.
-        beta=g/theta(iz)           !Buoyancy coefficient
+        beta=gtr           !Buoyancy coefficient (g/tref)
 
         !print*,"FINDING Dup, k=",iz," zw=",zw(iz)
 
         if (iz .lt. kte) then      !cant integrate upwards from highest level
 
           found = 0
-          izz=iz       
-          DO WHILE (found .EQ. 0) 
+          izz=iz
+          DO WHILE (found .EQ. 0)
 
             if (izz .lt. kte) then
-              dzt=dz(izz)                    ! layer depth above 
+              dzt=dz(izz)                    ! layer depth above
               zup=zup-beta*theta(iz)*dzt     ! initial PE the parcel has at iz
               !print*,"  ",iz,izz,theta(izz),dz(izz)
-              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt/2. ! PE gained by lifting a parcel to izz+1
+              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt*0.5 ! PE gained by lifting a parcel to izz+1
               zzz=zzz+dzt                   ! depth of layer iz to izz+1
               !print*,"  PE=",zup," TKE=",qtke(iz)," z=",zw(izz)
               if (qtke(iz).lt.zup .and. qtke(iz).ge.zup_inf) then
@@ -1341,7 +2581,7 @@ CONTAINS
                  if (bbb .ne. 0.) then
                     !fractional distance up into the layer where TKE becomes < PE
                     tl=(-beta*(theta(izz)-theta(iz)) + &
-                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2. + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2 + &
                       &       2.*bbb*beta*(qtke(iz)-zup_inf))))/bbb/beta
                  else
                     if (theta(izz) .ne. theta(iz))then
@@ -1383,14 +2623,14 @@ CONTAINS
               dzt=dz(izz-1)
               zdo=zdo+beta*theta(iz)*dzt
               !print*,"  ",iz,izz,theta(izz),dz(izz-1)
-              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt/2.
+              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt*0.5
               zzz=zzz+dzt
               !print*,"  PE=",zdo," TKE=",qtke(iz)," z=",zw(izz)
               if (qtke(iz).lt.zdo .and. qtke(iz).ge.zdo_sup) then
                  bbb=(theta(izz)-theta(izz-1))/dzt
                  if (bbb .ne. 0.) then
                     tl=(beta*(theta(izz)-theta(iz))+ &
-                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2. + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2 + &
                       &       2.*bbb*beta*(qtke(iz)-zdo_sup))))/bbb/beta
                  else
                     if (theta(izz) .ne. theta(iz)) then
@@ -1444,8 +2684,7 @@ CONTAINS
 !     SUBROUTINE  mym_turbulence:
 !
 !     Input variables:    see subroutine mym_initialize
-!       levflag         : <>3;  Level 2.5
-!                         = 3;  Level 3
+!       closure        : closure level (2.5, 2.6, or 3.0)
 !
 !     # ql, vt, vq, qke, tsq, qsq and cov are changed to input variables.
 !
@@ -1472,16 +2711,35 @@ CONTAINS
 !     # dtl, dqw, dtv, gm and gh are allowed to share storage units with
 !       dfm, dfh, dfq, tcd and qcd, respectively, for saving memory.
 !
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the vertical diffusivity coefficients and the 
+!! production terms for the turbulent quantities.      
+!>\section gen_mym_turbulence GSD mym_turbulence General Algorithm
+!! Two subroutines mym_level2() and mym_length() are called within this
+!!subrouine to collect variable to carry out successive calculations:
+!! - mym_level2() calculates the level 2 nondimensional wind shear \f$G_M\f$
+!! and vertical temperature gradient \f$G_H\f$ as well as the level 2 stability
+!! functions \f$S_h\f$ and \f$S_m\f$.
+!! - mym_length() calculates the mixing lengths.
+!! - The stability criteria from Helfand and Labraga (1989) are applied.
+!! - The stability functions for level 2.5 or level 3.0 are calculated.
+!! - If level 3.0 is used, counter-gradient terms are calculated.
+!! - Production terms of TKE,\f$\theta^{'2}\f$,\f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$
+!! are calculated.
+!! - Eddy diffusivity \f$K_h\f$ and eddy viscosity \f$K_m\f$ are calculated.
+!! - TKE budget terms are calculated (if the namelist parameter \p bl_mynn_tkebudget 
+!! is set to True)
   SUBROUTINE  mym_turbulence (                                &
     &            kts,kte,                                     &
-    &            levflag,                                     &
-    &            dz, zw,                                      &
-    &            u, v, thl, ql, qw,                           &
+    &            closure,                                     &
+    &            dz, dx, zw,                                  &
+    &            u, v, thl, thetav, ql, qw,                   &
+    &            thlsg, qwsg,                                 &
     &            qke, tsq, qsq, cov,                          &
     &            vt, vq,                                      &
     &            rmo, flt, flq,                               &
     &            zi,theta,                                    &
-    &            sh,                                          &
+    &            sh, sm,                                      &
     &            El,                                          &
     &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
     &		 qWT1D,qSHEAR1D,qBUOY1D,qDISS1D,              &
@@ -1500,13 +2758,14 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(IN)   :: levflag,bl_mynn_mixlength,bl_mynn_edmf
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
+    REAL, INTENT(IN)      :: closure
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,& 
+    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu,dx
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,thetav,qw,& 
          &ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1D,edmf_w1,edmf_a1,edmf_qc1,&
-         &TKEprodTD
+         &TKEprodTD,thlsg,qwsg
 
     REAL, DIMENSION(kts:kte), INTENT(out) :: dfm,dfh,dfq,&
          &pdk,pdt,pdq,pdc,tcd,qcd,el
@@ -1516,7 +2775,7 @@ CONTAINS
     REAL :: q3sq_old,dlsq1,qWTP_old,qWTP_new
     REAL :: dudz,dvdz,dTdz,&
             upwp,vpwp,Tpwp
-    INTEGER, INTENT(in) :: bl_mynn_tkebudget
+    LOGICAL, INTENT(in) :: bl_mynn_tkebudget
 
     REAL, DIMENSION(kts:kte) :: qkw,dtl,dqw,dtv,gm,gh,sm,sh
 
@@ -1528,10 +2787,11 @@ CONTAINS
     REAL :: zi, cldavg
     REAL, DIMENSION(kts:kte), INTENT(in) :: theta
 
-    REAL ::  a2den, duz, ri, HLmod  !JOE-Canuto/Kitamura mod
-!JOE-stability criteria for cw
-    REAL:: auh,aum,adh,adm,aeh,aem,Req,Rsl,Rsl2
-!JOE-end
+    REAL ::  a2fac, duz, ri !JOE-Canuto/Kitamura mod
+
+    REAL:: auh,aum,adh,adm,aeh,aem,Req,Rsl,Rsl2,&
+           gmelq,sm20,sh20,sm25max,sh25max,sm25min,sh25min,&
+           sm_pbl,sh_pbl,zi2,wt,slht,wtpr
 
     DOUBLE PRECISION  q2sq, t2sq, r2sq, c2sq, elsq, gmel, ghel
     DOUBLE PRECISION  q3sq, t3sq, r3sq, c3sq, dlsq, qdiv
@@ -1540,7 +2800,8 @@ CONTAINS
 !   Stochastic
     INTEGER,  INTENT(IN)                          ::    spp_pbl
     REAL, DIMENSION(KTS:KTE)                      ::    rstoch_col
-    REAL :: prlimit
+    REAL :: Prnum, Prlim
+    REAL, PARAMETER :: Prlimit = 5.0
 
 
 !
@@ -1556,15 +2817,16 @@ CONTAINS
 !    e5c =  6.0*a1*a1
 !
 
-    CALL mym_level2 (kts,kte,&
-    &            dz, &
-    &            u, v, thl, qw, &
-    &            ql, vt, vq, &
-    &            dtl, dqw, dtv, gm, gh, sm, sh )
+    CALL mym_level2 (kts,kte,                   &
+    &            dz,                            &
+    &            u, v, thl, thetav, qw,         &
+    &            thlsg, qwsg,                   &
+    &            ql, vt, vq,                    &
+    &            dtl, dqw, dtv, gm, gh, sm, sh  )
 !
     CALL mym_length (                           &
     &            kts,kte,                       &
-    &            dz, zw,                        &
+    &            dz, dx, zw,                    &
     &            rmo, flt, flq,                 &
     &            vt, vq,                        &
     &            u, v, qke,                     &
@@ -1580,20 +2842,32 @@ CONTAINS
        afk = dz(k)/( dz(k)+dz(k-1) )
        abk = 1.0 -afk
        elsq = el (k)**2
-       q2sq = b1*elsq*( sm(k)*gm(k)+sh(k)*gh(k) )
        q3sq = qkw(k)**2
+       q2sq = b1*elsq*( sm(k)*gm(k)+sh(k)*gh(k) )
 
-!JOE-Canuto/Kitamura mod
+       sh20 = MAX(sh(k), 1e-5)
+       sm20 = MAX(sm(k), 1e-5)
+       sh(k)= MAX(sh(k), 1e-5)
+
+       !Canuto/Kitamura mod
        duz = ( u(k)-u(k-1) )**2 +( v(k)-v(k-1) )**2
        duz =   duz                    /dzk**2
        !   **  Gradient Richardson number  **
        ri = -gh(k)/MAX( duz, 1.0e-10 )
        IF (CKmod .eq. 1) THEN
-          a2den = 1. + MAX(ri,0.0)
+          a2fac = 1./(1. + MAX(ri,0.0))
        ELSE
-          a2den = 1. + 0.0
+          a2fac = 1.
        ENDIF
-!JOE-end
+       !end Canuto/Kitamura mod
+
+       !level 2.0 Prandtl number
+       !Prnum = MIN(sm20/sh20, 4.0)
+       !The form of Zilitinkevich et al. (2006) but modified
+       !half-way towards Esau and Grachev (2007, Wind Eng)
+       !Prnum = MIN(0.76 + 3.0*MAX(ri,0.0), Prlimit)
+       Prnum = MIN(0.76 + 4.0*MAX(ri,0.0), Prlimit)
+       !Prnum = MIN(0.76 + 5.0*MAX(ri,0.0), Prlimit)
 !
 !  Modified: Dec/22/2005, from here, (dlsq -> elsq)
        gmel = gm (k)*elsq
@@ -1603,7 +2877,7 @@ CONTAINS
        ! Level 2.0 debug prints
        IF ( debug_code ) THEN
          IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
-           print*,"MYNN; mym_turbulence2.0; sh=",sh(k)," k=",k
+           print*,"MYNN; mym_turbulence 2.0; sh=",sh(k)," k=",k
            print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
            print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
            print*," qke=",qke(k)," el=",el(k)," ri=",ri
@@ -1611,75 +2885,131 @@ CONTAINS
          ENDIF
        ENDIF
 
-!JOE-Apply Helfand & Labraga stability check for all Ric
-!      when CKmod == 1. (currently not forced below)
-       IF (CKmod .eq. 1) THEN
-          HLmod = q2sq -1.
-       ELSE
-          HLmod = q3sq
-       ENDIF
-
 !     **  Since qkw is set to more than 0.0, q3sq > 0.0.  **
 
-!JOE-test new stability criteria in level 2.5 (as well as level 3) - little/no impact
+!     new stability criteria in level 2.5 (as well as level 3) - little/no impact
 !     **  Limitation on q, instead of L/q  **
-          dlsq =  elsq
-          IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
-!JOE-end
+       dlsq =  elsq
+       IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
 
        IF ( q3sq .LT. q2sq ) THEN
-       !IF ( HLmod .LT. q2sq ) THEN
           !Apply Helfand & Labraga mod
           qdiv = SQRT( q3sq/q2sq )   !HL89: (1-alfa)
-          sm(k) = sm(k) * qdiv
-          sh(k) = sh(k) * qdiv
 !
+          !Use level 2.5 stability functions
+          !e1   = q3sq - e1c*ghel*a2fac
+          !e2   = q3sq - e2c*ghel*a2fac
+          !e3   = e1   + e3c*ghel*a2fac**2
+          !e4   = e1   - e4c*ghel*a2fac
+          !eden = e2*e4 + e3*e5c*gmel
+          !eden = MAX( eden, 1.0d-20 )
+          !sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
+          !!JOE-Canuto/Kitamura mod
+          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
+          !sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
+          !sm(k) = Prnum*sh(k)
+          !sm(k) = sm(k) * qdiv
+
+          !Use level 2.0 functions as in original MYNN
+          sh(k) = sh(k) * qdiv
+          sm(k) = sm(k) * qdiv
+        !  !sm_pbl = sm(k) * qdiv
+        !
+        !  !Or, use the simple Pr relationship
+        !  sm(k) = Prnum*sh(k)
+        !
+        !  !or blend them:
+        !  zi2   = MAX(zi, 300.)
+        !  wt    =.5*TANH((zw(k) - zi2)/200.) + .5
+        !  sm(k) = sm_pbl*(1.-wt) + sm(k)*wt
+
+          !Recalculate terms for later use
           !JOE-Canuto/Kitamura mod
           !e1   = q3sq - e1c*ghel * qdiv**2
           !e2   = q3sq - e2c*ghel * qdiv**2
           !e3   = e1   + e3c*ghel * qdiv**2
           !e4   = e1   - e4c*ghel * qdiv**2
-          e1   = q3sq - e1c*ghel/a2den * qdiv**2
-          e2   = q3sq - e2c*ghel/a2den * qdiv**2
-          e3   = e1   + e3c*ghel/(a2den**2) * qdiv**2
-          e4   = e1   - e4c*ghel/a2den * qdiv**2
+          e1   = q3sq - e1c*ghel*a2fac * qdiv**2
+          e2   = q3sq - e2c*ghel*a2fac * qdiv**2
+          e3   = e1   + e3c*ghel*a2fac**2 * qdiv**2
+          e4   = e1   - e4c*ghel*a2fac * qdiv**2
           eden = e2*e4 + e3*e5c*gmel * qdiv**2
           eden = MAX( eden, 1.0d-20 )
+          !!JOE-Canuto/Kitamura mod
+          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden  - retro 5
+          !sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
+          !sm(k) = Prnum*sh(k)
        ELSE
           !JOE-Canuto/Kitamura mod
           !e1   = q3sq - e1c*ghel
           !e2   = q3sq - e2c*ghel
           !e3   = e1   + e3c*ghel
           !e4   = e1   - e4c*ghel
-          e1   = q3sq - e1c*ghel/a2den
-          e2   = q3sq - e2c*ghel/a2den
-          e3   = e1   + e3c*ghel/(a2den**2)
-          e4   = e1   - e4c*ghel/a2den
+          e1   = q3sq - e1c*ghel*a2fac
+          e2   = q3sq - e2c*ghel*a2fac
+          e3   = e1   + e3c*ghel*a2fac**2
+          e4   = e1   - e4c*ghel*a2fac
           eden = e2*e4 + e3*e5c*gmel
           eden = MAX( eden, 1.0d-20 )
 
           qdiv = 1.0
+          !Use level 2.5 stability functions
           sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
-          !JOE-Canuto/Kitamura mod
-          !sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
-          sh(k) = q3sq*(a2/a2den)*( e2+3.0*c1*e5c*gmel )/eden
+        !  sm_pbl = q3sq*a1*( e3-3.0*c1*e4       )/eden
+          !!JOE-Canuto/Kitamura mod
+          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
+          sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
+        !  sm(k) = Prnum*sh(k)
+
+        !  !or blend them:
+        !  zi2   = MAX(zi, 300.)
+        !  wt    = .5*TANH((zw(k) - zi2)/200.) + .5
+        !  sm(k) = sm_pbl*(1.-wt) + sm(k)*wt
        END IF !end Helfand & Labraga check
+
+       !Impose broad limits on Sh and Sm:
+       gmelq    = MAX(gmel/q3sq, 1e-8)
+       sm25max  = 4.  !MIN(sm20*3.0, SQRT(.1936/gmelq))
+       sh25max  = 4.  !MIN(sh20*3.0, 0.76*b2)
+       sm25min  = 0.0 !MAX(sm20*0.1, 1e-6)
+       sh25min  = 0.0 !MAX(sh20*0.1, 1e-6)
 
        !JOE: Level 2.5 debug prints
        ! HL88 , lev2.5 criteria from eqs. 3.17, 3.19, & 3.20
        IF ( debug_code ) THEN
-         IF (sh(k)<0.0 .OR. sm(k)<0.0 .OR. &
-           sh(k) > 0.76*b2 .or. (sm(k)**2*gm(k) .gt. .44**2)) THEN
-           print*,"MYNN; mym_turbulence2.5; sh=",sh(k)," k=",k
-           print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-           print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-           print*," qke=",qke(k)," el=",el(k)," ri=",ri
+         IF ((sh(k)<sh25min .OR. sm(k)<sm25min .OR. &
+              sh(k)>sh25max .OR. sm(k)>sm25max) ) THEN
+           print*,"In mym_turbulence 2.5: k=",k
+           print*," sm=",sm(k)," sh=",sh(k)
+           print*," ri=",ri," Pr=",sm(k)/MAX(sh(k),1e-8)
+           print*," gm=",gm(k)," gh=",gh(k)
+           print*," q2sq=",q2sq," q3sq=",q3sq, q3sq/q2sq
+           print*," qke=",qke(k)," el=",el(k)
            print*," PBLH=",zi," u=",u(k)," v=",v(k)
+           print*," SMnum=",q3sq*a1*( e3-3.0*c1*e4)," SMdenom=",eden
+           print*," SHnum=",q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel ),&
+                  " SHdenom=",eden
          ENDIF
        ENDIF
 
+       !Enforce constraints for level 2.5 functions
+       IF ( sh(k) > sh25max ) sh(k) = sh25max
+       IF ( sh(k) < sh25min ) sh(k) = sh25min
+       !IF ( sm(k) > sm25max ) sm(k) = sm25max
+       !IF ( sm(k) < sm25min ) sm(k) = sm25min
+       !sm(k) = Prnum*sh(k)
+
+       !surface layer PR
+       !slht  = zi*0.1
+       !wtpr  = min( max( (slht - zw(k))/slht, 0.0), 1.0) ! 1 at z=0, 0 above sfc layer
+       !Prlim = 1.0*wtpr + (1.0 - wtpr)*Prlimit
+       !Prlim = 2.0*wtpr + (1.0 - wtpr)*Prlimit
+       !sm(k) = MIN(sm(k), Prlim*Sh(k))
+       !Pending more testing, keep same Pr limit in sfc layer
+       sm(k) = MIN(sm(k), Prlimit*Sh(k))
+
 !   **  Level 3 : start  **
-       IF ( levflag .EQ. 3 ) THEN
+       IF ( closure .GE. 3.0 ) THEN
           t2sq = qdiv*b2*elsq*sh(k)*dtl(k)**2
           r2sq = qdiv*b2*elsq*sh(k)*dqw(k)**2
           c2sq = qdiv*b2*elsq*sh(k)*dtl(k)*dqw(k)
@@ -1692,6 +3022,7 @@ CONTAINS
 !
           vtt  = 1.0 +vt(k)*abk +vt(k-1)*afk
           vqq  = tv0 +vq(k)*abk +vq(k-1)*afk
+
           t2sq = vtt*t2sq +vqq*c2sq
           r2sq = vtt*c2sq +vqq*r2sq
           c2sq = MAX( vtt*t2sq+vqq*r2sq, 0.0d0 )
@@ -1706,18 +3037,18 @@ CONTAINS
           IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
 !
 !     **  Limitation on c3sq (0.12 =< cw =< 0.76) **
-          !JOE: use Janjic's (2001; p 13-17) methodology (eqs 4.11-414 and 5.7-5.10)
+          ! Use Janjic's (2001; p 13-17) methodology (eqs 4.11-414 and 5.7-5.10)
           ! to calculate an exact limit for c3sq:
-          auh = 27.*a1*((a2/a2den)**2)*b2*(g/tref)**2
-          aum = 54.*(a1**2)*(a2/a2den)*b2*c1*(g/tref)
-          adh = 9.*a1*((a2/a2den)**2)*(12.*a1 + 3.*b2)*(g/tref)**2
-          adm = 18.*(a1**2)*(a2/a2den)*(b2 - 3.*(a2/a2den))*(g/tref)
+          auh = 27.*a1*((a2*a2fac)**2)*b2*(gtr)**2
+          aum = 54.*(a1**2)*(a2*a2fac)*b2*c1*(gtr)
+          adh = 9.*a1*((a2*a2fac)**2)*(12.*a1 + 3.*b2)*(gtr)**2
+          adm = 18.*(a1**2)*(a2*a2fac)*(b2 - 3.*(a2*a2fac))*(gtr)
 
-          aeh = (9.*a1*((a2/a2den)**2)*b1 +9.*a1*((a2/a2den)**2)* &
-                (12.*a1 + 3.*b2))*(g/tref)
-          aem = 3.*a1*(a2/a2den)*b1*(3.*(a2/a2den) + 3.*b2*c1 + &
+          aeh = (9.*a1*((a2*a2fac)**2)*b1 +9.*a1*((a2*a2fac)**2)* &
+                (12.*a1 + 3.*b2))*(gtr)
+          aem = 3.*a1*(a2*a2fac)*b1*(3.*(a2*a2fac) + 3.*b2*c1 + &
                 (18.*a1*c1 - b2)) + &
-                (18.)*(a1**2)*(a2/a2den)*(b2 - 3.*(a2/a2den))
+                (18.)*(a1**2)*(a2*a2fac)*(b2 - 3.*(a2*a2fac))
 
           Req = -aeh/aem
           Rsl = (auh + aum*Req)/(3.*adh + 3.*adm*Req)
@@ -1735,23 +3066,23 @@ CONTAINS
           !e2   = q3sq - e2c*ghel * qdiv**2
           !e3   = q3sq + e3c*ghel * qdiv**2
           !e4   = q3sq - e4c*ghel * qdiv**2
-          e2   = q3sq - e2c*ghel/a2den * qdiv**2
-          e3   = q3sq + e3c*ghel/(a2den**2) * qdiv**2
-          e4   = q3sq - e4c*ghel/a2den * qdiv**2
+          e2   = q3sq - e2c*ghel*a2fac * qdiv**2
+          e3   = q3sq + e3c*ghel*a2fac**2 * qdiv**2
+          e4   = q3sq - e4c*ghel*a2fac * qdiv**2
           eden = e2*e4  + e3 *e5c*gmel * qdiv**2
 
           !JOE-Canuto/Kitamura mod
           !wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
           !     &        *( e2*e4c - e3c*e5c*gmel * qdiv**2 )
           wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
-               &        *( e2*e4c/a2den - e3c*e5c*gmel/(a2den**2) * qdiv**2 )
+               &        *( e2*e4c*a2fac - e3c*e5c*gmel*a2fac**2 * qdiv**2 )
 
           IF ( wden .NE. 0.0 ) THEN
              !JOE: test dynamic limits
-             !clow = q3sq*( 0.12-cw25 )*eden/wden
-             !cupp = q3sq*( 0.76-cw25 )*eden/wden
-             clow = q3sq*( Rsl -cw25 )*eden/wden
-             cupp = q3sq*( Rsl2-cw25 )*eden/wden
+             clow = q3sq*( 0.12-cw25 )*eden/wden
+             cupp = q3sq*( 0.76-cw25 )*eden/wden
+             !clow = q3sq*( Rsl -cw25 )*eden/wden
+             !cupp = q3sq*( Rsl2-cw25 )*eden/wden
 !
              IF ( wden .GT. 0.0 ) THEN
                 c3sq  = MIN( MAX( c3sq, c2sq+clow ), c2sq+cupp )
@@ -1766,7 +3097,7 @@ CONTAINS
 
           !JOE-Canuto/Kitamura mod
           !e6c  = 3.0*a2*cc3*gtr * dlsq/elsq
-          e6c  = 3.0*(a2/a2den)*cc3*gtr * dlsq/elsq
+          e6c  = 3.0*(a2*a2fac)*cc3*gtr * dlsq/elsq
 
           !============================
           !     **  for Gamma_theta  **
@@ -1795,8 +3126,8 @@ CONTAINS
 
           !JOE-Canuto/Kitamura mod
           !smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c+e4c)*a1/a2
-          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c/(a2den**2) + &
-               & e4c/a2den)*a1/(a2/a2den)
+          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c*a2fac**2 + &
+               & e4c*a2fac)*a1/(a2*a2fac)
 
           gamv = e1  *enum*gtr/eden
           sm(k) = sm(k) +smd
@@ -1826,31 +3157,21 @@ CONTAINS
           gamv = 0.0
        END IF
 !
-!      Add stochastic perturbation of prandtl number limit
-       if (spp_pbl==1) then
-          prlimit = MIN(MAX(1.,2.5 + 5.0*rstoch_col(k)), 10.)
-          IF(sm(k) > sh(k)*Prlimit) THEN
-             sm(k) = sh(k)*Prlimit
-          ENDIF
-       ENDIF
-!
 !      Add min background stability function (diffusivity) within model levels
-!      with active plumes and low cloud fractions.
+!      with active plumes and clouds.
        cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
        IF (edmf_a1(k) > 0.001 .OR. cldavg > 0.02) THEN
-           cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
-           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &                           
+           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
            !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
-           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &                           
+           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
            !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
 
            ! for mass-flux columns
            sm(k) = MAX(sm(k), 0.03*MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
            sh(k) = MAX(sh(k), 0.03*MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
            ! for clouds
-           sm(k) = MAX(sm(k), 0.03*MIN(cldavg,1.0) )
-           sh(k) = MAX(sh(k), 0.03*MIN(cldavg,1.0) )
-
+           sm(k) = MAX(sm(k), 0.05*MIN(cldavg,1.0) )
+           sh(k) = MAX(sh(k), 0.05*MIN(cldavg,1.0) )
        ENDIF
 !
        elq = el(k)*qkw(k)
@@ -1859,8 +3180,8 @@ CONTAINS
        ! Production of TKE (pdk), T-variance (pdt),
        ! q-variance (pdq), and covariance (pdc)
        pdk(k) = elq*( sm(k)*gm(k) &
-            &                    +sh(k)*gh(k)+gamv ) + & ! JAYMES TKE
-            &   TKEprodTD(k)                             ! JOE-top-down
+            &                    +sh(k)*gh(k)+gamv ) + &
+            &   TKEprodTD(k)
        pdt(k) = elh*( sh(k)*dtl(k)+gamt )*dtl(k)
        pdq(k) = elh*( sh(k)*dqw(k)+gamq )*dqw(k)
        pdc(k) = elh*( sh(k)*dtl(k)+gamt )&
@@ -1880,43 +3201,36 @@ CONTAINS
        dfq(k) =     dfm(k)
 !  Modified: Dec/22/2005, up to here
 
-   IF ( bl_mynn_tkebudget == 1) THEN
+   IF ( bl_mynn_tkebudget ) THEN
        !TKE BUDGET
-       dudz = ( u(k)-u(k-1) )/dzk
-       dvdz = ( v(k)-v(k-1) )/dzk
-       dTdz = ( thl(k)-thl(k-1) )/dzk
+!       dudz = ( u(k)-u(k-1) )/dzk
+!       dvdz = ( v(k)-v(k-1) )/dzk
+!       dTdz = ( thl(k)-thl(k-1) )/dzk
 
-       upwp = -elq*sm(k)*dudz
-       vpwp = -elq*sm(k)*dvdz
-       Tpwp = -elq*sh(k)*dTdz
-       Tpwp = SIGN(MAX(ABS(Tpwp),1.E-6),Tpwp)
+!       upwp = -elq*sm(k)*dudz
+!       vpwp = -elq*sm(k)*dvdz
+!       Tpwp = -elq*sh(k)*dTdz
+!       Tpwp = SIGN(MAX(ABS(Tpwp),1.E-6),Tpwp)
 
-       IF ( k .EQ. kts+1 ) THEN
-          qWT1D(kts)=0.
-          q3sq_old =0.
-          qWTP_old =0.
-          !**  Limitation on q, instead of L/q  **
-          dlsq1 = MAX(el(kts)**2,1.0)
-          IF ( q3sq_old/dlsq1 .LT. -gh(k) ) q3sq_old = -dlsq1*gh(k)
-       ENDIF
-
-       !!!Vertical Transport Term
-       qWTP_new = elq*Sqfac*sm(k)*(q3sq - q3sq_old)/dzk
-       qWT1D(k) = 0.5*(qWTP_new - qWTP_old)/dzk
-       qWTP_old = elq*Sqfac*sm(k)*(q3sq - q3sq_old)/dzk
-       q3sq_old = q3sq
+       
+!!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB   
 
        !!!Shear Term
        !!!qSHEAR1D(k)=-(upwp*dudz + vpwp*dvdz)
-       qSHEAR1D(k) = elq*sm(k)*gm(k)
+       qSHEAR1D(k) = elq*sm(k)*gm(k) !staggered
 
        !!!Buoyancy Term    
-       !!!qBUOY1D(k)=g*Tpwp/thl(k)
+       !!!qBUOY1D(k)=grav*Tpwp/thl(k)
        !qBUOY1D(k)= elq*(sh(k)*gh(k) + gamv)
-       qBUOY1D(k) = elq*(sh(k)*(-dTdz*g/thl(k)) + gamv)
+       !qBUOY1D(k) = elq*(sh(k)*(-dTdz*grav/thl(k)) + gamv) !! ORIGINAL CODE
+       
+       !! Buoyncy term takes the TKEprodTD(k) production now
+       qBUOY1D(k) = elq*(sh(k)*gh(k)+gamv)+TKEprodTD(k) !staggered
 
-       !!!Dissipation Term
-       qDISS1D(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.))
+       !!!Dissipation Term (now it evaluated on mym_predict)
+       !qDISS1D(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.)) !! ORIGINAL CODE
+       
+       !! >> EOB  
     ENDIF
 
     END DO
@@ -1939,13 +3253,6 @@ CONTAINS
     END DO
 !
 
-   IF ( bl_mynn_tkebudget == 1) THEN
-      !JOE-TKE BUDGET
-      qWT1D(kts)=0.
-      qSHEAR1D(kts)=qSHEAR1D(kts+1)
-      qBUOY1D(kts)=qBUOY1D(kts+1)
-      qDISS1D(kts)=qDISS1D(kts+1)
-   ENDIF
 
     if (spp_pbl==1) then
        DO k = kts,kte
@@ -2006,16 +3313,18 @@ CONTAINS
 !       scheme (program).
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_predict (kts,kte,&
-       &            levflag,  &
-       &            delt,&
-       &            dz, &
-       &            ust, flt, flq, pmz, phh, &
-       &            el, dfq, &
-       &            pdk, pdt, pdq, pdc,&
-       &            qke, tsq, qsq, cov, &
-       &            s_aw,s_awqke,bl_mynn_edmf_tke &
-       &)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine predicts the turbulent quantities at the next step.
+  SUBROUTINE  mym_predict (kts,kte,                                     &
+       &            closure,                                            &
+       &            delt,                                               &
+       &            dz,                                                 &
+       &            ust, flt, flq, pmz, phh,                            &
+       &            el, dfq, rho,                                       &
+       &            pdk, pdt, pdq, pdc,                                 &
+       &            qke, tsq, qsq, cov,                                 &
+       &            s_aw,s_awqke,bl_mynn_edmf_tke,                      &
+       &            qWT1D, qDISS1D,bl_mynn_tkebudget)  !! TKE budget  (Puhales, 2020)
 
 !-------------------------------------------------------------------
     INTEGER, INTENT(IN) :: kts,kte    
@@ -2025,22 +3334,30 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(IN) :: levflag
+    REAL, INTENT(IN)    :: closure
     INTEGER, INTENT(IN) :: bl_mynn_edmf_tke
     REAL, INTENT(IN)    :: delt
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq,el
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq, el, rho
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: pdk, pdt, pdq, pdc
     REAL, INTENT(IN)    ::  flt, flq, ust, pmz, phh
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: qke,tsq, qsq, cov
 ! WA 8/3/15
     REAL, DIMENSION(kts:kte+1), INTENT(INOUT) :: s_awqke,s_aw
-
+    
+    !!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
+    REAL, DIMENSION(kts:kte), INTENT(OUT) :: qWT1D, qDISS1D  
+    LOGICAL, INTENT(IN) :: bl_mynn_tkebudget  
+    REAL, DIMENSION(kts:kte) :: tke_up,dzinv  
+    !! >> EOB
+    
     INTEGER :: k
     REAL, DIMENSION(kts:kte) :: qkw, bp, rp, df3q
     REAL :: vkz,pdk1,phm,pdt1,pdq1,pdc1,b1l,b2l,onoff
     REAL, DIMENSION(kts:kte) :: dtz
     REAL, DIMENSION(kts:kte) :: a,b,c,d,x
 
+    REAL, DIMENSION(kts:kte) :: rhoinv
+    REAL, DIMENSION(kts:kte+1) :: rhoz,kqdz,kmdz
 
     ! REGULATE THE MOMENTUM MIXING FROM THE MASS-FLUX SCHEME (on or off)
     IF (bl_mynn_edmf_tke == 0) THEN
@@ -2049,8 +3366,8 @@ CONTAINS
        onoff=1.0
     ENDIF
 
-!   **  Strictly, vkz*h(i,j) -> vk*( 0.5*dz(1)*h(i,j)+z0 )  **
-    vkz = vk*0.5*dz(kts)
+!   **  Strictly, vkz*h(i,j) -> karman*( 0.5*dz(1)*h(i,j)+z0 )  **
+    vkz = karman*0.5*dz(kts)
 !
 !   **  dfq for the TKE is 3.0*dfm.  **
 !
@@ -2061,6 +3378,33 @@ CONTAINS
        dtz(k)=delt/dz(k)
     END DO
 !
+!JOE-add conservation + stability criteria
+    !Prepare "constants" for diffusion equation.
+    !khdz = rho*Kh/dz = rho*dfh
+    rhoz(kts)  =rho(kts)
+    rhoinv(kts)=1./rho(kts)
+    kqdz(kts)  =rhoz(kts)*df3q(kts)
+    kmdz(kts)  =rhoz(kts)*dfq(kts)
+    DO k=kts+1,kte
+       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
+       rhoz(k)  =  MAX(rhoz(k),1E-4)
+       rhoinv(k)=1./MAX(rho(k),1E-4)
+       kqdz(k)  = rhoz(k)*df3q(k) ! for TKE
+       kmdz(k)  = rhoz(k)*dfq(k)  ! for T'2, q'2, and T'q'
+    ENDDO
+    rhoz(kte+1)=rhoz(kte)
+    kqdz(kte+1)=rhoz(kte+1)*df3q(kte)
+    kmdz(kte+1)=rhoz(kte+1)*dfq(kte)
+
+    !stability criteria for mf
+    DO k=kts+1,kte-1
+       kqdz(k) = MAX(kqdz(k),  0.5* s_aw(k))
+       kqdz(k) = MAX(kqdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+       kmdz(k) = MAX(kmdz(k),  0.5* s_aw(k))
+       kmdz(k) = MAX(kmdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+    ENDDO
+!JOE-end conservation mods
+
     pdk1 = 2.0*ust**3*pmz/( vkz )
     phm  = 2.0/ust   *phh/( vkz )
     pdt1 = phm*flt**2
@@ -2097,11 +3441,21 @@ CONTAINS
 !       c(k-kts+1)=-dtz(k)*df3q(k+1)
 !       d(k-kts+1)=rp(k)*delt + qke(k)
 ! WA 8/3/15 add EDMF contribution
-       a(k-kts+1)=-dtz(k)*df3q(k) + 0.5*dtz(k)*s_aw(k)*onoff
-       b(k-kts+1)=1. + dtz(k)*(df3q(k)+df3q(k+1)) &
-                     + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff + bp(k)*delt
-       c(k-kts+1)=-dtz(k)*df3q(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
-       d(k-kts+1)=rp(k)*delt + qke(k) + dtz(k)*(s_awqke(k)-s_awqke(k+1))*onoff
+!       a(k)=   - dtz(k)*df3q(k) + 0.5*dtz(k)*s_aw(k)*onoff
+!       b(k)=1. + dtz(k)*(df3q(k)+df3q(k+1)) &
+!               + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff + bp(k)*delt
+!       c(k)=   - dtz(k)*df3q(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
+!       d(k)=rp(k)*delt + qke(k) + dtz(k)*(s_awqke(k)-s_awqke(k+1))*onoff
+!JOE 8/22/20 improve conservation
+       a(k)=   - dtz(k)*kqdz(k)*rhoinv(k)                       &
+           &   + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff
+       b(k)=1. + dtz(k)*(kqdz(k)+kqdz(k+1))*rhoinv(k)           &
+           &   + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff &
+           &   + bp(k)*delt
+       c(k)=   - dtz(k)*kqdz(k+1)*rhoinv(k)                     &
+           &   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff
+       d(k)=rp(k)*delt + qke(k)                                 &
+           &   + dtz(k)*rhoinv(k)*(s_awqke(k)-s_awqke(k+1))*onoff
     ENDDO
 
 !!    DO k=kts+1,kte-1
@@ -2111,10 +3465,16 @@ CONTAINS
 !!       d(k-kts+1)=rp(k)*delt + qke(k) - qke(k)*bp(k)*delt
 !!    ENDDO
 
-    a(kte)=-1. !0.
+!! "no flux at top"
+!    a(kte)=-1. !0.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
+!! "prescribed value"
+    a(kte)=0.
     b(kte)=1.
     c(kte)=0.
-    d(kte)=0.
+    d(kte)=qke(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
     CALL tridiag2(kte,a,b,c,d,x)
@@ -2122,15 +3482,89 @@ CONTAINS
     DO k=kts,kte
 !       qke(k)=max(d(k-kts+1), 1.e-4)
        qke(k)=max(x(k), 1.e-4)
+       qke(k)=min(qke(k), 150.)
     ENDDO
       
+   
+!!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
+    IF (bl_mynn_tkebudget) THEN
+       !! TKE Vertical transport << EOBvt
+        tke_up=0.5*qke
+        dzinv=1./dz
+        k=kts
+        qWT1D(k)=dzinv(k)*(                                    &
+            &  (kqdz(k+1)*(tke_up(k+1)-tke_up(k))-kqdz(k)*tke_up(k)) &
+            &  + 0.5*rhoinv(k)*(s_aw(k+1)*tke_up(k+1)          &
+            &  +      (s_aw(k+1)-s_aw(k))*tke_up(k)            &
+            &  +      (s_awqke(k)-s_awqke(k+1)))*onoff) !unstaggered
+        DO k=kts+1,kte-1
+            qWT1D(k)=dzinv(k)*(                                &
+            & (kqdz(k+1)*(tke_up(k+1)-tke_up(k))-kqdz(k)*(tke_up(k)-tke_up(k-1))) &
+            &  + 0.5*rhoinv(k)*(s_aw(k+1)*tke_up(k+1)          &
+            &  +      (s_aw(k+1)-s_aw(k))*tke_up(k)            &
+            &  -                  s_aw(k)*tke_up(k-1)          &
+            &  +      (s_awqke(k)-s_awqke(k+1)))*onoff) !unstaggered
+        ENDDO
+        k=kte
+        qWT1D(k)=dzinv(k)*(-kqdz(k)*(tke_up(k)-tke_up(k-1)) &
+            &  + 0.5*rhoinv(k)*(-s_aw(k)*tke_up(k)-s_aw(k)*tke_up(k-1)+s_awqke(k))*onoff) !unstaggared
+        !!  >> EOBvt
+        qDISS1D=bp*tke_up !! TKE dissipation rate !unstaggered
+    END IF
+!! >> EOB 
+   
+    IF ( closure > 2.5 ) THEN
 
-    IF ( levflag .EQ. 3 ) THEN
+       !   **  Prediction of the moisture variance  **
+       DO k = kts,kte-1
+          b2l   = b2*0.5*( el(k+1)+el(k) )
+          bp(k) = 2.*qkw(k) / b2l
+          rp(k) = pdq(k+1) + pdq(k)
+       END DO
+
+       !zero gradient for qsq at bottom and top
+       !a(1)=0.
+       !b(1)=1.
+       !c(1)=-1.
+       !d(1)=0.
+
+       ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
+       DO k=kts,kte-1
+          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
+          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
+          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
+          d(k)=rp(k)*delt + qsq(k)
+       ENDDO
+
+       a(kte)=-1. !0.
+       b(kte)=1.
+       c(kte)=0.
+       d(kte)=0.
+
+!       CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+       
+       DO k=kts,kte
+          !qsq(k)=d(k-kts+1)
+          qsq(k)=MAX(x(k),1e-17)
+       ENDDO
+    ELSE
+       !level 2.5 - use level 2 diagnostic
+       DO k = kts,kte-1
+          IF ( qkw(k) .LE. 0.0 ) THEN
+             b2l = 0.0
+          ELSE
+             b2l = b2*0.25*( el(k+1)+el(k) )/qkw(k)
+          END IF
+          qsq(k) = b2l*( pdq(k+1)+pdq(k) )
+       END DO
+       qsq(kte)=qsq(kte-1)
+    END IF
+!!!!!!!!!!!!!!!!!!!!!!end level 2.6   
+
+    IF ( closure .GE. 3.0 ) THEN
 !
-!  Modified: Dec/22/2005, from here
 !   **  dfq for the scalar variance is 1.0*dfm.  **
-!       CALL coefvu ( dfq, 1.0 ) make change here 
-!  Modified: Dec/22/2005, up to here
 !
 !   **  Prediction of the temperature variance  **
 !!       DO k = kts+1,kte-1
@@ -2149,10 +3583,15 @@ CONTAINS
 
 ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
        DO k=kts,kte-1
-          a(k-kts+1)=-dtz(k)*dfq(k)
-          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          c(k-kts+1)=-dtz(k)*dfq(k+1)
-          d(k-kts+1)=rp(k)*delt + tsq(k)
+          !a(k-kts+1)=-dtz(k)*dfq(k)
+          !b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          !c(k-kts+1)=-dtz(k)*dfq(k+1)
+          !d(k-kts+1)=rp(k)*delt + tsq(k)
+!JOE 8/22/20 improve conservation
+          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
+          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
+          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
+          d(k)=rp(k)*delt + tsq(k)
        ENDDO
 
 !!       DO k=kts+1,kte-1
@@ -2166,58 +3605,15 @@ CONTAINS
        b(kte)=1.
        c(kte)=0.
        d(kte)=0.
-
-!       CALL tridiag(kte,a,b,c,d)
-    CALL tridiag2(kte,a,b,c,d,x)
-       
-       DO k=kts,kte
-!          tsq(k)=d(k-kts+1)
-           tsq(k)=x(k)
-       ENDDO
-       
-!   **  Prediction of the moisture variance  **
-!!       DO k = kts+1,kte-1
-       DO k = kts,kte-1
-          b2l = b2*0.5*( el(k+1)+el(k) )
-          bp(k) = 2.*qkw(k) / b2l
-          rp(k) = pdq(k+1) +pdq(k) 
-       END DO
-       
-!zero gradient for qsq at bottom and top
-       
-!!       a(1)=0.
-!!       b(1)=1.
-!!       c(1)=-1.
-!!       d(1)=0.
-
-! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
-       DO k=kts,kte-1
-          a(k-kts+1)=-dtz(k)*dfq(k)
-          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          c(k-kts+1)=-dtz(k)*dfq(k+1)
-          d(k-kts+1)=rp(k)*delt + qsq(k)
-       ENDDO
-
-!!       DO k=kts+1,kte-1
-!!          a(k-kts+1)=-dtz(k)*dfq(k)
-!!          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))
-!!          c(k-kts+1)=-dtz(k)*dfq(k+1)
-!!          d(k-kts+1)=rp(k)*delt + qsq(k) -qsq(k)*bp(k)*delt
-!!       ENDDO
-
-       a(kte)=-1. !0.
-       b(kte)=1.
-       c(kte)=0.
-       d(kte)=0.
        
 !       CALL tridiag(kte,a,b,c,d)
        CALL tridiag2(kte,a,b,c,d,x)
 
        DO k=kts,kte
-!          qsq(k)=d(k-kts+1)
-           qsq(k)=x(k)
+!          tsq(k)=d(k-kts+1)
+           tsq(k)=x(k)
        ENDDO
-       
+
 !   **  Prediction of the temperature-moisture covariance  **
 !!       DO k = kts+1,kte-1
        DO k = kts,kte-1
@@ -2235,10 +3631,15 @@ CONTAINS
 
 ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
        DO k=kts,kte-1
-          a(k-kts+1)=-dtz(k)*dfq(k)
-          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          c(k-kts+1)=-dtz(k)*dfq(k+1)
-          d(k-kts+1)=rp(k)*delt + cov(k)
+          !a(k-kts+1)=-dtz(k)*dfq(k)
+          !b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          !c(k-kts+1)=-dtz(k)*dfq(k+1)
+          !d(k-kts+1)=rp(k)*delt + cov(k)
+!JOE 8/22/20 improve conservation
+          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
+          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
+          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
+          d(k)=rp(k)*delt + cov(k)
        ENDDO
 
 !!       DO k=kts+1,kte-1
@@ -2262,7 +3663,8 @@ CONTAINS
        ENDDO
        
     ELSE
-!!       DO k = kts+1,kte-1
+
+       !Not level 3 - default to level 2 diagnostic
        DO k = kts,kte-1
           IF ( qkw(k) .LE. 0.0 ) THEN
              b2l = 0.0
@@ -2271,16 +3673,10 @@ CONTAINS
           END IF
 !
           tsq(k) = b2l*( pdt(k+1)+pdt(k) )
-          qsq(k) = b2l*( pdq(k+1)+pdq(k) )
           cov(k) = b2l*( pdc(k+1)+pdc(k) )
        END DO
        
-!!       tsq(kts)=tsq(kts+1)
-!!       qsq(kts)=qsq(kts+1)
-!!       cov(kts)=cov(kts+1)
-
        tsq(kte)=tsq(kte-1)
-       qsq(kte)=qsq(kte-1)
        cov(kte)=cov(kte-1)
       
     END IF
@@ -2306,8 +3702,8 @@ CONTAINS
 !     Output variables:   see subroutine mym_initialize
 !       cld(nx,nz,ny)   : Cloud fraction
 !
-!     Work arrays:
-!       qmq(nx,nz,ny)   : Q_w-Q_{sl}, where Q_{sl} is the saturation
+!     Work arrays/variables:
+!       qmq             : Q_w-Q_{sl}, where Q_{sl} is the saturation
 !                         specific humidity at T=Tl
 !       alp(nx,nz,ny)   : Functions in the condensation process
 !       bet(nx,nz,ny)   : ditto
@@ -2317,21 +3713,26 @@ CONTAINS
 !     # qmq, alp, bet and sgm are allowed to share storage units with
 !       any four of other work arrays for saving memory.
 !
-!     # Results are sensitive particularly to values of cp and rd.
+!     # Results are sensitive particularly to values of cp and r_d.
 !       Set these values to those adopted by you.
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_condensation (kts,kte,  &
-    &            dx, dz, zw,              &
-    &            thl, qw, qv, qc, qi,     &
-    &            p,exner,                 &
-    &            tsq, qsq, cov,           &
-    &            Sh, el, bl_mynn_cloudpdf,&
-    &            qc_bl1D, qi_bl1D,        &
-    &            cldfra_bl1D,             &
-    &            PBLH1,HFX1,              &
-    &            Vt, Vq, th, sgm, rmo,    &
-    &            spp_pbl,rstoch_col       )
+!>\ingroup gsd_mynn_edmf 
+!! This subroutine calculates the nonconvective component of the 
+!! subgrid cloud fraction and mixing ratio as well as the functions used to 
+!! calculate the buoyancy flux. Different cloud PDFs can be selected by
+!! use of the namelist parameter \p bl_mynn_cloudpdf .
+  SUBROUTINE  mym_condensation (kts,kte,   &
+    &            dx, dz, zw, u1, v1, xland,&
+    &            thl, qw, qv, qc, qi,      &
+    &            p,exner,                  &
+    &            tsq, qsq, cov,            &
+    &            Sh, el, bl_mynn_cloudpdf, &
+    &            qc_bl1D, qi_bl1D,         &
+    &            cldfra_bl1D,              &
+    &            PBLH1,HFX1,               &
+    &            Vt, Vq, th, sgm, rmo,     &
+    &            spp_pbl,rstoch_col        )
 
 !-------------------------------------------------------------------
 
@@ -2342,34 +3743,35 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    REAL, INTENT(IN)      :: dx,PBLH1,HFX1,rmo
+    REAL, INTENT(IN)      :: dx,PBLH1,HFX1,rmo,xland
     REAL, DIMENSION(kts:kte), INTENT(IN) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(IN) :: zw
     REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner,thl,qw,qv,qc,qi, &
-         &tsq, qsq, cov, th
+         &tsq, qsq, cov, th, u1, v1
 
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: vt,vq,sgm
 
-    REAL, DIMENSION(kts:kte) :: qmq,alp,a,bet,b,ql,q1,RH
+    REAL, DIMENSION(kts:kte) :: alp,a,bet,b,ql,q1,RH
     REAL, DIMENSION(kts:kte), INTENT(OUT) :: qc_bl1D,qi_bl1D, &
                                              cldfra_bl1D
     DOUBLE PRECISION :: t3sq, r3sq, c3sq
 
-    REAL :: qsl,esat,qsat,tlk,qsat_tl,dqsl,cld0,q1k,eq1,qll,&
-         &q2p,pt,rac,qt,t,xl,rsl,cpm,cdhdz,Fng,qww,alpha,beta,bb,&
-         &ls_min,ls,wt,cld_factor,fac_damp,liq_frac,ql_ice,ql_water,&
-         &low_weight
+    REAL :: qsl,esat,qsat,dqsl,cld0,q1k,qlk,eq1,qll,&
+         &q2p,pt,rac,qt,t,xl,rsl,cpm,Fng,qww,alpha,beta,bb,&
+         &ls,wt,cld_factor,fac_damp,liq_frac,ql_ice,ql_water,&
+         &qmq,qsat_tk,wsp,wspfac
     INTEGER :: i,j,k
 
     REAL :: erf
 
-    !JOE: NEW VARIABLES FOR ALTERNATE SIGMA
+    !VARIABLES FOR ALTERNATIVE SIGMA
     REAL::dth,dtl,dqw,dzk,els
     REAL, DIMENSION(kts:kte), INTENT(IN) :: Sh,el
 
-    !JOE: variables for BL clouds
-    REAL::zagl,damp,PBLH2,ql_limit
-    REAL            :: lfac
+    !variables for SGS BL clouds
+    REAL            :: zagl,damp,PBLH2
+    REAL            :: cfmax
+    INTEGER, PARAMETER :: pdf_opt=1   ! 0: traditional SD77, 1: CB02,CB05
 
     !JAYMES:  variables for tropopause-height estimation
     REAL            :: theta1, theta2, ht1, ht2
@@ -2423,7 +3825,7 @@ CONTAINS
            !qsl=ep_2*esat/(p(k)-ep_3*esat)
            qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
            !dqw/dT: Clausius-Clapeyron
-           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           dqsl = qsl*ep_2*xlv/( r_d*t**2 )
 
            alp(k) = 1.0/( 1.0+dqsl*xlvcp )
            bet(k) = dqsl*exner(k)
@@ -2436,14 +3838,15 @@ CONTAINS
            c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
            r3sq = r3sq +bet(k)**2*t3sq -2.0*bet(k)*c3sq
            !DEFICIT/EXCESS WATER CONTENT
-           qmq(k) = qw(k) -qsl
+           qmq  = qw(k) -qsl
            !ORIGINAL STANDARD DEVIATION
            sgm(k) = SQRT( MAX( r3sq, 1.0d-10 ))
            !NORMALIZED DEPARTURE FROM SATURATION
-           q1(k)   = qmq(k) / sgm(k)
+           q1(k)   = qmq / sgm(k)
            !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
            cldfra_bl1D(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
 
+           q1k  = q1(k)
            eq1  = rrp*EXP( -0.5*q1k*q1k )
            qll  = MAX( cldfra_bl1D(k)*q1k + eq1, 0.0 )
            !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
@@ -2456,7 +3859,7 @@ CONTAINS
            if(cldfra_bl1D(k)>0.01 .and. qc_bl1D(k)<1.E-6)qc_bl1D(k)=1.E-6
            if(cldfra_bl1D(k)>0.01 .and. qi_bl1D(k)<1.E-8)qi_bl1D(k)=1.E-8
 
-           !Now estimate the buiyancy flux functions
+           !Now estimate the buoyancy flux functions
            q2p = xlvcp/exner(k)
            pt = thl(k) +q2p*ql(k) ! potential temp
 
@@ -2482,7 +3885,7 @@ CONTAINS
            !qsl=ep_2*esat/(p(k)-ep_3*esat)
            qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
            !dqw/dT: Clausius-Clapeyron
-           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           dqsl = qsl*ep_2*xlv/( r_d*t**2 )
 
            alp(k) = 1.0/( 1.0+dqsl*xlvcp )
            bet(k) = dqsl*exner(k)
@@ -2497,8 +3900,8 @@ CONTAINS
            sgm(k) = SQRT( MAX( (alp(k)**2 * MAX(el(k)**2,0.1) * &
                              b2 * MAX(Sh(k),0.03))/4. * &
                       (dqw/dzk - bet(k)*(dth/dzk ))**2 , 1.0e-10) )
-           qmq(k) = qw(k) -qsl
-           q1(k)   = qmq(k) / sgm(k)
+           qmq   = qw(k) -qsl
+           q1(k) = qmq / sgm(k)
            cldfra_bl1D(K) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
 
            !now compute estimated lwc for PBL scheme's use 
@@ -2516,7 +3919,7 @@ CONTAINS
            if(cldfra_bl1D(k)>0.01 .and. qc_bl1D(k)<1.E-6)qc_bl1D(k)=1.E-6
            if(cldfra_bl1D(k)>0.01 .and. qi_bl1D(k)<1.E-8)qi_bl1D(k)=1.E-8
 
-           !Now estimate the buiyancy flux functions
+           !Now estimate the buoyancy flux functions
            q2p = xlvcp/exner(k)
            pt = thl(k) +q2p*ql(k) ! potential temp
 
@@ -2533,140 +3936,106 @@ CONTAINS
         END DO
 
       CASE (2, -2)
+
         !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
-        !JAYMES- this added 27 Apr 2015
+        !but with use of higher-order moments to estimate sigma
         PBLH2=MAX(10.,PBLH1)
         zagl = 0.
         DO k = kts,kte-1
+           zagl = zagl + dz(k)
            t  = th(k)*exner(k)
-           !SATURATED VAPOR PRESSURE
-           esat = esat_blend(t)
-           !SATURATED SPECIFIC HUMIDITY
-           !qsl=ep_2*esat/(p(k)-ep_3*esat)
-           qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
-           !dqw/dT: Clausius-Clapeyron
-           dqsl = qsl*ep_2*ev/( rd*t**2 )
-           !RH (0 to 1.0)
-           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
 
+           xl = xl_blend(t)                  ! obtain latent heat
+           qsat_tk = qsat_blend(t,  p(k))    ! saturation water vapor mixing ratio at tk and p
+           rh(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsat_tk)),0.001)
+
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsat_tk*ep_2*xlv/( r_d*t**2 )
            alp(k) = 1.0/( 1.0+dqsl*xlvcp )
            bet(k) = dqsl*exner(k)
+ 
+           rsl = xl*qsat_tk / (r_v*t**2)     ! slope of C-C curve at t (=abs temperature)
+                                             ! CB02, Eqn. 4
+           cpm = cp + qw(k)*cpv              ! CB02, sec. 2, para. 1
+           a(k) = 1./(1. + xl*rsl/cpm)       ! CB02 variable "a"
+           b(k) = a(k)*rsl                   ! CB02 variable "b"
 
-           xl = xl_blend(t)                    ! obtain latent heat
-           tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
-           qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
-                                               !   at tl and p
-           rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
-                                               ! CB02, Eqn. 4
-           cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
-           a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
            !SPP
            qw_pert = qw(k) + qw(k)*0.5*rstoch_col(k)*real(spp_pbl)
-           !qmq(k) = a(k) * (qw(k) - qsat_tl) ! saturation deficit/excess;
-                                               !   the numerator of Q1
-           qmq(k) = a(k) * (qw_pert - qsat_tl)
-           b(k) = a(k)*rsl                     ! CB02 variable "b"
-           dtl =    0.5*(thl(k+1)*(p(k+1)/p1000mb)**rcp + tlk) &
-               & - 0.5*(tlk + thl(MAX(k-1,kts))*(p(MAX(k-1,kts))/p1000mb)**rcp)
-           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
 
-           if (k .eq. kts) then
-             dzk = 0.5*dz(k)
-           else
-             dzk = dz(k)
-           end if
+           !This form of qmq (the numerator of Q1) no longer uses the a(k) factor
+           qmq    = qw_pert - qsat_tk          ! saturation deficit/excess;
 
-           cdhdz = dtl/dzk + (g/cpm)*(1.+qw(k))  ! expression below Eq. 9
-                                                 ! in CB02
-           zagl = zagl + dz(k)
-           !Use analog to surface layer length scale to make the cloud mixing length scale
-           !become less than z in stable conditions.
-           els  = zagl !save for more testing:  /(1.0 + 1.0*MIN( 0.5*dz(1)*MAX(rmo,0.0), 1. ))
+           !Use the form of Eq. (6) in Chaboureau and Bechtold (2002)
+           !except neglect all but the first term for sig_r
+           r3sq = MAX( qsq(k), 0.0 )
+           !Calculate sigma using higher-order moments:
+           sgm(k) = SQRT( r3sq )
+           !Set limits on sigma relative to saturation water vapor
+           sgm(k) = MIN( sgm(k), qsat_tk*0.666 ) !500 )
+           sgm(k) = MAX( sgm(k), qsat_tk*0.035 ) !Note: 0.02 results in SWDOWN similar
+                                                 !to the first-order version of sigma
+           q1(k) = qmq  / sgm(k)  ! Q1, the normalized saturation
+           q1k   = q1(k)          ! backup Q1 for later modification
 
-           !ls_min = 300. + MIN(3.*MAX(HFX1,0.),300.)
-           ls_min = 300. + MIN(2.*MAX(HFX1,0.),150.)
-           ls_min = MIN(MAX(els,25.),ls_min) ! Let this be the minimum possible length scale:
-           if (zagl > PBLH1+2000.) ls_min = MAX(ls_min + 0.5*(PBLH1+2000.-zagl),300.)
-                                        !   25 m < ls_min(=zagl) < 300 m
-           lfac=MIN(4.25+dx/4000.,6.)   ! A dx-dependent multiplier for the master length scale:
-                                        !   lfac(750 m) = 4.4
-                                        !   lfac(3 km)  = 5.0
-                                        !   lfac(13 km) = 6.0
-           ls = MAX(MIN(lfac*el(k),600.),ls_min)  ! Bounded:  ls_min < ls < 600 m
-                   ! Note: CB02 use 900 m as a constant free-atmosphere length scale. 
+           ! Specify cloud fraction
+           !Original C-B cloud fraction, allows cloud fractions out to q1 = -3.5
+           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.55*q1(k)))) ! Eq. 7 in CB02
+           !wayne's  - over-diffuse, when limits removed from vt & vq & fng
+           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.2*(q1(k)+0.4))))
+           !effort to reduce rh-dependency
+           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(2.9*(q1(k)+0.4))))
+           cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.8*(q1(k)+0.4))))
+           !moderate - best compromise??
+           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.55*(q1(k)+0.2))))
+           !closer to original for Q1 < -1, best for holding onto stratus, not good flowers
+           !cldfra_bl1D(K) = max(0., min(1., 0.5+0.36*atan(1.9*(q1(k)+0.4))))
 
-                   ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the 
-                   ! MYNN master length scale (el) must exceed 60 m before ls
-                   ! becomes responsive to el, otherwise ls = ls_min = 300 m.
 
-           sgm(k) = MAX(1.e-10, 0.225*ls*SQRT(MAX(0., & ! Eq. 9 in CB02:
-                   & (a(k)*dqw/dzk)**2              & ! < 1st term in brackets,
-                   & -2*a(k)*b(k)*cdhdz*dqw/dzk     & ! < 2nd term,
-                   & +b(k)**2 * cdhdz**2)))           ! < 3rd term
-                   ! CB02 use a multiplier of 0.2, but 0.225 is chosen
-                   ! based on tests
-
-           q1(k) = qmq(k) / sgm(k)  ! Q1, the normalized saturation
-           cldfra_bl1D(K) = MAX(0., MIN(1., 0.5+0.36*ATAN(1.55*q1(k)))) ! Eq. 7 in CB02
-
-        END DO
-
-        ! JAYMES- this option added 8 May 2015
-        ! The cloud water formulations are taken from CB02, Eq. 8.
-        ! "fng" represents the non-Gaussian contribution to the liquid
-        ! water flux; these formulations are from Cuijpers and Bechtold
-        ! (1995), Eq. 7.  CB95 also draws from Bechtold et al. 1995,
-        ! hereafter BCMT95
-        zagl = 0.
-        DO k = kts,kte-1
-           t    = th(k)*exner(k)
-           q1k  = q1(k)
-           zagl = zagl + dz(k)
-
-           !CLOUD WATER AND ICE
-           IF (q1k < 0.) THEN        !unstaurated
+           ! Specify hydrometeors
+           ! JAYMES- this option added 8 May 2015
+           ! The cloud water formulations are taken from CB02, Eq. 8.
+           IF (q1k < 0.) THEN        !unsaturated
               ql_water = sgm(k)*EXP(1.2*q1k-1)
-!              ql_ice   = sgm(k)*EXP(0.9*q1k-2.6)
-              !Reduce ice mixing ratios in the upper troposphere
-              low_weight = MIN(MAX(p(k)-40000.0, 0.0),40000.0)/40000.0
-              ql_ice   = low_weight * sgm(k)*EXP(1.1*q1k-1.6) &  !low-lev
-                  + (1.-low_weight) * sgm(k)*EXP(1.1*q1k-2.8)!upper-lev
+              ql_ice   = sgm(k)*EXP(1.2*q1k-1.)
            ELSE IF (q1k > 2.) THEN   !supersaturated
               ql_water = sgm(k)*q1k
-              ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*q1k
+              ql_ice   = sgm(k)*q1k
            ELSE                      !slightly saturated (0 > q1 < 2)
               ql_water = sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
-              ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
+              ql_ice   = sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
            ENDIF
 
-           !In saturated grid cells, use average of current estimate and prev time step
-           IF ( qc(k) > 1.e-7 ) ql_water = 0.5 * ( ql_water + qc(k) )
-           IF ( qi(k) > 1.e-9 ) ql_ice = 0.5 * ( ql_ice + qi(k) )
+           !In saturated grid cells, use average of SGS and resolved values
+           if ( qc(k) > 1.e-7 ) ql_water = 0.5 * ( ql_water + qc(k) )
+           if ( qi(k) > 1.e-9 ) ql_ice = 0.5 * ( ql_ice + qi(k) )
 
-           IF (cldfra_bl1D(K) < 0.005) THEN
+           if (cldfra_bl1D(k) < 0.01) then
               ql_ice   = 0.0
               ql_water = 0.0
-           ENDIF
+              cldfra_bl1D(k) = 0.0
+           endif
 
-           !PHASE PARTITIONING:  Make some inferences about the relative amounts of subgrid cloud water vs. ice
-           !based on collocated explicit clouds.  Otherise, use a simple temperature-dependent partitioning.
-           IF ( qc(k) + qi(k) > 0.0 ) THEN ! explicit condensate exists, so attempt to retain its phase partitioning
-              IF ( qi(k) == 0.0 ) THEN       ! explicit contains no ice; assume subgrid liquid
-                liq_frac = 1.0  
-              ELSE IF ( qc(k) == 0.0 ) THEN  ! explicit contains no liquid; assume subgrid ice
-                liq_frac = 0.0
-              ELSE IF ( (qc(k) >= 1.E-10) .AND. (qi(k) >= 1.E-10) ) THEN  ! explicit contains mixed phase of workably 
-                                                                          ! large amounts; assume subgrid follows 
-                                                                          ! same partioning
-                liq_frac = qc(k) / ( qc(k) + qi(k) )
-              ELSE 
-                liq_frac = MIN(1.0, MAX(0.0, (t-238.)/31.)) ! explicit contains mixed phase, but at least one 
-                                                                   ! species is very small, so make a temperature-
-                                                                   ! depedent guess
-              ENDIF
-           ELSE                          ! no explicit condensate, so make a temperature-dependent guess
-             liq_frac = MIN(1.0, MAX(0.0, (t-238.)/31.))
-           ENDIF
+           !PHASE PARTITIONING:  Make some inferences about the relative amounts of 
+           !subgrid cloud water vs. ice based on collocated explicit clouds.  Otherise, 
+           !use a simple temperature-dependent partitioning.
+           ! IF ( qc(k) + qi(k) > 0.0 ) THEN ! explicit condensate exists, retain its phase partitioning
+           !    IF ( qi(k) == 0.0 ) THEN       ! explicit contains no ice; assume subgrid liquid
+           !      liq_frac = 1.0
+           !    ELSE IF ( qc(k) == 0.0 ) THEN  ! explicit contains no liquid; assume subgrid ice
+           !      liq_frac = 0.0
+           !    ELSE IF ( (qc(k) >= 1.E-10) .AND. (qi(k) >= 1.E-10) ) THEN  ! explicit contains mixed phase of workably 
+           !                                                                ! large amounts; assume subgrid follows 
+           !                                                               ! same partioning
+           !      liq_frac = qc(k) / ( qc(k) + qi(k) )
+           !    ELSE
+           !      liq_frac = MIN(1.0, MAX(0.0, (t-tice)/(t0c-tice))) ! explicit contains mixed phase, but at least one 
+           !                                                         ! species is very small, so make a temperature-
+           !                                                         ! depedent guess
+           !    ENDIF
+           ! ELSE                          ! no explicit condensate, so make a temperature-dependent guess
+             liq_frac = MIN(1.0, MAX(0.0, (t-tice)/(tliq-tice)))
+           ! ENDIF
 
            qc_bl1D(k) = liq_frac*ql_water       ! apply liq_frac to ql_water and ql_ice
            qi_bl1D(k) = (1.0-liq_frac)*ql_ice
@@ -2674,11 +4043,17 @@ CONTAINS
            !Above tropopause:  eliminate subgrid clouds from CB scheme
            if (k .ge. k_tropo-1) then
               cldfra_bl1D(K) = 0.
-              qc_bl1D(k)  = 0.
-              qi_bl1D(k)  = 0.
+              qc_bl1D(k)     = 0.
+              qi_bl1D(k)     = 0.
            endif
-       
+
            !Buoyancy-flux-related calculations follow...
+           !limiting Q1 to avoid too much diffusion in cloud layers
+           if ((xland-1.5).GE.0) then   ! water
+              q1k=max(Q1(k),-2.5)
+           else                         ! land
+              q1k=max(Q1(k),-2.0)
+           endif
            ! "Fng" represents the non-Gaussian transport factor
            ! (non-dimensional) from Bechtold et al. 1995 
            ! (hereafter BCMT95), section 3(c).  Their suggested 
@@ -2690,51 +4065,80 @@ CONTAINS
            !ELSE
            !  Fng = 1.-1.5*q1k
            !ENDIF
-           ! For purposes of the buoyancy flux in stratus, we will use Fng = 1
-           !Fng = 1.
-           Q1(k)=MAX(Q1(k),-5.0)
-           IF (Q1(k) .GE. 1.0) THEN
+           ! Use the form of "Fng" from Bechtold and Siebesma (1998, JAS)
+           IF (q1k .GE. 1.0) THEN
               Fng = 1.0
-           ELSEIF (Q1(k) .GE. -1.7 .AND. Q1(k) < 1.0) THEN
-              Fng = EXP(-0.4*(Q1(k)-1.0))
-           ELSEIF (Q1(k) .GE. -2.5 .AND. Q1(k) .LT. -1.7) THEN
-              Fng = 3.0 + EXP(-3.8*(Q1(k)+1.7))
+           ELSEIF (q1k .GE. -1.7 .AND. q1k .LT. 1.0) THEN
+              Fng = EXP(-0.4*(q1k-1.0))
+           ELSEIF (q1k .GE. -2.5 .AND. q1k .LT. -1.7) THEN
+              Fng = 3.0 + EXP(-3.8*(q1k+1.7))
            ELSE
-              Fng = MIN(23.9 + EXP(-1.6*(Q1(k)+2.5)), 60.)
+              Fng = MIN(23.9 + EXP(-1.6*(q1k+2.5)), 60.)
            ENDIF
-           Fng = MIN(Fng, 20.)
 
-           xl    = xl_blend(t)
-           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
-                             ! "b" in CB02 (i.e., b(k) above) by a factor 
-                             ! of T/theta.  Strictly, b(k) above is formulated in
-                             ! terms of sat. mixing ratio, but bb in BCMT95 is
-                             ! cast in terms of sat. specific humidity.  The
-                             ! conversion is neglected here. 
-           qww   = 1.+0.61*qw(k)
-           alpha = 0.61*th(k)
-           beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
-           vt(k) = qww   - MIN(cldfra_bl1D(K),0.5)*beta*bb*Fng   - 1.
-           vq(k) = alpha + MIN(cldfra_bl1D(K),0.5)*beta*a(k)*Fng - tv0
-           ! vt and vq correspond to beta-theta and beta-q, respectively,  
-           ! in NN09, Eq. B8.  They also correspond to the bracketed
-           ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
-           ! The "-1" and "-tv0" terms are included for consistency with 
-           ! the legacy vt and vq formulations (above).
+           if (pdf_opt .eq. 1) then
+              cfmax= min(cldfra_bl1D(K), 0.6)
+              bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
+                                ! "b" in CB02 (i.e., b(k) above) by a factor 
+                                ! of T/theta.  Strictly, b(k) above is formulated in
+                                ! terms of sat. mixing ratio, but bb in BCMT95 is
+                                ! cast in terms of sat. specific humidity.  The
+                                ! conversion is neglected here. 
+              qww   = 1.+0.61*qw(k)
+              alpha = 0.61*th(k)
+              beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
+              vt(k) = qww   - cfmax*beta*bb*Fng   - 1.
+              vq(k) = alpha + cfmax*beta*a(k)*Fng - tv0
+              ! vt and vq correspond to beta-theta and beta-q, respectively,  
+              ! in NN09, Eq. B8.  They also correspond to the bracketed
+              ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
+              ! The "-1" and "-tv0" terms are included for consistency with 
+              ! the legacy vt and vq formulations (above).
+           else
+
+              !original buoyancy flux functions from SD77
+              eq1  = rrp*exp( -0.5*q1k*q1k )
+              qll  = max( cldfra_bl1D(k)*q1k + eq1, 0.0 )
+              q2p = xl/cp/exner(k)
+
+              !qt is a THETA-V CONVERSION FOR TOTAL WATER
+              cfmax= min(cldfra_bl1D(K), 0.6)
+              qt   = 1.0 +p608*qw(k) -(1.+p608)*(qc_bl1D(k)+qi_bl1D(k))*cfmax
+              rac  = alp(k)*( cfmax-qll*eq1 )*( q2p*qt-(1.+p608)*th(k) )
+
+              !BUOYANCY FACTORS: wherever vt and vq are used, there is a
+              !"+1" and "+tv0", respectively, so these are subtracted out here.
+              !vt is unitless and vq has units of K.
+              vt(k) =         qt-1.0 -rac*bet(k)
+              vq(k) = p608*th(k)-tv0 +rac
+           endif
 
            ! dampen the amplification factor (cld_factor) with height in order
            ! to limit excessively large cloud fractions aloft
-           fac_damp = 1. -MIN(MAX( zagl-(PBLH2+1000.),0.0)/ &
-                              MAX((zw(k_tropo)-(PBLH2+1000.)),500.), 1.)
+           !fac_damp = 1.! -MIN(MAX( zagl-(PBLH2+1000.),0.0)/ &
+                        !      MAX((zw(k_tropo)-(PBLH2+1000.)),500.), 1.)
+           !fac_damp = min(zagl * 0.01, 1.0)
+           wsp      =sqrt(u1(k)**2 + v1(k)**2)
+           wspfac   = 1.0 - min(max(0.,wsp-15),10.)/10. ! reduce as winds go from 15 to 25 m/s.
+           fac_damp = min(zagl * 0.0025, 1.0)*wspfac
            !cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.5 ) / 0.51 )**3.3
-           cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.75 ) / 0.26 )**1.9
+           !cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.75 ) / 0.26 )**1.9 !HRRRv4
+           !cld_factor = 1.0 + fac_damp*(MAX(0.0, ( RH(k) - 0.80 )) / 0.22 )**2
+           !cld_factor = 1.0 + fac_damp*(MAX(0.0, ( RH(k) - 0.90 )) / 0.11 )**2
+           !cld_factor = 1.0 + fac_damp*1.8*(max(0.0, q1k + 0.2 ))**2 !too low of albedo
+           !cld_factor = 1.0 + fac_damp*1.8*(max(0.0, q1k + 0.2 ))**2
+           !make this enhancement over water only?
+           !if ((xland-1.5).GE.0) then   ! water
+              cld_factor = 1.0 + fac_damp*min((max(0.0, ( RH(k) - 0.92 )) / 0.25 )**2, 0.3)
+           !else
+           !   cld_factor = 1.0
+           !endif
            cldfra_bl1D(K) = MIN( 1., cld_factor*cldfra_bl1D(K) )
-
-         END DO
+        enddo
 
       END SELECT !end cloudPDF option
 
-      !FOR TESTING PURPOSES ONLY, ISOLATE ON THE MASS-CLOUDS.
+      !For testing purposes only, option for isolating on the mass-flux clouds.
       IF (bl_mynn_cloudpdf .LT. 0) THEN
          DO k = kts,kte-1
             cldfra_bl1D(k) = 0.0
@@ -2749,7 +4153,6 @@ CONTAINS
       qc_bl1D(kte)=0.
       qi_bl1D(kte)=0.
       cldfra_bl1D(kte)=0.
-
     RETURN
 
 #ifdef HARDCODE_VERTICAL
@@ -2760,25 +4163,29 @@ CONTAINS
   END SUBROUTINE mym_condensation
 
 ! ==================================================================
-  SUBROUTINE mynn_tendencies(kts,kte,      &
-       &levflag,grav_settling,             &
+!>\ingroup gsd_mynn_edmf
+!! This subroutine solves for tendencies of U, V, \f$\theta\f$, qv,
+!! qc, and qi
+  SUBROUTINE mynn_tendencies(kts,kte,i,    &
        &delt,dz,rho,                       &
        &u,v,th,tk,qv,qc,qi,qnc,qni,        &
-       &p,exner,                           &
+       &psfc,p,exner,                      &
        &thl,sqv,sqc,sqi,sqw,               &
-       &qnwfa,qnifa,qnbca,                 &
-       &ust,flt,flq,flqv,flqc,wspd,qcg,    &
+       &qnwfa,qnifa,qnbca,ozone,           &
+       &ust,flt,flq,flqv,flqc,wspd,        &
        &uoce,voce,                         &
        &tsq,qsq,cov,                       &
        &tcd,qcd,                           &
        &dfm,dfh,dfq,                       &
        &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqnc,Dqni,   &
-       &Dqnwfa,Dqnifa,Dqnbca,              &
-       &vdfg1,diss_heat,                   &
+       &Dqnwfa,Dqnifa,Dqnbca,Dozone,       &
+       &diss_heat,                         &
        &s_aw,s_awthl,s_awqt,s_awqv,s_awqc, &
        &s_awu,s_awv,                       &
        &s_awqnc,s_awqni,                   &
        &s_awqnwfa,s_awqnifa,s_awqnbca,     &
+       &sd_aw,sd_awthl,sd_awqt,sd_awqv,    &
+       &sd_awqc,sd_awu,sd_awv,             &
        &sub_thl,sub_sqv,                   &
        &sub_u,sub_v,                       &
        &det_thl,det_sqv,det_sqc,           &
@@ -2790,66 +4197,69 @@ CONTAINS
        &bl_mynn_mixqt,                     &
        &bl_mynn_edmf,                      &
        &bl_mynn_edmf_mom,                  &
-       &bl_mynn_mixscalars                )
+       &bl_mynn_mixscalars                 )
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(in) :: kts,kte
+    INTEGER, INTENT(in) :: kts,kte,i
 
 #ifdef HARDCODE_VERTICAL
 # define kts 1
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(in) :: grav_settling,levflag
     INTEGER, INTENT(in) :: bl_mynn_cloudmix,bl_mynn_mixqt,&
                            bl_mynn_edmf,bl_mynn_edmf_mom, &
                            bl_mynn_mixscalars
     LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
                            FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA
 
-!! grav_settling = 1 or 2 for gravitational settling of droplets
-!! grav_settling = 0 otherwise
 ! thl - liquid water potential temperature
 ! qw - total water
-! dfm,dfh,dfq - as above
+! dfm,dfh,dfq - diffusivities i.e., dfh(k) = elq*sh(k) / dzk
 ! flt - surface flux of thl
 ! flq - surface flux of qw
 
 ! mass-flux plumes
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: s_aw,s_awthl,s_awqt,&
-         &s_awqnc,s_awqni,s_awqv,s_awqc,s_awu,s_awv,s_awqnwfa,s_awqnifa,&
-                                                    s_awqnbca
+         &s_awqnc,s_awqni,s_awqv,s_awqc,s_awu,s_awv,              &
+         &s_awqnwfa,s_awqnifa,s_awqnbca,                          &
+         &sd_aw,sd_awthl,sd_awqt,sd_awqv,sd_awqc,sd_awu,sd_awv
 ! tendencies from mass-flux environmental subsidence and detrainment
     REAL, DIMENSION(kts:kte), INTENT(in) :: sub_thl,sub_sqv,  &
          &sub_u,sub_v,det_thl,det_sqv,det_sqc,det_u,det_v
     REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,th,tk,qv,qc,qi,qni,qnc,&
          &rho,p,exner,dfq,dz,tsq,qsq,cov,tcd,qcd,cldfra_bl1d,diss_heat
     REAL, DIMENSION(kts:kte), INTENT(inout) :: thl,sqw,sqv,sqc,sqi,&
-         &qnwfa,qnifa,qnbca,dfm,dfh
+         &qnwfa,qnifa,qnbca,ozone,dfm,dfh
     REAL, DIMENSION(kts:kte), INTENT(inout) :: du,dv,dth,dqv,dqc,dqi,&
-         &dqni,dqnc,dqnwfa,dqnifa,dqnbca
-    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
+         &dqni,dqnc,dqnwfa,dqnifa,dqnbca,dozone
+    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,&
+         &psfc
+    !debugging
+    REAL ::wsp,wsp2,tk2,th2
+    LOGICAL :: problem
+    integer :: kproblem
 
-!    REAL, INTENT(IN) :: delt,ust,flt,flq,qcg,&
-!         &gradu_top,gradv_top,gradth_top,gradqv_top
+!    REAL, INTENT(IN) :: gradu_top,gradv_top,gradth_top,gradqv_top
 
 !local vars
 
-    REAL, DIMENSION(kts:kte) :: dtz,vt,vq,dfhc,dfmc !Kh for clouds (Pr < 2)
+    REAL, DIMENSION(kts:kte) :: dtz,dfhc,dfmc,delp
     REAL, DIMENSION(kts:kte) :: sqv2,sqc2,sqi2,sqw2,qni2,qnc2, & !AFTER MIXING
-                                qnwfa2,qnifa2,qnbca2
-    REAL, DIMENSION(kts:kte) :: zfac,plumeKh
+                                qnwfa2,qnifa2,qnbca2,ozone2
+    REAL, DIMENSION(kts:kte) :: zfac,plumeKh,rhoinv
     REAL, DIMENSION(kts:kte) :: a,b,c,d,x
     REAL, DIMENSION(kts:kte+1) :: rhoz, & !rho on model interface
           &         khdz, kmdz
     REAL :: rhs,gfluxm,gfluxp,dztop,maxdfh,mindfh,maxcf,maxKh,zw
-    REAL :: grav_settling2,vdfg1    !Katata-fogdes
-    REAL :: t,esat,qsl,onoff,kh,km,dzk
+    REAL :: t,esat,qsl,onoff,kh,km,dzk,rhosfc
+    REAL :: ustdrag,ustdiff,qvflux
+    REAL :: th_new,portion_qc,portion_qi,condensate,qsat
     INTEGER :: k,kk
 
     !Activate nonlocal mixing from the mass-flux scheme for
-    !scalars (0.0 = no; 1.0 = yes)
-    REAL, PARAMETER :: nonloc = 0.0
+    !number concentrations and aerosols (0.0 = no; 1.0 = yes)
+    REAL, PARAMETER :: nonloc = 1.0
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
@@ -2863,28 +4273,43 @@ CONTAINS
     ENDIF
 
     !Prepare "constants" for diffusion equation.
-    !khdz = rho*Kh/dz
-    dtz(kts)=delt/dz(kts)
-    kh=dfh(kts)*dz(kts)
-    km=dfm(kts)*dz(kts)
-    rhoz(kts)=rho(kts)
-    khdz(kts)=rhoz(kts)*kh/dz(kts)
-    kmdz(kts)=rhoz(kts)*km/dz(kts)
+    !khdz = rho*Kh/dz = rho*dfh
+    rhosfc     = psfc/(R_d*(tk(kts)+p608*qv(kts)))
+    dtz(kts)   =delt/dz(kts)
+    rhoz(kts)  =rho(kts)
+    rhoinv(kts)=1./rho(kts)
+    khdz(kts)  =rhoz(kts)*dfh(kts)
+    kmdz(kts)  =rhoz(kts)*dfm(kts)
+    delp(kts)  = psfc - (p(kts+1)*dz(kts) + p(kts)*dz(kts+1))/(dz(kts)+dz(kts+1))
     DO k=kts+1,kte
-       dtz(k)=delt/dz(k)
-       rhoz(k)=(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
-
-       dzk = 0.5  *( dz(k)+dz(k-1) )
-       kh  = dfh(k)*dzk
-       km  = dfm(k)*dzk
-       khdz(k)= rhoz(k)*kh/dzk
-       kmdz(k)= rhoz(k)*km/dzk
+       dtz(k)   =delt/dz(k)
+       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
+       rhoz(k)  =  MAX(rhoz(k),1E-4)
+       rhoinv(k)=1./MAX(rho(k),1E-4)
+       dzk      = 0.5  *( dz(k)+dz(k-1) )
+       khdz(k)  = rhoz(k)*dfh(k)
+       kmdz(k)  = rhoz(k)*dfm(k)
     ENDDO
-    rhoz(kte+1)=rho(kte)
-    kh=dfh(kte)*dz(kte)
-    km=dfm(kte)*dz(kte)
-    khdz(kte+1)=rhoz(kte+1)*kh/dz(kte)
-    kmdz(kte+1)=rhoz(kte+1)*km/dz(kte)
+    DO k=kts+1,kte-1
+       delp(k)  = (p(k)*dz(k-1) + p(k-1)*dz(k))/(dz(k)+dz(k-1)) - &
+                  (p(k+1)*dz(k) + p(k)*dz(k+1))/(dz(k)+dz(k+1))
+    ENDDO
+    delp(kte)  =delp(kte-1)
+    rhoz(kte+1)=rhoz(kte)
+    khdz(kte+1)=rhoz(kte+1)*dfh(kte)
+    kmdz(kte+1)=rhoz(kte+1)*dfm(kte)
+
+    !stability criteria for mf
+    DO k=kts+1,kte-1
+       khdz(k) = MAX(khdz(k),  0.5*s_aw(k))
+       khdz(k) = MAX(khdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+       kmdz(k) = MAX(kmdz(k),  0.5*s_aw(k))
+       kmdz(k) = MAX(kmdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+    ENDDO
+
+    ustdrag = MIN(ust*ust,0.99)/wspd  ! limit at ~ 20 m/s
+    ustdiff = MIN(ust*ust,0.01)/wspd  ! limit at ~ 2 m/s
+    dth(kts:kte) = 0.0  ! must initialize for moisture_check routine
 
 !!============================================
 !! u
@@ -2892,25 +4317,37 @@ CONTAINS
 
     k=kts
 
-    a(1)=0.
-    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
-    c(1)=-dtz(k)*dfm(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
-    d(1)=u(k) + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff + &
-         sub_u(k)*delt + det_u(k)*delt
+!original approach (drag in b-vector):
+!    a(1)=0.
+!    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    c(1)=-dtz(k)*dfm(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    d(1)=u(k) + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff + &
+!         sub_u(k)*delt + det_u(k)*delt
 
-!JOE - tend test
-!    a(k)=0.
-!    b(k)=1.+dtz(k)*dfm(k+1)    - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    c(k)=-dtz(k)*dfm(k+1)      - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    d(k)=u(k)*(1.-ust**2/wspd*dtz(k)) + &
-!         dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff
+!rho-weighted (drag in b-vector):
+    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(kmdz(k+1)+rhosfc*ust**2/wspd)*rhoinv(k) &
+           & - 0.5*dtz(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) &
+           & - 0.5*dtz(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    d(k)=u(k)  + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff - &
+       & dtz(k)*rhoinv(k)*sd_awu(k+1)*onoff + sub_u(k)*delt + det_u(k)*delt
+
+!rho-weighted with drag term moved out of b-array
+!    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
+!    b(k)=1.+dtz(k)*(kmdz(k+1))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+!    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+!    d(k)=u(k)*(1.-ust**2/wspd*dtz(k)*rhosfc/rho(k)) + dtz(k)*uoce*ust**2/wspd - &
+!    !!!d(k)=u(k)*(1.-ust**2/wspd*dtz(k)) + dtz(k)*uoce*ust**2/wspd - &
+!      &  dtz(k)*rhoinv(k)*s_awu(k+1)*onoff - dtz(k)*rhoinv(k)*sd_awu(k+1)*onoff + sub_u(k)*delt + det_u(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=   - dtz(k)*dfm(k)            + 0.5*dtz(k)*s_aw(k)*onoff
-       b(k)=1. + dtz(k)*(dfm(k)+dfm(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
-       c(k)=   - dtz(k)*dfm(k+1)          - 0.5*dtz(k)*s_aw(k+1)*onoff
-       d(k)=u(k) + dtz(k)*(s_awu(k)-s_awu(k+1))*onoff + &
-            sub_u(k)*delt + det_u(k)*delt
+       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)*onoff 
+       b(k)=1.+dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))*onoff
+       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+       d(k)=u(k) + dtz(k)*rhoinv(k)*(s_awu(k)-s_awu(k+1))*onoff + dtz(k)*rhoinv(k)*(sd_awu(k)-sd_awu(k+1))*onoff + &
+           &    sub_u(k)*delt + det_u(k)*delt
     ENDDO
 
 !! no flux at the top
@@ -2933,6 +4370,7 @@ CONTAINS
 
 !    CALL tridiag(kte,a,b,c,d)
     CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
 !       du(k)=(d(k-kts+1)-u(k))/delt
@@ -2945,26 +4383,36 @@ CONTAINS
 
     k=kts
 
-    a(1)=0.
-    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
-    c(1)=   - dtz(k)*dfm(k+1)               - 0.5*dtz(k)*s_aw(k+1)*onoff
-!!    d(1)=v(k)
-    d(1)=v(k) + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff + &
-          sub_v(k)*delt + det_v(k)*delt
+!original approach (drag in b-vector):
+!    a(1)=0.
+!    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    c(1)=   - dtz(k)*dfm(k+1)               - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    d(1)=v(k) + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff + &
+!          sub_v(k)*delt + det_v(k)*delt
 
-!JOE - tend test
-!    a(k)=0.
-!    b(k)=1.+dtz(k)*dfm(k+1)  - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    c(k)=  -dtz(k)*dfm(k+1)  - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    d(k)=v(k)*(1.-ust**2/wspd*dtz(k)) + &
-!         dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff
+!rho-weighted (drag in b-vector):
+    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(kmdz(k+1) + rhosfc*ust**2/wspd)*rhoinv(k) &
+        &  - 0.5*dtz(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    d(k)=v(k)  + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff - dtz(k)*rhoinv(k)*sd_awv(k+1)*onoff + &
+       & sub_v(k)*delt + det_v(k)*delt
+
+!rho-weighted with drag	term moved out of b-array
+!    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
+!    b(k)=1.+dtz(k)*(kmdz(k+1))*rhoinv(k)  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+!    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)    - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+!    d(k)=v(k)*(1.-ust**2/wspd*dtz(k)*rhosfc/rho(k)) + dtz(k)*voce*ust**2/wspd - &
+!    !!!d(k)=v(k)*(1.-ust**2/wspd*dtz(k)) + dtz(k)*voce*ust**2/wspd - &
+!      &  dtz(k)*rhoinv(k)*s_awv(k+1)*onoff - dtz(k)*rhoinv(k)*sd_awv(k+1)*onoff + sub_v(k)*delt + det_v(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=   - dtz(k)*dfm(k)            + 0.5*dtz(k)*s_aw(k)*onoff
-       b(k)=1. + dtz(k)*(dfm(k)+dfm(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
-       c(k)=   - dtz(k)*dfm(k+1)          - 0.5*dtz(k)*s_aw(k+1)*onoff
-       d(k)=v(k) + dtz(k)*(s_awv(k)-s_awv(k+1))*onoff + &
-            sub_v(k)*delt + det_v(k)*delt
+       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)   + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)*onoff
+       b(k)=1.+dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))*onoff
+       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff 
+       d(k)=v(k) + dtz(k)*rhoinv(k)*(s_awv(k)-s_awv(k+1))*onoff + dtz(k)*rhoinv(k)*(sd_awv(k)-sd_awv(k+1))*onoff + &
+           &    sub_v(k)*delt + det_v(k)*delt
     ENDDO
 
 !! no flux at the top
@@ -2987,6 +4435,7 @@ CONTAINS
 
 !    CALL tridiag(kte,a,b,c,d)
     CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
 !       dv(k)=(d(k-kts+1)-v(k))/delt
@@ -2995,7 +4444,6 @@ CONTAINS
 
 !!============================================
 !! thl tendency
-!! NOTE: currently, gravitational settling is removed
 !!============================================
     k=kts
 
@@ -3003,7 +4451,7 @@ CONTAINS
 !    b(k)=1.+dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
 !    c(k)=  -dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
 !    d(k)=thl(k) + dtz(k)*flt + tcd(k)*delt &
-!        & -dtz(k)*s_awthl(kts+1) + diss_heat(k)*delt*dheat_opt + &
+!        & -dtz(k)*s_awthl(kts+1) + diss_heat(k)*delt + &
 !        & sub_thl(k)*delt + det_thl(k)*delt
 !
 !    DO k=kts+1,kte-1
@@ -3011,25 +4459,27 @@ CONTAINS
 !       b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
 !       c(k)=  -dtz(k)*dfh(k+1)          - 0.5*dtz(k)*s_aw(k+1)
 !       d(k)=thl(k) + tcd(k)*delt + dtz(k)*(s_awthl(k)-s_awthl(k+1)) &
-!           &       + diss_heat(k)*delt*dheat_opt + &
+!           &       + diss_heat(k)*delt + &
 !           &         sub_thl(k)*delt + det_thl(k)*delt
 !    ENDDO
 
-!rho-weighted:                                                                                                           
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k)           - 0.5*dtz(k)*s_aw(k+1)
-    d(k)=thl(k)  + dtz(k)*flt + tcd(k)*delt - dtz(k)*s_awthl(k+1) + &
-       & diss_heat(k)*delt*dheat_opt + sub_thl(k)*delt + det_thl(k)*delt
+!rho-weighted: rhosfc*X*rhoinv(k)
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=thl(k)  + dtz(k)*rhosfc*flt*rhoinv(k) + tcd(k)*delt &
+       & - dtz(k)*rhoinv(k)*s_awthl(k+1) -dtz(k)*rhoinv(k)*sd_awthl(k+1) + &
+       & diss_heat(k)*delt + sub_thl(k)*delt + det_thl(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-       d(k)=thl(k) + tcd(k)*delt + dtz(k)*(s_awthl(k)-s_awthl(k+1)) + &
-          &         diss_heat(k)*delt*dheat_opt + &
-          &         sub_thl(k)*delt + det_thl(k)*delt
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+           &   0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=thl(k) + tcd(k)*delt + &
+          & dtz(k)*rhoinv(k)*(s_awthl(k)-s_awthl(k+1)) + dtz(k)*rhoinv(k)*(sd_awthl(k)-sd_awthl(k+1)) + &
+          &       diss_heat(k)*delt + &
+          &       sub_thl(k)*delt + det_thl(k)*delt
     ENDDO
 
 !! no flux at the top
@@ -3052,8 +4502,8 @@ CONTAINS
     d(kte)=thl(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,x)
-    CALL tridiag3(kte,a,b,c,d,x)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
        !thl(k)=d(k-kts+1)
@@ -3084,17 +4534,17 @@ IF (bl_mynn_mixqt > 0) THEN
 !    ENDDO
 
 !rho-weighted:
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k)           - 0.5*dtz(k)*s_aw(k+1)
-    d(k)=sqw(k)  + dtz(k)*flq + qcd(k)*delt - dtz(k)*s_awqt(k+1)
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqw(k)  + dtz(k)*rhosfc*flq*rhoinv(k) + qcd(k)*delt - dtz(k)*rhoinv(k)*s_awqt(k+1) - dtz(k)*rhoinv(k)*sd_awqt(k+1)
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-       d(k)=sqw(k) + qcd(k)*delt + dtz(k)*(s_awqt(k)-s_awqt(k+1))
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqw(k) + qcd(k)*delt + dtz(k)*rhoinv(k)*(s_awqt(k)-s_awqt(k+1)) + dtz(k)*rhoinv(k)*(sd_awqt(k)-sd_awqt(k+1))
     ENDDO
 
 !! no flux at the top
@@ -3115,8 +4565,8 @@ IF (bl_mynn_mixqt > 0) THEN
     d(kte)=sqw(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,sqw2)
-    CALL tridiag3(kte,a,b,c,d,sqw2)
+    CALL tridiag2(kte,a,b,c,d,sqw2)
+!    CALL tridiag3(kte,a,b,c,d,sqw2)
 
 !    DO k=kts,kte
 !       sqw2(k)=d(k-kts+1)
@@ -3149,18 +4599,19 @@ IF (bl_mynn_mixqt == 0) THEN
 !    ENDDO
 
 !rho-weighted:
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k)           - 0.5*dtz(k)*s_aw(k+1)
-    d(k)=sqc(k)  + dtz(k)*flqc + qcd(k)*delt - dtz(k)*s_awqc(k+1) + &
-       & det_sqc(k)*delt
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqc(k)  + dtz(k)*rhosfc*flqc*rhoinv(k) + qcd(k)*delt &
+       &  - dtz(k)*rhoinv(k)*s_awqc(k+1) - dtz(k)*rhoinv(k)*sd_awqc(k+1) + &
+       &  det_sqc(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-       d(k)=sqc(k) + qcd(k)*delt + dtz(k)*(s_awqc(k)-s_awqc(k+1)) + &
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqc(k) + qcd(k)*delt + dtz(k)*rhoinv(k)*(s_awqc(k)-s_awqc(k+1)) + dtz(k)*rhoinv(k)*(sd_awqc(k)-sd_awqc(k+1)) + &
           & det_sqc(k)*delt
     ENDDO
 
@@ -3171,8 +4622,8 @@ IF (bl_mynn_mixqt == 0) THEN
     d(kte)=sqc(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,sqc2)
-    CALL tridiag3(kte,a,b,c,d,sqc2)
+    CALL tridiag2(kte,a,b,c,d,sqc2)
+!    CALL tridiag3(kte,a,b,c,d,sqc2)
 
 !    DO k=kts,kte
 !       sqc2(k)=d(k-kts+1)
@@ -3205,19 +4656,27 @@ IF (bl_mynn_mixqt == 0) THEN
 !          & sub_sqv(k)*delt + det_sqv(k)*delt
 !    ENDDO
 
-!rho-weighted:
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k)           - 0.5*dtz(k)*s_aw(k+1)
-    d(k)=sqv(k)  + dtz(k)*flqv + qcd(k)*delt - dtz(k)*s_awqv(k+1) + &
+    !limit unreasonably large negative fluxes:
+    qvflux = flqv
+    if (qvflux < 0.0) then
+       !do not allow specified surface flux to reduce qv below 1e-8 kg/kg
+       qvflux = max(qvflux, (min(0.9*sqv(kts) - 1e-8, 0.0)/dtz(kts)))
+    endif
+
+!rho-weighted:  rhosfc*X*rhoinv(k)
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqv(k)  + dtz(k)*rhosfc*qvflux*rhoinv(k) + qcd(k)*delt &
+       &  - dtz(k)*rhoinv(k)*s_awqv(k+1) - dtz(k)*rhoinv(k)*sd_awqv(k+1) + &
        & sub_sqv(k)*delt + det_sqv(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)
-       d(k)=sqv(k) + qcd(k)*delt + dtz(k)*(s_awqv(k)-s_awqv(k+1)) + &
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqv(k) + qcd(k)*delt + dtz(k)*rhoinv(k)*(s_awqv(k)-s_awqv(k+1)) + dtz(k)*rhoinv(k)*(sd_awqv(k)-sd_awqv(k+1)) + &
           & sub_sqv(k)*delt + det_sqv(k)*delt
     ENDDO
 
@@ -3241,8 +4700,8 @@ IF (bl_mynn_mixqt == 0) THEN
     d(kte)=sqv(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,sqv2)
-    CALL tridiag3(kte,a,b,c,d,sqv2)
+    CALL tridiag2(kte,a,b,c,d,sqv2)
+!    CALL tridiag3(kte,a,b,c,d,sqv2)
 
 !    DO k=kts,kte
 !       sqv2(k)=d(k-kts+1)
@@ -3271,15 +4730,15 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
 !    ENDDO
 
 !rho-weighted:
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k)
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k)
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
     d(k)=sqi(k)
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k)
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k)
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
        d(k)=sqi(k)
     ENDDO
 
@@ -3303,8 +4762,8 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
     d(kte)=sqi(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,sqi2)
-    CALL tridiag3(kte,a,b,c,d,sqi2)
+    CALL tridiag2(kte,a,b,c,d,sqi2)
+!    CALL tridiag3(kte,a,b,c,d,sqi2)
 
 !    DO k=kts,kte
 !       sqi2(k)=d(k-kts+1)
@@ -3321,17 +4780,17 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNI .AND. &
 
     k=kts
 
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    d(k)=qni(k)  - dtz(k)*s_awqni(k+1)*nonloc
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    d(k)=qni(k)  - dtz(k)*rhoinv(k)*s_awqni(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-       d(k)=qni(k) + dtz(k)*(s_awqni(k)-s_awqni(k+1))*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+       d(k)=qni(k) + dtz(k)*rhoinv(k)*(s_awqni(k)-s_awqni(k+1))*nonloc
     ENDDO
 
 !! prescribed value
@@ -3341,8 +4800,8 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNI .AND. &
     d(kte)=qni(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,x)
-    CALL tridiag3(kte,a,b,c,d,x)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
        !qni2(k)=d(k-kts+1)
@@ -3362,17 +4821,17 @@ ENDIF
 
     k=kts
 
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k)           - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    d(k)=qnc(k)  - dtz(k)*s_awqnc(k+1)*nonloc
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    d(k)=qnc(k)  - dtz(k)*rhoinv(k)*s_awqnc(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
-       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-       d(k)=qnc(k) + dtz(k)*(s_awqnc(k)-s_awqnc(k+1))*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+       d(k)=qnc(k) + dtz(k)*rhoinv(k)*(s_awqnc(k)-s_awqnc(k+1))*nonloc
     ENDDO
 
 !! prescribed value
@@ -3382,8 +4841,8 @@ ENDIF
     d(kte)=qnc(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,x)
-    CALL tridiag3(kte,a,b,c,d,x)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
        !qnc2(k)=d(k-kts+1)
@@ -3402,18 +4861,18 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNWFA .AND. &
 
     k=kts
 
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))/rho(k) - &
-           &    0.5*dtz(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    d(k)=qnwfa(k)  - dtz(k)*s_awqnwfa(k+1)*nonloc
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) - &
+           &    0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    d(k)=qnwfa(k)  - dtz(k)*rhoinv(k)*s_awqnwfa(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
-       b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-       d(k)=qnwfa(k) + dtz(k)*(s_awqnwfa(k)-s_awqnwfa(k+1))*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+       d(k)=qnwfa(k) + dtz(k)*rhoinv(k)*(s_awqnwfa(k)-s_awqnwfa(k+1))*nonloc
     ENDDO
 
 ! prescribed value
@@ -3423,8 +4882,8 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNWFA .AND. &
     d(kte)=qnwfa(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,x)
-    CALL tridiag3(kte,a,b,c,d,x)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
        !qnwfa2(k)=d(k)
@@ -3444,18 +4903,18 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNIFA .AND. &
 
    k=kts
 
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))/rho(k) - &
-           &    0.5*dtz(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    d(k)=qnifa(k)  - dtz(k)*s_awqnifa(k+1)*nonloc
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) - &
+           &    0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    d(k)=qnifa(k)  - dtz(k)*rhoinv(k)*s_awqnifa(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
-       b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-       d(k)=qnifa(k) + dtz(k)*(s_awqnifa(k)-s_awqnifa(k+1))*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+       d(k)=qnifa(k) + dtz(k)*rhoinv(k)*(s_awqnifa(k)-s_awqnifa(k+1))*nonloc
     ENDDO
 
 ! prescribed value
@@ -3465,8 +4924,8 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNIFA .AND. &
     d(kte)=qnifa(kte)
 
 !    CALL tridiag(kte,a,b,c,d)
-!    CALL tridiag2(kte,a,b,c,d,x)
-    CALL tridiag3(kte,a,b,c,d,x)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
        !qnifa2(k)=d(k-kts+1)
@@ -3479,25 +4938,25 @@ ELSE
 ENDIF
 
 !============================================
-! Black carbon aerosols ( qnbca ).
+! Black-carbon aerosols ( qnbca ).           
 !============================================
 IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNBCA .AND. &
       bl_mynn_mixscalars > 0) THEN
 
    k=kts
 
-    a(k)=  -dtz(k)*khdz(k)/rho(k)
-    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))/rho(k) - &
-           &    0.5*dtz(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-    d(k)=qnbca(k)  - dtz(k)*s_awqnbca(k+1)*nonloc
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) - &
+           &    0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    d(k)=qnbca(k)  - dtz(k)*rhoinv(k)*s_awqnbca(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)/rho(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
-       b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))/rho(k) + &
-           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)/rho(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
-       d(k)=qnbca(k) + dtz(k)*(s_awqnbca(k)-s_awqnbca(k+1))*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) + &
+           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+       d(k)=qnbca(k) + dtz(k)*rhoinv(k)*(s_awqnbca(k)-s_awqnbca(k+1))*nonloc
     ENDDO
 
 ! prescribed value
@@ -3520,63 +4979,95 @@ ELSE
     qnbca2=qnbca
 ENDIF
 
+!============================================
+! Ozone - local mixing only
+!============================================
+
+    k=kts
+
+!rho-weighted:
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
+    d(k)=ozone(k)
+
+    DO k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
+       d(k)=ozone(k)
+    ENDDO
+
+! prescribed value                                                                                                           
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=ozone(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
+
+    DO k=kts,kte
+       !ozone2(k)=d(k-kts+1)
+       dozone(k)=(x(k)-ozone(k))/delt
+    ENDDO
 
 !!============================================
 !! Compute tendencies and convert to mixing ratios for WRF.
 !! Note that the momentum tendencies are calculated above.
 !!============================================
 
-    IF (bl_mynn_mixqt > 0) THEN 
+   IF (bl_mynn_mixqt > 0) THEN 
       DO k=kts,kte
-         t  = th(k)*exner(k)
+         !compute updated theta using updated thl and old condensate
+         th_new = thl(k) + xlvcp/exner(k)*sqc(k) &
+           &             + xlscp/exner(k)*sqi(k)
+
+         t  = th_new*exner(k)
+         qsat = qsat_blend(t,p(k)) 
          !SATURATED VAPOR PRESSURE
-         esat=esat_blend(t)
+         !esat=esat_blend(t)
          !SATURATED SPECIFIC HUMIDITY
          !qsl=ep_2*esat/(p(k)-ep_3*esat)
-         qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
+         !qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
 
-         !IF (qsl >= sqw2(k)) THEN !unsaturated
-         !   sqv2(k) = MAX(0.0,sqw2(k))
-         !   sqi2(k) = MAX(0.0,sqi2(k))
-         !   sqc2(k) = MAX(0.0,sqw2(k) - sqv2(k) - sqi2(k))
-         !ELSE                     !saturated
-            IF (FLAG_QI) THEN
-              !sqv2(k) = qsl
-              sqi2(k) = MAX(0., sqi2(k))
-              sqc2(k) = MAX(0., sqw2(k) - sqi2(k) - qsl)      !updated cloud water
-              sqv2(k) = MAX(0., sqw2(k) - sqc2(k) - sqi2(k))  !updated water vapor
-            ELSE
-              !sqv2(k) = qsl
-              sqi2(k) = 0.0
-              sqc2(k) = MAX(0., sqw2(k) - qsl)         !updated cloud water
-              sqv2(k) = MAX(0., sqw2(k) - sqc2(k))     ! updated water vapor
-            ENDIF
-         !ENDIF
+         IF (sqc(k) > 0.0 .or. sqi(k) > 0.0) THEN !initially saturated
+            sqv2(k) = MIN(sqw2(k),qsat)
+            portion_qc = sqc(k)/(sqc(k) + sqi(k))
+            portion_qi = sqi(k)/(sqc(k) + sqi(k))
+            condensate = MAX(sqw2(k) - qsat, 0.0)
+            sqc2(k) = condensate*portion_qc
+            sqi2(k) = condensate*portion_qi
+         ELSE                     ! initially unsaturated -----
+            sqv2(k) = sqw2(k)     ! let microphys decide what to do
+            sqi2(k) = 0.0         ! if sqw2 > qsat 
+            sqc2(k) = 0.0
+         ENDIF
+         !dqv(k) = (sqv2(k) - sqv(k))/delt
+         !dqc(k) = (sqc2(k) - sqc(k))/delt
+         !dqi(k) = (sqi2(k) - sqi(k))/delt
       ENDDO
-    ENDIF
+   ENDIF
+
 
     !=====================
     ! WATER VAPOR TENDENCY
     !=====================
     DO k=kts,kte
        Dqv(k)=(sqv2(k)/(1.-sqv2(k)) - qv(k))/delt
-       !IF(-Dqv(k) > qv(k)) Dqv(k)=-qv(k)
+       !if (sqv2(k) < 0.0)print*,"neg qv:",sqv2(k),k
     ENDDO
 
     IF (bl_mynn_cloudmix > 0) THEN
       !=====================
       ! CLOUD WATER TENDENCY
       !=====================
-      !qc fog settling tendency is now computed in module_bl_fogdes.F, so
-      !sqc should only be changed by eddy diffusion or mass-flux.
       !print*,"FLAG_QC:",FLAG_QC
       IF (FLAG_QC) THEN
          DO k=kts,kte
             Dqc(k)=(sqc2(k)/(1.-sqv2(k)) - qc(k))/delt
-            IF(Dqc(k)*delt + qc(k) < 0.) THEN
-              !print*,'  neg qc:',qsl,sqw2(k),sqi2(k),sqc2(k),qc(k),tk(k)
-              Dqc(k)=-qc(k)/delt 
-            ENDIF
+            !if (sqc2(k) < 0.0)print*,"neg qc:",sqc2(k),k
          ENDDO
       ELSE
          DO k=kts,kte
@@ -3589,7 +5080,6 @@ ENDIF
       !===================
       IF (FLAG_QNC .AND. bl_mynn_mixscalars > 0) THEN
          DO k=kts,kte
-           !IF(sqc2(k)>1.e-9)qnc2(k)=MAX(qnc2(k),1.e6)
            Dqnc(k) = (qnc2(k)-qnc(k))/delt
            !IF(Dqnc(k)*delt + qnc(k) < 0.)Dqnc(k)=-qnc(k)/delt
          ENDDO 
@@ -3605,10 +5095,7 @@ ENDIF
       IF (FLAG_QI) THEN
          DO k=kts,kte
            Dqi(k)=(sqi2(k)/(1.-sqv2(k)) - qi(k))/delt
-           IF(Dqi(k)*delt + qi(k) < 0.) THEN
-           !   !print*,' neg qi;',qsl,sqw2(k),sqi2(k),sqc2(k),qi(k),tk(k)
-              Dqi(k)=-qi(k)/delt
-           ENDIF
+           !if (sqi2(k) < 0.0)print*,"neg qi:",sqi2(k),k
          ENDDO
       ELSE
          DO k=kts,kte
@@ -3639,13 +5126,27 @@ ENDIF
       ENDDO
     ENDIF
 
+    !ensure non-negative moist species
+    CALL moisture_check(kte, delt, delp, exner,  &
+                        sqv2, sqc2, sqi2, thl,   &
+                        dqv, dqc, dqi, dth )
+
+    !=====================
+    ! OZONE TENDENCY CHECK
+    !=====================
+    DO k=kts,kte
+       IF(Dozone(k)*delt + ozone(k) < 0.) THEN
+         Dozone(k)=-ozone(k)*0.99/delt
+       ENDIF
+    ENDDO
+
     !===================
     ! THETA TENDENCY
     !===================
     IF (FLAG_QI) THEN
       DO k=kts,kte
-         Dth(k)=(thl(k) + xlvcp/exner(k)*sqc(k) &
-           &            + xlscp/exner(k)*sqi(k) &
+         Dth(k)=(thl(k) + xlvcp/exner(k)*sqc2(k) &
+           &            + xlscp/exner(k)*sqi2(k) &
            &            - th(k))/delt
          !Use form from Tripoli and Cotton (1981) with their
          !suggested min temperature to improve accuracy:
@@ -3655,7 +5156,7 @@ ENDIF
       ENDDO
     ELSE
       DO k=kts,kte
-         Dth(k)=(thl(k)+xlvcp/exner(k)*sqc(k) - th(k))/delt
+         Dth(k)=(thl(k)+xlvcp/exner(k)*sqc2(k) - th(k))/delt
          !Use form from Tripoli and Cotton (1981) with their
          !suggested min temperature to improve accuracy.
          !Dth(k)=(thl(k)*(1.+ xlvcp/MAX(tk(k),TKmin)*sqc(k))  &
@@ -3677,12 +5178,10 @@ ENDIF
           ! Ice-friendly aerosols
           !=====================
           Dqnifa(k)=(qnifa2(k) - qnifa(k))/delt
-          IF (FLAG_QNBCA) THEN
-             !=====================
-             ! Black carbon aerosols
-             !=====================
-             Dqnbca(k)=(qnbca2(k) - qnbca(k))/delt
-          ENDIF
+          !=====================
+          ! Black-carbon aerosols
+          !=====================
+          Dqnbca(k)=(qnbca2(k) - qnbca(k))/delt
        ENDDO
     ELSE
        DO k=kts,kte
@@ -3692,6 +5191,43 @@ ENDIF
        ENDDO
     ENDIF
 
+    !ensure non-negative moist species
+    !note: if called down here, dth needs to be updated, but
+    !      if called before the theta-tendency calculation, do not compute dth
+    !CALL moisture_check(kte, delt, delp, exner,     &
+    !                    sqv, sqc, sqi, thl,         &
+    !                    dqv, dqc, dqi, dth )
+
+    if (debug_code) then
+       problem = .false.
+       do k=kts,kte
+          wsp  = sqrt(u(k)**2 + v(k)**2)
+          wsp2 = sqrt((u(k)+du(k)*delt)**2 + (v(k)+du(k)*delt)**2)
+          th2  = th(k) + Dth(k)*delt
+          tk2  = th2*exner(k)
+          if (wsp2 > 200. .or. tk2 > 360. .or. tk2 < 160.) then
+             problem = .true.
+             print*,"Outgoing problem at: i=",i," k=",k
+             print*," incoming wsp=",wsp," outgoing wsp=",wsp2
+             print*," incoming T=",th(k)*exner(k),"outgoing T:",tk2
+             print*," du=",du(k)*delt," dv=",dv(k)*delt," dth=",dth(k)*delt
+             print*," km=",kmdz(k)*dz(k)," kh=",khdz(k)*dz(k)
+             print*," u*=",ust," wspd=",wspd,"rhosfc=",rhosfc
+             print*," LH=",flq*rhosfc*1004.," HFX=",flt*rhosfc*1004.
+             print*," drag term=",ust**2/wspd*dtz(k)*rhosfc/rho(kts)
+             kproblem = k
+          endif
+       enddo
+       if (problem) then
+          print*,"==thl:",thl(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qv:",sqv2(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qc:",sqc2(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qi:",sqi2(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====u:",u(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====v:",v(max(kproblem-3,1):min(kproblem+3,kte))
+       endif
+    endif
+
 #ifdef HARDCODE_VERTICAL
 # undef kts
 # undef kte
@@ -3700,54 +5236,182 @@ ENDIF
   END SUBROUTINE mynn_tendencies
 
 ! ==================================================================
-#if (WRF_CHEM == 1)
-  SUBROUTINE mynn_mix_chem(kts,kte,       &
-       levflag,grav_settling,             &
-       delt,dz,                           &
-       nchem, kdvel, ndvel, num_vert_mix, &
+  SUBROUTINE moisture_check(kte, delt, dp, exner, &
+                            qv, qc, qi, th,       &
+                            dqv, dqc, dqi, dth )
+
+  ! This subroutine was adopted from the CAM-UW ShCu scheme and 
+  ! adapted for use here.
+  !
+  ! If qc < qcmin, qi < qimin, or qv < qvmin happens in any layer,
+  ! force them to be larger than minimum value by (1) condensating 
+  ! water vapor into liquid or ice, and (2) by transporting water vapor 
+  ! from the very lower layer.
+  ! 
+  ! We then update the final state variables and tendencies associated
+  ! with this correction. If any condensation happens, update theta too.
+  ! Note that (qv,qc,qi,th) are the final state variables after
+  ! applying corresponding input tendencies and corrective tendencies.
+
+    implicit none
+    integer,  intent(in)     :: kte
+    real, intent(in)         :: delt
+    real, dimension(kte), intent(in)     :: dp, exner
+    real, dimension(kte), intent(inout)  :: qv, qc, qi, th
+    real, dimension(kte), intent(inout)  :: dqv, dqc, dqi, dth
+    integer   k
+    real ::  dqc2, dqi2, dqv2, sum, aa, dum
+    real, parameter :: qvmin = 1e-20,   &
+                       qcmin = 0.0,     &
+                       qimin = 0.0
+
+    do k = kte, 1, -1  ! From the top to the surface
+       dqc2 = max(0.0, qcmin-qc(k)) !qc deficit (>=0)
+       dqi2 = max(0.0, qimin-qi(k)) !qi deficit (>=0)
+
+       !fix tendencies
+       dqc(k) = dqc(k) +  dqc2/delt
+       dqi(k) = dqi(k) +  dqi2/delt
+       dqv(k) = dqv(k) - (dqc2+dqi2)/delt
+       dth(k) = dth(k) + xlvcp/exner(k)*(dqc2/delt) + &
+                         xlscp/exner(k)*(dqi2/delt)
+       !update species
+       qc(k)  = qc(k)  +  dqc2
+       qi(k)  = qi(k)  +  dqi2
+       qv(k)  = qv(k)  -  dqc2 - dqi2
+       th(k)  = th(k)  +  xlvcp/exner(k)*dqc2 + &
+                          xlscp/exner(k)*dqi2
+
+       !then fix qv
+       dqv2   = max(0.0, qvmin-qv(k)) !qv deficit (>=0)
+       dqv(k) = dqv(k) + dqv2/delt
+       qv(k)  = qv(k)  + dqv2
+       if( k .ne. 1 ) then
+           qv(k-1)   = qv(k-1)  - dqv2*dp(k)/dp(k-1)
+           dqv(k-1)  = dqv(k-1) - dqv2*dp(k)/dp(k-1)/delt
+       endif
+       qv(k) = max(qv(k),qvmin)
+       qc(k) = max(qc(k),qcmin)
+       qi(k) = max(qi(k),qimin)
+    end do
+    ! Extra moisture used to satisfy 'qv(1)>=qvmin' is proportionally
+    ! extracted from all the layers that has 'qv > 2*qvmin'. This fully
+    ! preserves column moisture.
+    if( dqv2 .gt. 1.e-20 ) then
+        sum = 0.0
+        do k = 1, kte
+           if( qv(k) .gt. 2.0*qvmin ) sum = sum + qv(k)*dp(k)
+        enddo
+        aa = dqv2*dp(1)/max(1.e-20,sum)
+        if( aa .lt. 0.5 ) then
+            do k = 1, kte
+               if( qv(k) .gt. 2.0*qvmin ) then
+                   dum    = aa*qv(k)
+                   qv(k)  = qv(k) - dum
+                   dqv(k) = dqv(k) - dum/delt
+               endif
+            enddo
+        else
+        ! For testing purposes only (not yet found in any output):
+        !    write(*,*) 'Full moisture conservation is impossible'
+        endif
+    endif
+
+    return
+
+  END SUBROUTINE moisture_check
+
+! ==================================================================
+
+  SUBROUTINE mynn_mix_chem(kts,kte,i,     &
+       delt,dz,pblh,                      &
+       nchem, kdvel, ndvel,               &
        chem1, vd1,                        &
-       qnc,qni,                           &
-       p,exner,                           &
-       thl,sqv,sqc,sqi,sqw,               &
-       ust,flt,flq,flqv,flqc,wspd,qcg,    &
-       uoce,voce,                         &
-       tsq,qsq,cov,                       &
-       tcd,qcd,                           &
-       dfm,dfh,dfq,                       &
-       s_aw,                              &
-       s_awchem,                          &
-       bl_mynn_cloudmix)
+       rho,                               &
+       flt, tcd, qcd,                     &
+       dfh,                               &
+       s_aw, s_awchem,                    &
+       emis_ant_no, frp, rrfs_sd,         &
+       enh_mix, smoke_dbg                 )
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(in) :: kts,kte
-    INTEGER, INTENT(in) :: grav_settling,levflag
-    INTEGER, INTENT(in) :: bl_mynn_cloudmix
-
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: qni,qnc,&
-         &p,exner,dfm,dfh,dfq,dz,tsq,qsq,cov,tcd,qcd
-    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: thl,sqw,sqv,sqc,sqi
-    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
-    INTEGER, INTENT(IN   )   ::   nchem, kdvel, ndvel, num_vert_mix
+    INTEGER, INTENT(in) :: kts,kte,i
+    REAL, DIMENSION(kts:kte), INTENT(IN)    :: dfh,dz,tcd,qcd
+    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: rho
+    REAL, INTENT(IN)    :: delt,flt,pblh
+    INTEGER, INTENT(IN) :: nchem, kdvel, ndvel
     REAL, DIMENSION( kts:kte+1), INTENT(IN) :: s_aw
     REAL, DIMENSION( kts:kte, nchem ), INTENT(INOUT) :: chem1
     REAL, DIMENSION( kts:kte+1,nchem), INTENT(IN) :: s_awchem
-    REAL, DIMENSION( ndvel ), INTENT(INOUT) :: vd1
-
+    REAL, DIMENSION( ndvel ), INTENT(IN) :: vd1
+    REAL, INTENT(IN) :: emis_ant_no,frp
+    LOGICAL, INTENT(IN) :: rrfs_sd,enh_mix,smoke_dbg
 !local vars
 
-    REAL, DIMENSION(kts:kte) :: dtz,vt,vq
-    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
-    REAL :: rhs,gfluxm,gfluxp,dztop
-    REAL :: t,esl,qsl
-    INTEGER :: k,kk
+    REAL, DIMENSION(kts:kte)     :: dtz
+    REAL, DIMENSION(kts:kte) :: a,b,c,d,x
+    REAL :: rhs,dztop
+    REAL :: t,dzk
+    REAL :: hght 
+    REAL :: khdz_old, khdz_back
+    INTEGER :: k,kk,kmaxfire                         ! JLS 12/21/21
     INTEGER :: ic  ! Chemical array loop index
-    REAL, DIMENSION( kts:kte, nchem ) :: chem_new
+    
+    INTEGER, SAVE :: icall
+
+    REAL, DIMENSION(kts:kte) :: rhoinv
+    REAL, DIMENSION(kts:kte+1) :: rhoz,khdz
+    REAL, PARAMETER :: NO_threshold    = 0.1      ! For anthropogenic sources
+    REAL, PARAMETER :: frp_threshold   = 10.0     ! RAR 02/11/22: I increased the frp threshold to enhance mixing over big fires
+    REAL, PARAMETER :: pblh_threshold  = 250.0
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
     DO k=kts,kte
        dtz(k)=delt/dz(k)
     ENDDO
+
+    !Prepare "constants" for diffusion equation.
+    !khdz = rho*Kh/dz = rho*dfh
+    rhoz(kts)  =rho(kts)
+    rhoinv(kts)=1./rho(kts)
+    khdz(kts)  =rhoz(kts)*dfh(kts)
+
+    DO k=kts+1,kte
+       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
+       rhoz(k)  =  MAX(rhoz(k),1E-4)
+       rhoinv(k)=1./MAX(rho(k),1E-4)
+       dzk      = 0.5  *( dz(k)+dz(k-1) )
+       khdz(k)  = rhoz(k)*dfh(k)
+    ENDDO
+    rhoz(kte+1)=rhoz(kte)
+    khdz(kte+1)=rhoz(kte+1)*dfh(kte)
+
+    !stability criteria for mf
+    DO k=kts+1,kte-1
+       khdz(k) = MAX(khdz(k),  0.5*s_aw(k))
+       khdz(k) = MAX(khdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+    ENDDO
+
+    !Enhanced mixing over fires
+    IF ( rrfs_sd .and. enh_mix ) THEN
+       DO k=kts+1,kte-1
+          khdz_old  = khdz(k)
+          khdz_back = pblh * 0.15 / dz(k)
+          !Modify based on anthropogenic emissions of NO and FRP
+          IF ( pblh < pblh_threshold ) THEN
+             IF ( emis_ant_no > NO_threshold ) THEN
+                khdz(k) = MAX(1.1*khdz(k),sqrt((emis_ant_no / NO_threshold)) / dz(k) * rhoz(k)) ! JLS 12/21/21
+!                khdz(k) = MAX(khdz(k),khdz_back)
+             ENDIF
+             IF ( frp > frp_threshold ) THEN
+                kmaxfire = ceiling(log(frp))
+                khdz(k) = MAX(1.1*khdz(k), (1. - k/(kmaxfire*2.)) * ((log(frp))**2.- 2.*log(frp)) / dz(k)*rhoz(k)) ! JLS 12/21/21
+!                khdz(k) = MAX(khdz(k),khdz_back)
+             ENDIF
+          ENDIF
+       ENDDO
+    ENDIF
 
   !============================================
   ! Patterned after mixing of water vapor in mynn_tendencies.
@@ -3756,17 +5420,19 @@ ENDIF
     DO ic = 1,nchem
        k=kts
 
-       a(1)=0.
-       b(1)=1.+dtz(k)*dfh(k+1)  - 0.5*dtz(k)*s_aw(k+1)
-       c(1)=-dtz(k)*dfh(k+1)    - 0.5*dtz(k)*s_aw(k+1)
-       d(1)=chem1(k,ic) + dtz(k) * -vd1(ic)*chem1(1,ic) - dtz(k)*s_awchem(k+1,ic)
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+       b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
+       d(k)=chem1(k,ic) & !dtz(k)*flt  !neglecting surface sources 
+            & - dtz(k)*vd1(ic)*chem1(k,ic) &
+            & - dtz(k)*rhoinv(k)*s_awchem(k+1,ic)
 
        DO k=kts+1,kte-1
-          a(k)=-dtz(k)*dfh(k)      + 0.5*dtz(k)*s_aw(k)
-          b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) +  0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
-          c(k)=-dtz(k)*dfh(k+1)    - 0.5*dtz(k)*s_aw(k+1)
-          ! d(kk)=chem1(k,ic) + qcd(k)*delt
-          d(k)=chem1(k,ic) + rhs*delt + dtz(k)*(s_awchem(k,ic)-s_awchem(k+1,ic))
+          a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)
+          b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+             &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))
+          c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
+          d(k)=chem1(k,ic) + dtz(k)*rhoinv(k)*(s_awchem(k,ic)-s_awchem(k+1,ic))
        ENDDO
 
       ! prescribed value at top
@@ -3775,17 +5441,17 @@ ENDIF
        c(kte)=0.
        d(kte)=chem1(kte,ic)
 
-       CALL tridiag(kte,a,b,c,d)
+       CALL tridiag3(kte,a,b,c,d,x)
 
        DO k=kts,kte
-          chem_new(k,ic)=d(k-kts+1)
+          chem1(k,ic)=x(k)
        ENDDO
     ENDDO
 
   END SUBROUTINE mynn_mix_chem
-#endif
 
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
   SUBROUTINE retrieve_exchange_coeffs(kts,kte,&
        &dfm,dfh,dz,K_m,K_h)
 
@@ -3813,6 +5479,7 @@ ENDIF
   END SUBROUTINE retrieve_exchange_coeffs
 
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
   SUBROUTINE tridiag(n,a,b,c,d)
 
 !! to solve system of linear eqs on tridiagonal matrix n times n
@@ -3848,6 +5515,7 @@ ENDIF
   END SUBROUTINE tridiag
 
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
       subroutine tridiag2(n,a,b,c,d,x)
       implicit none
 !      a - sub-diagonal (means it is the diagonal below the main diagonal)
@@ -3882,6 +5550,7 @@ ENDIF
 
     end subroutine tridiag2
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
        subroutine tridiag3(kte,a,b,c,d,x)
 
 !ccccccccccccccccccccccccccccccc                                                                   
@@ -3921,1187 +5590,27 @@ ENDIF
 
         return
         end subroutine tridiag3
-! ==================================================================
-  SUBROUTINE mynn_bl_driver(            &
-       &initflag,restart,cycling,       &
-       &grav_settling,                  &
-       &delt,dz,dx,znt,                 &
-       &u,v,w,th,qv,qc,qi,qnc,qni,      &
-       &qnwfa,qnifa,qnbca,              &
-       &p,exner,rho,T3D,                &
-       &xland,ts,qsfc,qcg,ps,           &
-       &ust,ch,hfx,qfx,rmol,wspd,       &
-       &uoce,voce,                      & !ocean current
-       &vdfg,                           & !Katata-added for fog dep
-       &Qke, & !TKE_PBL,                            &
-       &qke_adv,bl_mynn_tkeadvect,      & !ACF for QKE advection
-#if (WRF_CHEM == 1)
-       chem3d, vd3d, nchem,             & ! WA 7/29/15 For WRF-Chem
-       kdvel, ndvel, num_vert_mix,      &
-#endif
-       &Tsq,Qsq,Cov,                    &
-       &RUBLTEN,RVBLTEN,RTHBLTEN,       &
-       &RQVBLTEN,RQCBLTEN,RQIBLTEN,     &
-       &RQNCBLTEN,RQNIBLTEN,            &
-       &RQNWFABLTEN,RQNIFABLTEN,        &
-       &RQNBCABLTEN,                    &
-       &exch_h,exch_m,                  &
-       &Pblh,kpbl,                      & 
-       &el_pbl,                         &
-       &dqke,qWT,qSHEAR,qBUOY,qDISS,    & !JOE-TKE BUDGET
-       &wstar,delta,                    & !JOE-added for grims
-       &bl_mynn_tkebudget,              &
-       &bl_mynn_cloudpdf,Sh3D,          &
-       &bl_mynn_mixlength,              &
-       &icloud_bl,qc_bl,qi_bl,cldfra_bl,&
-       &bl_mynn_edmf,                   &
-       &bl_mynn_edmf_mom,bl_mynn_edmf_tke, &
-       &bl_mynn_mixscalars,             &
-       &bl_mynn_output,                 &
-       &bl_mynn_cloudmix,bl_mynn_mixqt, &
-       &edmf_a,edmf_w,edmf_qt,          &
-       &edmf_thl,edmf_ent,edmf_qc,      &
-       &sub_thl3D,sub_sqv3D,            &
-       &det_thl3D,det_sqv3D,            &
-       &nupdraft,maxMF,ktop_plume,      &
-       &spp_pbl,pattern_spp_pbl,        &
-       &RTHRATEN,                       &
-       &FLAG_QC,FLAG_QI,FLAG_QNC,       &
-       &FLAG_QNI,FLAG_QNWFA,FLAG_QNIFA, &
-       &FLAG_QNBCA                      &
-       &,IDS,IDE,JDS,JDE,KDS,KDE        &
-       &,IMS,IME,JMS,JME,KMS,KME        &
-       &,ITS,ITE,JTS,JTE,KTS,KTE)
-    
-!-------------------------------------------------------------------
-
-    INTEGER, INTENT(in) :: initflag
-    !INPUT NAMELIST OPTIONS:
-    LOGICAL, INTENT(IN) :: restart,cycling
-    INTEGER, INTENT(in) :: grav_settling
-    INTEGER, INTENT(in) :: bl_mynn_tkebudget
-    INTEGER, INTENT(in) :: bl_mynn_cloudpdf
-    INTEGER, INTENT(in) :: bl_mynn_mixlength
-    INTEGER, INTENT(in) :: bl_mynn_edmf
-    LOGICAL, INTENT(IN) :: bl_mynn_tkeadvect
-    INTEGER, INTENT(in) :: bl_mynn_edmf_mom
-    INTEGER, INTENT(in) :: bl_mynn_edmf_tke
-    INTEGER, INTENT(in) :: bl_mynn_mixscalars
-    INTEGER, INTENT(in) :: bl_mynn_output
-    INTEGER, INTENT(in) :: bl_mynn_cloudmix
-    INTEGER, INTENT(in) :: bl_mynn_mixqt
-    INTEGER, INTENT(in) :: icloud_bl
-
-    LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
-                           FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA
-    
-    INTEGER,INTENT(IN) :: &
-         & IDS,IDE,JDS,JDE,KDS,KDE &
-         &,IMS,IME,JMS,JME,KMS,KME &
-         &,ITS,ITE,JTS,JTE,KTS,KTE
-
-#ifdef HARDCODE_VERTICAL
-# define kts 1
-# define kte HARDCODE_VERTICAL
-#endif
-
-! initflag > 0  for TRUE
-! else        for FALSE
-!       levflag         : <>3;  Level 2.5
-!                         = 3;  Level 3
-! grav_settling = 1 when gravitational settling accounted for
-! grav_settling = 0 when gravitational settling NOT accounted for
-    
-    REAL, INTENT(in) :: delt
-!WRF
-    REAL, INTENT(in) :: dx
-!END WRF
-!FV3
-!     REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(in) :: dx
-!END FV3
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(in) :: dz,&
-         &u,v,w,th,qv,p,exner,rho,T3D
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(in)::&
-         &qc,qi,qni,qnc,qnwfa,qnifa,qnbca
-    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(in) :: xland,ust,&
-         &ch,rmol,ts,qsfc,qcg,ps,hfx,qfx,wspd,uoce,voce,vdfg,znt
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &Qke,Tsq,Qsq,Cov, &
-         !&tke_pbl, & !JOE-added for coupling (TKE_PBL = QKE/2)
-         &qke_adv    !ACF for QKE advection
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,&
-         &RQIBLTEN,RQNIBLTEN,RTHRATEN,RQNCBLTEN, &
-         &RQNWFABLTEN,RQNIFABLTEN,RQNBCABLTEN
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
-         &exch_h,exch_m
-
-   REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(inout) :: &
-         & edmf_a,edmf_w,edmf_qt,edmf_thl,edmf_ent,edmf_qc, &
-         & sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
-
-    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(inout) :: &
-         &Pblh,wstar,delta  !JOE-added for GRIMS
-
-    REAL, DIMENSION(IMS:IME,JMS:JME) :: &
-         &Psig_bl,Psig_shcu
-
-    INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: & 
-         &KPBL,nupdraft,ktop_plume
-
-    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(OUT) :: &
-         &maxmf
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &el_pbl
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
-         &qWT,qSHEAR,qBUOY,qDISS,dqke
-    ! 3D budget arrays are not allocated when bl_mynn_tkebudget == 0.
-    ! 1D (local) budget arrays are used for passing between subroutines.
-    REAL, DIMENSION(KTS:KTE) :: qWT1,qSHEAR1,qBUOY1,qDISS1,dqke1,diss_heat
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: Sh3D
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &qc_bl,qi_bl,cldfra_bl
-    REAL, DIMENSION(KTS:KTE) :: qc_bl1D,qi_bl1D,cldfra_bl1D,&
-                         qc_bl1D_old,qi_bl1D_old,cldfra_bl1D_old
-
-! WA 7/29/15 Mix chemical arrays
-#if (WRF_CHEM == 1)
-    INTEGER, INTENT(IN   ) ::   nchem, kdvel, ndvel, num_vert_mix
-    REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, nchem ), INTENT(INOUT), OPTIONAL :: chem3d
-    REAL,    DIMENSION( ims:ime, kdvel, jms:jme, ndvel ), INTENT(IN), OPTIONAL :: vd3d
-    REAL,    DIMENSION( kts:kte, nchem ) :: chem1
-    REAL,    DIMENSION( kts:kte+1, nchem ) :: s_awchem1
-    REAL,    DIMENSION( ndvel ) :: vd1
-    INTEGER ic
-#endif
-
-!local vars
-    INTEGER :: ITF,JTF,KTF, IMD,JMD
-    INTEGER :: i,j,k
-    REAL, DIMENSION(KTS:KTE) :: thl,thvl,tl,sqv,sqc,sqi,sqw,&
-         &El, Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
-         &Vt, Vq, sgm, thlsg
-
-    REAL, DIMENSION(KTS:KTE) :: thetav,sh,u1,v1,w1,p1,ex1,dz1,th1,tk1,rho1,&
-           & qke1,tsq1,qsq1,cov1,qv1,qi1,qc1,du1,dv1,dth1,dqv1,dqc1,dqi1, &
-           & k_m1,k_h1,qni1,dqni1,qnc1,dqnc1,qnwfa1,qnifa1,qnbca1, &
-                                             dqnwfa1,dqnifa1,dqnbca1
-
-!JOE: mass-flux variables
-    REAL, DIMENSION(KTS:KTE) :: dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf
-    REAL, DIMENSION(KTS:KTE) :: edmf_a1,edmf_w1,edmf_qt1,edmf_thl1,&
-                                edmf_ent1,edmf_qc1
-    REAL, DIMENSION(KTS:KTE) :: sub_thl,sub_sqv,sub_u,sub_v, &
-                        det_thl,det_sqv,det_sqc,det_u,det_v
-    REAL,DIMENSION(KTS:KTE+1) :: s_aw1,s_awthl1,s_awqt1,&
-                  s_awqv1,s_awqc1,s_awu1,s_awv1,s_awqke1,&
-                  s_awqnc1,s_awqni1,s_awqnwfa1,s_awqnifa1,s_awqnbca1
-
-    REAL, DIMENSION(KTS:KTE+1) :: zw
-    REAL :: cpm,sqcg,flt,flq,flqv,flqc,pmz,phh,exnerg,zet,&
-          & afk,abk,ts_decay, qc_bl2, qi_bl2,             &
-          & th_sfc,ztop_plume,sqc9,sqi9
-
-!JOE-add GRIMS parameters & variables
-   real,parameter    ::  d1 = 0.02, d2 = 0.05, d3 = 0.001
-   real,parameter    ::  h1 = 0.33333335, h2 = 0.6666667
-   REAL :: govrth, sflux, bfx0, wstar3, wm2, wm3, delb
-!JOE-end GRIMS
-!JOE-top-down diffusion
-   REAL, DIMENSION(ITS:ITE,JTS:JTE) :: maxKHtopdown
-   REAL,DIMENSION(KTS:KTE) :: KHtopdown,zfac,wscalek2,&
-                             zfacent,TKEprodTD
-   REAL :: bfxpbl,dthvx,tmp1,temps,templ,zl1,wstar3_2
-   real :: ent_eff,radsum,radflux,we,rcldb,rvls,&
-           minrad,zminrad
-   real, parameter :: pfac =2.0, zfmin = 0.01, phifac=8.0
-   integer :: kk,kminrad
-   logical :: cloudflg
-!JOE-end top down
-
-    INTEGER, SAVE :: levflag
-
-    LOGICAL :: INITIALIZE_QKE
-
-! Stochastic fields 
-     INTEGER,  INTENT(IN)                                               ::spp_pbl
-     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN),OPTIONAL  ::pattern_spp_pbl
-     REAL, DIMENSION(KTS:KTE)                         ::    rstoch_col
-
-
-    IF ( debug_code ) THEN
-       print*,'in MYNN driver; at beginning'
-    ENDIF
-
-!***  Begin debugging
-    IMD=(IMS+IME)/2
-    JMD=(JMS+JME)/2
-!***  End debugging 
-
-!WRF
-    JTF=MIN0(JTE,JDE-1)
-    ITF=MIN0(ITE,IDE-1)
-    KTF=MIN0(KTE,KDE-1)
-!FV3
-!    JTF=JTE
-!    ITF=ITE
-!    KTF=KTE
-
-    levflag=mynn_level
-
-    IF (bl_mynn_edmf > 0) THEN
-      ! setup random seed
-      !call init_random_seed
-
-      IF (bl_mynn_output > 0) THEN !research mode
-         edmf_a(its:ite,kts:kte,jts:jte)=0.
-         edmf_w(its:ite,kts:kte,jts:jte)=0.
-         edmf_qt(its:ite,kts:kte,jts:jte)=0.
-         edmf_thl(its:ite,kts:kte,jts:jte)=0.
-         edmf_ent(its:ite,kts:kte,jts:jte)=0.
-         edmf_qc(its:ite,kts:kte,jts:jte)=0.
-         sub_thl3D(its:ite,kts:kte,jts:jte)=0.
-         sub_sqv3D(its:ite,kts:kte,jts:jte)=0.
-         det_thl3D(its:ite,kts:kte,jts:jte)=0.
-         det_sqv3D(its:ite,kts:kte,jts:jte)=0.
-      ENDIF
-      ktop_plume(its:ite,jts:jte)=0   !int
-      nupdraft(its:ite,jts:jte)=0     !int
-      maxmf(its:ite,jts:jte)=0.
-    ENDIF
-    maxKHtopdown(its:ite,jts:jte)=0.
-
-    IF (initflag > 0) THEN
-
-       !Test to see if we want to initialize qke
-       IF ( (restart .or. cycling)) THEN
-          IF (MAXVAL(QKE(its:ite,kts,jts:jte)) < 0.0002) THEN
-             INITIALIZE_QKE = .TRUE.
-             !print*,"QKE is too small, must initialize"
-          ELSE
-             INITIALIZE_QKE = .FALSE.
-             !print*,"Using background QKE, will not initialize"
-          ENDIF
-       ELSE ! not cycling or restarting:
-          INITIALIZE_QKE = .TRUE.
-          !print*,"not restart nor cycling, must initialize QKE"
-       ENDIF
- 
-       Sh3D(its:ite,kts:kte,jts:jte)=0.
-       el_pbl(its:ite,kts:kte,jts:jte)=0.
-       tsq(its:ite,kts:kte,jts:jte)=0.
-       qsq(its:ite,kts:kte,jts:jte)=0.
-       cov(its:ite,kts:kte,jts:jte)=0.
-       dqc1(kts:kte)=0.0
-       dqi1(kts:kte)=0.0
-       dqni1(kts:kte)=0.0
-       dqnc1(kts:kte)=0.0
-       dqnwfa1(kts:kte)=0.0
-       dqnifa1(kts:kte)=0.0
-       dqnbca1(kts:kte)=0.0
-       qc_bl1D(kts:kte)=0.0
-       qi_bl1D(kts:kte)=0.0
-       cldfra_bl1D(kts:kte)=0.0
-       qc_bl1D_old(kts:kte)=0.0
-       cldfra_bl1D_old(kts:kte)=0.0
-       edmf_a1(kts:kte)=0.0
-       edmf_w1(kts:kte)=0.0
-       edmf_qc1(kts:kte)=0.0
-       sgm(kts:kte)=0.0
-       vt(kts:kte)=0.0
-       vq(kts:kte)=0.0
-
-       DO j=JTS,JTF
-          DO k=KTS,KTE
-             DO i=ITS,ITF
-                exch_m(i,k,j)=0.
-                exch_h(i,k,j)=0.
-            ENDDO
-         ENDDO
-       ENDDO
-
-       IF ( bl_mynn_tkebudget == 1) THEN
-         DO j=JTS,JTF
-            DO k=KTS,KTE
-               DO i=ITS,ITF
-                  qWT(i,k,j)=0.
-                  qSHEAR(i,k,j)=0.
-                  qBUOY(i,k,j)=0.
-                  qDISS(i,k,j)=0.
-                  dqke(i,k,j)=0.
-               ENDDO
-            ENDDO
-         ENDDO
-       ENDIF
-
-       DO j=JTS,JTF
-          DO i=ITS,ITF
-             DO k=KTS,KTE !KTF
-                dz1(k)=dz(i,k,j)
-                u1(k) = u(i,k,j)
-                v1(k) = v(i,k,j)
-                w1(k) = w(i,k,j)
-                th1(k)=th(i,k,j)
-                tk1(k)=T3D(i,k,j)
-                rho1(k)=rho(i,k,j)
-                sqc(k)=qc(i,k,j)/(1.+qv(i,k,j))
-                sqv(k)=qv(i,k,j)/(1.+qv(i,k,j))
-                thetav(k)=th(i,k,j)*(1.+0.61*sqv(k))
-                IF (icloud_bl > 0) THEN
-                   CLDFRA_BL1D(k)=CLDFRA_BL(i,k,j)
-                   QC_BL1D(k)=QC_BL(i,k,j)
-                   QI_BL1D(k)=QI_BL(i,k,j)
-                ENDIF
-                IF (PRESENT(qi) .AND. FLAG_QI ) THEN
-                   sqi(k)=qi(i,k,j)/(1.+qv(i,k,j))
-                   sqw(k)=sqv(k)+sqc(k)+sqi(k)
-                   thl(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc(k) &
-                       &           - xlscp/exner(i,k,j)*sqi(k)
-                   !Use form from Tripoli and Cotton (1981) with their
-                   !suggested min temperature to improve accuracy.
-                   !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
-                   !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
-                   !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
-                   IF(sqc(k)<1e-6 .and. sqi(k)<1e-8 .and. CLDFRA_BL1D(k)>0.001)THEN
-                      sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
-                      sqi9=QI_BL1D(k)*CLDFRA_BL1D(k)
-                   ELSE
-                      sqc9=sqc(k)
-                      sqi9=sqi(k)
-                   ENDIF
-                   thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
-                         &           - xlscp/exner(i,k,j)*sqi9
-                ELSE
-                   sqi(k)=0.0
-                   sqw(k)=sqv(k)+sqc(k)
-                   thl(k)=th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
-                   !Use form from Tripoli and Cotton (1981) with their 
-                   !suggested min temperature to improve accuracy.      
-                   !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
-                   !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
-                   IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
-		      sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
-                      sqi9=0.0
-                   ELSE
-                      sqc9=sqc(k)
-                      sqi9=0.0
-                   ENDIF
-                   thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
-                         &           - xlscp/exner(i,k,j)*sqi9
-                ENDIF
-                thvl(k)=thlsg(k)*(1.+0.61*sqv(k))
-
-                IF (k==kts) THEN
-                   zw(k)=0.
-                ELSE
-                   zw(k)=zw(k-1)+dz(i,k-1,j)
-                ENDIF
-                IF (INITIALIZE_QKE) THEN
-                   !Initialize tke for initial PBLH calc only - using 
-                   !simple PBLH form of Koracin and Berkowicz (1988, BLM)
-                   !to linearly taper off tke towards top of PBL.
-                   qke1(k)=5.*ust(i,j) * MAX((ust(i,j)*700. - zw(k))/(MAX(ust(i,j),0.01)*700.), 0.01)
-                ELSE
-                   qke1(k)=qke(i,k,j)
-                ENDIF
-                el(k)=el_pbl(i,k,j)
-                sh(k)=Sh3D(i,k,j)
-                tsq1(k)=tsq(i,k,j)
-                qsq1(k)=qsq(i,k,j)
-                cov1(k)=cov(i,k,j)
-                if (spp_pbl==1) then
-                    rstoch_col(k)=pattern_spp_pbl(i,k,j)
-                else
-                    rstoch_col(k)=0.0
-                endif
-
-             ENDDO
-
-             zw(kte+1)=zw(kte)+dz(i,kte,j)
-
-!             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
-             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
-               &  Qke1,zw,dz1,xland(i,j),KPBL(i,j))
-             
-             IF (scaleaware > 0.) THEN
-                CALL SCALE_AWARE(dx,PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
-             ELSE
-                Psig_bl(i,j)=1.0
-                Psig_shcu(i,j)=1.0
-             ENDIF
-
-             CALL mym_initialize (             & 
-                  &kts,kte,                    &
-                  &dz1, zw, u1, v1, thl, sqv,  &
-                  &PBLH(i,j), th1, sh,         &
-                  &ust(i,j), rmol(i,j),        &
-                  &el, Qke1, Tsq1, Qsq1, Cov1, &
-                  &Psig_bl(i,j), cldfra_bl1D,  &
-                  &bl_mynn_mixlength,          &
-                  &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
-                  &INITIALIZE_QKE,             &
-                  &spp_pbl,rstoch_col )
-
-             !UPDATE 3D VARIABLES
-             DO k=KTS,KTE !KTF
-                el_pbl(i,k,j)=el(k)
-                sh3d(i,k,j)=sh(k)
-                qke(i,k,j)=qke1(k)
-                tsq(i,k,j)=tsq1(k)
-                qsq(i,k,j)=qsq1(k)
-                cov(i,k,j)=cov1(k)
-                !ACF,JOE- initialize qke_adv array if using advection
-                IF (bl_mynn_tkeadvect) THEN
-                   qke_adv(i,k,j)=qke1(k)
-                ENDIF
-             ENDDO
-
-!***  Begin debugging
-!             k=kdebug
-!             IF(I==IMD .AND. J==JMD)THEN
-!               PRINT*,"MYNN DRIVER INIT: k=",1," sh=",sh(k)
-!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",exch_m(i,k,j)
-!               PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
-!               PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",Tsq(i,k,j)
-!               PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
-!             ENDIF
-!***  End debugging
-
-          ENDDO
-       ENDDO
-
-    ENDIF ! end initflag
-
-    !ACF- copy qke_adv array into qke if using advection
-    IF (bl_mynn_tkeadvect) THEN
-       qke=qke_adv
-    ENDIF
-
-    DO j=JTS,JTF
-       DO i=ITS,ITF
-          DO k=KTS,KTE !KTF
-            !JOE-TKE BUDGET
-             IF ( bl_mynn_tkebudget == 1) THEN
-                dqke(i,k,j)=qke(i,k,j)
-             END IF
-             IF (icloud_bl > 0) THEN
-                CLDFRA_BL1D(k)=CLDFRA_BL(i,k,j)
-                QC_BL1D(k)=QC_BL(i,k,j)
-                QI_BL1D(k)=QI_BL(i,k,j)
-                cldfra_bl1D_old(k)=cldfra_bl(i,k,j)
-                qc_bl1D_old(k)=qc_bl(i,k,j)
-                qi_bl1D_old(k)=qi_bl(i,k,j)
-             ENDIF
-             dz1(k)= dz(i,k,j)
-             u1(k) = u(i,k,j)
-             v1(k) = v(i,k,j)
-             w1(k) = w(i,k,j)
-             th1(k)= th(i,k,j)
-             tk1(k)=T3D(i,k,j)
-             rho1(k)=rho(i,k,j)
-             qv1(k)= qv(i,k,j)
-             qc1(k)= qc(i,k,j)
-             sqv(k)= qv(i,k,j)/(1.+qv(i,k,j))
-             sqc(k)= qc(i,k,j)/(1.+qv(i,k,j))
-             dqc1(k)=0.0
-             dqi1(k)=0.0
-             dqni1(k)=0.0
-             dqnc1(k)=0.0
-             dqnwfa1(k)=0.0
-             dqnifa1(k)=0.0
-             dqnbca1(k)=0.0
-             IF(PRESENT(qi) .AND. FLAG_QI)THEN
-                qi1(k)= qi(i,k,j)
-                sqi(k)= qi(i,k,j)/(1.+qv(i,k,j))
-                sqw(k)= sqv(k)+sqc(k)+sqi(k)
-                thl(k)= th(i,k,j) - xlvcp/exner(i,k,j)*sqc(k) &
-                     &            - xlscp/exner(i,k,j)*sqi(k)
-                !Use form from Tripoli and Cotton (1981) with their
-                !suggested min temperature to improve accuracy.    
-                !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
-                !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
-                !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
-                IF(sqc(k)<1e-6 .and. sqi(k)<1e-8 .and. CLDFRA_BL1D(k)>0.001)THEN
-                   sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
-                   sqi9=QI_BL1D(k)*CLDFRA_BL1D(k)
-                ELSE
-                   sqc9=sqc(k)
-                   sqi9=sqi(k)
-                ENDIF
-                thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
-                      &           - xlscp/exner(i,k,j)*sqi9
-             ELSE
-                qi1(k)=0.0
-                sqi(k)=0.0
-                sqw(k)= sqv(k)+sqc(k)
-                thl(k)= th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
-                !Use form from Tripoli and Cotton (1981) with their
-                !suggested min temperature to improve accuracy.    
-                !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
-                !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
-                IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
-                   sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
-                   sqi9=QI_BL1D(k)*CLDFRA_BL1D(k)
-                ELSE
-                   sqc9=sqc(k)
-                   sqi9=0.0
-                ENDIF
-                thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
-                      &           - xlscp/exner(i,k,j)*sqi9 
-            ENDIF
-            thetav(k)=th(i,k,j)*(1.+0.608*sqv(k))
-            thvl(k)=thlsg(k)*(1.+0.61*sqv(k))
-
-             IF (PRESENT(qni) .AND. FLAG_QNI ) THEN
-                qni1(k)=qni(i,k,j)
-             ELSE
-                qni1(k)=0.0
-             ENDIF
-             IF (PRESENT(qnc) .AND. FLAG_QNC ) THEN
-                qnc1(k)=qnc(i,k,j)
-             ELSE
-                qnc1(k)=0.0
-             ENDIF
-             IF (PRESENT(qnwfa) .AND. FLAG_QNWFA ) THEN
-                qnwfa1(k)=qnwfa(i,k,j)
-             ELSE
-                qnwfa1(k)=0.0
-             ENDIF
-             IF (PRESENT(qnifa) .AND. FLAG_QNIFA ) THEN
-                qnifa1(k)=qnifa(i,k,j)
-             ELSE
-                qnifa1(k)=0.0
-             ENDIF
-             IF (PRESENT(qnbca) .AND. FLAG_QNBCA ) THEN
-                qnbca1(k)=qnbca(i,k,j)
-             ELSE
-                qnbca1(k)=0.0
-             ENDIF
-             p1(k) = p(i,k,j)
-             ex1(k)= exner(i,k,j)
-             el(k) = el_pbl(i,k,j)
-             qke1(k)=qke(i,k,j)
-             sh(k) = sh3d(i,k,j)
-             tsq1(k)=tsq(i,k,j)
-             qsq1(k)=qsq(i,k,j)
-             cov1(k)=cov(i,k,j)
-             if (spp_pbl==1) then
-                rstoch_col(k)=pattern_spp_pbl(i,k,j)
-             else
-                rstoch_col(k)=0.0
-             endif
-
-
-             !edmf
-             edmf_a1(k)=0.0
-             edmf_w1(k)=0.0
-             edmf_qc1(k)=0.0
-             s_aw1(k)=0.
-             s_awthl1(k)=0.
-             s_awqt1(k)=0.
-             s_awqv1(k)=0.
-             s_awqc1(k)=0.
-             s_awu1(k)=0.
-             s_awv1(k)=0.
-             s_awqke1(k)=0.
-             s_awqnc1(k)=0.
-             s_awqni1(k)=0.
-             s_awqnwfa1(k)=0.
-             s_awqnifa1(k)=0.
-             s_awqnbca1(k)=0.
-             sub_thl(k)=0.
-             sub_sqv(k)=0.
-             sub_u(k)=0.
-             sub_v(k)=0.
-             det_thl(k)=0.
-             det_sqv(k)=0.
-             det_sqc(k)=0.
-             det_u(k)=0.
-             det_v(k)=0.
-
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-      IF (PRESENT(chem3d) .AND. PRESENT(vd3d)) THEN
-             ! WA 7/29/15 Set up chemical arrays
-             DO ic = 1,nchem
-                chem1(k,ic) = chem3d(i,k,j,ic)
-                s_awchem1(k,ic)=0.
-             ENDDO
-             DO ic = 1,ndvel
-                IF (k == KTS) THEN
-                   vd1(ic) = vd3d(i,1,j,ic)
-                ENDIF
-             ENDDO
-      ELSE
-             DO ic = 1,nchem
-                chem1(k,ic) = 0.
-                s_awchem1(k,ic)=0.
-             ENDDO
-             DO ic = 1,ndvel
-                IF (k == KTS) THEN
-                   vd1(ic) = 0.
-                ENDIF
-             ENDDO
-      ENDIF
-    ENDIF
-#endif
-
-             IF (k==kts) THEN
-                zw(k)=0.
-             ELSE
-                zw(k)=zw(k-1)+dz(i,k-1,j)
-             ENDIF
-          ENDDO ! end k
-
-          zw(kte+1)=zw(kte)+dz(i,kte,j)
-          !EDMF
-          s_aw1(kte+1)=0.
-          s_awthl1(kte+1)=0.
-          s_awqt1(kte+1)=0.
-          s_awqv1(kte+1)=0.
-          s_awqc1(kte+1)=0.
-          s_awu1(kte+1)=0.
-          s_awv1(kte+1)=0.
-          s_awqke1(kte+1)=0.
-          s_awqnc1(kte+1)=0.
-          s_awqni1(kte+1)=0.
-          s_awqnwfa1(kte+1)=0.
-          s_awqnifa1(kte+1)=0.
-          s_awqnbca1(kte+1)=0.
-#if (WRF_CHEM == 1)
-          DO ic = 1,nchem
-             s_awchem1(kte+1,ic)=0.
-          ENDDO
-#endif
-
-!          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
-          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
-          & Qke1,zw,dz1,xland(i,j),KPBL(i,j))
-
-          IF (scaleaware > 0.) THEN
-             CALL SCALE_AWARE(dx,PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
-          ELSE
-             Psig_bl(i,j)=1.0
-             Psig_shcu(i,j)=1.0
-          ENDIF
-
-          sqcg= 0.0   !JOE, it was: qcg(i,j)/(1.+qcg(i,j))
-          cpm=cp*(1.+0.84*qv(i,kts,j))
-          exnerg=(ps(i,j)/p1000mb)**rcp
-
-          !-----------------------------------------------------
-          !ORIGINAL CODE
-          !flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
-          ! +xlvcp*ch(i,j)*(sqc(kts)/exner(i,kts,j) -sqcg/exnerg)
-          !flq = qfx(i,j)/  rho(i,kts,j)       &
-          !    -ch(i,j)*(sqc(kts)   -sqcg )
-          !-----------------------------------------------------
-          ! Katata-added - The deposition velocity of cloud (fog)
-          ! water is used instead of CH.
-          flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
-            & +xlvcp*vdfg(i,j)*(sqc(kts)/exner(i,kts,j)- sqcg/exnerg)
-          flq = qfx(i,j)/  rho(i,kts,j)       &
-            & -vdfg(i,j)*(sqc(kts) - sqcg )
-!JOE-test- should this be after the call to mym_condensation?-using old vt & vq
-!same as original form
-!         flt = flt + xlvcp*ch(i,j)*(sqc(kts)/exner(i,kts,j) -sqcg/exnerg)
-          flqv = qfx(i,j)/rho(i,kts,j)
-          flqc = -vdfg(i,j)*(sqc(kts) - sqcg )
-          th_sfc = ts(i,j)/ex1(kts)
-
-          zet = 0.5*dz(i,kts,j)*rmol(i,j)
-          if ( zet >= 0.0 ) then
-            pmz = 1.0 + (cphm_st-1.0) * zet
-            phh = 1.0 +  cphh_st      * zet
-          else
-            pmz = 1.0/    (1.0-cphm_unst*zet)**0.25 - zet
-            phh = 1.0/SQRT(1.0-cphh_unst*zet)
-          end if
-
-          !-- Estimate wstar & delta for GRIMS shallow-cu-------
-          govrth = g/th1(kts)
-          sflux = hfx(i,j)/rho(i,kts,j)/cpm + &
-                  qfx(i,j)/rho(i,kts,j)*ep_1*th1(kts)
-          bfx0 = max(sflux,0.)
-          wstar3     = (govrth*bfx0*pblh(i,j))
-          wstar(i,j) = wstar3**h1
-          wm3        = wstar3 + 5.*ust(i,j)**3.
-          wm2        = wm3**h2
-          delb       = govrth*d3*pblh(i,j)
-          delta(i,j) = min(d1*pblh(i,j) + d2*wm2/delb, 100.)
-          !-- End GRIMS-----------------------------------------
-
-          CALL  mym_condensation ( kts,kte,      &
-               &dx,dz1,zw,thl,sqw,sqv,sqc,sqi,   &
-               &p1,ex1,tsq1,qsq1,cov1,           &
-               &Sh,el,bl_mynn_cloudpdf,          &
-               &qc_bl1D,qi_bl1D,cldfra_bl1D,     &
-               &PBLH(i,j),HFX(i,j),              &
-               &Vt, Vq, th1, sgm, rmol(i,j),     &
-               &spp_pbl, rstoch_col              )
-
-          !ADD TKE source driven by cloud top cooling
-          IF (bl_mynn_topdown.eq.1)then
-             cloudflg=.false.
-             minrad=100.
-             kminrad=kpbl(i,j)
-             zminrad=PBLH(i,j)
-             KHtopdown(kts:kte)=0.0
-             TKEprodTD(kts:kte)=0.0
-             maxKHtopdown(i,j)=0.0
-             !CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
-             DO kk = MAX(1,kpbl(i,j)-2),kpbl(i,j)+3
-                if(sqc(kk).gt. 1.e-6 .OR. sqi(kk).gt. 1.e-6 .OR. &
-                   cldfra_bl1D(kk).gt.0.5) then
-                   cloudflg=.true.
-                endif
-                if(rthraten(i,kk,j) < minrad)then
-                   minrad=rthraten(i,kk,j)
-                   kminrad=kk
-                   zminrad=zw(kk) + 0.5*dz1(kk)
-                endif
-             ENDDO
-             IF (MAX(kminrad,kpbl(i,j)) < 2)cloudflg = .false.
-             IF (cloudflg) THEN
-                zl1 = dz1(kts)
-                k = MAX(kpbl(i,j)-1, kminrad-1)
-                !Best estimate of height of TKE source (top of downdrafts):
-                !zminrad = 0.5*pblh(i,j) + 0.5*zminrad
-
-                templ=thl(k)*ex1(k)
-                !rvls is ws at full level
-                rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep_2/p1(k+1))
-                temps=templ + (sqw(k)-rvls)/(cp/xlv  +  ep_2*xlv*rvls/(rd*templ**2))
-                rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep_2/p1(k+1))
-                rcldb=max(sqw(k)-rvls,0.)
-
-                !entrainment efficiency
-                dthvx     = (thl(k+2) + th1(k+2)*ep_1*sqw(k+2)) &
-                          - (thl(k)   + th1(k)  *ep_1*sqw(k))
-                dthvx     = max(dthvx,0.1)
-                tmp1      = xlvcp * rcldb/(ex1(k)*dthvx)
-                !Originally from Nichols and Turton (1986), where a2 = 60, but lowered
-                !here to 8, as in Grenier and Bretherton (2001).
-                ent_eff   = 0.2 + 0.2*8.*tmp1
-
-                radsum=0.
-                DO kk = MAX(1,kpbl(i,j)-3),kpbl(i,j)+3
-                   radflux=rthraten(i,kk,j)*ex1(kk)         !converts theta/s to temp/s
-                   radflux=radflux*cp/g*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
-                   if (radflux < 0.0 ) radsum=abs(radflux)+radsum
-                ENDDO
-
-                !More strict limits over land to reduce stable-layer mixouts
-                if ((xland(i,j)-1.5).GE.0)THEN ! WATER
-                   radsum=MIN(radsum,120.0)
-                   bfx0 = max(radsum/rho1(k)/cp,0.)
-                else                           ! LAND
-                   radsum=MIN(0.25*radsum,30.0)!practically turn off over land
-                   bfx0 = max(radsum/rho1(k)/cp - max(sflux,0.0),0.)
-                endif
-
-                !entrainment from PBL top thermals
-                wm3    = g/thetav(k)*bfx0*MIN(pblh(i,j),1500.) ! this is wstar3(i)
-                wm2    = wm2 + wm3**h2
-                bfxpbl = - ent_eff * bfx0
-                dthvx  = max(thetav(k+1)-thetav(k),0.1)
-                we     = max(bfxpbl/dthvx,-sqrt(wm3**h2))
-
-                DO kk = kts,kpbl(i,j)+3
-                   !Analytic vertical profile
-                   zfac(kk) = min(max((1.-(zw(kk+1)-zl1)/(zminrad-zl1)),zfmin),1.)
-                   zfacent(kk) = 10.*MAX((zminrad-zw(kk+1))/zminrad,0.0)*(1.-zfac(kk))**3
-
-                   !Calculate an eddy diffusivity profile (not used at the moment)
-                   wscalek2(kk) = (phifac*karman*wm3*(zfac(kk)))**h1
-                   !Modify shape of KH to be similar to Lock et al (2000): use pfac = 3.0
-                   KHtopdown(kk) = wscalek2(kk)*karman*(zminrad-zw(kk+1))*(1.-zfac(kk))**3 !pfac
-                   KHtopdown(kk) = MAX(KHtopdown(kk),0.0)
-                   !Do not include xkzm at kpbl-1 since it changes entrainment
-                   !if (kk.eq.kpbl(i,j)-1 .and. cloudflg .and. we.lt.0.0) then
-                   !   KHtopdown(kk) = 0.0
-                   !endif
-                   
-                   !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
-                   !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
-                   !An analytic profile controls the magnitude of this TKE prod in the vertical. 
-                   TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh(i,j),100.)*zfacent(kk)
-                   TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
-                ENDDO
-             ENDIF !end cloud check
-             maxKHtopdown(i,j)=MAXVAL(KHtopdown(:))
-          ELSE
-             maxKHtopdown(i,j)=0.0
-             KHtopdown(kts:kte) = 0.0
-             TKEprodTD(kts:kte)=0.0
-          ENDIF !end top-down check
-
-          IF (bl_mynn_edmf > 0) THEN
-            !PRINT*,"Calling DMP Mass-Flux: i= ",i," j=",j
-            CALL DMP_mf(                          &
-               &kts,kte,delt,zw,dz1,p1,           &
-               &bl_mynn_edmf_mom,                 &
-               &bl_mynn_edmf_tke,                 &
-               &bl_mynn_mixscalars,               &
-               &u1,v1,w1,th1,thl,thetav,tk1,      &
-               &sqw,sqv,sqc,qke1,                 &
-               &qnc1,qni1,qnwfa1,qnifa1,qnbca1,   &
-               &ex1,Vt,Vq,sgm,                    &
-               &ust(i,j),flt,flq,flqv,flqc,       &
-               &PBLH(i,j),KPBL(i,j),DX,           &
-               &xland(i,j),th_sfc,                &
-            ! now outputs - tendencies
-            ! &,dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf &
-            ! outputs - updraft properties
-               & edmf_a1,edmf_w1,edmf_qt1,        &
-               & edmf_thl1,edmf_ent1,edmf_qc1,    &
-            ! for the solver
-               & s_aw1,s_awthl1,s_awqt1,          &
-               & s_awqv1,s_awqc1,                 &
-               & s_awu1,s_awv1,s_awqke1,          &
-               & s_awqnc1,s_awqni1,               &
-               & s_awqnwfa1,s_awqnifa1,           &
-               & s_awqnbca1,                      &
-               & sub_thl,sub_sqv,                 &
-               & sub_u,sub_v,                     &
-               & det_thl,det_sqv,det_sqc,         &
-               & det_u,det_v,                     &
-#if (WRF_CHEM == 1)
-               & nchem,chem1,s_awchem1,           &
-#endif
-               & qc_bl1D,cldfra_bl1D,             &
-               & qc_bl1D_old,cldfra_bl1D_old,     &
-               & FLAG_QC,FLAG_QI,                 &
-               & FLAG_QNC,FLAG_QNI,               &
-               & FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA,&
-               & Psig_shcu(i,j),                  &
-               & nupdraft(i,j),ktop_plume(i,j),   &
-               & maxmf(i,j),ztop_plume,           &
-               & spp_pbl,rstoch_col               &
-            )
-
-          ENDIF
-
-          CALL mym_turbulence (                  & 
-               &kts,kte,levflag,                 &
-               &dz1, zw, u1, v1, thl, sqc, sqw,  &
-               &qke1, tsq1, qsq1, cov1,          &
-               &vt, vq,                          &
-               &rmol(i,j), flt, flq,             &
-               &PBLH(i,j),th1,                   &
-               &Sh,el,                           &
-               &Dfm,Dfh,Dfq,                     &
-               &Tcd,Qcd,Pdk,                     &
-               &Pdt,Pdq,Pdc,                     &
-               &qWT1,qSHEAR1,qBUOY1,qDISS1,      &
-               &bl_mynn_tkebudget,               &
-               &Psig_bl(i,j),Psig_shcu(i,j),     &     
-               &cldfra_bl1D,bl_mynn_mixlength,   &
-               &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
-               &TKEprodTD,                       &
-               &spp_pbl,rstoch_col)
-
-          CALL mym_predict (kts,kte,levflag,     &
-               &delt, dz1,                       &
-               &ust(i,j), flt, flq, pmz, phh,    &
-               &el, dfq, pdk, pdt, pdq, pdc,     &
-               &Qke1, Tsq1, Qsq1, Cov1,          &
-               &s_aw1, s_awqke1, bl_mynn_edmf_tke)
-
-          DO k=kts,kte-1
-             ! Set max dissipative heating rate close to 0.1 K per hour (=0.000027...)
-             diss_heat(k) = MIN(MAX(twothirds*(qke1(k)**1.5)/(b1*MAX(0.5*(el(k)+el(k+1)),1.))/cp, 0.0),0.00003)
-          ENDDO
-          diss_heat(kte) = 0.
-
-          CALL mynn_tendencies(kts,kte,          &
-               &levflag,grav_settling,           &
-               &delt, dz1, rho1,                 &
-               &u1, v1, th1, tk1, qv1,           &
-               &qc1, qi1, qnc1, qni1,            &
-               &p1, ex1, thl, sqv, sqc, sqi, sqw,&
-               &qnwfa1, qnifa1, qnbca1,          &
-               &ust(i,j),flt,flq,flqv,flqc,      &
-               &wspd(i,j),qcg(i,j),              &
-               &uoce(i,j),voce(i,j),             &
-               &tsq1, qsq1, cov1,                &
-               &tcd, qcd,                        &
-               &dfm, dfh, dfq,                   &
-               &Du1, Dv1, Dth1, Dqv1,            &
-               &Dqc1, Dqi1, Dqnc1, Dqni1,        &
-               &Dqnwfa1, Dqnifa1, Dqnbca1,       &
-               &vdfg(i,j), diss_heat,            &
-               ! mass flux components
-               &s_aw1,s_awthl1,s_awqt1,          &
-               &s_awqv1,s_awqc1,s_awu1,s_awv1,   &
-               &s_awqnc1,s_awqni1,               &
-               &s_awqnwfa1,s_awqnifa1,           &
-               &s_awqnbca1,                      &
-               &sub_thl,sub_sqv,                 &
-               &sub_u,sub_v,                     &
-               &det_thl,det_sqv,det_sqc,         &
-               &det_u,det_v,                     &
-               &FLAG_QC,FLAG_QI,FLAG_QNC,        &
-               &FLAG_QNI,FLAG_QNWFA,FLAG_QNIFA,  &
-               &FLAG_QNBCA,                      &
-               &cldfra_bl1d,                     &
-               &bl_mynn_cloudmix,                &
-               &bl_mynn_mixqt,                   &
-               &bl_mynn_edmf,                    &
-               &bl_mynn_edmf_mom,                &
-               &bl_mynn_mixscalars             )
-
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-          CALL mynn_mix_chem(kts,kte,           &
-               levflag,grav_settling,           &
-               delt, dz1,                       &
-               nchem, kdvel, ndvel, num_vert_mix, &
-               chem1, vd1,                      &
-               qnc1,qni1,                       &
-               p1, ex1, thl, sqv, sqc, sqi, sqw,&
-               ust(i,j),flt,flq,flqv,flqc,      &
-               wspd(i,j),qcg(i,j),              &
-               uoce(i,j),voce(i,j),             &
-               tsq1, qsq1, cov1,                &
-               tcd, qcd,                        &
-               &dfm, dfh, dfq,                  &
-               ! mass flux components
-               & s_aw1,                         &
-               & s_awchem1,                     &
-               &bl_mynn_cloudmix)
-    ENDIF
-#endif
-
- 
-          CALL retrieve_exchange_coeffs(kts,kte,&
-               &dfm, dfh, dz1, K_m1, K_h1)
-
-          !UPDATE 3D ARRAYS
-          DO k=KTS,KTE !KTF
-             exch_m(i,k,j)=K_m1(k)
-             exch_h(i,k,j)=K_h1(k)
-             RUBLTEN(i,k,j)=du1(k)
-             RVBLTEN(i,k,j)=dv1(k)
-             RTHBLTEN(i,k,j)=dth1(k)
-             RQVBLTEN(i,k,j)=dqv1(k)
-             IF(bl_mynn_cloudmix > 0)THEN
-               IF (PRESENT(qc) .AND. FLAG_QC) RQCBLTEN(i,k,j)=dqc1(k)
-               IF (PRESENT(qi) .AND. FLAG_QI) RQIBLTEN(i,k,j)=dqi1(k)
-             ELSE
-               IF (PRESENT(qc) .AND. FLAG_QC) RQCBLTEN(i,k,j)=0.
-               IF (PRESENT(qi) .AND. FLAG_QI) RQIBLTEN(i,k,j)=0.
-             ENDIF
-             IF(bl_mynn_cloudmix > 0 .AND. bl_mynn_mixscalars > 0)THEN
-               IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k,j)=dqnc1(k)
-               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k,j)=dqni1(k)
-               IF (PRESENT(qnwfa) .AND. FLAG_QNWFA) RQNWFABLTEN(i,k,j)=dqnwfa1(k)
-               IF (PRESENT(qnifa) .AND. FLAG_QNIFA) RQNIFABLTEN(i,k,j)=dqnifa1(k)
-               IF (PRESENT(qnbca) .AND. FLAG_QNBCA) RQNBCABLTEN(i,k,j)=dqnbca1(k)
-             ELSE
-               IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k,j)=0.
-               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k,j)=0.
-               IF (PRESENT(qnwfa) .AND. FLAG_QNWFA) RQNWFABLTEN(i,k,j)=0.
-               IF (PRESENT(qnifa) .AND. FLAG_QNIFA) RQNIFABLTEN(i,k,j)=0.
-               IF (PRESENT(qnbca) .AND. FLAG_QNBCA) RQNBCABLTEN(i,k,j)=0.
-             ENDIF
-
-             IF(icloud_bl > 0)THEN
-               !DIAGNOSTIC-DECAY FOR SUBGRID-SCALE CLOUDS
-               IF (CLDFRA_BL1D(k) < cldfra_bl1D_old(k)) THEN
-                  !DECAY TIMESCALE FOR CALM CONDITION IS THE EDDY TURNOVER
-                  !TIMESCALE, BUT FOR WINDY CONDITIONS, IT IS THE ADVECTIVE 
-                  !TIMESCALE. USE THE MINIMUM OF THE TWO.
-                  ts_decay = MIN( 1800., 3.*dx/MAX(SQRT(u1(k)**2 + v1(k)**2),1.0) )
-                  cldfra_bl(i,k,j)= MAX(cldfra_bl1D(k),cldfra_bl1D_old(k)-(0.25*delt/ts_decay))
-                  ! qc_bl2 and qi_bl2 are decay rates 
-                  qc_bl2          = MAX(qc_bl1D(k),qc_bl1D_old(k))
-                  qc_bl2          = MAX(qc_bl2,1.0E-5)
-                  qi_bl2          = MAX(qi_bl1D(k),qi_bl1D_old(k))
-                  qi_bl2          = MAX(qi_bl2,1.0E-6)
-                  qc_bl(i,k,j)    = MAX(qc_bl1D(k),qc_bl1D_old(k)-(MIN(qc_bl2,1.0E-4) * delt/ts_decay))
-                  qi_bl(i,k,j)    = MAX(qi_bl1D(k),qi_bl1D_old(k)-(MIN(qi_bl2,1.0E-5) * delt/ts_decay))
-                  IF (cldfra_bl(i,k,j) < 0.005 .OR. &
-                     (qc_bl(i,k,j) + qi_bl(i,k,j)) < 1E-9) THEN
-                     CLDFRA_BL(i,k,j)= 0.
-                     QC_BL(i,k,j)    = 0.
-                     QI_BL(i,k,j)    = 0.
-                  ENDIF
-               ELSE
-                  qc_bl(i,k,j)=qc_bl1D(k)
-                  qi_bl(i,k,j)=qi_bl1D(k)
-                  cldfra_bl(i,k,j)=cldfra_bl1D(k)
-               ENDIF
-             ENDIF
-
-             el_pbl(i,k,j)=el(k)
-             qke(i,k,j)=qke1(k)
-             tsq(i,k,j)=tsq1(k)
-             qsq(i,k,j)=qsq1(k)
-             cov(i,k,j)=cov1(k)
-             sh3d(i,k,j)=sh(k)
-
-          ENDDO !end-k
-
-          IF ( bl_mynn_tkebudget == 1) THEN
-             DO k = kts,kte
-                dqke(i,k,j)  = (qke1(k)-dqke(i,k,j))*0.5  !qke->tke
-                qWT(i,k,j)   = qWT1(k)*delt
-                qSHEAR(i,k,j)= qSHEAR1(k)*delt
-                qBUOY(i,k,j) = qBUOY1(k)*delt
-                qDISS(i,k,j) = qDISS1(k)*delt
-             ENDDO
-          ENDIF
-
-          !update updraft properties
-          IF (bl_mynn_output > 0) THEN !research mode == 1
-             DO k = kts,kte
-                edmf_a(i,k,j)=edmf_a1(k)
-                edmf_w(i,k,j)=edmf_w1(k)
-                edmf_qt(i,k,j)=edmf_qt1(k)
-                edmf_thl(i,k,j)=edmf_thl1(k)
-                edmf_ent(i,k,j)=edmf_ent1(k)
-                edmf_qc(i,k,j)=edmf_qc1(k)
-                sub_thl3D(i,k,j)=sub_thl(k)
-                sub_sqv3D(i,k,j)=sub_sqv(k)
-                det_thl3D(i,k,j)=det_thl(k)
-                det_sqv3D(i,k,j)=det_sqv(k)
-             ENDDO
-          ENDIF
-
-          !***  Begin debug prints
-          IF ( debug_code ) THEN
-             DO k = kts,kte
-               IF ( sh(k) < 0. .OR. sh(k)> 200.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," sh=",sh(k)
-               IF ( qke(i,k,j) < -1. .OR. qke(i,k,j)> 200.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," qke=",qke(i,k,j)
-               IF ( el_pbl(i,k,j) < 0. .OR. el_pbl(i,k,j)> 2000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," el_pbl=",el_pbl(i,k,j)
-               IF ( ABS(vt(k)) > 0.8 )print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vt=",vt(k)
-               IF ( ABS(vq(k)) > 6000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vq=",vq(k) 
-               IF ( exch_m(i,k,j) < 0. .OR. exch_m(i,k,j)> 2000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," exxch_m=",exch_m(i,k,j)
-               IF ( vdfg(i,j) < 0. .OR. vdfg(i,j)>5. )print*,&
-                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vdfg=",vdfg(i,j)
-               IF ( ABS(QFX(i,j))>.001)print*,&
-                  "SUSPICIOUS VALUES AT: i,j=",i,j," QFX=",QFX(i,j)
-               IF ( ABS(HFX(i,j))>1000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,j=",i,j," HFX=",HFX(i,j)
-               IF (icloud_bl > 0) then
-                  IF( cldfra_bl(i,k,j) < 0.0 .OR. cldfra_bl(i,k,j)> 1.)THEN
-                  PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl(i,k,j)," qc_bl=",QC_BL(i,k,j)
-                  ENDIF
-               ENDIF
-
-               !IF (I==IMD .AND. J==JMD) THEN
-               !   PRINT*,"MYNN DRIVER END: k=",k," sh=",sh(k)
-               !   PRINT*," sqw=",sqw(k)," thl=",thl(k)," exch_m=",exch_m(i,k,j)
-               !   PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
-               !   PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",tsq(i,k,j)
-               !   PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
-               !   PRINT*," vq=",vq(k)," vt=",vt(k)," vdfg=",vdfg(i,j)
-               !ENDIF
-             ENDDO !end-k
-          ENDIF
-          !***  End debug prints
-
-          !JOE-add tke_pbl for coupling w/shallow-cu schemes (TKE_PBL = QKE/2.)
-          !    TKE_PBL is defined on interfaces, while QKE is at middle of layer.
-          !tke_pbl(i,kts,j) = 0.5*MAX(qke(i,kts,j),1.0e-10)
-          !DO k = kts+1,kte
-          !   afk = dz1(k)/( dz1(k)+dz1(k-1) )
-          !   abk = 1.0 -afk
-          !   tke_pbl(i,k,j) = 0.5*MAX(qke(i,k,j)*abk+qke(i,k-1,j)*afk,1.0e-3)
-          !ENDDO
-
-       ENDDO
-    ENDDO
-
-!ACF copy qke into qke_adv if using advection
-    IF (bl_mynn_tkeadvect) THEN
-       qke_adv=qke
-    ENDIF
-!ACF-end
-
-#ifdef HARDCODE_VERTICAL
-# undef kts
-# undef kte
-#endif
-
-  END SUBROUTINE mynn_bl_driver
 
 ! ==================================================================
-  SUBROUTINE mynn_bl_init_driver(                   &
-       &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,          &
-       &RQCBLTEN,RQIBLTEN & !,RQNIBLTEN,RQNCBLTEN   &
-       &,QKE,                                       &
-       &EXCH_H                                      &
-       !&,icloud_bl,qc_bl,cldfra_bl                 &
-       &,RESTART,ALLOWED_TO_READ,LEVEL              &
-       &,IDS,IDE,JDS,JDE,KDS,KDE                    &
-       &,IMS,IME,JMS,JME,KMS,KME                    &
-       &,ITS,ITE,JTS,JTE,KTS,KTE)
-
-    !---------------------------------------------------------------
-    LOGICAL,INTENT(IN) :: ALLOWED_TO_READ,RESTART
-    INTEGER,INTENT(IN) :: LEVEL !,icloud_bl
-
-    INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,                    &
-         &                IMS,IME,JMS,JME,KMS,KME,                    &
-         &                ITS,ITE,JTS,JTE,KTS,KTE
-    
-    
-    REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
-         &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,                 &
-         &RQCBLTEN,RQIBLTEN,& !RQNIBLTEN,RQNCBLTEN       &
-         &QKE,EXCH_H
-
-!    REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
-!         &qc_bl,cldfra_bl
-
-    INTEGER :: I,J,K,ITF,JTF,KTF
-    
-    JTF=MIN0(JTE,JDE-1)
-    KTF=MIN0(KTE,KDE-1)
-    ITF=MIN0(ITE,IDE-1)
-    
-    IF(.NOT.RESTART)THEN
-       DO J=JTS,JTF
-          DO K=KTS,KTF
-             DO I=ITS,ITF
-                RUBLTEN(i,k,j)=0.
-                RVBLTEN(i,k,j)=0.
-                RTHBLTEN(i,k,j)=0.
-                RQVBLTEN(i,k,j)=0.
-                if( p_qc >= param_first_scalar ) RQCBLTEN(i,k,j)=0.
-                if( p_qi >= param_first_scalar ) RQIBLTEN(i,k,j)=0.
-                !if( p_qnc >= param_first_scalar ) RQNCBLTEN(i,k,j)=0.
-                !if( p_qni >= param_first_scalar ) RQNIBLTEN(i,k,j)=0.
-                !QKE(i,k,j)=0.
-                EXCH_H(i,k,j)=0.
-!                if(icloud_bl > 0) qc_bl(i,k,j)=0.
-!                if(icloud_bl > 0) cldfra_bl(i,k,j)=0.
-             ENDDO
-          ENDDO
-       ENDDO
-    ENDIF
-
-    mynn_level=level
-
-  END SUBROUTINE mynn_bl_init_driver
-
-! ==================================================================
-
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates hybrid diagnotic boundary-layer height (PBLH).
+!!
+!! NOTES ON THE PBLH FORMULATION: The 1.5-theta-increase method defines
+!!PBL heights as the level at.
+!!which the potential temperature first exceeds the minimum potential.
+!!temperature within the boundary layer by 1.5 K. When applied to.
+!!observed temperatures, this method has been shown to produce PBL-
+!!height estimates that are unbiased relative to profiler-based.
+!!estimates (Nielsen-Gammon et al. 2008 \cite Nielsen_Gammon_2008). 
+!! However, their study did not
+!!include LLJs. Banta and Pichugina (2008) \cite Pichugina_2008  show that a TKE-based.
+!!threshold is a good estimate of the PBL height in LLJs. Therefore,
+!!a hybrid definition is implemented that uses both methods, weighting
+!!the TKE-method more during stable conditions (PBLH < 400 m).
+!!A variable tke threshold (TKEeps) is used since no hard-wired
+!!value could be found to work best in all conditions.
+!>\section gen_get_pblh  GSD get_pblh General Algorithm
+!> @{
   SUBROUTINE GET_PBLH(KTS,KTE,zi,thetav1D,qke1D,zw1D,dz1D,landsea,kzi)
 
     !---------------------------------------------------------------
@@ -5142,7 +5651,7 @@ ENDIF
     !Initialize KPBL (kzi)
     kzi = 2
 
-    !FIND MIN THETAV IN THE LOWEST 200 M AGL
+    !> - FIND MIN THETAV IN THE LOWEST 200 M AGL
     k = kts+1
     kthv = 1
     minthv = 9.E9
@@ -5156,7 +5665,7 @@ ENDIF
        !IF (zw1D(k) .GT. sbl_lim) exit
     ENDDO
 
-    !FIND THETAV-BASED PBLH (BEST FOR DAYTIME).
+    !> - FIND THETAV-BASED PBLH (BEST FOR DAYTIME).
     zi=0.
     k = kthv+1
     IF((landsea-1.5).GE.0)THEN
@@ -5182,10 +5691,10 @@ ENDIF
     ENDDO
     !print*,"IN GET_PBLH:",thsfc,zi
 
-    !FOR STABLE BOUNDARY LAYERS, USE TKE METHOD TO COMPLEMENT THE
-    !THETAV-BASED DEFINITION (WHEN THE THETA-V BASED PBLH IS BELOW ~0.5 KM).
-    !THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE 
-    !WHEN THE THETA-V-BASED DEFINITION IS ABOVE ~1 KM.
+    !> - FOR STABLE BOUNDARY LAYERS, USE TKE METHOD TO COMPLEMENT THE
+    !! THETAV-BASED DEFINITION (WHEN THE THETA-V BASED PBLH IS BELOW ~0.5 KM).
+    !!THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE 
+    !!WHEN THE THETA-V-BASED DEFINITION IS ABOVE ~1 KM.
     ktke = 1
     maxqke = MAX(Qke1D(kts),0.)
     !Use 5% of tke max (Kosovic and Curry, 2000; JAS)
@@ -5205,19 +5714,19 @@ ENDIF
              & MIN((TKEeps-qtke)/MAX(qtkem1-qtke, 1E-6), 1.0)
            !IN CASE OF NEAR ZERO TKE, SET PBLH = LOWEST LEVEL.
            PBLH_TKE = MAX(PBLH_TKE,zw1D(kts+1))
-           !print *,"PBLH_TKE:",i,j,PBLH_TKE, Qke1D(k)/2., zw1D(kts+1)
+           !print *,"PBLH_TKE:",i,PBLH_TKE, Qke1D(k)/2., zw1D(kts+1)
        ENDIF
        !k = k+1
        IF (k .EQ. kte-1) PBLH_TKE = zw1D(kts+1) !EXIT SAFEGUARD
        IF (PBLH_TKE .NE. 0.) exit
     ENDDO
 
-    !With TKE advection turned on, the TKE-based PBLH can be very large 
-    !in grid points with convective precipitation (> 8 km!),
-    !so an artificial limit is imposed to not let PBLH_TKE exceed the
-    !theta_v-based PBL height +/- 350 m.
-    !This has no impact on 98-99% of the domain, but is the simplest patch
-    !that adequately addresses these extremely large PBLHs.
+    !> - With TKE advection turned on, the TKE-based PBLH can be very large 
+    !! in grid points with convective precipitation (> 8 km!),
+    !! so an artificial limit is imposed to not let PBLH_TKE exceed the
+    !!theta_v-based PBL height +/- 350 m.
+    !!This has no impact on 98-99% of the domain, but is the simplest patch
+    !!that adequately addresses these extremely large PBLHs.
     PBLH_TKE = MIN(PBLH_TKE,zi+350.)
     PBLH_TKE = MAX(PBLH_TKE,MAX(zi-350.,10.))
 
@@ -5243,60 +5752,68 @@ ENDIF
 #endif
 
   END SUBROUTINE GET_PBLH
+!> @}
   
 ! ==================================================================
-! Dynamic Multi-Plume (DMP) Mass-Flux Scheme
-!
-! Much thanks to Kay Suslj of NASA-JPL for contributing the original version
-! of this mass-flux scheme. Considerable changes have been made from it's
-! original form. Some additions include:
-!  1) scale-aware tapering as dx -> 0
-!  2) transport of TKE (extra namelist option)
-!  3) Chaboureau-Bechtold cloud fraction & coupling to radiation (when icloud_bl > 0)
-!  4) some extra limits for numerical stability
-! This scheme remains under development, so consider it experimental code. 
-!
-  SUBROUTINE DMP_mf(                       &
-                 & kts,kte,dt,zw,dz,p,      &
-                 & momentum_opt,            &
-                 & tke_opt,                 &
-                 & scalar_opt,              &
-                 & u,v,w,th,thl,thv,tk,     &
-                 & qt,qv,qc,qke,            &
-                 qnc,qni,qnwfa,qnifa,qnbca, &
-                 & exner,vt,vq,sgm,         &
-                 & ust,flt,flq,flqv,flqc,   &
-                 & pblh,kpbl,DX,landsea,ts, &
+!>\ingroup gsd_mynn_edmf
+!! This subroutine is the Dynamic Multi-Plume (DMP) Mass-Flux Scheme.
+!! 
+!! dmp_mf() calculates the nonlocal turbulent transport from the dynamic
+!! multiplume mass-flux scheme as well as the shallow-cumulus component of 
+!! the subgrid clouds. Note that this mass-flux scheme is called when the
+!! namelist paramter \p bl_mynn_edmf is set to 1 (recommended).
+!!
+!! Much thanks to Kay Suslj of NASA-JPL for contributing the original version
+!! of this mass-flux scheme. Considerable changes have been made from it's
+!! original form. Some additions include:
+!!  -# scale-aware tapering as dx -> 0
+!!  -# transport of TKE (extra namelist option)
+!!  -# Chaboureau-Bechtold cloud fraction & coupling to radiation (when icloud_bl > 0)
+!!  -# some extra limits for numerical stability
+!!
+!! This scheme remains under development, so consider it experimental code. 
+!!
+  SUBROUTINE DMP_mf(                            &
+                 & kts,kte,dt,zw,dz,p,rho,      &
+                 & momentum_opt,                &
+                 & tke_opt,                     &
+                 & scalar_opt,                  &
+                 & u,v,w,th,thl,thv,tk,         &
+                 & qt,qv,qc,qke,                &
+                 & qnc,qni,qnwfa,qnifa,qnbca,   &
+                 & exner,vt,vq,sgm,             &
+                 & ust,flt,fltv,flq,flqv,       &
+                 & pblh,kpbl,dx,landsea,ts,     &
             ! outputs - updraft properties   
-                 & edmf_a,edmf_w,           &
-                 & edmf_qt,edmf_thl,        &
-                 & edmf_ent,edmf_qc,        &
+                 & edmf_a,edmf_w,               &
+                 & edmf_qt,edmf_thl,            &
+                 & edmf_ent,edmf_qc,            &
             ! outputs - variables needed for solver 
-                 & s_aw,s_awthl,s_awqt,     &
-                 & s_awqv,s_awqc,           &
-                 & s_awu,s_awv,s_awqke,     &
-                 & s_awqnc,s_awqni,         &
-                 & s_awqnwfa,s_awqnifa,     &
-                 & s_awqnbca,               &
-                 & sub_thl,sub_sqv,         &
-                 & sub_u,sub_v,             &
-                 & det_thl,det_sqv,det_sqc, &
-                 & det_u,det_v,             &
-#if (WRF_CHEM == 1)
-                 & nchem,chem,s_awchem,     &
-#endif
+                 & s_aw,s_awthl,s_awqt,         &
+                 & s_awqv,s_awqc,               &
+                 & s_awu,s_awv,s_awqke,         &
+                 & s_awqnc,s_awqni,             &
+                 & s_awqnwfa,s_awqnifa,         &
+                 & s_awqnbca,                   &
+                 & sub_thl,sub_sqv,             &
+                 & sub_u,sub_v,                 &
+                 & det_thl,det_sqv,det_sqc,     &
+                 & det_u,det_v,                 &
+            ! chem/smoke
+                 & nchem,chem1,s_awchem,        &
+                 & mix_chem,                    &
             ! in/outputs - subgrid scale clouds
                  & qc_bl1d,cldfra_bl1d,         &
                  & qc_bl1D_old,cldfra_bl1D_old, &
             ! inputs - flags for moist arrays
-                 & F_QC,F_QI,               &
-                 F_QNC,F_QNI,               &
-                 & F_QNWFA,F_QNIFA,F_QNBCA, &
-                 & Psig_shcu,               &
+                 & F_QC,F_QI,                   &
+                 & F_QNC,F_QNI,                 &
+                 & F_QNWFA,F_QNIFA,F_QNBCA,     &
+                 & Psig_shcu,                   &
             ! output info
-                 &nup2,ktop,maxmf,ztop,     &
+                 &nup2,ktop,maxmf,ztop,         &
             ! unputs for stochastic perturbations
-                 &spp_pbl,rstoch_col) 
+                 &spp_pbl,rstoch_col            ) 
 
   ! inputs:
      INTEGER, INTENT(IN) :: KTS,KTE,KPBL,momentum_opt,tke_opt,scalar_opt
@@ -5310,45 +5827,38 @@ ENDIF
      INTEGER,  INTENT(IN)          :: spp_pbl
      REAL, DIMENSION(KTS:KTE)      :: rstoch_col
 
-     REAL,DIMENSION(KTS:KTE), INTENT(IN) :: U,V,W,TH,THL,TK,QT,QV,QC,&
-                      exner,dz,THV,P,qke,qnc,qni,qnwfa,qnifa,qnbca
-     REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: ZW  !height at full-sigma
-     REAL, INTENT(IN) :: DT,UST,FLT,FLQ,FLQV,FLQC,PBLH,&
-                         DX,Psig_shcu,landsea,ts
-     LOGICAL, OPTIONAL :: F_QC,F_QI,F_QNC,F_QNI,F_QNWFA,F_QNIFA,F_QNBCA
+     REAL,DIMENSION(KTS:KTE), INTENT(IN) ::                            &
+                   u,v,w,th,thl,tk,qt,qv,qc,                           &
+                   exner,dz,THV,P,rho,qke,qnc,qni,qnwfa,qnifa,qnbca
+     REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: zw    !height at full-sigma
+     REAL, INTENT(IN) :: dt,ust,flt,fltv,flq,flqv,pblh,                &
+                         dx,psig_shcu,landsea,ts
+     LOGICAL, OPTIONAL :: f_qc,f_qi,f_qnc,f_qni,                       &
+                   f_qnwfa,f_qnifa,f_qnbca
 
   ! outputs - updraft properties
-     REAL,DIMENSION(KTS:KTE), INTENT(OUT) :: edmf_a,edmf_w,        &
-                      & edmf_qt,edmf_thl, edmf_ent,edmf_qc
+     REAL,DIMENSION(KTS:KTE), INTENT(OUT) :: edmf_a,edmf_w,            &
+                      & edmf_qt,edmf_thl,edmf_ent,edmf_qc
      !add one local edmf variable:
      REAL,DIMENSION(KTS:KTE) :: edmf_th
   ! output
      INTEGER, INTENT(OUT) :: nup2,ktop
      REAL, INTENT(OUT) :: maxmf,ztop
-  ! outputs - variables needed for solver
-     REAL,DIMENSION(KTS:KTE+1) :: s_aw,      & !sum ai*wis_awphi
-                               s_awthl,      & !sum ai*wi*phii
-                                s_awqt,      &
-                                s_awqv,      &
-                                s_awqc,      &
-                               s_awqnc,      &
-                               s_awqni,      &
-                             s_awqnwfa,      &
-                             s_awqnifa,      &
-                             s_awqnbca,      &
-                                 s_awu,      &
-                                 s_awv,      &
-                               s_awqke, s_aw2
+  ! outputs - variables needed for solver - sum ai*rho*wis_awphi
+     REAL,DIMENSION(KTS:KTE+1) :: s_aw,s_awthl,s_awqt,                 &
+                         s_awqv,s_awqc,s_awqnc,s_awqni,                &
+                         s_awqnwfa,s_awqnifa,s_awqnbca,                &
+                         s_awu,s_awv,s_awqke,s_aw2
 
-     REAL,DIMENSION(KTS:KTE), INTENT(INOUT) :: qc_bl1d,cldfra_bl1d, &
+     REAL,DIMENSION(KTS:KTE), INTENT(INOUT) :: qc_bl1d,cldfra_bl1d,    &
                                        qc_bl1d_old,cldfra_bl1d_old
 
-    INTEGER, PARAMETER :: NUP=10, debug_mf=0
+    INTEGER, PARAMETER :: nup=10, debug_mf=0
 
   !------------- local variables -------------------
   ! updraft properties defined on interfaces (k=1 is the top of the
   ! first model layer
-     REAL,DIMENSION(KTS:KTE+1,1:NUP) :: UPW,UPTHL,UPQT,UPQC,UPQV, &
+     REAL,DIMENSION(KTS:KTE+1,1:NUP) :: UPW,UPTHL,UPQT,UPQC,UPQV,      &
                                         UPA,UPU,UPV,UPTHV,UPQKE,UPQNC, &
                                         UPQNI,UPQNWFA,UPQNIFA,UPQNBCA
   ! entrainment variables
@@ -5356,21 +5866,22 @@ ENDIF
      INTEGER,DIMENSION(KTS:KTE,1:NUP) :: ENTi
   ! internal variables
      INTEGER :: K,I,k50
-     REAL :: fltv,wstar,qstar,thstar,sigmaW,sigmaQT,sigmaTH,z0,    &
+     REAL :: fltv2,wstar,qstar,thstar,sigmaW,sigmaQT,sigmaTH,z0,       &
              pwmin,pwmax,wmin,wmax,wlv,Psig_w,maxw,maxqc,wpbl
-     REAL :: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,QNCn,QNIn,QNWFAn,QNIFAn,QNBCAn, &
-             Wn2,Wn,EntEXP,EntW,BCOEFF,THVkm1,THVk,Pk
+     REAL :: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,QNCn,QNIn,                 &
+             QNWFAn,QNIFAn,QNBCAn,                                     &
+             Wn2,Wn,EntEXP,EntEXM,EntW,BCOEFF,THVkm1,THVk,Pk,rho_int
 
   ! w parameters
      REAL,PARAMETER :: &
-          &Wa=2./3., &
-          &Wb=0.002,&
+          &Wa=2./3.,   &
+          &Wb=0.002,   &
           &Wc=1.5 
         
   ! Lateral entrainment parameters ( L0=100 and ENT0=0.1) were taken from
   ! Suselj et al (2013, jas). Note that Suselj et al (2014,waf) use L0=200 and ENT0=0.2.
      REAL,PARAMETER :: &
-         & L0=100.,&
+         & L0=100.,    &
          & ENT0=0.1
 
   ! Implement ideas from Neggers (2016, JAMES):
@@ -5383,15 +5894,15 @@ ENDIF
           ! Note that changing d to -1.7 doubles the area coverage of the largest plumes relative to the smallest plumes.
      REAL :: cn,c,l,n,an2,hux,maxwidth,wspd_pbl,cloud_base,width_flx
 
-#if (WRF_CHEM == 1)
+  ! chem/smoke
      INTEGER, INTENT(IN) :: nchem
-     REAL,DIMENSION(kts:kte, nchem) :: chem
+     REAL,DIMENSION(:, :) :: chem1
      REAL,DIMENSION(kts:kte+1, nchem) :: s_awchem
      REAL,DIMENSION(nchem) :: chemn
      REAL,DIMENSION(KTS:KTE+1,1:NUP, nchem) :: UPCHEM
      INTEGER :: ic
      REAL,DIMENSION(KTS:KTE+1, nchem) :: edmf_chem
-#endif
+     LOGICAL, INTENT(IN) :: mix_chem
 
   !JOE: add declaration of ERF
    REAL :: ERF
@@ -5400,18 +5911,17 @@ ENDIF
 
   ! VARIABLES FOR CHABOUREAU-BECHTOLD CLOUD FRACTION
    REAL,DIMENSION(KTS:KTE), INTENT(INOUT) :: vt, vq, sgm
-   REAL :: sigq,xl,tlk,qsat_tl,rsl,cpm,a,qmq,mf_cf,Q1,diffqt,&
+   REAL :: sigq,xl,rsl,cpm,a,qmq,mf_cf,Aup,Q1,diffqt,qsat_tk,&
            Fng,qww,alpha,beta,bb,f,pt,t,q2p,b9,satvp,rhgrid, &
            Ac_mf,Ac_strat,qc_mf
+   REAL, PARAMETER :: cf_thresh = 0.5 ! only overwrite stratus CF less than this value
 
   ! Variables for plume interpolation/saturation check
    REAL,DIMENSION(KTS:KTE) :: exneri,dzi
-   REAL ::  THp, QTp, QCp, QCs, esat, qsl
+   REAL :: THp, QTp, QCp, QCs, esat, qsl
+   REAL :: csigma,acfac,ac_wsp,ac_cld
 
-   ! WA TEST 11/9/15 for consistent reduction of updraft params
-   REAL :: csigma,acfac
-
-   !JOE- plume overshoot
+   !plume overshoot
    INTEGER :: overshoot
    REAL :: bvf, Frz, dzp
 
@@ -5428,13 +5938,19 @@ ENDIF
                                        envm_u,envm_v  !environmental variables defined at middle of layer
    REAL,DIMENSION(KTS:KTE+1) ::  envi_a,envi_w        !environmental variables defined at model interface
    REAL :: temp,sublim,qc_ent,qv_ent,qt_ent,thl_ent,detrate,  &
-           detrateUV,oow,exc_fac,aratio,detturb,qc_grid
-   REAL, PARAMETER :: Cdet = 1./45.
+           detrateUV,oow,exc_fac,aratio,detturb,qc_grid,qc_sgs,&
+           qc_plume,exc_heat,exc_moist,tk_int
+   REAL, PARAMETER :: Cdet   = 1./45.
+   REAL, PARAMETER :: dzpmax = 300. !limit dz used in detrainment - can be excessing in thick layers
    !parameter "Csub" determines the propotion of upward vertical velocity that contributes to
    !environmenatal subsidence. Some portion is expected to be compensated by downdrafts instead of
    !gentle environmental subsidence. 1.0 assumes all upward vertical velocity in the mass-flux scheme
    !is compensated by "gentle" environmental subsidence. 
    REAL, PARAMETER :: Csub=0.25
+
+   !Factor for the pressure gradient effects on momentum transport
+   REAL, PARAMETER :: pgfac = 0.00  ! Zhang and Wu showed 0.4 is more appropriate for lower troposphere
+   REAL :: Uk,Ukm1,Vk,Vkm1,dxsa
 
 ! check the inputs
 !     print *,'dt',dt
@@ -5464,11 +5980,10 @@ ENDIF
   UPQNWFA=0.
   UPQNIFA=0.
   UPQNBCA=0.
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-      UPCHEM(KTS:KTE+1,1:NUP,1:nchem)=0.0
-    ENDIF
-#endif
+  IF ( mix_chem ) THEN
+     UPCHEM(KTS:KTE+1,1:NUP,1:nchem)=0.0
+  ENDIF
+
   ENT=0.001
 ! Initialize mean updraft properties
   edmf_a  =0.
@@ -5477,11 +5992,10 @@ ENDIF
   edmf_thl=0.
   edmf_ent=0.
   edmf_qc =0.
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-      edmf_chem(kts:kte+1,1:nchem) = 0.0
-    ENDIF
-#endif
+  IF ( mix_chem ) THEN
+     edmf_chem(kts:kte+1,1:nchem) = 0.0
+  ENDIF
+
 ! Initialize the variables needed for implicit solver
   s_aw=0.
   s_awthl=0.
@@ -5496,11 +6010,10 @@ ENDIF
   s_awqnwfa=0.
   s_awqnifa=0.
   s_awqnbca=0.
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-      s_awchem(kts:kte+1,1:nchem) = 0.0
-    ENDIF
-#endif
+  IF ( mix_chem ) THEN
+     s_awchem(kts:kte+1,1:nchem) = 0.0
+  ENDIF
+
 ! Initialize explicit tendencies for subsidence & detrainment
   sub_thl = 0.
   sub_sqv = 0.
@@ -5519,7 +6032,7 @@ ENDIF
   cloud_base  = 9000.0
 !  DO WHILE (ZW(k) < pblh + 500.)
   DO k=1,kte-1
-     IF(ZW(k) > pblh + 500.) exit
+     IF(zw(k) > pblh + 500.) exit
 
      wpbl = w(k)
      IF(w(k) < 0.)wpbl = 2.*w(k)
@@ -5529,7 +6042,8 @@ ENDIF
      IF(ZW(k)<=50.)k50=k
 
      !Search for cloud base
-     IF(qc(k)>1E-5 .AND. cloud_base == 9000.0)THEN
+     qc_sgs = MAX(qc(k), qc_bl1d(k)*cldfra_bl1d(k))
+     IF(qc_sgs> 1E-5 .AND. cloud_base == 9000.0)THEN
        cloud_base = 0.5*(ZW(k)+ZW(k+1))
      ENDIF
 
@@ -5541,18 +6055,15 @@ ENDIF
   Psig_w = MIN(Psig_w, Psig_shcu)
   !print*," maxw=", maxw," Psig_w=",Psig_w," Psig_shcu=",Psig_shcu
 
-  fltv = flt + svp1*flq
-  !PRINT*," fltv=",fltv," zi=",pblh 
-
   !Completely shut off MF scheme for strong resolved-scale vertical velocities.
-  IF(Psig_w == 0.0 .and. fltv > 0.0) fltv = -1.*fltv
+  fltv2 = fltv
+  IF(Psig_w == 0.0 .and. fltv > 0.0) fltv2 = -1.*fltv
 
-! if surface buoyancy is positive we do integration, otherwise not, and make sure that 
-! PBLH > twice the height of the surface layer (set at z0 = 50m)
-! Also, ensure that it is at least slightly superadiabatic up through 50 m
-      superadiabatic = .false.
+  ! If surface buoyancy is positive we do integration, otherwise no.
+  ! Also, ensure that it is at least slightly superadiabatic up through 50 m
+  superadiabatic = .false.
   IF((landsea-1.5).GE.0)THEN
-     hux = -0.002   ! WATER  ! dT/dz must be < - 0.2 K per 100 m.
+     hux = -0.001   ! WATER  ! dT/dz must be < - 0.1 K per 100 m.
   ELSE
      hux = -0.005  ! LAND    ! dT/dz must be < - 0.5 K per 100 m.
   ENDIF
@@ -5580,36 +6091,40 @@ ENDIF
   !   (2) Apply a scale-break, assuming no plumes with diameter larger than PBLH can exist.
   !   (3) max plume size beneath clouds deck approx = 0.5 * cloud_base.
   !   (4) add wspd-dependent limit, when plume model breaks down. (hurricanes)
-  !   (5) land-only limit to reduce plume sizes in weakly forced conditions
+  !   (5) limit to reduce max plume sizes in weakly forced conditions. This is only
+  !       meant to "soften" the activation of the mass-flux scheme.
   ! Criteria (1)
     NUP2 = max(1,min(NUP,INT(dx*dcut/dl)))
   !Criteria (2)
-    maxwidth = 1.2*PBLH 
+    maxwidth = 1.1*PBLH 
   ! Criteria (3)
-    maxwidth = MIN(maxwidth,0.75*cloud_base)
+    maxwidth = MIN(maxwidth,0.5*cloud_base)
   ! Criteria (4)
     wspd_pbl=SQRT(MAX(u(kts)**2 + v(kts)**2, 0.01))
     !Note: area fraction (acfac) is modified below
-  ! Criteria (5)
-    IF((landsea-1.5).LT.0)THEN
-      width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.050)/0.03) + .5),1000.), 0.)
-      maxwidth = MIN(maxwidth,width_flx)
-    ENDIF
+  ! Criteria (5) - only a function of flt (not fltv)
+    if ((landsea-1.5).LT.0) then  !land
+      !width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.050)/0.03) + .5),1000.), 0.)
+      width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.040)/0.03) + .5),1000.), 0.) 
+    else                          !water
+      width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.003)/0.01) + .5),1000.), 0.)
+    endif
+    maxwidth = MIN(maxwidth,width_flx)
   ! Convert maxwidth to number of plumes
     NUP2 = MIN(MAX(INT((maxwidth - MOD(maxwidth,100.))/100), 0), NUP2)
 
-  !Initialize values:
+  !Initialize values for 2d output fields:
   ktop = 0
   ztop = 0.0
   maxmf= 0.0
 
-  IF ( fltv > 0.002 .AND. NUP2 .GE. 1 .AND. superadiabatic) then
-    !PRINT*," Conditions met to run mass-flux scheme",fltv,pblh
+  IF ( fltv2 > 0.002 .AND. NUP2 .GE. 1 .AND. superadiabatic) then
+    !PRINT*," Conditions met to run mass-flux scheme",fltv2,pblh
 
     ! Find coef C for number size density N
     cn = 0.
     d=-1.9  !set d to value suggested by Neggers 2015 (JAMES).
-    !d=-1.9 + .2*tanh((fltv - 0.05)/0.15) 
+    !d=-1.9 + .2*tanh((fltv2 - 0.05)/0.15) 
     do I=1,NUP !NUP2
        IF(I > NUP2) exit
        l  = dl*I                            ! diameter of plume
@@ -5617,23 +6132,30 @@ ENDIF
     enddo
     C = Atot/cn   !Normalize C according to the defined total fraction (Atot)
 
+    ! Make updraft area (UPA) a function of the buoyancy flux
+    if ((landsea-1.5).LT.0) then  !land
+       !acfac = .5*tanh((fltv2 - 0.03)/0.09) + .5
+       !acfac = .5*tanh((fltv2 - 0.02)/0.09) + .5
+       acfac = .5*tanh((fltv2 - 0.02)/0.05) + .5
+    else                          !water
+       acfac = .5*tanh((fltv2 - 0.01)/0.03) + .5
+    endif
+    !add a windspeed-dependent adjustment to acfac that tapers off
+    !the mass-flux scheme linearly above sfc wind speeds of 20 m/s:
+    ac_wsp = 1.0 - min(max(wspd_pbl - 20.0, 0.0), 10.0)/10.0
+    !reduce area fraction beneath cloud bases < 1200 m AGL
+    ac_cld = min(cloud_base/1200., 1.0)
+    acfac  = acfac * min(ac_wsp, ac_cld)
+
     ! Find the portion of the total fraction (Atot) of each plume size:
     An2 = 0.
     do I=1,NUP !NUP2
        IF(I > NUP2) exit
        l  = dl*I                            ! diameter of plume
-       N = C*l**d                           ! number density of plume n
+       N  = C*l**d                          ! number density of plume n
        UPA(1,I) = N*l*l/(dx*dx) * dl        ! fractional area of plume n
-       ! Make updraft area (UPA) a function of the buoyancy flux
-!       acfac = .5*tanh((fltv - 0.03)/0.09) + .5
-!       acfac = .5*tanh((fltv - 0.02)/0.09) + .5 
-       acfac = .5*tanh((fltv - 0.01)/0.09) + .5
 
-       !add a windspeed-dependent adjustment to acfac that tapers off
-       !the mass-flux scheme linearly above sfc wind speeds of 20 m/s:
-       acfac = acfac*(1. - MIN(MAX(wspd_pbl - 20.0, 0.0), 10.0)/10.) 
-
-       UPA(1,I)=UPA(1,I)*acfac
+       UPA(1,I) = UPA(1,I)*acfac
        An2 = An2 + UPA(1,I)                 ! total fractional area of all plumes
        !print*," plume size=",l,"; area=",UPA(1,I),"; total=",An2
     end do
@@ -5643,7 +6165,7 @@ ENDIF
     pwmin=0.1       ! was 0.5
     pwmax=0.4       ! was 3.0
 
-    wstar=max(1.E-2,(g/thv(1)*fltv*pblh)**(1./3.))
+    wstar=max(1.E-2,(gtr*fltv2*pblh)**(onethird))
     qstar=max(flq,1.0E-5)/wstar
     thstar=flt/wstar
 
@@ -5653,24 +6175,27 @@ ENDIF
        csigma = 1.34   ! LAND
     ENDIF
 
-    IF (env_subs) THEN
+    if (env_subs) then
        exc_fac = 0.0
-    ELSE
-       exc_fac = 0.58
-    ENDIF
+    else
+       if ((landsea-1.5).GE.0) then
+         !water: increase factor to compensate for decreased pwmin/pwmax
+         exc_fac = 0.58*4.0*min(cloud_base/1000., 1.0)
+       else
+         !land: no need to increase factor - already sufficiently large superadiabatic layers
+         exc_fac = 0.58
+       endif
+    endif
 
     !Note: sigmaW is typically about 0.5*wstar
-    sigmaW =1.34*wstar*(z0/pblh)**(1./3.)*(1 - 0.8*z0/pblh)
-    sigmaQT=csigma*qstar*(z0/pblh)**(-1./3.)
-    sigmaTH=csigma*thstar*(z0/pblh)**(-1./3.)
+    sigmaW =csigma*wstar*(z0/pblh)**(onethird)*(1 - 0.8*z0/pblh)
+    sigmaQT=csigma*qstar*(z0/pblh)**(onethird)
+    sigmaTH=csigma*thstar*(z0/pblh)**(onethird)
 
     !Note: Given the pwmin & pwmax set above, these max/mins are
     !      rarely exceeded. 
-    wmin=MIN(sigmaW*pwmin,0.05)
-    wmax=MIN(sigmaW*pwmax,0.4)
-
-    !recompute acfac for plume excess
-    acfac = .5*tanh((fltv - 0.03)/0.07) + .5
+    wmin=MIN(sigmaW*pwmin,0.1)
+    wmax=MIN(sigmaW*pwmax,0.5)
 
     !SPECIFY SURFACE UPDRAFT PROPERTIES AT MODEL INTERFACE BETWEEN K = 1 & 2
     DO I=1,NUP !NUP2
@@ -5683,15 +6208,30 @@ ENDIF
 
        UPU(1,I)=(U(KTS)*DZ(KTS+1)+U(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
        UPV(1,I)=(V(KTS)*DZ(KTS+1)+V(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
-       UPQC(1,I)=0
+       UPQC(1,I)=0.0
        !UPQC(1,I)=(QC(KTS)*DZ(KTS+1)+QC(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
-       UPQT(1,I)=(QT(KTS)*DZ(KTS+1)+QT(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))&
-           &     +exc_fac*UPW(1,I)*sigmaQT/sigmaW       
+
+       exc_heat = exc_fac*UPW(1,I)*sigmaTH/sigmaW
        UPTHV(1,I)=(THV(KTS)*DZ(KTS+1)+THV(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1)) &
-           &     +exc_fac*UPW(1,I)*sigmaTH/sigmaW
+           &     + exc_heat
 !was       UPTHL(1,I)= UPTHV(1,I)/(1.+svp1*UPQT(1,I))  !assume no saturated parcel at surface
        UPTHL(1,I)=(THL(KTS)*DZ(KTS+1)+THL(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1)) &
-           &     +exc_fac*UPW(1,I)*sigmaTH/sigmaW
+           &     + exc_heat
+
+       !calculate exc_moist by use of surface fluxes
+       exc_moist=exc_fac*UPW(1,I)*sigmaQT/sigmaW
+       !calculate exc_moist by conserving rh:
+!       tk_int  =(tk(kts)*dz(kts+1)+tk(kts+1)*dz(kts))/(dz(kts+1)+dz(kts))
+!       pk      =(p(kts)*dz(kts+1)+p(kts+1)*dz(kts))/(dz(kts+1)+dz(kts))
+!       qtk     =(qt(kts)*dz(kts+1)+qt(kts+1)*dz(kts))/(dz(kts)+dz(kts+1))
+!       qsat_tk = qsat_blend(tk_int,  pk)    ! saturation water vapor mixing ratio at tk and p
+!       rhgrid  =MAX(MIN(1.0,qtk/MAX(1.E-8,qsat_tk)),0.001)
+!       tk_int  = tk_int + exc_heat
+!       qsat_tk = qsat_blend(tk_int,  pk) 
+!       exc_moist= max(rhgrid*qsat_tk - qtk, 0.0)
+       UPQT(1,I)=(QT(KTS)*DZ(KTS+1)+QT(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))&
+            &     +exc_moist
+
        UPQKE(1,I)=(QKE(KTS)*DZ(KTS+1)+QKE(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
        UPQNC(1,I)=(QNC(KTS)*DZ(KTS+1)+QNC(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
        UPQNI(1,I)=(QNI(KTS)*DZ(KTS+1)+QNI(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
@@ -5700,16 +6240,14 @@ ENDIF
        UPQNBCA(1,I)=(QNBCA(KTS)*DZ(KTS+1)+QNBCA(KTS+1)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
     ENDDO
 
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
+    IF ( mix_chem ) THEN
       DO I=1,NUP !NUP2
         IF(I > NUP2) exit
         do ic = 1,nchem
-          UPCHEM(1,I,ic)=(CHEM(KTS,ic)*DZ(KTS+1)+CHEM(KTS+1,ic)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
+          UPCHEM(1,I,ic)=(chem1(KTS,ic)*DZ(KTS+1)+chem1(KTS+1,ic)*DZ(KTS))/(DZ(KTS)+DZ(KTS+1))
         enddo
       ENDDO
     ENDIF
-#endif
 
     !Initialize environmental variables which can be modified by detrainment
     DO k=kts,kte
@@ -5720,23 +6258,30 @@ ENDIF
        envm_v(k)=V(k)
     ENDDO
 
-  !QCn = 0.
-  ! do integration  updraft
+    !dxsa is scale-adaptive factor governing the pressure-gradient term of the momentum transport
+    dxsa = 1. - MIN(MAX((12000.0-dx)/(12000.0-3000.0), 0.), 1.)
+
+    ! do integration  updraft
     DO I=1,NUP !NUP2
        IF(I > NUP2) exit
        QCn = 0.
        overshoot = 0
        l  = dl*I                            ! diameter of plume
        DO k=KTS+1,KTE-1
-          !w-dependency for entrainment a la Tian and Kuang (2016)
+          !Entrainment from Tian and Kuang (2016)
           !ENT(k,i) = 0.35/(MIN(MAX(UPW(K-1,I),0.75),1.9)*l)
           wmin = 0.3 + l*0.0005 !* MAX(pblh-ZW(k+1), 0.0)/pblh
-          ENT(k,i) = 0.31/(MIN(MAX(UPW(K-1,I),wmin),1.9)*l)
+          ENT(k,i) = 0.33/(MIN(MAX(UPW(K-1,I),wmin),0.9)*l)
+
           !Entrainment from Negggers (2015, JAMES)
           !ENT(k,i) = 0.02*l**-0.35 - 0.0009
+          !ENT(k,i) = 0.04*l**-0.50 - 0.0009   !more plume diversity
+          !ENT(k,i) = 0.04*l**-0.495 - 0.0009  !"neg1+"
+
           !Minimum background entrainment 
           ENT(k,i) = max(ENT(k,i),0.0003)
           !ENT(k,i) = max(ENT(k,i),0.05/ZW(k))  !not needed for Tian and Kuang
+
           !JOE - increase entrainment for plumes extending very high.
           IF(ZW(k) >= MIN(pblh+1500., 4000.))THEN
             ENT(k,i)=ENT(k,i) + (ZW(k)-MIN(pblh+1500.,4000.))*5.0E-6
@@ -5747,12 +6292,19 @@ ENDIF
 
           ENT(k,i) = min(ENT(k,i),0.9/(ZW(k+1)-ZW(k)))
 
+          ! Define environment U & V at the model interface levels
+          Uk  =(U(k)*DZ(k+1)+U(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
+          Ukm1=(U(k-1)*DZ(k)+U(k)*DZ(k-1))/(DZ(k-1)+DZ(k))
+          Vk  =(V(k)*DZ(k+1)+V(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
+          Vkm1=(V(k-1)*DZ(k)+V(k)*DZ(k-1))/(DZ(k-1)+DZ(k))
+
           ! Linear entrainment:
           EntExp= ENT(K,I)*(ZW(k+1)-ZW(k))
+          EntExm= EntExp*0.3333    !reduce entrainment for momentum
           QTn =UPQT(k-1,I) *(1.-EntExp) + QT(k)*EntExp
           THLn=UPTHL(k-1,I)*(1.-EntExp) + THL(k)*EntExp
-          Un  =UPU(k-1,I)  *(1.-EntExp) + U(k)*EntExp
-          Vn  =UPV(k-1,I)  *(1.-EntExp) + V(k)*EntExp
+          Un  =UPU(k-1,I)  *(1.-EntExm) + U(k)*EntExm + dxsa*pgfac*(Uk - Ukm1)
+          Vn  =UPV(k-1,I)  *(1.-EntExm) + V(k)*EntExm + dxsa*pgfac*(Vk - Vkm1)
           QKEn=UPQKE(k-1,I)*(1.-EntExp) + QKE(k)*EntExp
           QNCn=UPQNC(k-1,I)*(1.-EntExp) + QNC(k)*EntExp
           QNIn=UPQNI(k-1,I)*(1.-EntExp) + QNI(k)*EntExp
@@ -5774,16 +6326,14 @@ ENDIF
           !Vn  =V(K)  *(1-EntExp)+UPV(K-1,I)*EntExp
           !QKEn=QKE(k)*(1-EntExp)+UPQKE(K-1,I)*EntExp
 
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-          do ic = 1,nchem
-             ! Exponential Entrainment:
-             !chemn(ic) = chem(k,ic)*(1-EntExp)+UPCHEM(K-1,I,ic)*EntExp
-             ! Linear entrainment:
-             chemn(ic)=UPCHEM(k-1,i,ic)*(1.-EntExp) + chem(k,ic)*EntExp
-         enddo
-    ENDIF
-#endif
+          if ( mix_chem ) then
+            do ic = 1,nchem
+              ! Exponential Entrainment:
+              !chemn(ic) = chem(k,ic)*(1-EntExp)+UPCHEM(K-1,I,ic)*EntExp
+              ! Linear entrainment:
+              chemn(ic)=UPCHEM(k-1,i,ic)*(1.-EntExp) + chem1(k,ic)*EntExp
+            enddo
+          endif
 
           ! Define pressure at model interface
           Pk    =(P(k)*DZ(k+1)+P(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
@@ -5795,7 +6345,7 @@ ENDIF
           THVkm1=(THV(k-1)*DZ(k)+THV(k)*DZ(k-1))/(DZ(k-1)+DZ(k))
 
 !          B=g*(0.5*(THVn+UPTHV(k-1,I))/THV(k-1) - 1.0)
-          B=g*(THVn/THVk - 1.0)
+          B=grav*(THVn/THVk - 1.0)
           IF(B>0.)THEN
             BCOEFF = 0.15        !w typically stays < 2.5, so doesnt hit the limits nearly as much
           ELSE
@@ -5825,6 +6375,7 @@ ENDIF
              Wn = UPW(K-1,I) - MIN(1.25*(ZW(k)-ZW(k-1))/200., 2.0)
           ENDIF
           Wn = MIN(MAX(Wn,0.0), 3.0)
+
           !Check to make sure that the plume made it up at least one level.
           !if it failed, then set nup2=0 and exit the mass-flux portion.
           IF (k==kts+1 .AND. Wn == 0.) THEN
@@ -5843,7 +6394,6 @@ ENDIF
           ENDIF
 
           !Allow strongly forced plumes to overshoot if KE is sufficient
-          !IF (fltv > 0.05 .AND. Wn <= 0 .AND. overshoot == 0) THEN
           IF (Wn <= 0.0 .AND. overshoot == 0) THEN
              overshoot = 1
              IF ( THVk-THVkm1 .GT. 0.0 ) THEN
@@ -5853,21 +6403,15 @@ ENDIF
                 !IF ( Frz >= 0.5 ) Wn =  MIN(Frz,1.0)*UPW(K-1,I)
                 dzp = dz(k)*MAX(MIN(Frz,1.0),0.0) ! portion of highest layer the plume penetrates
              ENDIF
-          !ELSEIF (fltv > 0.05 .AND. overshoot == 1) THEN
           ELSE
              dzp = dz(k)
-          !   !Do not let overshooting parcel go more than 1 layer up
-          !   Wn = 0.0
           ENDIF
-          !print*,"k=",k," dzp=",dzp
 
           !Limit very tall plumes
-!          Wn2=Wn2*EXP(-MAX(ZW(k)-(pblh+2000.),0.0)/1000.)
-!          IF(ZW(k) >= pblh+3000.)Wn2=0.
           Wn=Wn*EXP(-MAX(ZW(k+1)-MIN(pblh+2000.,3500.),0.0)/1000.)
 
           !JOE- minimize the plume penetratration in stratocu-topped PBL
-   !       IF (fltv < 0.06) THEN
+   !       IF (fltv2 < 0.06) THEN
    !          IF(ZW(k+1) >= pblh-200. .AND. qc(k) > 1e-5 .AND. I > 4) Wn=0.
    !       ENDIF
 
@@ -5879,23 +6423,23 @@ ENDIF
           oow      = -0.060/MAX(1.0,(0.5*(Wn+UPW(K-1,I))))   !coef for dynamical detrainment rate
           detrate  = MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0002) ! dynamical detrainment rate (m^-1)
           detrateUV= MIN(MAX(oow*(Wn-UPW(K-1,I))/dz(k), detturb), .0001) ! dynamical detrainment rate (m^-1) 
-          envm_thl(k)=envm_thl(k) + (0.5*(thl_ent + UPTHL(K-1,I)) - thl(k))*detrate*aratio*MIN(dzp,300.)
+          envm_thl(k)=envm_thl(k) + (0.5*(thl_ent + UPTHL(K-1,I)) - thl(k))*detrate*aratio*MIN(dzp,dzpmax)
           qv_ent = 0.5*(MAX(qt_ent-qc_ent,0.) + MAX(UPQT(K-1,I)-UPQC(K-1,I),0.))
-          envm_sqv(k)=envm_sqv(k) + (qv_ent-QV(K))*detrate*aratio*MIN(dzp,300.)
+          envm_sqv(k)=envm_sqv(k) + (qv_ent-QV(K))*detrate*aratio*MIN(dzp,dzpmax)
           IF (UPQC(K-1,I) > 1E-8) THEN
              IF (QC(K) > 1E-6) THEN
                 qc_grid = QC(K)
              ELSE
                 qc_grid = cldfra_bl1d(k)*qc_bl1d(K)
              ENDIF
-             envm_sqc(k)=envm_sqc(k) + MAX(UPA(K-1,I)*0.5*(QCn + UPQC(K-1,I)) - qc_grid, 0.0)*detrate*aratio*MIN(dzp,300.)
+             envm_sqc(k)=envm_sqc(k) + MAX(UPA(K-1,I)*0.5*(QCn + UPQC(K-1,I)) - qc_grid, 0.0)*detrate*aratio*MIN(dzp,dzpmax)
           ENDIF
-          envm_u(k)  =envm_u(k)   + (0.5*(Un + UPU(K-1,I)) - U(K))*detrateUV*aratio*MIN(dzp,300.)
-          envm_v(k)  =envm_v(k)   + (0.5*(Vn + UPV(K-1,I)) - V(K))*detrateUV*aratio*MIN(dzp,300.)
+          envm_u(k)  =envm_u(k)   + (0.5*(Un + UPU(K-1,I)) - U(K))*detrateUV*aratio*MIN(dzp,dzpmax)
+          envm_v(k)  =envm_v(k)   + (0.5*(Vn + UPV(K-1,I)) - V(K))*detrateUV*aratio*MIN(dzp,dzpmax)
 
           IF (Wn > 0.) THEN
              !Update plume variables at current k index
-             UPW(K,I)=Wn  !Wn !sqrt(Wn2)
+             UPW(K,I)=Wn  !sqrt(Wn2)
              UPTHV(K,I)=THVn
              UPTHL(K,I)=THLn
              UPQT(K,I)=QTn
@@ -5909,13 +6453,11 @@ ENDIF
              UPQNIFA(K,I)=QNIFAn
              UPQNBCA(K,I)=QNBCAn
              UPA(K,I)=UPA(K-1,I)
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-             do ic = 1,nchem
-                UPCHEM(k,I,ic) = chemn(ic)
-             enddo
-    ENDIF
-#endif
+             IF ( mix_chem ) THEN
+               do ic = 1,nchem
+                 UPCHEM(k,I,ic) = chemn(ic)
+               enddo
+             ENDIF
              ktop = MAX(ktop,k)
           ELSE
              exit  !exit k-loop
@@ -5925,7 +6467,7 @@ ENDIF
           IF (MAXVAL(UPW(:,I)) > 10.0 .OR. MINVAL(UPA(:,I)) < 0.0 .OR. &
               MAXVAL(UPA(:,I)) > Atot .OR. NUP2 > 10) THEN
              ! surface values
-             print *,'flq:',flq,' fltv:',fltv,' Nup2=',Nup2
+             print *,'flq:',flq,' fltv:',fltv2,' Nup2=',Nup2
              print *,'pblh:',pblh,' wstar:',wstar,' ktop=',ktop
              print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
              ! means
@@ -5942,7 +6484,7 @@ ENDIF
     ENDDO
   ELSE
     !At least one of the conditions was not met for activating the MF scheme.
-    NUP2=0. 
+    NUP2=0.
   END IF !end criteria for mass-flux scheme
 
   ktop=MIN(ktop,KTE-1)  !  Just to be safe...
@@ -5956,48 +6498,58 @@ ENDIF
 
     !Calculate the fluxes for each variable
     !All s_aw* variable are == 0 at k=1
-    DO k=KTS,KTE
-      IF(k > KTOP) exit
-      DO i=1,NUP !NUP2
-        IF(I > NUP2) exit
-        s_aw(k+1)   = s_aw(k+1)    + UPA(K,i)*UPW(K,i)*Psig_w
-        s_awthl(k+1)= s_awthl(k+1) + UPA(K,i)*UPW(K,i)*UPTHL(K,i)*Psig_w
-        s_awqt(k+1) = s_awqt(k+1)  + UPA(K,i)*UPW(K,i)*UPQT(K,i)*Psig_w
-        s_awqc(k+1) = s_awqc(k+1)  + UPA(K,i)*UPW(K,i)*UPQC(K,i)*Psig_w
+    DO i=1,NUP !NUP2
+      IF(I > NUP2) exit
+      DO k=KTS,KTE-1
+        IF(k > ktop) exit
+        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
+        s_aw(k+1)   = s_aw(k+1)    + rho_int*UPA(K,i)*UPW(K,i)*Psig_w
+        s_awthl(k+1)= s_awthl(k+1) + rho_int*UPA(K,i)*UPW(K,i)*UPTHL(K,i)*Psig_w
+        s_awqt(k+1) = s_awqt(k+1)  + rho_int*UPA(K,i)*UPW(K,i)*UPQT(K,i)*Psig_w
+        !to conform to grid mean properties, move qc to qv in grid mean
+        !saturated layers, so total water fluxes are preserved but 
+        !negative qc fluxes in unsaturated layers is reduced.
+        IF (qc(k) > 1e-12 .OR. qc(k+1) > 1e-12) then
+          qc_plume = UPQC(K,i)
+        ELSE
+          qc_plume = 0.0
+        ENDIF
+        s_awqc(k+1) = s_awqc(k+1)  + rho_int*UPA(K,i)*UPW(K,i)*qc_plume*Psig_w
         IF (momentum_opt > 0) THEN
-          s_awu(k+1)  = s_awu(k+1)   + UPA(K,i)*UPW(K,i)*UPU(K,i)*Psig_w
-          s_awv(k+1)  = s_awv(k+1)   + UPA(K,i)*UPW(K,i)*UPV(K,i)*Psig_w
+          s_awu(k+1)  = s_awu(k+1)   + rho_int*UPA(K,i)*UPW(K,i)*UPU(K,i)*Psig_w
+          s_awv(k+1)  = s_awv(k+1)   + rho_int*UPA(K,i)*UPW(K,i)*UPV(K,i)*Psig_w
         ENDIF
         IF (tke_opt > 0) THEN
-          s_awqke(k+1)= s_awqke(k+1) + UPA(K,i)*UPW(K,i)*UPQKE(K,i)*Psig_w
+          s_awqke(k+1)= s_awqke(k+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQKE(K,i)*Psig_w
         ENDIF
+        s_awqv(k+1) = s_awqt(k+1)  - s_awqc(k+1)
       ENDDO
-      s_awqv(k+1) = s_awqt(k+1)  - s_awqc(k+1)
     ENDDO
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
+
+    IF ( mix_chem ) THEN
       DO k=KTS,KTE
         IF(k > KTOP) exit
+        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
         DO i=1,NUP !NUP2
           IF(I > NUP2) exit
           do ic = 1,nchem
-            s_awchem(k+1,ic) = s_awchem(k+1,ic) + UPA(K,i)*UPW(K,i)*UPCHEM(K,i,ic)*Psig_w
+            s_awchem(k+1,ic) = s_awchem(k+1,ic) + rho_int*UPA(K,i)*UPW(K,i)*UPCHEM(K,i,ic)*Psig_w
           enddo
         ENDDO
       ENDDO
     ENDIF
-#endif
 
     IF (scalar_opt > 0) THEN
       DO k=KTS,KTE
         IF(k > KTOP) exit
+        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
         DO I=1,NUP !NUP2
           IF (I > NUP2) exit
-          s_awqnc(k+1)= s_awqnc(K+1) + UPA(K,i)*UPW(K,i)*UPQNC(K,i)*Psig_w
-          s_awqni(k+1)= s_awqni(K+1) + UPA(K,i)*UPW(K,i)*UPQNI(K,i)*Psig_w
-          s_awqnwfa(k+1)= s_awqnwfa(K+1) + UPA(K,i)*UPW(K,i)*UPQNWFA(K,i)*Psig_w
-          s_awqnifa(k+1)= s_awqnifa(K+1) + UPA(K,i)*UPW(K,i)*UPQNIFA(K,i)*Psig_w
-          s_awqnbca(k+1)= s_awqnbca(K+1) + UPA(K,i)*UPW(K,i)*UPQNBCA(K,i)*Psig_w
+          s_awqnc(k+1)= s_awqnc(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNC(K,i)*Psig_w
+          s_awqni(k+1)= s_awqni(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNI(K,i)*Psig_w
+          s_awqnwfa(k+1)= s_awqnwfa(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNWFA(K,i)*Psig_w
+          s_awqnifa(k+1)= s_awqnifa(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNIFA(K,i)*Psig_w
+          s_awqnbca(k+1)= s_awqnbca(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNBCA(K,i)*Psig_w
         ENDDO
       ENDDO
     ENDIF
@@ -6035,11 +6587,9 @@ ENDIF
        IF (tke_opt > 0) THEN
           s_awqke= s_awqke*adjustment
        ENDIF
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-       s_awchem = s_awchem*adjustment
-    ENDIF
-#endif
+       IF ( mix_chem ) THEN
+          s_awchem = s_awchem*adjustment
+       ENDIF
        UPA = UPA*adjustment
     ENDIF
     !Print*,"adjustment=",adjustment," fluxportion=",fluxportion," flt=",flt
@@ -6048,21 +6598,15 @@ ENDIF
     !all edmf_* variables at k=1 correspond to the interface at top of first model layer
     DO k=KTS,KTE-1
       IF(k > KTOP) exit
+      rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
       DO I=1,NUP !NUP2
         IF(I > NUP2) exit
         edmf_a(K)  =edmf_a(K)  +UPA(K,i)
-        edmf_w(K)  =edmf_w(K)  +UPA(K,i)*UPW(K,i)
-        edmf_qt(K) =edmf_qt(K) +UPA(K,i)*UPQT(K,i)
-        edmf_thl(K)=edmf_thl(K)+UPA(K,i)*UPTHL(K,i)
-        edmf_ent(K)=edmf_ent(K)+UPA(K,i)*ENT(K,i)
-        edmf_qc(K) =edmf_qc(K) +UPA(K,i)*UPQC(K,i)
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-        do ic = 1,nchem
-          edmf_chem(k,ic) = edmf_chem(k,ic) + UPA(K,I)*UPCHEM(k,i,ic)
-        enddo
-    ENDIF
-#endif
+        edmf_w(K)  =edmf_w(K)  +rho_int*UPA(K,i)*UPW(K,i)
+        edmf_qt(K) =edmf_qt(K) +rho_int*UPA(K,i)*UPQT(K,i)
+        edmf_thl(K)=edmf_thl(K)+rho_int*UPA(K,i)*UPTHL(K,i)
+        edmf_ent(K)=edmf_ent(K)+rho_int*UPA(K,i)*ENT(K,i)
+        edmf_qc(K) =edmf_qc(K) +rho_int*UPA(K,i)*UPQC(K,i)
       ENDDO
 
       !Note that only edmf_a is multiplied by Psig_w. This takes care of the
@@ -6073,18 +6617,32 @@ ENDIF
         edmf_thl(k)=edmf_thl(k)/edmf_a(k)
         edmf_ent(k)=edmf_ent(k)/edmf_a(k)
         edmf_qc(k)=edmf_qc(k)/edmf_a(k)
-#if (WRF_CHEM == 1)
-    IF (bl_mynn_mixchem == 1) THEN
-        do ic = 1,nchem
-          edmf_chem(k,ic) = edmf_chem(k,ic)/edmf_a(k)
-        enddo
-    ENDIF
-#endif
         edmf_a(k)=edmf_a(k)*Psig_w
+
         !FIND MAXIMUM MASS-FLUX IN THE COLUMN:
         IF(edmf_a(k)*edmf_w(k) > maxmf) maxmf = edmf_a(k)*edmf_w(k)
       ENDIF
-    ENDDO
+    ENDDO ! end k
+
+    !smoke/chem
+    IF ( mix_chem ) THEN
+      DO k=KTS,KTE-1
+        IF(k > KTOP) exit
+        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
+        DO I=1,NUP !NUP2
+          IF(I > NUP2) exit
+          do ic = 1,nchem
+            edmf_chem(k,ic) = edmf_chem(k,ic) + rho_int*UPA(K,I)*UPCHEM(k,i,ic)
+          enddo
+        ENDDO
+
+        IF (edmf_a(k)>0.) THEN
+          do ic = 1,nchem
+            edmf_chem(k,ic) = edmf_chem(k,ic)/edmf_a(k)
+          enddo
+        ENDIF
+      ENDDO ! end k
+    ENDIF
 
     !Calculate the effects environmental subsidence.
      !All envi_*variables are valid at the interfaces, like the edmf_* variables
@@ -6138,6 +6696,7 @@ ENDIF
           det_sqv(k)=Cdet*(envm_sqv(k)-qv(k))*envi_a(k)*Psig_w
           det_sqc(k)=Cdet*(envm_sqc(k)-qc(k))*envi_a(k)*Psig_w
        ENDDO
+
        IF (momentum_opt > 0) THEN
          sub_u(kts)=0.5*envi_w(kts)*envi_a(kts)*(u(kts+1)-u(kts))/dzi(kts)
          sub_v(kts)=0.5*envi_w(kts)*envi_a(kts)*(v(kts+1)-v(kts))/dzi(kts)
@@ -6168,44 +6727,38 @@ ENDIF
 !     mym_condensation. Here, a shallow-cu component is added, but no cumulus
 !     clouds can be added at k=1 (start loop at k=2).  
     DO K=KTS+1,KTE-2
-        IF(k > KTOP) exit
-        IF(0.5*(edmf_qc(k)+edmf_qc(k-1))>0.0)THEN
-
-            satvp = 3.80*exp(17.27*(th(k)-273.)/ &
-                   (th(k)-36.))/(.01*p(k))
-            rhgrid = max(.01,MIN( 1., qv(k) /satvp))
-
-            !then interpolate plume thl, th, and qt to mass levels
+       IF(k > KTOP) exit
+         IF(0.5*(edmf_qc(k)+edmf_qc(k-1))>0.0)THEN
+            !interpolate plume quantities to mass levels
+            Aup = (edmf_a(k)*dzi(k-1)+edmf_a(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
             THp = (edmf_th(k)*dzi(k-1)+edmf_th(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
             QTp = (edmf_qt(k)*dzi(k-1)+edmf_qt(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
             !convert TH to T
-            t = THp*exner(k)
+!            t = THp*exner(k)
             !SATURATED VAPOR PRESSURE
-            esat = esat_blend(t)
+            esat = esat_blend(tk(k))
             !SATURATED SPECIFIC HUMIDITY
-            qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat)) 
+            qsl=ep_2*esat/max(1.e-7,(p(k)-ep_3*esat)) 
 
             !condensed liquid in the plume on mass levels
             IF (edmf_qc(k)>0.0 .AND. edmf_qc(k-1)>0.0)THEN
-              QCp = 0.5*(edmf_qc(k)+edmf_qc(k-1))
+              QCp = (edmf_qc(k)*dzi(k-1)+edmf_qc(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
             ELSE
-              QCp = MAX(0.0, QTp-qsl)
+              QCp = MAX(edmf_qc(k),edmf_qc(k-1))
             ENDIF
 
             !COMPUTE CLDFRA & QC_BL FROM MASS-FLUX SCHEME and recompute vt & vq
-
-            xl = xl_blend(tk(k))                ! obtain blended heat capacity 
-            tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
-            qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
-                                                !   at tl and p
-            rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
+            xl = xl_blend(tk(k))                ! obtain blended heat capacity
+            qsat_tk = qsat_blend(tk(k),p(k))    ! get saturation water vapor mixing ratio
+                                                !   at t and p
+            rsl = xl*qsat_tk / (r_v*tk(k)**2)   ! slope of C-C curve at t (abs temp)
                                                 ! CB02, Eqn. 4
             cpm = cp + qt(k)*cpv                ! CB02, sec. 2, para. 1
             a   = 1./(1. + xl*rsl/cpm)          ! CB02 variable "a"
             b9  = a*rsl                         ! CB02 variable "b" 
 
             q2p  = xlvcp/exner(k)
-            pt = thl(k) +q2p*QCp*0.5*(edmf_a(k)+edmf_a(k-1)) ! potential temp (env + plume)
+            pt = thl(k) +q2p*QCp*Aup ! potential temp (env + plume)
             bb = b9*tk(k)/pt ! bb is "b9" in BCMT95.  Their "b9" differs from
                            ! "b9" in CB02 by a factor
                            ! of T/theta.  Strictly, b9 above is formulated in
@@ -6214,8 +6767,7 @@ ENDIF
                            ! conversion is neglected here.
             qww   = 1.+0.61*qt(k)
             alpha = 0.61*pt
-            t     = TH(k)*exner(k)
-            beta  = pt*xl/(t*cp) - 1.61*pt
+            beta  = pt*xl/(tk(k)*cp) - 1.61*pt
             !Buoyancy flux terms have been moved to the end of this section...
 
             !Now calculate convective component of the cloud fraction:
@@ -6224,79 +6776,111 @@ ENDIF
             else
                f = 1.0
             endif
-            sigq = 9.E-3 * 0.5*(edmf_a(k)+edmf_a(k-1)) * &
-               &           0.5*(edmf_w(k)+edmf_w(k-1)) * f       ! convective component of sigma (CB2005)
-            !sigq = MAX(sigq, 1.0E-4)
-            sigq = SQRT(sigq**2 + sgm(k)**2)    ! combined conv + stratus components
 
-            qmq = a * (qt(k) - qsat_tl)           ! saturation deficit/excess;
-                                                !   the numerator of Q1
-            mf_cf = min(max(0.5 + 0.36 * atan(1.55*(qmq/sigq)),0.01),0.6)
-            IF ( debug_code ) THEN
-               print*,"In MYNN, StEM edmf"
-               print*,"  CB: env qt=",qt(k)," qsat=",qsat_tl
-               print*,"      satdef=",QTp - qsat_tl
-               print*,"  CB: sigq=",sigq," qmq=",qmq," tlk=",tlk
-               print*,"  CB: mf_cf=",mf_cf," cldfra_bl=",cldfra_bl1d(k)," edmf_a=",edmf_a(k)
-            ENDIF
+            !CB form:
+            !sigq = 3.5E-3 * Aup * 0.5*(edmf_w(k)+edmf_w(k-1)) * f  ! convective component of sigma (CB2005)
+            !sigq = SQRT(sigq**2 + sgm(k)**2)    ! combined conv + stratus components
+
+            !Per S.DeRoode 2009?
+            !sigq = 4. * Aup * (QTp - qt(k))
+            sigq = 10. * Aup * (QTp - qt(k)) 
+            !constrain sigq wrt saturation:
+            sigq = max(sigq, qsat_tk*0.02 )
+            sigq = min(sigq, qsat_tk*0.25 )
+
+            qmq = a * (qt(k) - qsat_tk)           ! saturation deficit/excess;
+            Q1  = qmq/sigq                        !   the numerator of Q1
+
+            if ((landsea-1.5).GE.0) then      ! WATER
+               !LES with adjustment
+               !mf_cf = min(max(0.5 + 0.36 * atan(1.20*(Q1+0.2)),0.01),0.6)
+               !Original CB
+               mf_cf = min(max(0.5 + 0.36 * atan(1.55*Q1),0.01),0.6)
+               mf_cf = max(mf_cf, 1.2 * Aup)
+               mf_cf = min(mf_cf, 5.0 * Aup)
+            else                              ! LAND
+               !LES form
+               !mf_cf = min(max(0.5 + 0.36 * atan(1.20*(Q1+0.4)),0.01),0.6)
+               !Original CB
+               mf_cf = min(max(0.5 + 0.36 * atan(1.55*Q1),0.01),0.6)
+               mf_cf = max(mf_cf, 1.75 * Aup)
+               mf_cf = min(mf_cf, 5.0  * Aup)
+            endif
+
+            ! WA TEST 4/15/22 use fit to Aup rather than CB
+            !IF (Aup > 0.1) THEN
+            !   mf_cf = 2.5 * Aup
+            !ELSE
+            !   mf_cf = 1.8 * Aup
+            !ENDIF
+
+            !IF ( debug_code ) THEN
+            !   print*,"In MYNN, StEM edmf"
+            !   print*,"  CB: env qt=",qt(k)," qsat=",qsat_tk
+            !   print*,"  k=",k," satdef=",QTp - qsat_tk," sgm=",sgm(k)
+            !   print*,"  CB: sigq=",sigq," qmq=",qmq," tk=",tk(k)
+            !   print*,"  CB: mf_cf=",mf_cf," cldfra_bl=",cldfra_bl1d(k)," edmf_a=",edmf_a(k)
+            !ENDIF
 
             ! Update cloud fractions and specific humidities in grid cells
-            ! where the mass-flux scheme is active. Now, we also use the
-            ! stratus component of the SGS clouds as well. The stratus cloud 
-            ! fractions (Ac_strat) are reduced slightly to give way to the 
-            ! mass-flux SGS cloud fractions (Ac_mf).
-            IF (cldfra_bl1d(k) < 0.5) THEN
-               IF (mf_cf > 0.5*(edmf_a(k)+edmf_a(k-1))) THEN
-                  !cldfra_bl1d(k) = mf_cf
-                  !qc_bl1d(k) = QCp*0.5*(edmf_a(k)+edmf_a(k-1))/mf_cf
-                  Ac_mf      = mf_cf
-                  Ac_strat   = cldfra_bl1d(k)*(1.0-mf_cf)
-                  cldfra_bl1d(k) = Ac_mf + Ac_strat
-                  !dillute Qc from updraft area to larger cloud area
-                  qc_mf      = QCp*0.5*(edmf_a(k)+edmf_a(k-1))/mf_cf
-                  !The mixing ratios from the stratus component are not well
-                  !estimated in shallow-cumulus regimes. Ensure stratus clouds 
-                  !have mixing ratio similar to cumulus
-                  QCs        = MIN(MAX(qc_bl1d(k), 0.5*qc_mf), 5E-4)
-                  qc_bl1d(k) = (qc_mf*Ac_mf + QCs*Ac_strat)/cldfra_bl1d(k)
-               ELSE
-                  !cldfra_bl1d(k)=0.5*(edmf_a(k)+edmf_a(k-1))
-                  !qc_bl1d(k) = QCp
-                  Ac_mf      = 0.5*(edmf_a(k)+edmf_a(k-1))
-                  Ac_strat   = cldfra_bl1d(k)*(1.0-Ac_mf)
-                  cldfra_bl1d(k)=Ac_mf + Ac_strat
-                  qc_mf      = QCp
-                  !Ensure stratus clouds have mixing ratio similar to cumulus
-                  QCs        = MIN(MAX(qc_bl1d(k), 0.5*qc_mf), 5E-4)
-                  qc_bl1d(k) = (QCp*Ac_mf + QCs*Ac_strat)/cldfra_bl1d(k)
-               ENDIF
-            ELSE
-               Ac_mf = mf_cf
-            ENDIF
+            ! where the mass-flux scheme is active. The specific humidities
+            ! are converted to grid means (not in-cloud quantities).
+
+            if ((landsea-1.5).GE.0) then     ! water
+               !don't overwrite stratus CF & qc_bl - degrades marine stratus
+               if (cldfra_bl1d(k) < cf_thresh) then
+                  if (QCp * Aup > 5e-5) then
+                     qc_bl1d(k) = 1.86 * (QCp * Aup) - 2.2e-5
+                  else
+                     qc_bl1d(k) = 1.18 * (QCp * Aup)
+                  endif
+                  if (mf_cf .ge. Aup) then
+                    qc_bl1d(k) = qc_bl1d(k) / mf_cf
+                  endif
+                  cldfra_bl1d(k) = mf_cf
+                  Ac_mf          = mf_cf
+               endif
+            else                             ! land
+               if (QCp * Aup > 5e-5) then
+                  qc_bl1d(k) = 1.86 * (QCp * Aup) - 2.2e-5
+               else
+                  qc_bl1d(k) = 1.18 * (QCp * Aup)
+               endif
+               if (mf_cf .ge. Aup) then
+                  qc_bl1d(k) = qc_bl1d(k) / mf_cf
+               endif
+               cldfra_bl1d(k) = mf_cf
+               Ac_mf          = mf_cf
+            endif
 
             !Now recalculate the terms for the buoyancy flux for mass-flux clouds:
-            !See mym_condensation for details on these formulations.  The
-            !cloud-fraction bounding was added to improve cloud retention,
-            !following RAP and HRRR testing.
-            !Fng = 2.05 ! the non-Gaussian transport factor (assumed constant)
-            !Use Bechtold and Siebesma (1998) piecewise estimation of Fng:
-            Q1 = qmq/MAX(sigq,1E-10)
-            Q1=MAX(Q1,-5.0)
-            IF (Q1 .GE. 1.0) THEN
-               Fng = 1.0
-            ELSEIF (Q1 .GE. -1.7 .AND. Q1 < 1.0) THEN
-               Fng = EXP(-0.4*(Q1-1.0))
-            ELSEIF (Q1 .GE. -2.5 .AND. Q1 .LT. -1.7) THEN
-               Fng = 3.0 + EXP(-3.8*(Q1+1.7))
-            ELSE
-               Fng = MIN(23.9 + EXP(-1.6*(Q1+2.5)), 60.)
-            ENDIF
+            !See mym_condensation for details on these formulations.
+            !Use Bechtold and Siebesma (1998) piecewise estimation of Fng with 
+            !limits ,since they really should be recalculated after all the other changes...:
+            !Only overwrite vt & vq in non-stratus condition
+            if (cldfra_bl1d(k) < cf_thresh) then
+               !if ((landsea-1.5).GE.0) then      ! WATER
+                  Q1=max(Q1,-2.25)
+               !else
+               !   Q1=max(Q1,-2.0)
+               !endif
 
-            vt(k) = qww   - MIN(0.40,Ac_mf)*beta*bb*Fng - 1.
-            vq(k) = alpha + MIN(0.40,Ac_mf)*beta*a*Fng  - tv0
-         ENDIF
+               if (Q1 .ge. 1.0) then
+                  Fng = 1.0
+               elseif (Q1 .ge. -1.7 .and. Q1 .lt. 1.0) then
+                  Fng = EXP(-0.4*(Q1-1.0))
+               elseif (Q1 .ge. -2.5 .and. Q1 .lt. -1.7) then
+                  Fng = 3.0 + EXP(-3.8*(Q1+1.7))
+               else
+                  Fng = min(23.9 + EXP(-1.6*(Q1+2.5)), 60.)
+               endif
 
-      ENDDO
+               !link the buoyancy flux function to active clouds only (c*Aup):
+               vt(k) = qww   - (1.5*Aup)*beta*bb*Fng - 1.
+               vq(k) = alpha + (1.5*Aup)*beta*a*Fng  - tv0
+            endif
+         endif
+      enddo !k-loop
 
     ENDIF  !end nup2 > 0
 
@@ -6311,7 +6895,7 @@ ENDIF
 !
 IF (edmf_w(1) > 4.0) THEN 
 ! surface values
-    print *,'flq:',flq,' fltv:',fltv
+    print *,'flq:',flq,' fltv:',fltv2
     print *,'pblh:',pblh,' wstar:',wstar
     print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
 ! means
@@ -6356,7 +6940,8 @@ ENDIF !END Debugging
 
 END SUBROUTINE DMP_MF
 !=================================================================
-
+!>\ingroup gsd_mynn_edmf
+!! This subroutine 
 subroutine condensation_edmf(QT,THL,P,zagl,THV,QC)
 !
 ! zero or one condensation for edmf: calculates THV and QC
@@ -6373,17 +6958,17 @@ real :: diff,exn,t,th,qs,qcold
 ! rcp ... Rd/cp
 ! xlv ... latent heat for water (2.5e6)
 ! cp
-! rvord .. rv/rd  (1.6) 
+! rvord .. r_v/r_d  (1.6) 
 
 ! number of iterations
   niter=50
 ! minimum difference (usually converges in < 8 iterations with diff = 2e-5)
-  diff=2.e-5
+  diff=1.e-6
 
   EXN=(P/p1000mb)**rcp
   !QC=0.  !better first guess QC is incoming from lower level, do not set to zero
   do i=1,NITER
-     T=EXN*THL + xlvcp*QC        
+     T=EXN*THL + xlvcp*QC
      QS=qsat_blend(T,P)
      QCOLD=QC
      QC=0.5*QC + 0.5*MAX((QT-QS),0.)
@@ -6417,6 +7002,408 @@ real :: diff,exn,t,th,qs,qcold
 end subroutine condensation_edmf
 
 !===============================================================
+
+subroutine condensation_edmf_r(QT,THL,P,zagl,THV,QC)
+!                                                                                                
+! zero or one condensation for edmf: calculates THL and QC                                       
+! similar to condensation_edmf but with different inputs                                         
+!                                                                                                
+real,intent(in)   :: QT,THV,P,zagl
+real,intent(out)  :: THL, QC
+
+integer :: niter,i
+real :: diff,exn,t,th,qs,qcold
+
+! number of iterations                                                                           
+  niter=50
+! minimum difference                                                                             
+  diff=2.e-5
+
+  EXN=(P/p1000mb)**rcp
+  ! assume first that th = thv                                                                   
+  T = THV*EXN
+  !QS = qsat_blend(T,P)                                                                          
+  !QC = QS - QT                                                                                  
+
+  QC=0.
+
+  do i=1,NITER
+     QCOLD = QC
+     T = EXN*THV/(1.+QT*(rvovrd-1.)-rvovrd*QC)
+     QS=qsat_blend(T,P)
+     QC= MAX((QT-QS),0.)
+     if (abs(QC-QCOLD)<Diff) exit
+  enddo
+  THL = (T - xlv/cp*QC)/EXN
+
+end subroutine condensation_edmf_r
+
+!===============================================================
+! ===================================================================
+! This is the downdraft mass flux scheme - analogus to edmf_JPL but  
+! flipped updraft to downdraft. This scheme is currently only tested 
+! for Stratocumulus cloud conditions. For a detailed desctiption of the
+! model, see paper.
+
+SUBROUTINE DDMF_JPL(kts,kte,dt,zw,dz,p,              &
+              &u,v,th,thl,thv,tk,qt,qv,qc,           &
+              &rho,exner,                            &
+              &ust,wthl,wqt,pblh,kpbl,               &
+              &edmf_a_dd,edmf_w_dd, edmf_qt_dd,      &
+              &edmf_thl_dd,edmf_ent_dd,edmf_qc_dd,   &
+              &sd_aw,sd_awthl,sd_awqt,               &
+              &sd_awqv,sd_awqc,sd_awu,sd_awv,        &
+              &sd_awqke,                             &
+              &qc_bl1d,cldfra_bl1d,                  &
+              &rthraten                              )
+
+        INTEGER, INTENT(IN) :: KTS,KTE,KPBL
+        REAL,DIMENSION(KTS:KTE), INTENT(IN) :: U,V,TH,THL,TK,QT,QV,QC,&
+            THV,P,rho,exner,rthraten,dz
+        ! zw .. heights of the downdraft levels (edges of boxes)
+        REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: ZW
+        REAL, INTENT(IN) :: DT,UST,WTHL,WQT,PBLH
+
+  ! outputs - downdraft properties
+        REAL,DIMENSION(KTS:KTE), INTENT(OUT) :: edmf_a_dd,edmf_w_dd,   &
+                      & edmf_qt_dd,edmf_thl_dd, edmf_ent_dd,edmf_qc_dd
+
+  ! outputs - variables needed for solver (sd_aw - sum ai*wi, sd_awphi - sum ai*wi*phii)
+        REAL,DIMENSION(KTS:KTE+1) :: sd_aw, sd_awthl, sd_awqt, sd_awu, &
+                            sd_awv, sd_awqc, sd_awqv, sd_awqke, sd_aw2
+
+        REAL,DIMENSION(KTS:KTE), INTENT(IN) :: qc_bl1d, cldfra_bl1d
+
+        INTEGER, PARAMETER :: NDOWN=5, debug_mf=0 !fixing number of plumes to 5
+  ! draw downdraft starting height randomly between cloud base and cloud top
+        INTEGER, DIMENSION(1:NDOWN) :: DD_initK
+        REAL   , DIMENSION(1:NDOWN) :: randNum
+  ! downdraft properties
+        REAL,DIMENSION(KTS:KTE+1,1:NDOWN) :: DOWNW,DOWNTHL,DOWNQT,&
+                    DOWNQC,DOWNA,DOWNU,DOWNV,DOWNTHV
+
+  ! entrainment variables
+        REAl,DIMENSION(KTS+1:KTE+1,1:NDOWN) :: ENT,ENTf
+        INTEGER,DIMENSION(KTS+1:KTE+1,1:NDOWN) :: ENTi
+
+  ! internal variables
+        INTEGER :: K,I,ki, kminrad, qlTop, p700_ind, qlBase
+        REAL :: wthv,wstar,qstar,thstar,sigmaW,sigmaQT,sigmaTH,z0, &
+            pwmin,pwmax,wmin,wmax,wlv,wtv,went,mindownw
+        REAL :: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,Wn2,Wn,THVk,Pk, &
+                EntEXP,EntW, Beta_dm, EntExp_M, rho_int
+        REAL :: jump_thetav, jump_qt, jump_thetal, &
+                refTHL, refTHV, refQT
+  ! DD specific internal variables
+        REAL :: minrad,zminrad, radflux, F0, wst_rad, wst_dd
+        logical :: cloudflg
+
+        REAL :: sigq,xl,rsl,cpm,a,mf_cf,diffqt,&
+               Fng,qww,alpha,beta,bb,f,pt,t,q2p,b9,satvp,rhgrid
+
+  ! w parameters
+        REAL,PARAMETER :: &
+            &Wa=1., &
+            &Wb=1.5,&
+            &Z00=100.,&
+            &BCOEFF=0.2
+  ! entrainment parameters
+        REAL,PARAMETER :: &
+        & L0=80,&
+        & ENT0=0.2
+
+   pwmin=-3. ! drawing from the negative tail -3sigma to -1sigma
+   pwmax=-1.
+
+  ! initialize downdraft properties
+   DOWNW=0.
+   DOWNTHL=0.
+   DOWNTHV=0.
+   DOWNQT=0.
+   DOWNA=0.
+   DOWNU=0.
+   DOWNV=0.
+   DOWNQC=0.
+   ENT=0.
+   DD_initK=0
+
+   edmf_a_dd  =0.
+   edmf_w_dd  =0.
+   edmf_qt_dd =0.
+   edmf_thl_dd=0.
+   edmf_ent_dd=0.
+   edmf_qc_dd =0.
+
+   sd_aw=0.
+   sd_awthl=0.
+   sd_awqt=0.
+   sd_awqv=0.
+   sd_awqc=0.
+   sd_awu=0.
+   sd_awv=0.
+   sd_awqke=0.
+
+  ! FIRST, CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
+   cloudflg=.false.
+   minrad=100.
+   kminrad=kpbl
+   zminrad=PBLH
+   qlTop = 1 !initialize at 0
+   qlBase = 1
+   wthv=wthl+svp1*wqt
+   do k = MAX(3,kpbl-2),kpbl+3
+      if (qc(k).gt. 1.e-6 .AND. cldfra_bl1D(k).gt.0.5) then
+          cloudflg=.true. ! found Sc cloud
+          qlTop = k       ! index for Sc cloud top
+      endif
+   enddo
+
+   do k = qlTop, kts, -1
+      if (qc(k) .gt. 1E-6) then
+         qlBase = k ! index for Sc cloud base
+      endif
+   enddo
+   qlBase = (qlTop+qlBase)/2 ! changed base to half way through the cloud
+
+!   call init_random_seed_1()
+!   call RANDOM_NUMBER(randNum)
+   do i=1,NDOWN
+      ! downdraft starts somewhere between cloud base to cloud top
+      ! the probability is equally distributed
+      DD_initK(i) = qlTop ! nint(randNum(i)*REAL(qlTop-qlBase)) + qlBase
+   enddo
+
+   ! LOOP RADFLUX
+   F0 = 0.
+   do k = 1, qlTop ! Snippet from YSU, YSU loops until qlTop - 1
+      radflux = rthraten(k) * exner(k) ! Converts theta/s to temperature/s
+      radflux = radflux * cp / grav * ( p(k) - p(k+1) ) ! Converts K/s to W/m^2
+      if ( radflux < 0.0 ) F0 = abs(radflux) + F0
+   enddo
+   F0 = max(F0, 1.0)
+   !found Sc cloud and cloud not at surface, trigger downdraft
+   if (cloudflg) then
+
+!      !get entrainent coefficient
+!      do i=1,NDOWN
+!         do k=kts+1,kte
+!            ENTf(k,i)=(ZW(k+1)-ZW(k))/L0
+!         enddo
+!      enddo
+!
+!      ! get Poisson P(dz/L0)
+!      call Poisson(1,NDOWN,kts+1,kte,ENTf,ENTi)
+
+
+      ! entrainent: Ent=Ent0/dz*P(dz/L0)
+      do i=1,NDOWN
+         do k=kts+1,kte
+!            ENT(k,i)=real(ENTi(k,i))*Ent0/(ZW(k+1)-ZW(k))
+            ENT(k,i) = 0.002
+            ENT(k,i) = min(ENT(k,i),0.9/(ZW(k+1)-ZW(k)))
+         enddo
+      enddo
+
+      !!![EW: INVJUMP] find 700mb height then subtract trpospheric lapse rate!!!
+      p700_ind = MINLOC(ABS(p-70000),1)!p1D is 70000
+      jump_thetav = thv(p700_ind) - thv(1) - (thv(p700_ind)-thv(qlTop+3))/(ZW(p700_ind)-ZW(qlTop+3))*(ZW(p700_ind)-ZW(qlTop))
+      jump_qt = qc(p700_ind) + qv(p700_ind) - qc(1) - qv(1)
+      jump_thetal = thl(p700_ind) - thl(1) - (thl(p700_ind)-thl(qlTop+3))/(ZW(p700_ind)-ZW(qlTop+3))*(ZW(p700_ind)-ZW(qlTop))
+
+      refTHL = thl(qlTop) !sum(thl(1:qlTop)) / (qlTop) ! avg over BL for now or just at qlTop
+      refTHV = thv(qlTop) !sum(thv(1:qlTop)) / (qlTop)
+      refQT  = qt(qlTop)  !sum(qt(1:qlTop))  / (qlTop)
+
+      ! wstar_rad, following Lock and MacVean (1999a)
+      wst_rad = ( grav * zw(qlTop) * F0 / (refTHL * rho(qlTop) * cp) ) ** (0.333)
+      wst_rad = max(wst_rad, 0.1)
+      wstar   = max(0.,(grav/thv(1)*wthv*pblh)**(onethird))
+      went    = thv(1) / ( grav * jump_thetav * zw(qlTop) ) * &
+                (0.15 * (wstar**3 + 5*ust**3) + 0.35 * wst_rad**3 )
+      qstar  = abs(went*jump_qt/wst_rad)
+      thstar = F0/rho(qlTop)/cp/wst_rad - went*jump_thetav/wst_rad
+      !wstar_dd = mixrad + surface wst
+      wst_dd = (0.15 * (wstar**3 + 5*ust**3) + 0.35 * wst_rad**3 ) ** (0.333)
+
+      print*,"qstar=",qstar," thstar=",thstar," wst_dd=",wst_dd
+      print*,"F0=",F0," wst_rad=",wst_rad," jump_thv=",jump_thetav
+      print*,"entrainment velocity=",went
+
+      sigmaW  = 0.2*wst_dd  ! 0.8*wst_dd !wst_rad tuning parameter ! 0.5 was good
+      sigmaQT = 40  * qstar ! 50 was good
+      sigmaTH = 1.0 * thstar! 0.5 was good
+
+      wmin=sigmaW*pwmin
+      wmax=sigmaW*pwmax
+      !print*,"sigw=",sigmaW," wmin=",wmin," wmax=",wmax
+
+      do I=1,NDOWN !downdraft now starts at different height
+         ki = DD_initK(I)
+
+         wlv=wmin+(wmax-wmin)/REAL(NDOWN)*(i-1)
+         wtv=wmin+(wmax-wmin)/REAL(NDOWN)*i
+
+         !DOWNW(ki,I)=0.5*(wlv+wtv)
+         DOWNW(ki,I)=wlv
+         !DOWNA(ki,I)=0.5*ERF(wtv/(sqrt(2.)*sigmaW))-0.5*ERF(wlv/(sqrt(2.)*sigmaW))
+         DOWNA(ki,I)=.1/REAL(NDOWN)
+         DOWNU(ki,I)=(u(ki-1)*DZ(ki) + u(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
+         DOWNV(ki,I)=(v(ki-1)*DZ(ki) + v(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
+
+         !reference now depends on where dd starts
+!         refTHL = 0.5 * (thl(ki) + thl(ki-1))
+!         refTHV = 0.5 * (thv(ki) + thv(ki-1))
+!         refQT  = 0.5 * (qt(ki)  + qt(ki-1) )
+
+         refTHL = (thl(ki-1)*DZ(ki) + thl(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
+         refTHV = (thv(ki-1)*DZ(ki) + thv(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
+         refQT  = (qt(ki-1)*DZ(ki)  + qt(ki)*DZ(ki-1))  /(DZ(ki)+DZ(ki-1))
+
+         !DOWNQC(ki,I) = 0.0
+         DOWNQC(ki,I) = (qc(ki-1)*DZ(ki) + qc(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
+         DOWNQT(ki,I) = refQT  !+ 0.5  *DOWNW(ki,I)*sigmaQT/sigmaW
+         DOWNTHV(ki,I)= refTHV + 0.01 *DOWNW(ki,I)*sigmaTH/sigmaW
+         DOWNTHL(ki,I)= refTHL + 0.01 *DOWNW(ki,I)*sigmaTH/sigmaW
+
+         !input :: QT,THV,P,zagl,  output :: THL, QC
+!         Pk  =(P(ki-1)*DZ(ki)+P(ki)*DZ(ki-1))/(DZ(ki)+DZ(ki-1))
+!         call condensation_edmf_r(DOWNQT(ki,I),   &
+!              &        DOWNTHL(ki,I),Pk,ZW(ki),   &
+!              &     DOWNTHV(ki,I),DOWNQC(ki,I)    )
+
+      enddo
+
+
+      !print*, " Begin integration of downdrafts:"
+      DO I=1,NDOWN
+         !print *, "Plume # =", I,"======================="
+         DO k=DD_initK(I)-1,KTS+1,-1
+            !starting at the first interface level below cloud top
+            !EntExp=exp(-ENT(K,I)*dz(k))
+            !EntExp_M=exp(-ENT(K,I)/3.*dz(k))
+            EntExp  =ENT(K,I)*dz(k)
+            EntExp_M=ENT(K,I)*0.333*dz(k)
+
+            QTn =DOWNQT(k+1,I) *(1.-EntExp) + QT(k)*EntExp
+            THLn=DOWNTHL(k+1,I)*(1.-EntExp) + THL(k)*EntExp
+            Un  =DOWNU(k+1,I)  *(1.-EntExp) + U(k)*EntExp_M
+            Vn  =DOWNV(k+1,I)  *(1.-EntExp) + V(k)*EntExp_M
+            !QKEn=DOWNQKE(k-1,I)*(1.-EntExp) + QKE(k)*EntExp
+
+!            QTn =DOWNQT(K+1,I) +(QT(K) -DOWNQT(K+1,I)) *(1.-EntExp)
+!            THLn=DOWNTHL(K+1,I)+(THL(K)-DOWNTHL(K+1,I))*(1.-EntExp)
+!            Un  =DOWNU(K+1,I)  +(U(K)  -DOWNU(K+1,I))*(1.-EntExp_M)
+!            Vn  =DOWNV(K+1,I)  +(V(K)  -DOWNV(K+1,I))*(1.-EntExp_M)
+
+            ! given new p & z, solve for thvn & qcn
+            Pk  =(P(k-1)*DZ(k)+P(k)*DZ(k-1))/(DZ(k)+DZ(k-1))
+            call condensation_edmf(QTn,THLn,Pk,ZW(k),THVn,QCn)
+!            B=grav*(0.5*(THVn+DOWNTHV(k+1,I))/THV(k)-1.)
+            THVk  =(THV(k-1)*DZ(k)+THV(k)*DZ(k-1))/(DZ(k)+DZ(k-1))
+            B=grav*(THVn/THVk - 1.0)
+!            Beta_dm = 2*Wb*ENT(K,I) + 0.5/(ZW(k)-dz(k)) * &
+!                 &    max(1. - exp((ZW(k) -dz(k))/Z00 - 1. ) , 0.)
+!            EntW=exp(-Beta_dm * dz(k))
+            EntW=EntExp
+!            if (Beta_dm >0) then
+!               Wn2=DOWNW(K+1,I)**2*EntW - Wa*B/Beta_dm * (1. - EntW)
+!            else
+!               Wn2=DOWNW(K+1,I)**2      - 2.*Wa*B*dz(k)
+!            end if
+
+            mindownw = MIN(DOWNW(K+1,I),-0.2)
+            Wn = DOWNW(K+1,I) + (-2.*ENT(K,I)*DOWNW(K+1,I) - &
+                    BCOEFF*B/mindownw)*MIN(dz(k), 250.)
+
+            !Do not allow a parcel to accelerate more than 1.25 m/s over 200 m.
+            !Add max increase of 2.0 m/s for coarse vertical resolution.
+            IF (Wn < DOWNW(K+1,I) - MIN(1.25*dz(k)/200., 2.0))THEN
+                Wn = DOWNW(K+1,I) - MIN(1.25*dz(k)/200., 2.0)
+            ENDIF
+            !Add symmetrical max decrease in w
+            IF (Wn > DOWNW(K+1,I) + MIN(1.25*dz(k)/200., 2.0))THEN
+                Wn = DOWNW(K+1,I) + MIN(1.25*dz(k)/200., 2.0)
+            ENDIF
+            Wn = MAX(MIN(Wn,0.0), -3.0)
+
+            !print *, "  k       =",      k,      " z    =", ZW(k)
+            !print *, "  entw    =",ENT(K,I),     " Bouy =", B
+            !print *, "  downthv =",   THVn,      " thvk =", thvk
+            !print *, "  downthl =",   THLn,      " thl  =", thl(k)
+            !print *, "  downqt  =",   QTn ,      " qt   =", qt(k)
+            !print *, "  downw+1 =",DOWNW(K+1,I), " Wn2  =", Wn
+
+            IF (Wn .lt. 0.) THEN !terminate when velocity is too small
+               DOWNW(K,I)  = Wn !-sqrt(Wn2)
+               DOWNTHV(K,I)= THVn
+               DOWNTHL(K,I)= THLn
+               DOWNQT(K,I) = QTn
+               DOWNQC(K,I) = QCn
+               DOWNU(K,I)  = Un
+               DOWNV(K,I)  = Vn
+               DOWNA(K,I)  = DOWNA(K+1,I)
+            ELSE
+               !plumes must go at least 2 levels
+               if (DD_initK(I) - K .lt. 2) then
+                  DOWNW(:,I)  = 0.0
+                  DOWNTHV(:,I)= 0.0
+                  DOWNTHL(:,I)= 0.0
+                  DOWNQT(:,I) = 0.0
+                  DOWNQC(:,I) = 0.0
+                  DOWNU(:,I)  = 0.0
+                  DOWNV(:,I)  = 0.0
+               endif
+               exit
+            ENDIF
+         ENDDO
+      ENDDO
+   endif ! end cloud flag
+
+   DOWNW(1,:) = 0. !make sure downdraft does not go to the surface
+   DOWNA(1,:) = 0.
+
+   ! Combine both moist and dry plume, write as one averaged plume
+   ! Even though downdraft starts at different height, average all up to qlTop
+   DO k=qlTop,KTS,-1
+      DO I=1,NDOWN
+         IF (I > NDOWN) exit
+         edmf_a_dd(K)  =edmf_a_dd(K)  +DOWNA(K-1,I)
+         edmf_w_dd(K)  =edmf_w_dd(K)  +DOWNA(K-1,I)*DOWNW(K-1,I)
+         edmf_qt_dd(K) =edmf_qt_dd(K) +DOWNA(K-1,I)*DOWNQT(K-1,I)
+         edmf_thl_dd(K)=edmf_thl_dd(K)+DOWNA(K-1,I)*DOWNTHL(K-1,I)
+         edmf_ent_dd(K)=edmf_ent_dd(K)+DOWNA(K-1,I)*ENT(K-1,I)
+         edmf_qc_dd(K) =edmf_qc_dd(K) +DOWNA(K-1,I)*DOWNQC(K-1,I)
+      ENDDO
+
+      IF (edmf_a_dd(k) >0.) THEN
+          edmf_w_dd(k)  =edmf_w_dd(k)  /edmf_a_dd(k)
+          edmf_qt_dd(k) =edmf_qt_dd(k) /edmf_a_dd(k)
+          edmf_thl_dd(k)=edmf_thl_dd(k)/edmf_a_dd(k)
+          edmf_ent_dd(k)=edmf_ent_dd(k)/edmf_a_dd(k)
+          edmf_qc_dd(k) =edmf_qc_dd(k) /edmf_a_dd(k)
+      ENDIF
+   ENDDO
+
+   !
+   ! computing variables needed for solver
+   !
+
+   DO k=KTS,qlTop
+      rho_int = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
+      DO I=1,NDOWN
+         sd_aw(k)   =sd_aw(k)   +rho_int*DOWNA(k,i)*DOWNW(k,i)
+         sd_awthl(k)=sd_awthl(k)+rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNTHL(k,i)
+         sd_awqt(k) =sd_awqt(k) +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNQT(k,i)
+         sd_awqc(k) =sd_awqc(k) +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNQC(k,i)
+         sd_awu(k)  =sd_awu(k)  +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNU(k,i)
+         sd_awv(k)  =sd_awv(k)  +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNV(k,i)
+      ENDDO
+      sd_awqv(k) = sd_awqt(k)  - sd_awqc(k)
+   ENDDO
+
+END SUBROUTINE DDMF_JPL
+!===============================================================
+
 
 SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
@@ -6492,34 +7479,33 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
   END SUBROUTINE SCALE_AWARE
 
 ! =====================================================================
-
+!>\ingroup gsd_mynn_edmf
+!! \author JAYMES- added 22 Apr 2015
+!! This function calculates saturation vapor pressure.  Separate ice and liquid functions
+!! are used (identical to those in module_mp_thompson.F, v3.6). Then, the
+!! final returned value is a temperature-dependant "blend". Because the final
+!! value is "phase-aware", this formulation may be preferred for use throughout
+!! the module (replacing "svp").
   FUNCTION esat_blend(t) 
-! JAYMES- added 22 Apr 2015
-! 
-! This calculates saturation vapor pressure.  Separate ice and liquid functions 
-! are used (identical to those in module_mp_thompson.F, v3.6).  Then, the 
-! final returned value is a temperature-dependant "blend".  Because the final 
-! value is "phase-aware", this formulation may be preferred for use throughout 
-! the module (replacing "svp").
 
       IMPLICIT NONE
       
       REAL, INTENT(IN):: t
       REAL :: esat_blend,XC,ESL,ESI,chi
 
-      XC=MAX(-80.,t-273.16)
+      XC=MAX(-80.,t - t0c) !note t0c = 273.15, tice is set in module mynn_common
 
 ! For 253 < t < 273.16 K, the vapor pressures are "blended" as a function of temperature, 
 ! using the approach of Chaboureau and Bechtold (2002), JAS, p. 2363.  The resulting 
 ! values are returned from the function.
-      IF (t .GE. 273.16) THEN
+      IF (t .GE. t0c) THEN
           esat_blend = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
-      ELSE IF (t .LE. 253.) THEN
+      ELSE IF (t .LE. tice) THEN
           esat_blend = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
       ELSE
           ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
           ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
-          chi  = (273.16-t)/20.16
+          chi  = (t0c - t)/(t0c - tice)
           esat_blend = (1.-chi)*ESL  + chi*ESI
       END IF
 
@@ -6527,9 +7513,11 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
 ! ====================================================================
 
+!>\ingroup gsd_mynn_edmf
+!! This function extends function "esat" and returns a "blended"
+!! saturation mixing ratio.
+!!\author JAYMES
   FUNCTION qsat_blend(t, P, waterice)
-! JAYMES- this function extends function "esat" and returns a "blended"
-! saturation mixing ratio.
 
       IMPLICIT NONE
 
@@ -6544,51 +7532,271 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
           wrt = waterice
       ENDIF
 
-      XC=MAX(-80.,t-273.16)
+      XC=MAX(-80.,t - t0c)
 
-      IF ((t .GE. 273.16) .OR. (wrt .EQ. 'w')) THEN
+      IF ((t .GE. t0c) .OR. (wrt .EQ. 'w')) THEN
           ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
-          qsat_blend = 0.622*ESL/(P-ESL) 
-      ELSE IF (t .LE. 253.) THEN
+          qsat_blend = 0.622*ESL/max(P-ESL, 1e-5) 
+!      ELSE IF (t .LE. 253.) THEN
+      ELSE IF (t .LE. tice) THEN
           ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
-          qsat_blend = 0.622*ESI/(P-ESI)
+          qsat_blend = 0.622*ESI/max(P-ESI, 1e-5)
       ELSE
           ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
           ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
-          RSLF = 0.622*ESL/(P-ESL)
-          RSIF = 0.622*ESI/(P-ESI)
-          chi  = (273.16-t)/20.16
-          qsat_blend = (1.-chi)*RSLF + chi*RSIF
+          RSLF = 0.622*ESL/max(P-ESL, 1e-5)
+          RSIF = 0.622*ESI/max(P-ESI, 1e-5)
+!          chi  = (273.16-t)/20.16
+          chi  = (t0c - t)/(t0c - tice) 
+         qsat_blend = (1.-chi)*RSLF + chi*RSIF
       END IF
 
   END FUNCTION qsat_blend
 
 ! ===================================================================
 
+!>\ingroup gsd_mynn_edmf
+!! This function interpolates the latent heats of vaporization and sublimation into
+!! a single, temperature-dependent, "blended" value, following 
+!! Chaboureau and Bechtold (2002) \cite Chaboureau_2002, Appendix.
+!!\author JAYMES
   FUNCTION xl_blend(t)
-! JAYMES- this function interpolates the latent heats of vaporization and
-! sublimation into a single, temperature-dependant, "blended" value, following
-! Chaboureau and Bechtold (2002), Appendix.
 
       IMPLICIT NONE
 
       REAL, INTENT(IN):: t
       REAL :: xl_blend,xlvt,xlst,chi
+      !note: t0c = 273.15, tice is set in mynn_common
 
-      IF (t .GE. 273.16) THEN
-          xl_blend = xlv + (cpv-cliq)*(t-273.16)  !vaporization/condensation
-      ELSE IF (t .LE. 253.) THEN
-          xl_blend = xls + (cpv-cice)*(t-273.16)  !sublimation/deposition
+      IF (t .GE. t0c) THEN
+          xl_blend = xlv + (cpv-cliq)*(t-t0c)  !vaporization/condensation
+      ELSE IF (t .LE. tice) THEN
+          xl_blend = xls + (cpv-cice)*(t-t0c)  !sublimation/deposition
       ELSE
-          xlvt = xlv + (cpv-cliq)*(t-273.16)  !vaporization/condensation
-          xlst = xls + (cpv-cice)*(t-273.16)  !sublimation/deposition
-          chi  = (273.16-t)/20.16
+          xlvt = xlv + (cpv-cliq)*(t-t0c)  !vaporization/condensation
+          xlst = xls + (cpv-cice)*(t-t0c)  !sublimation/deposition
+!          chi  = (273.16-t)/20.16
+          chi  = (t0c - t)/(t0c - tice)
           xl_blend = (1.-chi)*xlvt + chi*xlst     !blended
       END IF
 
   END FUNCTION xl_blend
 
 ! ===================================================================
+
+  FUNCTION phim(zet)
+     ! New stability function parameters for momentum (Puhales, 2020, WRF 4.2.1)
+     ! The forms in unstable conditions (z/L < 0) use Grachev et al. (2000), which are a blend of 
+     ! the classical (Kansas) forms (i.e., Paulson 1970, Dyer and Hicks 1970), valid for weakly 
+     ! unstable conditions (-1 < z/L < 0). The stability functions for stable conditions use an
+     ! updated form taken from Cheng and Brutsaert (2005), which extends the validity into very
+     ! stable conditions [z/L ~ O(10)].
+      IMPLICIT NONE
+
+      REAL, INTENT(IN):: zet
+      REAL :: dummy_0,dummy_1,dummy_11,dummy_2,dummy_22,dummy_3,dummy_33,dummy_4,dummy_44,dummy_psi
+      REAL, PARAMETER :: am_st=6.1, bm_st=2.5, rbm_st=1./bm_st
+      REAL, PARAMETER :: ah_st=5.3, bh_st=1.1, rbh_st=1./bh_st
+      REAL, PARAMETER :: am_unst=10., ah_unst=34.
+      REAL :: phi_m,phim
+
+      if ( zet >= 0.0 ) then
+         dummy_0=1+zet**bm_st
+         dummy_1=zet+dummy_0**(rbm_st)
+         dummy_11=1+dummy_0**(rbm_st-1)*zet**(bm_st-1)
+         dummy_2=(-am_st/dummy_1)*dummy_11
+         phi_m = 1-zet*dummy_2
+      else
+         dummy_0 = (1.0-cphm_unst*zet)**0.25
+         phi_m = 1./dummy_0
+         dummy_psi = 2.*log(0.5*(1.+dummy_0))+log(0.5*(1.+dummy_0**2))-2.*atan(dummy_0)+1.570796
+
+         dummy_0=(1.-am_unst*zet)          ! parentesis arg
+         dummy_1=dummy_0**0.333333         ! y
+         dummy_11=-0.33333*am_unst*dummy_0**-0.6666667 ! dy/dzet
+         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
+         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
+         dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
+         dummy_33 = 1.1547*dummy_11        ! dg/dzet
+         dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
+         dummy_44 = (1.5/dummy_2)*dummy_22-1.73205*dummy_33/(1.+dummy_3**2)! dpsic/dzet
+
+         dummy_0 = zet**2
+         dummy_1 = 1./(1.+dummy_0) ! denon
+         dummy_11 = 2.*zet         ! denon/dzet
+         dummy_2 = ((1-phi_m)/zet+dummy_11*dummy_4+dummy_0*dummy_44)*dummy_1
+         dummy_22 = -dummy_11*(dummy_psi+dummy_0*dummy_4)*dummy_1**2
+
+         phi_m = 1.-zet*(dummy_2+dummy_22)
+      end if
+
+      !phim = phi_m - zet
+      phim = phi_m
+
+  END FUNCTION phim
+! ===================================================================
+
+  FUNCTION phih(zet)
+    ! New stability function parameters for heat (Puhales, 2020, WRF 4.2.1)
+    ! The forms in unstable conditions (z/L < 0) use Grachev et al. (2000), which are a blend of
+    ! the classical (Kansas) forms (i.e., Paulson 1970, Dyer and Hicks 1970), valid for weakly
+    ! unstable conditions (-1 < z/L < 0). The stability functions for stable conditions use an
+    ! updated form taken from Cheng and Brutsaert (2005), which extends the validity into very
+    ! stable conditions [z/L ~ O(10)].
+      IMPLICIT NONE
+
+      REAL, INTENT(IN):: zet
+      REAL :: dummy_0,dummy_1,dummy_11,dummy_2,dummy_22,dummy_3,dummy_33,dummy_4,dummy_44,dummy_psi
+      REAL, PARAMETER :: am_st=6.1, bm_st=2.5, rbm_st=1./bm_st
+      REAL, PARAMETER :: ah_st=5.3, bh_st=1.1, rbh_st=1./bh_st
+      REAL, PARAMETER :: am_unst=10., ah_unst=34.
+      REAL :: phh,phih
+
+      if ( zet >= 0.0 ) then
+         dummy_0=1+zet**bh_st
+         dummy_1=zet+dummy_0**(rbh_st)
+         dummy_11=1+dummy_0**(rbh_st-1)*zet**(bh_st-1)
+         dummy_2=(-ah_st/dummy_1)*dummy_11
+         phih = 1-zet*dummy_2
+      else
+         dummy_0 = (1.0-cphh_unst*zet)**0.5
+         phh = 1./dummy_0
+         dummy_psi = 2.*log(0.5*(1.+dummy_0))
+
+         dummy_0=(1.-ah_unst*zet)          ! parentesis arg
+         dummy_1=dummy_0**0.333333         ! y
+         dummy_11=-0.33333*ah_unst*dummy_0**-0.6666667 ! dy/dzet
+         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
+         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
+         dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
+         dummy_33 = 1.1547*dummy_11        ! dg/dzet
+         dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
+         dummy_44 = (1.5/dummy_2)*dummy_22-1.73205*dummy_33/(1.+dummy_3**2)! dpsic/dzet
+
+         dummy_0 = zet**2
+         dummy_1 = 1./(1.+dummy_0)         ! denon
+         dummy_11 = 2.*zet                 ! ddenon/dzet
+         dummy_2 = ((1-phh)/zet+dummy_11*dummy_4+dummy_0*dummy_44)*dummy_1
+         dummy_22 = -dummy_11*(dummy_psi+dummy_0*dummy_4)*dummy_1**2
+
+         phih = 1.-zet*(dummy_2+dummy_22)
+      end if
+
+END FUNCTION phih
+! ==================================================================
+ SUBROUTINE topdown_cloudrad(kts,kte,dz1,zw,xland,kpbl,PBLH,  &
+               &sqc,sqi,sqw,thl,th1,ex1,p1,rho1,thetav,       &
+               &cldfra_bl1D,rthraten,                         &
+               &maxKHtopdown,KHtopdown,TKEprodTD              )
+
+    !input
+    integer, intent(in) :: kte,kts
+    real, dimension(kts:kte), intent(in) :: dz1,sqc,sqi,sqw,&
+          thl,th1,ex1,p1,rho1,thetav,cldfra_bl1D,rthraten
+    real, dimension(kts:kte+1), intent(in) :: zw
+    real, intent(in) :: pblh,xland
+    integer,intent(in) :: kpbl
+    !output
+    real, intent(out) :: maxKHtopdown
+    real, dimension(kts:kte), intent(out) :: KHtopdown,TKEprodTD
+    !local
+    real, dimension(kts:kte) :: zfac,wscalek2,zfacent
+    real :: bfx0,sflux,wm2,wm3,h1,h2,bfxpbl,dthvx,tmp1
+    real :: temps,templ,zl1,wstar3_2
+    real :: ent_eff,radsum,radflux,we,rcldb,rvls,minrad,zminrad
+    real, parameter :: pfac =2.0, zfmin = 0.01, phifac=8.0
+    integer :: k,kk,kminrad
+    logical :: cloudflg
+
+    cloudflg=.false.
+    minrad=100.
+    kminrad=kpbl
+    zminrad=PBLH
+    KHtopdown(kts:kte)=0.0
+    TKEprodTD(kts:kte)=0.0
+    maxKHtopdown=0.0
+
+    !CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
+    DO kk = MAX(1,kpbl-2),kpbl+3
+       if (sqc(kk).gt. 1.e-6 .OR. sqi(kk).gt. 1.e-6 .OR. &
+           cldfra_bl1D(kk).gt.0.5) then
+          cloudflg=.true.
+       endif
+       if (rthraten(kk) < minrad)then
+          minrad=rthraten(kk)
+          kminrad=kk
+          zminrad=zw(kk) + 0.5*dz1(kk)
+       endif
+    ENDDO
+
+    IF (MAX(kminrad,kpbl) < 2)cloudflg = .false.
+    IF (cloudflg) THEN
+       zl1 = dz1(kts)
+       k = MAX(kpbl-1, kminrad-1)
+       !Best estimate of height of TKE source (top of downdrafts):
+       !zminrad = 0.5*pblh(i) + 0.5*zminrad
+
+       templ=thl(k)*ex1(k)
+       !rvls is ws at full level
+       rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep_2/p1(k+1))
+       temps=templ + (sqw(k)-rvls)/(cp/xlv  +  ep_2*xlv*rvls/(r_d*templ**2))
+       rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep_2/p1(k+1))
+       rcldb=max(sqw(k)-rvls,0.)
+
+       !entrainment efficiency
+       dthvx     = (thl(k+2) + th1(k+2)*p608*sqw(k+2)) &
+                 - (thl(k)   + th1(k)  *p608*sqw(k))
+       dthvx     = max(dthvx,0.1)
+       tmp1      = xlvcp * rcldb/(ex1(k)*dthvx)
+       !Originally from Nichols and Turton (1986), where a2 = 60, but lowered
+       !here to 8, as in Grenier and Bretherton (2001).
+       ent_eff   = 0.2 + 0.2*8.*tmp1
+
+       radsum=0.
+       DO kk = MAX(1,kpbl-3),kpbl+3
+          radflux=rthraten(kk)*ex1(kk)         !converts theta/s to temp/s
+          radflux=radflux*cp/grav*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
+          if (radflux < 0.0 ) radsum=abs(radflux)+radsum
+       ENDDO
+
+       !More strict limits over land to reduce stable-layer mixouts
+       if ((xland-1.5).GE.0)THEN      ! WATER
+          radsum=MIN(radsum,90.0)
+          bfx0 = max(radsum/rho1(k)/cp,0.)
+       else                           ! LAND
+          radsum=MIN(0.25*radsum,30.0)!practically turn off over land
+          bfx0 = max(radsum/rho1(k)/cp - max(sflux,0.0),0.)
+       endif
+
+       !entrainment from PBL top thermals
+       wm3    = grav/thetav(k)*bfx0*MIN(pblh,1500.) ! this is wstar3(i)
+       wm2    = wm2 + wm3**h2
+       bfxpbl = - ent_eff * bfx0
+       dthvx  = max(thetav(k+1)-thetav(k),0.1)
+       we     = max(bfxpbl/dthvx,-sqrt(wm3**h2))
+
+       DO kk = kts,kpbl+3
+          !Analytic vertical profile
+          zfac(kk) = min(max((1.-(zw(kk+1)-zl1)/(zminrad-zl1)),zfmin),1.)
+          zfacent(kk) = 10.*MAX((zminrad-zw(kk+1))/zminrad,0.0)*(1.-zfac(kk))**3
+
+          !Calculate an eddy diffusivity profile (not used at the moment)
+          wscalek2(kk) = (phifac*karman*wm3*(zfac(kk)))**h1
+          !Modify shape of Kh to be similar to Lock et al (2000): use pfac = 3.0
+          KHtopdown(kk) = wscalek2(kk)*karman*(zminrad-zw(kk+1))*(1.-zfac(kk))**3 !pfac
+          KHtopdown(kk) = MAX(KHtopdown(kk),0.0)
+
+          !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
+          !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
+          !An analytic profile controls the magnitude of this TKE prod in the vertical.
+          TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh,100.)*zfacent(kk)
+          TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
+       ENDDO
+    ENDIF !end cloud check
+    maxKHtopdown=MAXVAL(KHtopdown(:))
+
+ END SUBROUTINE topdown_cloudrad
+! ==================================================================
 ! ===================================================================
 ! ===================================================================
 

--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -400,7 +400,7 @@ CONTAINS
        &dqke,qwt,qshear,qbuoy,qdiss,    &
        &qc_bl,qi_bl,cldfra_bl,          &
        &bl_mynn_tkeadvect,              &
-       &bl_mynn_tkebudget,              &
+       &tke_budget,                     &
        &bl_mynn_cloudpdf,               &
        &bl_mynn_mixlength,              &
        &icloud_bl,                      &
@@ -429,8 +429,8 @@ CONTAINS
 
     INTEGER, INTENT(in) :: initflag
     !INPUT NAMELIST OPTIONS:
-    LOGICAL, INTENT(IN) :: restart,cycling
-    LOGICAL, INTENT(in) :: bl_mynn_tkebudget
+    LOGICAL, INTENT(in) :: restart,cycling
+    INTEGER, INTENT(in) :: tke_budget
     INTEGER, INTENT(in) :: bl_mynn_cloudpdf
     INTEGER, INTENT(in) :: bl_mynn_mixlength
     INTEGER, INTENT(in) :: bl_mynn_edmf
@@ -512,7 +512,7 @@ CONTAINS
 
     REAL, DIMENSION(IMS:IME,KMS:KME), optional, INTENT(out) :: &
          &qwt,qshear,qbuoy,qdiss,dqke
-    ! 3D budget arrays are not allocated when bl_mynn_tkebudget == .false.
+    ! 3D budget arrays are not allocated when tke_budget == 0
     ! 1D (local) budget arrays are used for passing between subroutines.
     REAL, DIMENSION(kts:kte) :: qwt1,qshear1,qbuoy1,qdiss1, &
          &dqke1,diss_heat
@@ -713,7 +713,7 @@ CONTAINS
           ENDDO
        ENDDO
 
-       IF ( bl_mynn_tkebudget ) THEN
+       IF (tke_budget .eq. 1) THEN
           DO k=KTS,KTE
              DO i=ITS,ITF
                 qWT(i,k)=0.
@@ -889,7 +889,7 @@ CONTAINS
     DO i=ITS,ITF
        DO k=KTS,KTE !KTF
             !JOE-TKE BUDGET
-             IF ( bl_mynn_tkebudget ) THEN
+             IF (tke_budget .eq. 1) THEN
                 dqke(i,k)=qke(i,k)
              END IF
              IF (icloud_bl > 0) THEN
@@ -1282,7 +1282,7 @@ CONTAINS
                &Tcd,Qcd,Pdk,                     &
                &Pdt,Pdq,Pdc,                     &
                &qWT1,qSHEAR1,qBUOY1,qDISS1,      &
-               &bl_mynn_tkebudget,               &
+               &tke_budget,                      &
                &Psig_bl(i),Psig_shcu(i),         &
                &cldfra_bl1D,bl_mynn_mixlength,   &
                &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
@@ -1298,7 +1298,7 @@ CONTAINS
                &el, dfq, rho1, pdk, pdt, pdq, pdc,&
                &Qke1, Tsq1, Qsq1, Cov1,          &
                &s_aw1, s_awqke1, bl_mynn_edmf_tke,&
-               &qWT1, qDISS1,bl_mynn_tkebudget) !! TKE budget  (Puhales, 2020)
+               &qWT1, qDISS1,tke_budget          ) !! TKE budget  (Puhales, 2020)
 
           if (dheat_opt > 0) then
              DO k=kts,kte-1
@@ -1435,7 +1435,7 @@ CONTAINS
              sm3d(i,k)=sm(k)
           enddo !end-k
 
-          if ( bl_mynn_tkebudget ) then
+          if (tke_budget .eq. 1) then
              !! TKE budget is now given in m**2/s**-3 (Puhales, 2020)
              !! Lower boundary condtions (using similarity relationships such as the prognostic equation for Qke)
              k=kts
@@ -2727,7 +2727,7 @@ CONTAINS
 !! - Production terms of TKE,\f$\theta^{'2}\f$,\f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$
 !! are calculated.
 !! - Eddy diffusivity \f$K_h\f$ and eddy viscosity \f$K_m\f$ are calculated.
-!! - TKE budget terms are calculated (if the namelist parameter \p bl_mynn_tkebudget 
+!! - TKE budget terms are calculated (if the namelist parameter \p tke_budget 
 !! is set to True)
   SUBROUTINE  mym_turbulence (                                &
     &            kts,kte,                                     &
@@ -2743,7 +2743,7 @@ CONTAINS
     &            El,                                          &
     &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
     &		 qWT1D,qSHEAR1D,qBUOY1D,qDISS1D,              &
-    &            bl_mynn_tkebudget,                           &
+    &            tke_budget,                                  &
     &            Psig_bl,Psig_shcu,cldfra_bl1D,bl_mynn_mixlength,&
     &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,       &
     &            TKEprodTD,                                   &
@@ -2758,7 +2758,7 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf,tke_budget
     REAL, INTENT(IN)      :: closure
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
@@ -2775,7 +2775,6 @@ CONTAINS
     REAL :: q3sq_old,dlsq1,qWTP_old,qWTP_new
     REAL :: dudz,dvdz,dTdz,&
             upwp,vpwp,Tpwp
-    LOGICAL, INTENT(in) :: bl_mynn_tkebudget
 
     REAL, DIMENSION(kts:kte) :: qkw,dtl,dqw,dtv,gm,gh,sm,sh
 
@@ -3201,7 +3200,7 @@ CONTAINS
        dfq(k) =     dfm(k)
 !  Modified: Dec/22/2005, up to here
 
-   IF ( bl_mynn_tkebudget ) THEN
+   IF (tke_budget .eq. 1) THEN
        !TKE BUDGET
 !       dudz = ( u(k)-u(k-1) )/dzk
 !       dvdz = ( v(k)-v(k-1) )/dzk
@@ -3324,7 +3323,7 @@ CONTAINS
        &            pdk, pdt, pdq, pdc,                                 &
        &            qke, tsq, qsq, cov,                                 &
        &            s_aw,s_awqke,bl_mynn_edmf_tke,                      &
-       &            qWT1D, qDISS1D,bl_mynn_tkebudget)  !! TKE budget  (Puhales, 2020)
+       &            qWT1D, qDISS1D,tke_budget)  !! TKE budget  (Puhales, 2020)
 
 !-------------------------------------------------------------------
     INTEGER, INTENT(IN) :: kts,kte    
@@ -3335,7 +3334,7 @@ CONTAINS
 #endif
 
     REAL, INTENT(IN)    :: closure
-    INTEGER, INTENT(IN) :: bl_mynn_edmf_tke
+    INTEGER, INTENT(IN) :: bl_mynn_edmf_tke, tke_budget
     REAL, INTENT(IN)    :: delt
     REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq, el, rho
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: pdk, pdt, pdq, pdc
@@ -3346,7 +3345,6 @@ CONTAINS
     
     !!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
     REAL, DIMENSION(kts:kte), INTENT(OUT) :: qWT1D, qDISS1D  
-    LOGICAL, INTENT(IN) :: bl_mynn_tkebudget  
     REAL, DIMENSION(kts:kte) :: tke_up,dzinv  
     !! >> EOB
     
@@ -3487,7 +3485,7 @@ CONTAINS
       
    
 !!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
-    IF (bl_mynn_tkebudget) THEN
+    IF (tke_budget .eq. 1) THEN
        !! TKE Vertical transport << EOBvt
         tke_up=0.5*qke
         dzinv=1./dz

--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -526,10 +526,8 @@ CONTAINS
 
 ! smoke/chemical arrays
     INTEGER, INTENT(IN   ) ::   nchem, kdvel, ndvel
-!    REAL,    DIMENSION( ims:ime, kms:kme, nchem ), INTENT(INOUT), optional :: chem3d
-!    REAL,    DIMENSION( ims:ime, kdvel, ndvel ), INTENT(IN), optional :: vdep
     REAL,    DIMENSION(ims:ime, kms:kme, nchem), INTENT(INOUT), optional :: chem3d
-    REAL,    DIMENSION(ims:ime, ndvel),   INTENT(IN),    optional :: vdep
+    REAL,    DIMENSION(ims:ime, ndvel),   INTENT(IN),   optional :: vdep
     REAL,    DIMENSION(ims:ime),     INTENT(IN),    optional :: frp,EMIS_ANT_NO
     !local
     REAL,    DIMENSION(kts:kte  ,nchem) :: chem1

--- a/phys/module_bl_mynn_common.F
+++ b/phys/module_bl_mynn_common.F
@@ -1,0 +1,98 @@
+!====================================================================
+
+ module module_bl_mynn_common
+
+!------------------------------------------
+!Define Model-specific constants/parameters.
+!This module will be used at the initialization stage
+!where all model-specific constants are read and saved into
+!memory. This module is then used again in the MYNN-EDMF. All
+!MYNN-specific constants are declared globally in the main
+!module (module_bl_mynn) further below:
+!------------------------------------------
+
+! The following 5-6 lines are the only lines in this file that are not
+! universal for all dycores... Any ideas how to universalize it?
+! For MPAS:
+! use mpas_kind_types,only: kind_phys => RKIND
+! For CCPP:
+!  use machine,  only : kind_phys
+! For WRF
+  use module_gfs_machine,  only : kind_phys
+
+!WRF CONSTANTS
+  use module_model_constants, only:         &
+    & karman, g, p1000mb,                   &
+    & cp, r_d, r_v, rcp, xlv, xlf, xls,     &
+    & svp1, svp2, svp3, p608, ep_2, rvovrd, &                                                                         
+    & cpv, cliq, cice, svpt0
+
+ implicit none
+ save
+! save :: cp, cpv, cice, cliq, p608, karman, rcp, & !taken directly from module_model_constants
+!         r_d, r_v, xls, xlv, xlf, rvovrd, ep_2,  & !taken directly from module_model_constants
+!         p1000mb, svp1, svp2, svp3,              & !taken directly from module_model_constants
+!         grav, t0c,                              & !renamed from module_model_constants
+!         zero, half, one, two, onethird,         & !set here
+!         twothirds, tref, tkmin, tice,           & !set here
+!         ep_3, gtr, rk, tv0, tv1, xlscp, xlvcp,  & !derived here
+!         g_inv                                     !derived here
+
+! To be specified from dycore
+! real:: cp           != 7.*r_d/2. (J/kg/K)
+! real:: cpv          != 4.*r_v    (J/kg/K) Spec heat H2O gas
+! real:: cice         != 2106.     (J/kg/K) Spec heat H2O ice
+! real:: cliq         != 4190.     (J/kg/K) Spec heat H2O liq
+! real:: p608         != R_v/R_d-1.
+! real:: ep_2         != R_d/R_v
+!! real:: grav         != accel due to gravity
+! real:: karman       != von Karman constant
+!! real:: t0c          != temperature of water at freezing, 273.15 K
+! real:: rcp          != r_d/cp
+! real:: r_d          != 287.  (J/kg/K) gas const dry air
+! real:: r_v          != 461.6 (J/kg/K) gas const water
+! real:: xlf          != 0.35E6 (J/kg) fusion at 0 C
+! real:: xlv          != 2.50E6 (J/kg) vaporization at 0 C
+! real:: xls          != 2.85E6 (J/kg) sublimation
+! real:: rvovrd       != r_v/r_d != 1.608
+
+! Specified locally
+ real,parameter:: zero   = 0.0
+ real,parameter:: half   = 0.5
+ real,parameter:: one    = 1.0
+ real,parameter:: two    = 2.0
+ real,parameter:: onethird  = 1./3.
+ real,parameter:: twothirds = 2./3.
+ real,parameter:: tref  = 300.0   ! reference temperature (K)
+ real,parameter:: TKmin = 253.0   ! for total water conversion, Tripoli and Cotton (1981)
+! real,parameter:: p1000mb=100000.0
+! real,parameter:: svp1  = 0.6112 !(kPa)
+! real,parameter:: svp2  = 17.67  !(dimensionless)
+! real,parameter:: svp3  = 29.65  !(K)
+ real,parameter:: tice  = 240.0  !-33 (C), temp at saturation w.r.t. ice
+ real,parameter:: grav  = g
+ real,parameter:: t0c   = svpt0        != 273.15
+
+! To be derived in the init routine
+ real,parameter:: ep_3   = 1.-ep_2 != 0.378
+ real,parameter:: gtr    = grav/tref
+ real,parameter:: rk     = cp/r_d
+ real,parameter:: tv0    =  p608*tref
+ real,parameter:: tv1    = (1.+p608)*tref
+ real,parameter:: xlscp  = (xlv+xlf)/cp
+ real,parameter:: xlvcp  = xlv/cp
+ real,parameter:: g_inv  = 1./grav
+
+! grav   = g
+! t0c    = svpt0        != 273.15
+! ep_3   = 1.-ep_2      != 0.378                                                                                   
+! gtr    = grav/tref
+! rk     = cp/r_d
+! tv0    = p608*tref
+! tv1    = (1.+p608)*tref
+! xlscp  = (xlv+xlf)/cp
+! xlvcp  = xlv/cp
+! g_inv  = 1./grav
+
+
+ end module module_bl_mynn_common

--- a/phys/module_bl_mynn_common.F
+++ b/phys/module_bl_mynn_common.F
@@ -10,7 +10,7 @@
 !MYNN-specific constants are declared globally in the main
 !module (module_bl_mynn) further below:
 !------------------------------------------
-
+!
 ! The following 5-6 lines are the only lines in this file that are not
 ! universal for all dycores... Any ideas how to universalize it?
 ! For MPAS:

--- a/phys/module_bl_mynn_wrapper.F
+++ b/phys/module_bl_mynn_wrapper.F
@@ -103,7 +103,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
      &  det_thl3d,det_sqv3d,                     &
      &  nupdraft,maxMF,ktop_plume,               &
      &  rthraten,                                &
-     &  bl_mynn_tkebudget,  bl_mynn_tkeadvect,   &
+     &  tke_budget,         bl_mynn_tkeadvect,   &
      &  bl_mynn_cloudpdf,   bl_mynn_mixlength,   &
      &  icloud_bl,          bl_mynn_edmf,        &
      &  bl_mynn_edmf_mom,   bl_mynn_edmf_tke,    &
@@ -145,7 +145,6 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
 ! NAMELIST OPTIONS (INPUT):
      logical, intent(in) ::                                 &
      &       bl_mynn_tkeadvect,                             &
-     &       bl_mynn_tkebudget,                             &
      &       cycling
       integer, intent(in) ::                                &
      &       bl_mynn_cloudpdf,                              &
@@ -158,7 +157,8 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
      &       bl_mynn_mixqt,                                 &
      &       bl_mynn_output,                                &
      &       bl_mynn_mixscalars,                            &
-     &       spp_pbl
+     &       spp_pbl,                                       &
+     &       tke_budget
       real, intent(in) ::                                   &
      &       bl_mynn_closure
 
@@ -283,7 +283,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
       allocate(det_thl2d(ims:ime,kms:kme))
       allocate(det_sqv2d(ims:ime,kms:kme))
    endif
-   if (bl_mynn_tkebudget) then
+   if (tke_budget .eq. 1) then
       allocate(dqke2d(ims:ime,kms:kme))
       allocate(qWT2d(ims:ime,kms:kme))
       allocate(qSHEAR2d(ims:ime,kms:kme))
@@ -461,7 +461,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
       if (debug) then
          print*
          write(0,*)"===CALLING mynn_bl_driver; input:"
-         print*,"bl_mynn_tkebudget=",bl_mynn_tkebudget
+         print*,"tke_budget=",tke_budget
          print*,"bl_mynn_tkeadvect=",bl_mynn_tkeadvect
          print*,"bl_mynn_cloudpdf=",bl_mynn_cloudpdf
          print*,"bl_mynn_mixlength=",bl_mynn_mixlength
@@ -536,7 +536,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
      &        qBUOY=qBUOY2d,qDISS=qDISS2d,                             & !output
      &        qc_bl=qc_bl2d,qi_bl=qi_bl2d,cldfra_bl=cldfra_bl2d,       & !output
      &        bl_mynn_tkeadvect=bl_mynn_tkeadvect,                     & !input parameter
-     &        bl_mynn_tkebudget=bl_mynn_tkebudget,                     & !input parameter
+     &        tke_budget=tke_budget,                                   & !input parameter
      &        bl_mynn_cloudpdf=bl_mynn_cloudpdf,                       & !input parameter
      &        bl_mynn_mixlength=bl_mynn_mixlength,                     & !input parameter
      &        icloud_bl=icloud_bl,                                     & !input parameter
@@ -585,7 +585,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
          enddo
       endif
 
-      if (bl_mynn_tkebudget) then
+      if (tke_budget .eq. 1) then
          do k=kts,ktf
          do i=its,itf
             dqke(i,k,j)     = dqke2d(i,k)
@@ -672,7 +672,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
       deallocate(det_thl2d)
       deallocate(det_sqv2d)
    endif
-   if (bl_mynn_tkebudget) then
+   if (tke_budget .eq. 1) then
       deallocate(dqke2d)
       deallocate(qwt2d)
       deallocate(qshear2d)

--- a/phys/module_bl_mynn_wrapper.F
+++ b/phys/module_bl_mynn_wrapper.F
@@ -118,14 +118,15 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
      &  its,ite,jts,jte,kts,kte                  )
 
 !     use module_gfs_machine,  only : kind_phys
-!     use module_bl_mynn_common, only: xlvcp, xlscp
      use module_bl_mynn, only: mynn_bl_driver
 
 !------------------------------------------------------------------- 
      implicit none
 !------------------------------------------------------------------- 
 
-     !smoke/chem
+     !smoke/chem: disclaimer: all smoke-related variables are still
+     !considered under development in CCPP. Until that work is
+     !completed, these flags/arrays must be kept hard-coded as is.
 #if (WRF_CHEM == 1)
      logical, intent(in) :: mix_chem
      integer, intent(in) :: nchem, ndvel, kdvel, num_vert_mix

--- a/phys/module_bl_mynn_wrapper.F
+++ b/phys/module_bl_mynn_wrapper.F
@@ -82,10 +82,9 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
      &  qke,qke_adv,sh3d,sm3d,                   &
 !--- chem/smoke
 #if (WRF_CHEM == 1)
-     &  chem3d,vd3d,nchem,kdevl,                 &
+     &  mix_chem,chem3d,vd3d,nchem,kdvel,        &
      &  ndvel,num_vert_mix,                      &
-     &  frp_mean,emis_ant_no,                    &
-     &  mix_chem,enh_mix,                        &
+!     &  frp_mean,emis_ant_no,enh_mix,            & !to be included soon
 #endif
 !--- end chem/smoke 
      &  Tsq,Qsq,Cov,                             &
@@ -128,18 +127,20 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
 
      !smoke/chem
 #if (WRF_CHEM == 1)
-     logical, intent(in) :: mix_chem, enh_mix
-     integer, intent(in) :: nchem, ndvel, kdvel
+     logical, intent(in) :: mix_chem
+     integer, intent(in) :: nchem, ndvel, kdvel, num_vert_mix
      logical, parameter ::                                  &
      &       rrfs_sd    =.false.,                           &
-     &       smoke_dbg  =.false.
+     &       smoke_dbg  =.false.,                           &
+     &       enh_mix    =.false.
 #else
      logical, parameter ::                                  &
      &       mix_chem   =.false.,                           &
      &       enh_mix    =.false.,                           &
      &       rrfs_sd    =.false.,                           &
      &       smoke_dbg  =.false.
-     integer, parameter :: nchem=2, ndvel=2, kdvel=1
+     integer, parameter :: nchem=2, ndvel=2, kdvel=1,       &
+             num_vert_mix = 1
 #endif
 
 ! NAMELIST OPTIONS (INPUT):
@@ -170,7 +171,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
 !MYNN-1D
       REAL,    intent(in) :: delt, dxc
       LOGICAL, intent(in) :: restart
-      INTEGER :: i, j, k, itf, jtf, ktf
+      INTEGER :: i, j, k, itf, jtf, ktf, n
       INTEGER, intent(in) :: initflag,                      &
      &           IDS,IDE,JDS,JDE,KDS,KDE,                   &
      &           IMS,IME,JMS,JME,KMS,KME,                   &
@@ -218,17 +219,15 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
 
 !smoke/chem arrays - no if-defs in module_bl_mynn.F, so must define arrays
 #if (WRF_CHEM == 1)
-      real, dimension(ims:ime, kms:kme, jms:jme), intent(inout), optional ::  &                                     
-     &         qgrs_smoke_conc, qgrs_dust_conc
-      real, allocatable, dimension(:,:,:,:) :: chem3d
-      real, dimension(ims:ime, kdvel, jms:jme, ndvel), intent(in), optional :: vd3d
-      real, dimension(ims:ime, jms:jme),   intent(in), optional :: frp_mean, emis_ant_no
+      real, dimension(ims:ime,kms:kme,jms:jme,nchem), intent(in) :: chem3d
+      real, dimension(ims:ime,kdvel,jms:jme, ndvel), intent(in)  :: vd3d
+      real, dimension(ims:ime,kms:kme,nchem) :: chem
+      real, dimension(ims:ime,ndvel)         :: vd
+      real, dimension(ims:ime)               :: frp_mean, emis_ant_no
 #else
-      real, dimension(ims:ime,kms:kme,jms:jme)       ::                &
-     &         qgrs_smoke_conc, qgrs_dust_conc
-      real, allocatable, dimension(:,:,:) :: chem3d
-      real, dimension(ims:ime,ndvel)      :: vd3d
-      real, dimension(ims:ime)            :: frp_mean, emis_ant_no
+      real, dimension(ims:ime,kms:kme,nchem) :: chem
+      real, dimension(ims:ime,ndvel)         :: vd
+      real, dimension(ims:ime) :: frp_mean, emis_ant_no
 #endif
 
 !MYNN-2D
@@ -398,32 +397,31 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
          enddo
          enddo
       endif
+
 #if (WRF_CHEM == 1)
       if (mix_chem) then
-         allocate ( chem3d(ime,kme,nchem) )
+         do n=1,nchem
          do k=kts,ktf
          do i=its,itf
-            chem3d(i,k,1)=qgrs_smoke_conc(i,k,j)
-            chem3d(i,k,2)=qgrs_dust_conc(i,k,j)
+            chem(i,k,n)=chem3d(i,k,j,n)
+         enddo
+         enddo
+         enddo
+
+         !set kdvel =1
+         do n=1,ndvel
+         do i=its,itf
+            vd(i,n)  =vd3d(i,1,j,n)
          enddo
          enddo
       endif
+      frp_mean = 0.0
+      emis_ant_no = 0.0
 #else
-      ! initializing chem3d should be done at higher level...
-      qgrs_smoke_conc = 1.0
-      qgrs_dust_conc  = 1.0
-      frp_mean        = 0.0
-      EMIS_ANT_NO = 0.
-      vd3d = 0. ! hli for chem dry deposition, 0 temporarily
-      if (mix_chem) then
-         allocate ( chem3d(ims:ime,kms:kme,nchem) )
-         do k=kts,ktf
-         do i=its,itf
-            chem3d(i,k,1)=qgrs_smoke_conc(i,k,j)
-            chem3d(i,k,2)=qgrs_dust_conc (i,k,j)
-         enddo
-         enddo
-      endif
+      chem     = 0.0
+      vd       = 0.0
+      frp_mean = 0.0
+      emis_ant_no = 0.0
 #endif
 
       ! Check incoming moist species to ensure non-negative values
@@ -516,7 +514,7 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
      &        qke=QKE(:,:,j),qke_adv=qke_adv(:,:,j),                   & !output
      &        sh3d=Sh3d(:,:,j),sm3d=Sm3d(:,:,j),                       & !output
      &        nchem=nchem,kdvel=kdvel,ndvel=ndvel,                     & !chem/smoke
-     &        Chem3d=chem3d,Vdep=vd3d,                                 &
+     &        Chem3d=chem,Vdep=vd,                                     &
      &        FRP=frp_mean,EMIS_ANT_NO=emis_ant_no,                    &
      &        mix_chem=mix_chem,enh_mix=enh_mix,                       &
      &        rrfs_sd=rrfs_sd,smoke_dbg=smoke_dbg,                     & !end chem/smoke
@@ -657,9 +655,6 @@ SUBROUTINE mynnedmf_wrapper_run(                 &
    enddo  !end j-loop 
 
    !Deallocate all temporary interface arrays
-   if (mix_chem) then
-      deallocate(chem3d)
-   endif
    if (bl_mynn_output > 0) then
       deallocate(edmf_a2d)
       deallocate(edmf_w2d)

--- a/phys/module_bl_mynn_wrapper.F
+++ b/phys/module_bl_mynn_wrapper.F
@@ -1,0 +1,790 @@
+!> \file module_bl_mynn_wrapper.F90
+!!  This serves as the interface between the WRF PBL driver and the MYNN 
+!!  eddy-diffusivity mass-flux scheme in module_bl_mynn.F. 
+
+!>\ingroup gsd_mynn_edmf
+!> The following references best describe the code within
+!!    Olson et al. (2019, NOAA Technical Memorandum)
+!!    Nakanishi and Niino (2009) \cite NAKANISHI_2009
+      MODULE module_bl_mynn_wrapper
+
+      use module_bl_mynn_common
+
+      contains
+
+!> \section arg_table_mynnedmf_wrapper_init Argument Table
+!! \htmlinclude mynnedmf_wrapper_init.html
+!!
+      subroutine mynnedmf_wrapper_init (              &
+        &  RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,&
+        &  RQIBLTEN,QKE,                              &
+        &  restart,allowed_to_read,                   &
+        &  P_QC,P_QI,PARAM_FIRST_SCALAR,              &
+        &  IDS,IDE,JDS,JDE,KDS,KDE,                   &
+        &  IMS,IME,JMS,JME,KMS,KME,                   &
+        &  ITS,ITE,JTS,JTE,KTS,KTE                    )
+
+        implicit none
+        
+        LOGICAL,INTENT(IN) :: ALLOWED_TO_READ,RESTART
+
+        INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,  &
+             &                IMS,IME,JMS,JME,KMS,KME,  &
+             &                ITS,ITE,JTS,JTE,KTS,KTE
+
+
+        REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
+             &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,                 &
+             &RQCBLTEN,RQIBLTEN,QKE
+
+        INTEGER,  intent(in) :: P_QC,P_QI,PARAM_FIRST_SCALAR
+
+        INTEGER :: I,J,K,ITF,JTF,KTF
+
+        JTF=MIN0(JTE,JDE-1)
+        KTF=MIN0(KTE,KDE-1)
+        ITF=MIN0(ITE,IDE-1)
+
+        IF (.NOT.RESTART) THEN
+         DO J=JTS,JTF
+          DO K=KTS,KTF
+           DO I=ITS,ITF
+              RUBLTEN(i,k,j)=0.
+              RVBLTEN(i,k,j)=0.
+              RTHBLTEN(i,k,j)=0.
+              RQVBLTEN(i,k,j)=0.
+              if( p_qc >= param_first_scalar ) RQCBLTEN(i,k,j)=0.
+              if( p_qi >= param_first_scalar ) RQIBLTEN(i,k,j)=0.
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDIF
+
+      end subroutine mynnedmf_wrapper_init
+
+      subroutine mynnedmf_wrapper_finalize ()
+      end subroutine mynnedmf_wrapper_finalize
+
+! \brief This scheme (1) performs pre-mynnedmf work, (2) runs the mynnedmf, and (3) performs post-mynnedmf work
+!> \section arg_table_mynnedmf_wrapper_run Argument Table
+!! \htmlinclude mynnedmf_wrapper_run.html
+!!
+SUBROUTINE mynnedmf_wrapper_run(                 &
+     &  initflag,restart,cycling,                &
+     &  delt,dz,dxc,znt,                         &
+     &  u,v,w,th,                                &
+     &  qv,qc,qi,qnc,qni,qnwfa,qnifa,qnbca,      &
+!     &  ozone,                                   &
+     &  p,exner,rho,t3d,                         &
+     &  xland,ts,qsfc,ps,                        &
+     &  ust,ch,hfx,qfx,rmol,wspd,                &
+     &  uoce,voce,                               &
+     &  qke,qke_adv,sh3d,sm3d,                   &
+!--- chem/smoke
+#if (WRF_CHEM == 1)
+     &  chem3d,vd3d,nchem,kdevl,                 &
+     &  ndvel,num_vert_mix,                      &
+     &  frp_mean,emis_ant_no,                    &
+     &  mix_chem,enh_mix,                        &
+#endif
+!--- end chem/smoke 
+     &  Tsq,Qsq,Cov,                             &
+     &  rublten,rvblten,rthblten,                &
+     &  rqvblten,rqcblten,rqiblten,              &
+     &  rqncblten,rqniblten,                     &
+     &  rqnwfablten,rqnifablten,rqnbcablten,     &
+!     &  ro3blten,                                &
+     &  exch_h,exch_m,pblh,kpbl,el_pbl,          &
+     &  dqke,qwt,qshear,qbuoy,qdiss,             &
+     &  qc_bl,qi_bl,cldfra_bl,                   &
+     &  edmf_a,edmf_w,edmf_qt,                   &
+     &  edmf_thl,edmf_ent,edmf_qc,               &
+     &  sub_thl3d,sub_sqv3d,                     &
+     &  det_thl3d,det_sqv3d,                     &
+     &  nupdraft,maxMF,ktop_plume,               &
+     &  rthraten,                                &
+     &  bl_mynn_tkebudget,  bl_mynn_tkeadvect,   &
+     &  bl_mynn_cloudpdf,   bl_mynn_mixlength,   &
+     &  icloud_bl,          bl_mynn_edmf,        &
+     &  bl_mynn_edmf_mom,   bl_mynn_edmf_tke,    &
+     &  bl_mynn_cloudmix,   bl_mynn_mixqt,       &
+     &  bl_mynn_output,     bl_mynn_closure,     &
+     &  bl_mynn_mixscalars,                      &
+     &  spp_pbl,pattern_spp_pbl,                 &
+     &  flag_qc,flag_qi,                         &
+     &  flag_qnc,flag_qni,                       &
+     &  flag_qnwfa,flag_qnifa,flag_qnbca,        &
+     &  ids,ide,jds,jde,kds,kde,                 &
+     &  ims,ime,jms,jme,kms,kme,                 &
+     &  its,ite,jts,jte,kts,kte                  )
+
+!     use module_gfs_machine,  only : kind_phys
+!     use module_bl_mynn_common, only: xlvcp, xlscp
+     use module_bl_mynn, only: mynn_bl_driver
+
+!------------------------------------------------------------------- 
+     implicit none
+!------------------------------------------------------------------- 
+
+     !smoke/chem
+#if (WRF_CHEM == 1)
+     logical, intent(in) :: mix_chem, enh_mix
+     integer, intent(in) :: nchem, ndvel, kdvel
+     logical, parameter ::                                  &
+     &       rrfs_sd    =.false.,                           &
+     &       smoke_dbg  =.false.
+#else
+     logical, parameter ::                                  &
+     &       mix_chem   =.false.,                           &
+     &       enh_mix    =.false.,                           &
+     &       rrfs_sd    =.false.,                           &
+     &       smoke_dbg  =.false.
+     integer, parameter :: nchem=2, ndvel=2, kdvel=1
+#endif
+
+! NAMELIST OPTIONS (INPUT):
+     logical, intent(in) ::                                 &
+     &       bl_mynn_tkeadvect,                             &
+     &       bl_mynn_tkebudget,                             &
+     &       cycling
+      integer, intent(in) ::                                &
+     &       bl_mynn_cloudpdf,                              &
+     &       bl_mynn_mixlength,                             &
+     &       icloud_bl,                                     &
+     &       bl_mynn_edmf,                                  &
+     &       bl_mynn_edmf_mom,                              &
+     &       bl_mynn_edmf_tke,                              &
+     &       bl_mynn_cloudmix,                              &
+     &       bl_mynn_mixqt,                                 &
+     &       bl_mynn_output,                                &
+     &       bl_mynn_mixscalars,                            &
+     &       spp_pbl
+      real, intent(in) ::                                   &
+     &       bl_mynn_closure
+
+      logical, intent(in) ::                                &
+     &       FLAG_QI, FLAG_QNI, FLAG_QC, FLAG_QNC,          &
+     &       FLAG_QNWFA, FLAG_QNIFA, FLAG_QNBCA
+      logical, parameter :: FLAG_OZONE = .false.
+
+!MYNN-1D
+      REAL,    intent(in) :: delt, dxc
+      LOGICAL, intent(in) :: restart
+      INTEGER :: i, j, k, itf, jtf, ktf
+      INTEGER, intent(in) :: initflag,                      &
+     &           IDS,IDE,JDS,JDE,KDS,KDE,                   &
+     &           IMS,IME,JMS,JME,KMS,KME,                   &
+     &           ITS,ITE,JTS,JTE,KTS,KTE
+
+!MYNN-3D
+      real, dimension(ims:ime,kms:kme,jms:jme), intent(in) ::          &
+     &       u,v,w,t3d,th,rho,exner,p,dz
+      real, dimension(ims:ime,kms:kme,jms:jme), intent(inout) ::       &
+     &       rublten,rvblten,rthblten,                                 &
+     &       rqvblten,rqcblten,rqiblten,                               &
+     &       rqncblten,rqniblten,                                      &
+     &       rqnwfablten,rqnifablten,rqnbcablten !,ro3blten
+      real, dimension(ims:ime,kms:kme,jms:jme), intent(inout) ::       &
+     &       qke, qke_adv, el_pbl, sh3d, sm3d
+      real, dimension(ims:ime,kms:kme,jms:jme), intent(inout) ::       &
+     &       Tsq, Qsq, Cov, exch_h, exch_m
+      real, dimension(ims:ime,kms:kme,jms:jme), intent(in) :: rthraten
+
+!optional 3D arrays
+      real, dimension(ims:ime,kms:kme,jms:jme), optional, intent(in)  ::    &
+     &       pattern_spp_pbl
+      real, dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       qc_bl, qi_bl, cldfra_bl
+      real, dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       edmf_a,edmf_w,edmf_qt,                                    &
+     &       edmf_thl,edmf_ent,edmf_qc,                                &
+     &       sub_thl3d,sub_sqv3d,det_thl3d,det_sqv3d
+      real, dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       dqke,qWT,qSHEAR,qBUOY,qDISS
+      real, dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       qv,qc,qi,qnc,qni,qnwfa,qnifa,qnbca!,o3
+
+!optional 2D arrays for passing into module_bl_myn.F
+      real, allocatable, dimension(:,:) ::                             &
+     &       qc_bl2d, qi_bl2d, cldfra_bl2d, pattern_spp_pbl2d
+      real, allocatable, dimension(:,:) ::                             &
+     &       edmf_a2d,edmf_w2d,edmf_qt2d,                              &
+     &       edmf_thl2d,edmf_ent2d,edmf_qc2d,                          &
+     &       sub_thl2d,sub_sqv2d,det_thl2d,det_sqv2d
+      real, allocatable, dimension(:,:) ::                             &
+     &       dqke2d,qWT2d,qSHEAR2d,qBUOY2d,qDISS2d
+      real, allocatable, dimension(:,:) ::                             &
+     &       qc2d,qi2d,qnc2d,qni2d,qnwfa2d,qnifa2d,qnbca2d!,o32d
+
+!smoke/chem arrays - no if-defs in module_bl_mynn.F, so must define arrays
+#if (WRF_CHEM == 1)
+      real, dimension(ims:ime, kms:kme, jms:jme), intent(inout), optional ::  &                                     
+     &         qgrs_smoke_conc, qgrs_dust_conc
+      real, allocatable, dimension(:,:,:,:) :: chem3d
+      real, dimension(ims:ime, kdvel, jms:jme, ndvel), intent(in), optional :: vd3d
+      real, dimension(ims:ime, jms:jme),   intent(in), optional :: frp_mean, emis_ant_no
+#else
+      real, dimension(ims:ime,kms:kme,jms:jme)       ::                &
+     &         qgrs_smoke_conc, qgrs_dust_conc
+      real, allocatable, dimension(:,:,:) :: chem3d
+      real, dimension(ims:ime,ndvel)      :: vd3d
+      real, dimension(ims:ime)            :: frp_mean, emis_ant_no
+#endif
+
+!MYNN-2D
+      real, dimension(ims:ime,jms:jme), intent(in) ::                  &
+     &        xland,ts,qsfc,ps,ch
+      real, dimension(ims:ime,jms:jme), intent(inout) ::               &
+     &        znt,pblh,maxmf,rmol,hfx,qfx,ust,wspd,                    &
+     &        uoce,voce
+      integer, dimension(ims:ime,jms:jme), intent(inout) ::            &
+     &        kpbl,nupdraft,ktop_plume
+
+!Local
+      real, dimension(ims:ime,kms:kme)         :: delp,sqv,sqc,sqi
+      real, dimension(ims:ime)                 :: dx
+      logical, parameter                       :: debug = .false.
+      real, dimension(ims:ime,kms:kme,jms:jme) :: ozone,r03blten
+
+   !write(0,*)"=============================================="
+   !write(0,*)"in mynn wrapper..."
+   !write(0,*)"initflag=",initflag
+   !write(0,*)"restart =",restart
+
+   jtf=MIN0(JTE,JDE-1)
+   ktf=MIN0(KTE,KDE-1)
+   itf=MIN0(ITE,IDE-1)
+
+   !For now, initialized bogus array
+   ozone=0.0
+   r03blten=0.0
+
+   !Allocate any arrays being used
+   if (icloud_bl > 0) then
+      allocate(qc_bl2d(ims:ime,kms:kme))
+      allocate(qi_bl2d(ims:ime,kms:kme))
+      allocate(cldfra_bl2d(ims:ime,kms:kme))
+      qc_bl2d=0.0
+      qi_bl2d=0.0
+      cldfra_bl2d=0.0
+   endif
+   if (spp_pbl > 0) then
+      allocate(pattern_spp_pbl2d(ims:ime,kms:kme))
+   endif
+   if (bl_mynn_output > 0) then
+      allocate(edmf_a2d(ims:ime,kms:kme))
+      allocate(edmf_w2d(ims:ime,kms:kme))
+      allocate(edmf_qt2d(ims:ime,kms:kme))
+      allocate(edmf_thl2d(ims:ime,kms:kme))
+      allocate(edmf_ent2d(ims:ime,kms:kme))
+      allocate(edmf_qc2d(ims:ime,kms:kme))
+      allocate(sub_thl2d(ims:ime,kms:kme))
+      allocate(sub_sqv2d(ims:ime,kms:kme))
+      allocate(det_thl2d(ims:ime,kms:kme))
+      allocate(det_sqv2d(ims:ime,kms:kme))
+   endif
+   if (bl_mynn_tkebudget) then
+      allocate(dqke2d(ims:ime,kms:kme))
+      allocate(qWT2d(ims:ime,kms:kme))
+      allocate(qSHEAR2d(ims:ime,kms:kme))
+      allocate(qBUOY2d(ims:ime,kms:kme))
+      allocate(qDISS2d(ims:ime,kms:kme))
+      dqke2d  =0.0
+      qWT2d   =0.0
+      qSHEAR2d=0.0
+      qBUOY2d =0.0
+      qDISS2d =0.0
+   endif
+   if (flag_qc) then
+      allocate(qc2d(ims:ime,kms:kme))
+      qc2d=0.0
+   endif
+   if (flag_qi) then
+      allocate(qi2d(ims:ime,kms:kme))
+      qi2d=0.0
+   endif
+   if (flag_qnc) then
+      allocate(qnc2d(ims:ime,kms:kme))
+      qnc2d=0.0
+   endif
+   if (flag_qni) then
+      allocate(qni2d(ims:ime,kms:kme))
+      qni2d=0.0
+   endif
+   if (flag_qnwfa) then
+      allocate(qnwfa2d(ims:ime,kms:kme))
+      qnwfa2d=0.0
+   endif
+   if (flag_qnifa) then
+      allocate(qnifa2d(ims:ime,kms:kme))
+      qnifa2d=0.0
+   endif
+   if (flag_qnbca) then
+      allocate(qnbca2d(ims:ime,kms:kme))
+      qnbca2d=0.0
+   endif
+   !---------------------------------
+   !Begin looping in the j-direction
+   !---------------------------------
+   do j = jts,jtf
+
+      !need sgs cloud info input for diagnostic-decay
+      if (icloud_bl > 0) then
+         do k=kts,ktf
+         do i=its,itf
+            qc_bl2d(i,k)     = qc_bl(i,k,j)
+            qi_bl2d(i,k)     = qi_bl(i,k,j)
+            cldfra_bl2d(i,k) = cldfra_bl(i,k,j)
+         enddo
+         enddo
+      endif
+
+      !spp input
+      if (spp_pbl > 0) then
+         do k=kts,ktf
+         do i=its,itf
+            pattern_spp_pbl2d(i,k) = pattern_spp_pbl(i,k,j)
+         enddo
+         enddo
+      endif
+
+      !intialize moist species
+      if (flag_qc) then
+         do k=kts,ktf
+         do i=its,itf
+            qc2d(i,k) = qc(i,k,j)
+         enddo
+         enddo
+      endif
+      if (flag_qi) then
+         do k=kts,ktf
+         do i=its,itf
+            qi2d(i,k) = qi(i,k,j)
+         enddo
+         enddo
+      endif
+      if (flag_qnc) then
+         do k=kts,ktf
+         do i=its,itf
+            qnc2d(i,k) = qnc(i,k,j)
+         enddo
+         enddo
+      endif
+      if (flag_qni) then
+         do k=kts,ktf
+         do i=its,itf
+            qni2d(i,k) = qni(i,k,j)
+         enddo
+         enddo
+      endif
+      if (flag_qnwfa) then
+         do k=kts,ktf
+         do i=its,itf
+            qnwfa2d(i,k) = qnwfa(i,k,j)
+         enddo
+         enddo
+      endif
+      if (flag_qnifa) then
+         do k=kts,ktf
+         do i=its,itf
+            qnifa2d(i,k) = qnifa(i,k,j)
+         enddo
+         enddo
+      endif
+      if (flag_qnbca) then
+         do k=kts,ktf
+         do i=its,itf
+            qnbca2d(i,k) = qnbca(i,k,j)
+         enddo
+         enddo
+      endif
+#if (WRF_CHEM == 1)
+      if (mix_chem) then
+         allocate ( chem3d(ime,kme,nchem) )
+         do k=kts,ktf
+         do i=its,itf
+            chem3d(i,k,1)=qgrs_smoke_conc(i,k,j)
+            chem3d(i,k,2)=qgrs_dust_conc(i,k,j)
+         enddo
+         enddo
+      endif
+#else
+      ! initializing chem3d should be done at higher level...
+      qgrs_smoke_conc = 1.0
+      qgrs_dust_conc  = 1.0
+      frp_mean        = 0.0
+      EMIS_ANT_NO = 0.
+      vd3d = 0. ! hli for chem dry deposition, 0 temporarily
+      if (mix_chem) then
+         allocate ( chem3d(ims:ime,kms:kme,nchem) )
+         do k=kts,ktf
+         do i=its,itf
+            chem3d(i,k,1)=qgrs_smoke_conc(i,k,j)
+            chem3d(i,k,2)=qgrs_dust_conc (i,k,j)
+         enddo
+         enddo
+      endif
+#endif
+
+      ! Check incoming moist species to ensure non-negative values
+      ! First, create pressure differences (delp) across model layers
+      do i=its,itf
+         dx(i)=dxc
+!         delp(i,1)  = ps(i,j) - (p(i,2,j)*dz(i,1,j) + p(i,1,j)*dz(i,2,j))/(dz(i,1,j)+dz(i,2,j))
+!         do k=2,kte-1
+!            delp(i,k) = (p(i,k,j)*dz(i,k-1,j) + p(i,k-1,j)*dz(i,k,j))/(dz(i,k,j)+dz(i,k-1,j)) - &
+!                        (p(i,k+1,j)*dz(i,k,j) + p(i,k,j)*dz(i,k+1,j))/(dz(i,k,j)+dz(i,k+1,j))
+!         enddo
+!         delp(i,kte) = delp(i,kte-1)
+      enddo
+
+!      do i=its,itf
+!         call moisture_check2(kte, delt,                 &
+!                              delp(i,:), exner(i,:,j),   &
+!                              qv(i,:,j), qc(i,:,j),      &
+!                              qi(i,:,j), t3d(i,:,j)      )
+!      enddo
+
+      !In WRF, mixing ratio is incoming. Convert to specific humidity:
+       do k=kts,ktf
+          do i=its,itf
+             sqv(i,k)=qv(i,k,j)/(1.0 + qv(i,k,j))
+             sqc(i,k)=qc2d(i,k)/(1.0 + qv(i,k,j))
+             sqi(i,k)=qi2d(i,k)/(1.0 + qv(i,k,j))
+         enddo
+      enddo
+
+!      do i=its,ite
+!         ts(i,j)=tsurf(i,j)/exner(i,1,j)  !theta
+!      enddo
+
+      if (debug) then
+         print*
+         write(0,*)"===CALLING mynn_bl_driver; input:"
+         print*,"bl_mynn_tkebudget=",bl_mynn_tkebudget
+         print*,"bl_mynn_tkeadvect=",bl_mynn_tkeadvect
+         print*,"bl_mynn_cloudpdf=",bl_mynn_cloudpdf
+         print*,"bl_mynn_mixlength=",bl_mynn_mixlength
+         print*,"bl_mynn_edmf=",bl_mynn_edmf
+         print*,"bl_mynn_edmf_mom=",bl_mynn_edmf_mom
+         print*,"bl_mynn_edmf_tke=",bl_mynn_edmf_tke
+         print*,"bl_mynn_cloudmix=",bl_mynn_cloudmix
+         print*,"bl_mynn_mixqt=",bl_mynn_mixqt
+         print*,"icloud_bl=",icloud_bl
+         print*,"T:",t3d(its,1,j),t3d(its,2,j),t3d(its,kte,j)
+         print*,"TH:",th(its,1,j),th(its,2,j),th(its,kte,j)
+         print*,"rho:",rho(its,1,j),rho(its,2,j),rho(its,kte,j)
+         print*,"exner:",exner(its,1,j),exner(its,2,j),exner(its,kte,j)
+         print*,"p:",p(its,1,j),p(its,2,j),p(its,kte,j)
+         print*,"dz:",dz(its,1,j),dz(its,2,j),dz(its,kte,j)
+         print*,"u:",u(its,1,j),u(its,2,j),u(its,kte,j)
+         print*,"v:",v(its,1,j),v(its,2,j),v(its,kte,j)
+         print*,"sqv:",sqv(its,1),sqv(its,2),sqv(its,kte)
+         print*,"sqc:",sqc(its,1),sqc(its,2),sqc(its,kte)
+         print*,"sqi:",sqi(its,1),sqi(its,2),sqi(its,kte)
+         print*,"rmol:",rmol(its,j)," ust:",ust(its,j)
+         print*,"dx=",dx(its),"initflag=",initflag
+         print*,"Thetasurf:",ts(its,j)
+         print*,"HFX:",hfx(its,j)," qfx",qfx(its,j)
+         print*,"qsfc:",qsfc(its,j)," ps:",ps(its,j)
+         print*,"wspd:",wspd(its,j)
+         print*,"znt:",znt(its,j)," delt=",delt
+         print*,"ite=",ite," kte=",kte
+         print*,"PBLH=",pblh(its,j)," KPBL=",KPBL(its,j)," xland=",xland(its,j)
+         print*," ch=",ch(its,j)
+         print*,"qke:",qke(its,1,j),qke(its,2,j),qke(its,kte,j)
+         print*,"el_pbl:",el_pbl(its,1,j),el_pbl(its,2,j),el_pbl(its,kte,j)
+         print*,"Sh3d:",Sh3d(its,1,j),sh3d(its,2,j),sh3d(its,kte,j)
+         print*,"max cf_bl:",maxval(cldfra_bl(its,:,j))
+      endif
+
+!print*,"In mynn wrapper, calling mynn_bl_driver"
+              CALL  mynn_bl_driver(                                    &
+     &        initflag=initflag,restart=restart,cycling=cycling,       &
+     &        delt=delt,dz=dz(:,:,j),dx=dx,znt=znt(:,j),               &
+     &        u=u(:,:,j),v=v(:,:,j),w=w(:,:,j),                        &
+     &        th=th(:,:,j),sqv3D=sqv,sqc3D=sqc,                        &
+     &        sqi3D=sqi,qnc=qnc2d,qni=qni2d,                           &
+     &        qnwfa=qnwfa2d,qnifa=qnifa2d,                             &
+     &        ozone=ozone(:,:,j),                                      &
+     &        p=p(:,:,j),exner=exner(:,:,j),rho=rho(:,:,j),            &
+     &        T3D=t3d(:,:,j),xland=xland(:,j),                         &
+     &        ts=ts(:,j),qsfc=qsfc(:,j),ps=ps(:,j),                    &
+     &        ust=ust(:,j),ch=ch(:,j),hfx=hfx(:,j),qfx=qfx(:,j),       &
+     &        rmol=rmol(:,j),wspd=wspd(:,j),                           &
+     &        uoce=uoce(:,j),voce=voce(:,j),                           & !input
+     &        qke=QKE(:,:,j),qke_adv=qke_adv(:,:,j),                   & !output
+     &        sh3d=Sh3d(:,:,j),sm3d=Sm3d(:,:,j),                       & !output
+     &        nchem=nchem,kdvel=kdvel,ndvel=ndvel,                     & !chem/smoke
+     &        Chem3d=chem3d,Vdep=vd3d,                                 &
+     &        FRP=frp_mean,EMIS_ANT_NO=emis_ant_no,                    &
+     &        mix_chem=mix_chem,enh_mix=enh_mix,                       &
+     &        rrfs_sd=rrfs_sd,smoke_dbg=smoke_dbg,                     & !end chem/smoke
+     &        tsq=tsq(:,:,j),qsq=qsq(:,:,j),cov=cov(:,:,j),            & !output
+     &        RUBLTEN=RUBLTEN(:,:,j),RVBLTEN=RVBLTEN(:,:,j),           & !output
+     &        RTHBLTEN=RTHBLTEN(:,:,j),RQVBLTEN=RQVBLTEN(:,:,j),       & !output
+     &        RQCBLTEN=rqcblten(:,:,j),RQIBLTEN=rqiblten(:,:,j),       & !output
+     &        RQNCBLTEN=rqncblten(:,:,j),RQNIBLTEN=rqniblten(:,:,j),   & !output
+     &        RQNWFABLTEN=RQNWFABLTEN(:,:,j),                          & !output
+     &        RQNIFABLTEN=RQNIFABLTEN(:,:,j),                          & !output
+     &        RQNBCABLTEN=RQNBCABLTEN(:,:,j),                          & !output
+     &        dozone=r03blten(:,:,j),                                  & !output
+     &        EXCH_H=exch_h(:,:,j),EXCH_M=exch_m(:,:,j),               & !output
+     &        pblh=pblh(:,j),KPBL=KPBL(:,j),                           & !output
+     &        el_pbl=el_pbl(:,:,j),                                    & !output
+     &        dqke=dqke2d,qWT=qWT2d,qSHEAR=qSHEAR2d,                   & !output
+     &        qBUOY=qBUOY2d,qDISS=qDISS2d,                             & !output
+     &        qc_bl=qc_bl2d,qi_bl=qi_bl2d,cldfra_bl=cldfra_bl2d,       & !output
+     &        bl_mynn_tkeadvect=bl_mynn_tkeadvect,                     & !input parameter
+     &        bl_mynn_tkebudget=bl_mynn_tkebudget,                     & !input parameter
+     &        bl_mynn_cloudpdf=bl_mynn_cloudpdf,                       & !input parameter
+     &        bl_mynn_mixlength=bl_mynn_mixlength,                     & !input parameter
+     &        icloud_bl=icloud_bl,                                     & !input parameter
+     &        closure=bl_mynn_closure,bl_mynn_edmf=bl_mynn_edmf,       & !input parameter
+     &        bl_mynn_edmf_mom=bl_mynn_edmf_mom,                       & !input parameter
+     &        bl_mynn_edmf_tke=bl_mynn_edmf_tke,                       & !input parameter
+     &        bl_mynn_mixscalars=bl_mynn_mixscalars,                   & !input parameter
+     &        bl_mynn_output=bl_mynn_output,                           & !input parameter
+     &        bl_mynn_cloudmix=bl_mynn_cloudmix,                       & !input parameter
+     &        bl_mynn_mixqt=bl_mynn_mixqt,                             & !input parameter
+     &        edmf_a=edmf_a2d,edmf_w=edmf_w2d,                         & !output
+     &        edmf_qt=edmf_qt2d,edmf_thl=edmf_thl2d,                   & !output
+     &        edmf_ent=edmf_ent2d,edmf_qc=edmf_qc2d,                   & !output
+     &        sub_thl3D=sub_thl2d,sub_sqv3D=sub_sqv2d,                 & !output
+     &        det_thl3D=det_thl2d,det_sqv3D=det_sqv2d,                 & !output
+     &        nupdraft=nupdraft(:,j),maxMF=maxMF(:,j),                 & !output
+     &        ktop_plume=ktop_plume(:,j),                              & !output
+     &        spp_pbl=spp_pbl,pattern_spp_pbl=pattern_spp_pbl2d,       & !input
+     &        RTHRATEN=rthraten(:,:,j),                                & !input
+     &        FLAG_QI=flag_qi,FLAG_QNI=flag_qni,                       & !input
+     &        FLAG_QC=flag_qc,FLAG_QNC=flag_qnc,                       & !input
+     &        FLAG_QNWFA=FLAG_QNWFA,FLAG_QNIFA=FLAG_QNIFA,             & !input
+     &        FLAG_QNBCA=FLAG_QNBCA,                                   & !input
+     &        IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde,         & !input
+     &        IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme,         & !input
+     &        ITS=its,ITE=itf,JTS=jts,JTE=jtf,KTS=kts,KTE=kte)           !input
+!print*,"In mynn wrapper, after bl_mynn_driver"
+
+     !- Convert spec hum to mixing ratio:
+      do k=kts,ktf
+        do i=its,itf
+           RQVBLTEN(i,k,j) = RQVBLTEN(i,k,j)/(1.0 - sqv(i,k))
+           RQCBLTEN(i,k,j) = RQCBLTEN(i,k,j)/(1.0 - sqv(i,k))
+           RQIBLTEN(i,k,j) = RQIBLTEN(i,k,j)/(1.0 - sqv(i,k))
+        enddo
+      enddo
+
+     !- Collect 3D ouput:
+      if (icloud_bl > 0) then
+         do k=kts,ktf
+         do i=its,itf
+            qc_bl(i,k,j)     = qc_bl2d(i,k)
+            qi_bl(i,k,j)     = qi_bl2d(i,k)
+            cldfra_bl(i,k,j) = cldfra_bl2d(i,k)
+         enddo
+         enddo
+      endif
+
+      if (bl_mynn_tkebudget) then
+         do k=kts,ktf
+         do i=its,itf
+            dqke(i,k,j)     = dqke2d(i,k)
+            qwt(i,k,j)      = qwt2d(i,k)
+            qshear(i,k,j)   = qshear2d(i,k)
+            qbuoy(i,k,j)    = qbuoy2d(i,k)
+            qdiss(i,k,j)    = qdiss2d(i,k)
+         enddo
+         enddo
+      endif
+
+      if (bl_mynn_output > 0) then
+         do k=kts,ktf
+         do i=its,itf
+            edmf_a(i,k,j)     = edmf_a2d(i,k)
+            edmf_w(i,k,j)     = edmf_w2d(i,k)
+            edmf_qt(i,k,j)    = edmf_qt2d(i,k)
+            edmf_thl(i,k,j)   = edmf_thl2d(i,k)
+            edmf_ent(i,k,j)   = edmf_ent2d(i,k)
+            edmf_qc(i,k,j)    = edmf_qc2d(i,k)
+            sub_thl3d(i,k,j)  = sub_thl2d(i,k)
+            sub_sqv3d(i,k,j)  = sub_sqv2d(i,k)
+            det_thl3d(i,k,j)  = det_thl2d(i,k)
+            det_sqv3d(i,k,j)  = det_sqv2d(i,k)
+         enddo
+         enddo
+      endif
+
+      if (debug) then
+          print*
+          print*,"===Finished with mynn_bl_driver; output:"
+          print*,"T:",t3d(its,1,j),t3d(its,2,j),t3d(its,kte,j)
+          print*,"TH:",th(its,1,j),th(its,2,j),th(its,kte,j)
+          print*,"rho:",rho(its,1,j),rho(its,2,j),rho(its,kte,j)
+          print*,"exner:",exner(its,1,j),exner(its,2,j),exner(its,kte,j)
+          print*,"p:",p(its,1,j),p(its,2,j),p(its,kte,j)
+          print*,"dz:",dz(its,1,j),dz(its,2,j),dz(its,kte,j)
+          print*,"u:",u(its,1,j),u(its,2,j),u(its,kte,j)
+          print*,"v:",v(its,1,j),v(its,2,j),v(its,kte,j)
+          print*,"sqv:",sqv(its,1),sqv(its,2),sqv(its,kte)
+          print*,"sqc:",sqc(its,1),sqc(its,2),sqc(its,kte)
+          print*,"sqi:",sqi(its,1),sqi(its,2),sqi(its,kte)
+          print*,"rmol:",rmol(its,j)," ust:",ust(its,j)
+          print*,"dx(its,j)=",dx(its),"initflag=",initflag
+          print*,"Thetasurf:",ts(its,j)
+          print*,"HFX:",hfx(its,j)," qfx",qfx(its,j)
+          print*,"qsfc:",qsfc(its,j)," ps:",ps(its,j)
+          print*,"wspd:",wspd(its,j)
+          print*,"znt:",znt(its,j)," delt=",delt
+          print*,"im=",ite," kte=",kte
+          print*,"PBLH=",pblh(its,j)," KPBL=",KPBL(its,j)," xland=",xland(its,j)
+          print*,"ch=",ch(its,j)
+          print*,"qke:",qke(its,1,j),qke(its,2,j),qke(its,kte,j)
+          print*,"el_pbl:",el_pbl(its,1,j),el_pbl(its,2,j),el_pbl(its,kte,j)
+          print*,"Sh3d:",Sh3d(its,1,j),sh3d(its,2,j),sh3d(its,kte,j)
+          print*,"exch_h:",exch_h(its,1,j),exch_h(its,2,j),exch_h(its,kte,j)
+          print*,"exch_m:",exch_m(its,1,j),exch_m(its,2,j),exch_m(its,kte,j)
+          print*,"max cf_bl:",maxval(cldfra_bl(its,:,j))
+          print*,"max qc_bl:",maxval(qc_bl(its,:,j))
+          print*,"dtdt:",rthblten(its,1,j),rthblten(its,2,j),rthblten(its,kte,j)
+          print*,"dudt:",rublten(its,1,j),rublten(its,2,j),rublten(its,kte,j)
+          print*,"dvdt:",rvblten(its,1,j),rvblten(its,2,j),rvblten(its,kte,j)
+          print*,"dqdt:",rqvblten(its,1,j),rqvblten(its,2,j),rqvblten(its,kte,j)
+          print*,"ktop_plume:",ktop_plume(its,j)," maxmf:",maxmf(its,j)
+          print*,"nup:",nupdraft(its,j)
+          print*
+       endif
+
+   enddo  !end j-loop 
+
+   !Deallocate all temporary interface arrays
+   if (mix_chem) then
+      deallocate(chem3d)
+   endif
+   if (bl_mynn_output > 0) then
+      deallocate(edmf_a2d)
+      deallocate(edmf_w2d)
+      deallocate(edmf_qt2d)
+      deallocate(edmf_thl2d)
+      deallocate(edmf_ent2d)
+      deallocate(edmf_qc2d)
+      deallocate(sub_thl2d)
+      deallocate(sub_sqv2d)
+      deallocate(det_thl2d)
+      deallocate(det_sqv2d)
+   endif
+   if (bl_mynn_tkebudget) then
+      deallocate(dqke2d)
+      deallocate(qwt2d)
+      deallocate(qshear2d)
+      deallocate(qbuoy2d)
+      deallocate(qdiss2d)
+   endif
+   if (icloud_bl > 0) then
+      deallocate(qc_bl2d)
+      deallocate(qi_bl2d)
+      deallocate(cldfra_bl2d)
+   endif
+   if (flag_qc)   deallocate(qc2d)
+   if (flag_qi)   deallocate(qi2d)
+   if (flag_qnc)  deallocate(qnc2d)
+   if (flag_qni)  deallocate(qni2d)
+   if (flag_qnwfa)deallocate(qnwfa2d)
+   if (flag_qnifa)deallocate(qnifa2d)
+   if (flag_qnbca)deallocate(qnbca2d)
+   if (spp_pbl > 0) then
+      deallocate(pattern_spp_pbl2d)
+   endif
+
+!print*,"In mynn wrapper, at end"
+
+  CONTAINS
+
+! ==================================================================
+  SUBROUTINE moisture_check2(kte, delt, dp, exner, &
+                             qv, qc, qi, th        )
+  !
+  ! If qc < qcmin, qi < qimin, or qv < qvmin happens in any layer,
+  ! force them to be larger than minimum value by (1) condensating 
+  ! water vapor into liquid or ice, and (2) by transporting water vapor 
+  ! from the very lower layer.
+  ! 
+  ! We then update the final state variables and tendencies associated
+  ! with this correction. If any condensation happens, update theta/temperature too.
+  ! Note that (qv,qc,qi,th) are the final state variables after
+  ! applying corresponding input tendencies and corrective tendencies.
+
+    implicit none
+    integer,  intent(in)     :: kte
+    real, intent(in)     :: delt
+    real, dimension(kte), intent(in)     :: dp
+    real, dimension(kte), intent(in)     :: exner
+    real, dimension(kte), intent(inout)  :: qv, qc, qi, th
+    integer   k
+    real ::  dqc2, dqi2, dqv2, sum, aa, dum
+    real, parameter :: qvmin1= 1e-8,    & !min at k=1
+                       qvmin = 1e-20,   & !min above k=1
+                       qcmin = 0.0,     &
+                       qimin = 0.0
+
+    do k = kte, 1, -1  ! From the top to the surface
+       dqc2 = max(0.0, qcmin-qc(k)) !qc deficit (>=0)
+       dqi2 = max(0.0, qimin-qi(k)) !qi deficit (>=0)
+
+       !update species
+       qc(k)  = qc(k)  +  dqc2
+       qi(k)  = qi(k)  +  dqi2
+       qv(k)  = qv(k)  -  dqc2 - dqi2
+       !for theta
+       !th(k)  = th(k)  +  xlvcp/exner(k)*dqc2 + &
+       !                   xlscp/exner(k)*dqi2
+       !for temperature
+       th(k)  = th(k)  +  xlvcp*dqc2 + &
+                          xlscp*dqi2
+
+       !then fix qv if lending qv made it negative
+       if (k .eq. 1) then
+          dqv2   = max(0.0, qvmin1-qv(k)) !qv deficit (>=0)
+          qv(k)  = qv(k)  + dqv2
+          qv(k)  = max(qv(k),qvmin1)
+          dqv2   = 0.0
+       else
+          dqv2   = max(0.0, qvmin-qv(k)) !qv deficit (>=0)
+          qv(k)  = qv(k)  + dqv2
+          qv(k-1)= qv(k-1)  - dqv2*dp(k)/dp(k-1)
+          qv(k)  = max(qv(k),qvmin)
+       endif
+       qc(k) = max(qc(k),qcmin)
+       qi(k) = max(qi(k),qimin)
+    end do
+
+    ! Extra moisture used to satisfy 'qv(1)>=qvmin' is proportionally
+    ! extracted from all the layers that has 'qv > 2*qvmin'. This fully
+    ! preserves column moisture.
+    if( dqv2 .gt. 1.e-20 ) then
+        sum = 0.0
+        do k = 1, kte
+           if( qv(k) .gt. 2.0*qvmin ) sum = sum + qv(k)*dp(k)
+        enddo
+        aa = dqv2*dp(1)/max(1.e-20,sum)
+        if( aa .lt. 0.5 ) then
+            do k = 1, kte
+               if( qv(k) .gt. 2.0*qvmin ) then
+                   dum    = aa*qv(k)
+                   qv(k)  = qv(k) - dum
+               endif
+            enddo
+        else
+        ! For testing purposes only (not yet found in any output):
+        !    write(*,*) 'Full moisture conservation is impossible'
+        endif
+    endif
+
+    return
+
+  END SUBROUTINE moisture_check2
+
+  END SUBROUTINE mynnedmf_wrapper_run
+
+!###=================================================================
+
+END MODULE module_bl_mynn_wrapper

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -134,7 +134,8 @@ CONTAINS
      &        ,tracer,tracer_tend,num_tracer                         &
      &        ,scalar_pblmix,tracer_pblmix                           &
 #if (WRF_CHEM == 1)
-               ,chem,vd,nchem,kdvel,ndvel,num_vert_mix             &
+              ,mynn_chem_vertmx,chem,vd,nchem,kdvel                  &
+     &        ,ndvel,num_vert_mix                                    &
 #endif
 !
 ! FASDAS
@@ -761,6 +762,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: nchem, kdvel,ndvel,num_vert_mix
     REAL, INTENT(INOUT),  DIMENSION( ims:ime, kms:kme, jms:jme,nchem ) :: CHEM
     REAL, INTENT(IN)   ,  DIMENSION( ims:ime, kdvel, jms:jme, ndvel )  :: VD
+    LOGICAL, INTENT(IN) :: mynn_chem_vertmx
 #endif
 
 !  LOCAL  VAR
@@ -1641,10 +1643,11 @@ CONTAINS
                    &uoce=uoce,voce=voce,                                 & !Ocean currents
                    &Qke=qke,qke_adv=qke_adv,Sh3d=Sh3d,Sm3d=Sm3d,         &
 #if (WRF_CHEM == 1)
+                   &mix_chem=mynn_chem_vertmx,                           &
                    &chem3d=chem,vd3d=vd,nchem=nchem,kdvel=kdvel,         &
                    &ndvel=ndvel,num_vert_mix=num_vert_mix,               &
-                   &FRP_MEAN=FRP_MEAN,EMIS_ANT_NO=EMIS_ANT_NO,           &
-                   &mix_chem=mynn_chem_vertmx,fire_turb=enh_vermix,      &
+!                   &FRP_MEAN=FRP_MEAN,EMIS_ANT_NO=EMIS_ANT_NO,           & !to be included soon
+!                   &fire_turb=enh_vermix,                                & !to be included soon
 #endif
                    &Tsq=tsq,Qsq=qsq,Cov=cov,                             &
                    &RUBLTEN=rublten,RVBLTEN=rvblten,RTHBLTEN=rthblten,   &

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -565,14 +565,14 @@ CONTAINS
                                      bl_mynn_output,           &
                                      bl_mynn_cloudmix,         &
                                      bl_mynn_mixqt,            &
-                                     icloud_bl
+                                     icloud_bl,                &
+                                     tke_budget
 
    REAL, OPTIONAL, INTENT(IN)  :: bl_mynn_closure
 
    REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), &
         & INTENT(INOUT) :: qke_adv
-   LOGICAL, OPTIONAL, INTENT(IN) :: bl_mynn_tkeadvect,         &
-                                    tke_budget
+   LOGICAL, OPTIONAL, INTENT(IN) :: bl_mynn_tkeadvect
 
 ! Katata-added -
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,              &
@@ -1667,7 +1667,7 @@ CONTAINS
                    &ktop_plume=ktop_plume,                               &
                    &RTHRATEN=RTHRATEN,                                   &
                    &bl_mynn_tkeadvect=bl_mynn_tkeadvect,                 &
-                   &bl_mynn_tkebudget=tke_budget,                        &
+                   &tke_budget=tke_budget,                               &
                    &bl_mynn_cloudpdf=bl_mynn_cloudpdf,                   &
                    &bl_mynn_mixlength=bl_mynn_mixlength,                 &
                    &icloud_bl=icloud_bl,                                 &

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -39,11 +39,11 @@ CONTAINS
                  ,exch_temf,cf3d_temf,cfm_temf                    &
                  ,flhc,flqc                                        &
               ! MYNN
-                 ,qke,Sh3d                                         &
+                 ,qke,Sh3d,Sm3d                                    &
                  ,qke_adv,bl_mynn_tkeadvect                        & !ACF for QKE advection
                  ,tsq,qsq,cov,rmol,ch,qcg,grav_settling            & 
-                 ,dqke,qWT,qSHEAR,qBUOY,qDISS,bl_mynn_tkebudget    &
-                 ,bl_mynn_cloudpdf                                 &
+                 ,dqke,qWT,qSHEAR,qBUOY,qDISS,tke_budget           &
+                 ,bl_mynn_closure,bl_mynn_cloudpdf                 &
                  ,bl_mynn_mixlength                                &
                  ,icloud_bl,qc_bl,qi_bl,cldfra_bl                  &
                  ,bl_mynn_edmf,bl_mynn_edmf_mom,bl_mynn_edmf_tke   &
@@ -149,7 +149,7 @@ CONTAINS
 #if (EM_CORE==1)
    USE module_state_description, ONLY :                            &
                    YSUSCHEME,MRFSCHEME,GFSSCHEME,MYJPBLSCHEME,ACMPBLSCHEME,&
-                   QNSEPBLSCHEME,MYNNPBLSCHEME2,MYNNPBLSCHEME3,BOULACSCHEME,&
+                   QNSEPBLSCHEME,MYNNPBLSCHEME,BOULACSCHEME,         &
                    CAMUWPBLSCHEME,BEPSCHEME,BEP_BEMSCHEME,MYJSFCSCHEME, &
                    FITCHSCHEME,SHINHONGSCHEME,                       &
                    TEMFPBLSCHEME,GBMPBLSCHEME,EEPSSCHEME,                  &
@@ -191,7 +191,7 @@ CONTAINS
    USE module_bl_mfshconvpbl
    USE module_bl_gbmpbl
 #if (EM_CORE==1)
-   USE module_bl_mynn
+   USE module_bl_mynn_wrapper
    USE module_bl_eeps
    USE module_bl_fogdes
    USE module_wind_fitch
@@ -545,7 +545,7 @@ CONTAINS
 !MYNN
    REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ),     &
           INTENT(INOUT) ::        tsq,qsq,cov, & !,k_m,k_h,k_q &
-                                  qke,Sh3d,                    &
+                                  qke,Sh3d,Sm3d,               &
                                   dqke,qWT,qSHEAR,qBUOY,qDISS, &
                                   qc_bl,qi_bl,cldfra_bl
 
@@ -555,8 +555,7 @@ CONTAINS
                                    sub_thl3D,sub_sqv3D,        &
                                    det_thl3D,det_sqv3D
 
-   INTEGER, OPTIONAL, INTENT(IN)  :: bl_mynn_tkebudget,        &
-                                     grav_settling,            &
+   INTEGER, OPTIONAL, INTENT(IN)  :: grav_settling,            &
                                      bl_mynn_cloudpdf,         &
                                      bl_mynn_mixlength,        &
                                      bl_mynn_edmf,             &
@@ -568,11 +567,13 @@ CONTAINS
                                      bl_mynn_mixqt,            &
                                      icloud_bl
 
-!ACF-QKE advection start
+   REAL, OPTIONAL, INTENT(IN)  :: bl_mynn_closure
+
    REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), &
         & INTENT(INOUT) :: qke_adv
-   LOGICAL, OPTIONAL, INTENT(IN) :: bl_mynn_tkeadvect
-!ACF-QKE advection end
+   LOGICAL, OPTIONAL, INTENT(IN) :: bl_mynn_tkeadvect,         &
+                                    tke_budget
+
 ! Katata-added -
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,              &
         &    INTENT(INOUT)::                               vdfg
@@ -951,9 +952,9 @@ CONTAINS
                call wrf_message("WARNING: When using an adaptive time-step the boundary layer"// &
                                 " time-step should be 0 (i.e., equivalent to model time-step).  ")
                call wrf_message("In order to proceed, for boundary layer calculations, the "// &
-                                "boundary layer time-step"// &
-                                 " will be rounded to the nearest minute," )
-                call wrf_message("possibly resulting in innacurate results.")
+                                "boundary layer time-step "// &
+                                "will be rounded to the nearest minute," )
+               call wrf_message("possibly resulting in innacurate results.")
             END IF
             DTBL=bldt*60
          else
@@ -1595,7 +1596,7 @@ CONTAINS
 
 #if (EM_CORE==1)
 
-        CASE (MYNNPBLSCHEME2, MYNNPBLSCHEME3)
+        CASE (MYNNPBLSCHEME)
 
            IF ( PRESENT( qv_curr )  .AND. PRESENT( qc_curr )  .AND. &
                 PRESENT( rqvblten ) .AND. PRESENT( rqcblten ) .AND. &
@@ -1603,14 +1604,9 @@ CONTAINS
                 PRESENT( rqniblten ) .AND. PRESENT( qni_curr ) .AND.&
                 PRESENT(qke) .AND. PRESENT(tsq) .AND.               &
                 PRESENT(qsq) .AND. PRESENT(cov) .AND.               &
-                PRESENT(rmol) .AND.                                 &
-                PRESENT(qcg) .AND. PRESENT(ch) .AND.                &
-                PRESENT(grav_settling) .AND.                        &
-                PRESENT(bl_mynn_tkebudget) .AND.                    &
-!ACF,JOE-QKE advection
-                PRESENT(qke_adv) .AND. PRESENT(bl_mynn_tkeadvect) .AND.&
-!ACF,JOE-end
-                PRESENT(vdfg) ) THEN
+                PRESENT(rmol) .AND. PRESENT(ch) .AND.               &
+                PRESENT(tke_budget) .AND. PRESENT(qke_adv) .AND.    &
+                PRESENT(bl_mynn_tkeadvect)  ) THEN
 
               CALL wrf_debug(100,'in MYNNPBL')
 
@@ -1623,30 +1619,32 @@ CONTAINS
               if (pert_mynn .and. multi_perturb == 1) then
                 allocate (qke_tmp(its:ite, kts:kte, jts:jte))
 
-                call Add_multi_perturb_pbl_perturbations (perts_qvapor, perts_qcloud, &
-                  perts_th, perts_tke, pert_mynn_qv, pert_mynn_qc, pert_mynn_t, pert_mynn_qke, &
-                  th_phy, qke, qke_adv, qv_curr, qc_curr, bl_mynn_tkeadvect, qke_tmp, its, ite, jts, jte, &
+                call Add_multi_perturb_pbl_perturbations (               &
+                  perts_qvapor, perts_qcloud, perts_th, perts_tke,       &
+                  pert_mynn_qv, pert_mynn_qc, pert_mynn_t, pert_mynn_qke,&
+                  th_phy, qke, qke_adv, qv_curr, qc_curr,                &
+                  bl_mynn_tkeadvect, qke_tmp, its, ite, jts, jte,        &
                   ims, ime, jms, jme, kms, kme, kts, kte)
               end if
 
-              CALL  mynn_bl_driver(&
+              CALL mynnedmf_wrapper_run(                                 &
                    &initflag=initflag,restart=restart,cycling=cycling,   &
-                   &grav_settling=grav_settling,                         &
-                   &delt=dtbl,dz=dz8w,dx=dx,znt=znt,                     &
+                   &delt=dtbl,dz=dz8w,dxc=dx,znt=znt,                    &
                    &u=u_phy,v=v_phy,w=w,th=th_phy,qv=qv_curr,            &
                    &qc=qc_curr,qi=qi_curr,                               &
                    &qnc=qnc_curr,qni=qni_curr,                           &
                    &QNWFA=qnwfa_curr,QNIFA=qnifa_curr,QNBCA=qnbca_curr,  &
+!                   &ozone=ozone,                                         &
                    &p=p_phy,exner=pi_phy,rho=rho,T3D=t_phy,              &
-                   &xland=xland,ts=tsk,qsfc=qsfc,qcg=qcg,ps=psfc,        &
+                   &xland=xland,ts=tsk,qsfc=qsfc,ps=psfc,                &
                    &ust=ust,ch=ch,hfx=hfx,qfx=qfx,rmol=rmol,wspd=wspd,   &
                    &uoce=uoce,voce=voce,                                 & !Ocean currents
-                   &vdfg=vdfg,                                           & !Katata -added
-                   &Qke=qke,Sh3d=Sh3d,                                   &
-                   &qke_adv=qke_adv,bl_mynn_tkeadvect=bl_mynn_tkeadvect, &
+                   &Qke=qke,qke_adv=qke_adv,Sh3d=Sh3d,Sm3d=Sm3d,         &
 #if (WRF_CHEM == 1)
-                   &chem3d=chem,vd3d=vd,nchem=nchem,kdvel=kdvel,         & ! WA 7/31/15
+                   &chem3d=chem,vd3d=vd,nchem=nchem,kdvel=kdvel,         &
                    &ndvel=ndvel,num_vert_mix=num_vert_mix,               &
+                   &FRP_MEAN=FRP_MEAN,EMIS_ANT_NO=EMIS_ANT_NO,           &
+                   &mix_chem=mynn_chem_vertmx,fire_turb=enh_vermix,      &
 #endif
                    &Tsq=tsq,Qsq=qsq,Cov=cov,                             &
                    &RUBLTEN=rublten,RVBLTEN=rvblten,RTHBLTEN=rthblten,   &
@@ -1654,51 +1652,54 @@ CONTAINS
                    &RQNCBLTEN=rqncblten,RQNIBLTEN=rqniblten,             &
                    &RQNWFABLTEN=rqnwfablten,RQNIFABLTEN=rqnifablten,     &
                    &RQNBCABLTEN=rqnbcablten,                             &
+!                   &Ro3BLTEN=ro3blten,                                   &
                    &EXCH_H=exch_h,EXCH_M=exch_m,                         &
-                   &pblh=pblh,KPBL=KPBL                                  &
-                   &,el_pbl=el_pbl                                       &
-                   &,dqke=dqke                                           &
-                   &,qWT=qWT,qSHEAR=qSHEAR,qBUOY=qBUOY,qDISS=qDISS       &
-                   &,WSTAR=wstar,DELTA=delta                             & ! for grims shallow-cu
-                   &,bl_mynn_tkebudget=bl_mynn_tkebudget                 &
-                   &,bl_mynn_cloudpdf=bl_mynn_cloudpdf                   &
-                   &,bl_mynn_mixlength=bl_mynn_mixlength                 &
-                   &,icloud_bl=icloud_bl,qc_bl=qc_bl,qi_bl=qi_bl         &
-                   &,cldfra_bl=cldfra_bl                                 &
-                   &,bl_mynn_edmf=bl_mynn_edmf                           &
-                   &,bl_mynn_edmf_mom=bl_mynn_edmf_mom                   &
-                   &,bl_mynn_edmf_tke=bl_mynn_edmf_tke                   &
-                   &,bl_mynn_mixscalars=bl_mynn_mixscalars               &
-                   &,bl_mynn_output=bl_mynn_output                       &
-                   &,bl_mynn_cloudmix=bl_mynn_cloudmix                   &
-                   &,bl_mynn_mixqt=bl_mynn_mixqt                         &
-                   &,edmf_a=edmf_a,edmf_w=edmf_w,edmf_qt=edmf_qt         &
-                   &,edmf_thl=edmf_thl,edmf_ent=edmf_ent,edmf_qc=edmf_qc &
-                   &,sub_thl3D=sub_thl3D,sub_sqv3D=sub_sqv3D             &                                                                               
-                   &,det_thl3D=det_thl3D,det_sqv3D=det_sqv3D             &
-                   &,nupdraft=nupdraft,maxMF=maxMF                       &
-                   &,ktop_plume=ktop_plume                               &
-                   &,spp_pbl=spp_pbl,pattern_spp_pbl=pattern_spp_pbl     &
-                   &,RTHRATEN=RTHRATEN                                   &
-                   &,FLAG_QC=flag_qc,FLAG_QI=flag_qi                     &
-                   &,FLAG_QNC=flag_qnc,FLAG_QNI=flag_qni                 &
-                   &,FLAG_QNWFA=flag_qnwfa,FLAG_QNIFA=flag_qnifa         &
-                   &,FLAG_QNBCA=flag_qnbca                               &
-                   ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde      &
-                   ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme      &
-                   ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte      &
-                   )
+                   &pblh=pblh,KPBL=KPBL,                                 &
+                   &el_pbl=el_pbl,                                       &
+                   &dqke=dqke,                                           &
+                   &qWT=qWT,qSHEAR=qSHEAR,qBUOY=qBUOY,qDISS=qDISS,       &
+                   &qc_bl=qc_bl,qi_bl=qi_bl,cldfra_bl=cldfra_bl,         &
+                   &edmf_a=edmf_a,edmf_w=edmf_w,edmf_qt=edmf_qt,         &
+                   &edmf_thl=edmf_thl,edmf_ent=edmf_ent,edmf_qc=edmf_qc, &
+                   &sub_thl3D=sub_thl3D,sub_sqv3D=sub_sqv3D,             &
+                   &det_thl3D=det_thl3D,det_sqv3D=det_sqv3D,             &
+                   &nupdraft=nupdraft,maxMF=maxMF,                       &
+                   &ktop_plume=ktop_plume,                               &
+                   &RTHRATEN=RTHRATEN,                                   &
+                   &bl_mynn_tkeadvect=bl_mynn_tkeadvect,                 &
+                   &bl_mynn_tkebudget=tke_budget,                        &
+                   &bl_mynn_cloudpdf=bl_mynn_cloudpdf,                   &
+                   &bl_mynn_mixlength=bl_mynn_mixlength,                 &
+                   &icloud_bl=icloud_bl,                                 &
+                   &bl_mynn_edmf=bl_mynn_edmf,                           &
+                   &bl_mynn_edmf_mom=bl_mynn_edmf_mom,                   &
+                   &bl_mynn_edmf_tke=bl_mynn_edmf_tke,                   &
+                   &bl_mynn_mixscalars=bl_mynn_mixscalars,               &
+                   &bl_mynn_output=bl_mynn_output,                       &
+                   &bl_mynn_cloudmix=bl_mynn_cloudmix,                   &
+                   &bl_mynn_mixqt=bl_mynn_mixqt,                         &
+                   &bl_mynn_closure=bl_mynn_closure,                     &
+                   &spp_pbl=spp_pbl,pattern_spp_pbl=pattern_spp_pbl,     &
+                   &FLAG_QC=flag_qc,FLAG_QI=flag_qi,                     &
+                   &FLAG_QNC=flag_qnc,FLAG_QNI=flag_qni,                 &
+                   &FLAG_QNWFA=flag_qnwfa,FLAG_QNIFA=flag_qnifa,         &
+                   &FLAG_QNBCA=flag_qnbca,                               &
+                   &IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde,     &
+                   &IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme,     &
+                   &ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte      )
 
               if (pert_mynn .and. multi_perturb == 1) then
-                call Remove_multi_perturb_pbl_perturbations (perts_qvapor, perts_qcloud, &
-                  perts_th, perts_tke, pert_mynn_qv, pert_mynn_qc, pert_mynn_t, pert_mynn_qke, &
-                  th_phy, qke, qke_adv, qv_curr, qc_curr, bl_mynn_tkeadvect, qke_tmp, its, ite, jts, jte, &
+                call Remove_multi_perturb_pbl_perturbations (            &
+                  perts_qvapor, perts_qcloud, perts_th, perts_tke,       &
+                  pert_mynn_qv, pert_mynn_qc, pert_mynn_t, pert_mynn_qke,&
+                  th_phy, qke, qke_adv, qv_curr, qc_curr,                &
+                  bl_mynn_tkeadvect, qke_tmp, its, ite, jts, jte,        &
                   ims, ime, jms, jme, kms, kme, kts, kte)
 
                   deallocate (qke_tmp)
               end if
            ELSE
-               WRITE ( message , FMT = '(A,20(L1,1X))' )            &
+               WRITE ( message , FMT = '(A,17(L1,1X))' )            &
                  'present: '//                                      &
                  'qv_curr, '//                                      &
                  'qc_curr, '//                                      &
@@ -1713,13 +1714,10 @@ CONTAINS
                  'qsq, '//                                          &
                  'cov, '//                                          &
                  'rmol, '//                                         &
-                 'qcg, '//                                          &
                  'ch, '//                                           &
-                 'grav_settling, '//                                &
-                 'bl_mynn_tkebudget, '//                            &
+                 'tke_budget, '//                                   &
                  'qke_adv, '//                                      &
-                 'bl_mynn_tkeadvect, '//                            &
-                 'vdfg = ' ,                                        &
+                 'bl_mynn_tkeadvect ' ,                             &
                   PRESENT( qv_curr ) ,                              &
                   PRESENT( qc_curr ) ,                              &
                   PRESENT( qi_curr ) ,                              &
@@ -1733,13 +1731,10 @@ CONTAINS
                   PRESENT( qsq      ) ,                             &
                   PRESENT( cov      ) ,                             &
                   PRESENT( rmol     ) ,                             &
-                  PRESENT( qcg      ) ,                             &
                   PRESENT( ch       ) ,                             &
-                  PRESENT( grav_settling),                          &
-                  PRESENT( bl_mynn_tkebudget) ,                     &
+                  PRESENT( tke_budget) ,                            &
                   PRESENT( qke_adv  ) ,                             &
-                  PRESENT( bl_mynn_tkeadvect) ,                     &
-                  PRESENT( vdfg )
+                  PRESENT( bl_mynn_tkeadvect)
                CALL wrf_debug(0,message)
               CALL wrf_error_fatal('Lack arguments to call MYNN pbl')
            ENDIF

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -575,10 +575,9 @@ CONTAINS
         & INTENT(INOUT) :: qke_adv
    LOGICAL, OPTIONAL, INTENT(IN) :: bl_mynn_tkeadvect
 
-! Katata-added -
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,              &
         &    INTENT(INOUT)::                               vdfg
-! Katata-end
+
    INTEGER, OPTIONAL, DIMENSION( ims:ime , jms:jme ),           &
         &    INTENT(OUT) ::               nupdraft,ktop_plume
    REAL, OPTIONAL, DIMENSION( ims:ime , jms:jme ),              &

--- a/phys/module_physics_addtendc.F
+++ b/phys/module_physics_addtendc.F
@@ -674,7 +674,7 @@ SUBROUTINE phy_bl_ten(config_flags,rk_step,n_moist,n_scalar,     &
                 its, ite, jts, jte, kts, kte                     )
        ENDIF
 
-      CASE (MYNNPBLSCHEME2,MYNNPBLSCHEME3)
+      CASE (MYNNPBLSCHEME)
 
            CALL add_a2a(rt_tendf,RTHBLTEN,config_flags,          &
                 ids,ide, jds, jde, kds, kde,                     &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -2680,7 +2680,7 @@ CHARACTER(LEN=8) :: name
    USE module_bl_mfshconvpbl
    USE module_bl_gbmpbl
 #if ( EM_CORE == 1 )
-   USE module_bl_mynn
+   USE module_bl_mynn_wrapper
    USE module_bl_eeps
    USE module_bl_temf
 #if ( WRFPLUS == 1 )
@@ -3853,32 +3853,20 @@ CALL lsm_mosaic_init(IVGTYP,config_flags%ISWATER,config_flags%ISURBAN,config_fla
 
 !mynn 
            
-        CASE (MYNNPBLSCHEME2, MYNNPBLSCHEME3)
+        CASE (MYNNPBLSCHEME)
            IF(isfc .NE. 5 .AND. isfc .NE. 1 .AND. isfc .NE. 2) CALL wrf_error_fatal &
                 ( 'module_physics_init: use mynnsfc or sfclay or myjsfc scheme for this pbl option')
            IF ((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.EQ.3)) CALL wrf_error_fatal &
             ( 'module_physics_init: use ysu (option1), myj (option 2), or boulac (option 8) with BEP/BEM urban scheme' )
-           
-           SELECT CASE(config_flags%bl_pbl_physics)
 
-             CASE(MYNNPBLSCHEME2)
-                mynn_closure_level=2
-
-             CASE(MYNNPBLSCHEME3)
-                mynn_closure_level=3
-
-             CASE DEFAULT
-
-           END SELECT
-
-           CALL mynn_bl_init_driver(&
+                CALL mynnedmf_wrapper_init(                  &
                 &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN, &
-                &RQIBLTEN,                                   &
-                &QKE,EXCH_H                                  &
-                &,restart,allowed_to_read,mynn_closure_level &
-                &,IDS,IDE,JDS,JDE,KDS,KDE                    &
-                &,IMS,IME,JMS,JME,KMS,KME                    &
-                &,ITS,ITE,JTS,JTE,KTS,KTE)
+                &RQIBLTEN,QKE,                               &
+                &restart,allowed_to_read,                    &
+                &P_QC,P_QI,PARAM_FIRST_SCALAR,               &
+                &IDS,IDE,JDS,JDE,KDS,KDE,                    &
+                &IMS,IME,JMS,JME,KMS,KME,                    &
+                &ITS,ITE,JTS,JTE,KTS,KTE                     )
 
       CASE (TEMFPBLSCHEME)
            ! if(isfc .ne. 0)CALL wrf_error_fatal &

--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -7,7 +7,6 @@
 
 !  This MODULE CONTAINS the following routines:
 
-
 MODULE module_physics_init
 
    USE module_state_description

--- a/phys/module_sf_fogdes.F
+++ b/phys/module_sf_fogdes.F
@@ -1,13 +1,13 @@
 MODULE module_sf_fogdes
 
   USE module_model_constants
-!JOE - add for consistent vdfg calc when grav_settling=1
-  USE module_bl_mynn, only: qcgmin, gno, gpw
-!JOE-end
+
 !-------------------------------------------------------------------
   IMPLICIT NONE
 !-------------------------------------------------------------------
-   REAL, PARAMETER :: myu = 1.8e-5  ! air viscosity (m^2/s)
+  REAL, PARAMETER :: myu = 1.8e-5  ! air viscosity (m^2/s)
+  REAL, PARAMETER :: gno=1.0  !original value seems too aggressive: 4.64158883361278196
+  REAL, PARAMETER :: gpw=5./3., qcgmin=1.e-8
 
 CONTAINS
 

--- a/phys/module_shcu_camuwshcu.F
+++ b/phys/module_shcu_camuwshcu.F
@@ -10,7 +10,7 @@
   use module_state_description, only: CAMUWPBLSCHEME, MYJPBLSCHEME
 #else
   use module_state_description, only: CAMUWPBLSCHEME, MYJPBLSCHEME, &
-      MYNNPBLSCHEME2, MYNNPBLSCHEME3
+      MYNNPBLSCHEME
 #endif
 #endif
   use error_function, only: erfc
@@ -190,7 +190,7 @@ end subroutine uwshcu_readnl
 #if ( NMM_CORE == 1 )
   case (CAMUWPBLSCHEME, MYJPBLSCHEME)
 #else
-  case (CAMUWPBLSCHEME, MYJPBLSCHEME, MYNNPBLSCHEME2, MYNNPBLSCHEME3)
+  case (CAMUWPBLSCHEME, MYJPBLSCHEME, MYNNPBLSCHEME)
 #endif
      !These are acceptable PBL schemes.
   case default

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -419,8 +419,7 @@
          END IF
       END DO
       IF ( ( exists ) .AND. &
-           ( ( model_config_rec % bl_pbl_physics(1) .EQ. MYNNPBLSCHEME2 ) .OR. &
-             ( model_config_rec % bl_pbl_physics(1) .EQ. MYNNPBLSCHEME3 ) .OR. &
+           ( ( model_config_rec % bl_pbl_physics(1) .EQ. MYNNPBLSCHEME ) .OR. &
              ( model_config_rec % bl_pbl_physics(1) .EQ. EEPSSCHEME     ) ) ) THEN
          WRITE(wrf_err_message,fmt='(a,i2)') '--- ERROR: LES PBL on fine grid does not work with CG PBL option ',model_config_rec % bl_pbl_physics(1)
          CALL wrf_message ( TRIM( wrf_err_message ) )
@@ -567,7 +566,7 @@
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec % shcu_physics(i) == dengshcuscheme .AND. &
               (model_config_rec % bl_pbl_physics(i) /= myjpblscheme .AND. &
-               model_config_rec % bl_pbl_physics(i) /= mynnpblscheme2 ) ) THEN
+               model_config_rec % bl_pbl_physics(i) /= mynnpblscheme ) ) THEN
             wrf_err_message = '--- ERROR: Deng shallow convection can only work with MYJ or MYNN (with bl_mynn_edmf off) PBL '
             CALL wrf_message ( wrf_err_message )
             wrf_err_message = '--- ERROR: Fix shcu_physics or bl_pbl_physics in namelist.input.'
@@ -1718,8 +1717,7 @@
          IF ( model_config_rec%shcu_physics(i) .EQ. GRIMSSHCUSCHEME ) THEN
             IF ( (model_config_rec%bl_pbl_physics(i) .EQ. YSUSCHEME) .OR. &
                  (model_config_rec%bl_pbl_physics(i) .EQ. SHINHONGSCHEME) .OR. &
-                 (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2) .OR. &
-                 (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3) ) THEN
+                 (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME ) ) THEN
                !NO PROBLEM
             ELSE
                model_config_rec%shcu_physics(i) = 0
@@ -1739,8 +1737,7 @@
 
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME2 ) .AND. &
-              ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME3 ) ) THEN
+         IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME  ) ) THEN
               model_config_rec % bl_mynn_edmf(i) = 0
               model_config_rec % bl_mynn_output(i) = 0
          END IF
@@ -1772,8 +1769,7 @@
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%icloud_bl .eq. 1) THEN
-           IF ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 .OR. &
-                model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) THEN
+           IF ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME ) THEN
               !CORRECTLY CONFIGURED
            ELSE
               model_config_rec%icloud_bl = 0
@@ -1796,8 +1792,7 @@
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
          IF ( model_config_rec%phot_blcld(i) ) THEN
            IF ( ( model_config_rec%icloud_bl .eq. 1 ) .AND.  &
-                ( ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2 ) .OR. &
-                  ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3 ) ) ) THEN
+                ( ( model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME ) ) ) THEN
                 !CORRECTLY CONFIGURED
            ELSE
               oops = oops + 1
@@ -2480,8 +2475,7 @@
       oops = 0
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ((model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME2) .OR. &
-             (model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME3) ) THEN
+         IF ((model_config_rec%bl_pbl_physics(i) .EQ. MYNNPBLSCHEME) ) THEN
             IF ( model_config_rec%bl_mynn_mixscalars(i) .EQ. 1 ) THEN
                 model_config_rec%scalar_pblmix(i) = 0
                 oops = oops + 1
@@ -3408,8 +3402,7 @@
 #if (EM_CORE == 1)
       DO i = 1, model_config_rec % max_dom
          IF ( .NOT. model_config_rec % grid_allowed(i) ) CYCLE
-         IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME2 ) .AND. &
-              ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME3 ) ) THEN
+         IF ( ( model_config_rec % bl_pbl_physics(i) .NE. MYNNPBLSCHEME  ) ) THEN
             model_config_rec % bl_mynn_edmf = 0
          END IF
       ENDDO

--- a/wrftladj/module_first_rk_step_part1_ad.F
+++ b/wrftladj/module_first_rk_step_part1_ad.F
@@ -393,11 +393,10 @@ BENCH_START(a_pbl_driver_tim)
      &        ,QKE=scalar(ims,kms,jms,P_qke_adv), tsq=grid%tsq, qsq=grid%qsq  &
      &        ,cov=grid%cov                                               &
      &        ,DQKE=grid%dqke,QWT=grid%qWT                                &
-     &        ,QSHEAR=grid%qSHEAR,QBUOY=grid%qBUOY,QDISS=grid%qDISS &
-     &        ,bl_mynn_tkebudget=config_flags%bl_mynn_tkebudget           &
+     &        ,QSHEAR=grid%qSHEAR,QBUOY=grid%qBUOY,QDISS=grid%qDISS       &
+     &        ,tke_budget=config_flags%tke_budget                         &
      &        ,rmol=grid%rmol, ch=grid%ch                                 &
-     &        ,qcg=grid%qcg, grav_settling=config_flags%grav_settling             &
-!    &        ,K_m=grid%K_m, K_h=grid%K_h, K_q=grid%K_q                   &
+     &        ,qcg=grid%qcg, grav_settling=config_flags%grav_settling     &
 !GWD for ARW
      &        ,GWD_OPT=config_flags%gwd_opt &
      &        ,DTAUX3D=grid%dtaux3d,DTAUY3D=grid%dtauy3d &

--- a/wrftladj/module_first_rk_step_part1_tl.F
+++ b/wrftladj/module_first_rk_step_part1_tl.F
@@ -332,10 +332,9 @@ BENCH_START(g_pbl_driver_tim)
      &        ,cov=grid%cov                                               &
      &        ,DQKE=grid%dqke,QWT=grid%qWT                                &
      &        ,QSHEAR=grid%qSHEAR,QBUOY=grid%qBUOY,QDISS=grid%qDISS       &
-     &        ,bl_mynn_tkebudget=config_flags%bl_mynn_tkebudget           &
+     &        ,tke_budget=config_flags%tke_budget                         &
      &        ,rmol=grid%rmol, ch=grid%ch                                 &
-     &        ,qcg=grid%qcg, grav_settling=config_flags%grav_settling             &
-!    &        ,K_m=grid%K_m, K_h=grid%K_h, K_q=grid%K_q                   &
+     &        ,qcg=grid%qcg, grav_settling=config_flags%grav_settling     &
 !GWD for ARW
      &        ,GWD_OPT=config_flags%gwd_opt &
      &        ,DTAUX3D=grid%dtaux3d,DTAUY3D=grid%dtauy3d &

--- a/wrftladj/module_pbl_driver_ad.F
+++ b/wrftladj/module_pbl_driver_ad.F
@@ -46,7 +46,7 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 &  mf_temf, thup_temf, qtup_temf, qlup_temf, exch_temf, cf3d_temf, &
 &  cfm_temf, flhc, flqc, qke, qke_adv, bl_mynn_tkeadvect, tsq, qsq, cov, &
 &  rmol, ch, qcg, grav_settling, el_mynn, dqke, qwt, qshear, qbuoy, qdiss&
-&  , bl_mynn_tkebudget, ids, ide, jds, jde, kds, kde, ims, ime, jms, jme&
+&  , tke_budget, ids, ide, jds, jde, kds, kde, ims, ime, jms, jme&
 &  , kms, kme, i_start, i_end, j_start, j_end, kts, kte, num_tiles, hol, &
 &  mol, regime, gwd_opt, dtaux3d, dtaux3db, dtauy3d, dtauy3db, dusfcg, &
 &  dusfcgb, dvsfcg, dvsfcgb, var2d, oc12d, oa1, oa2, oa3, oa4, ol1, ol2, &
@@ -318,7 +318,7 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 !,k_m,k_h,k_q &
   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT) ::&
 &  tsq, qsq, cov, qke, el_mynn, dqke, qwt, qshear, qbuoy, qdiss
-  INTEGER, OPTIONAL, INTENT(IN) :: bl_mynn_tkebudget, grav_settling
+  INTEGER, OPTIONAL, INTENT(IN) :: tke_budget, grav_settling
 !ACF-QKE advection start
   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT) ::&
 &  qke_adv

--- a/wrftladj/module_pbl_driver_ad.F
+++ b/wrftladj/module_pbl_driver_ad.F
@@ -65,7 +65,7 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 
    USE module_state_description, ONLY :                            &
                    YSUSCHEME,MRFSCHEME,GFSSCHEME,MYJPBLSCHEME,ACMPBLSCHEME,&
-                   QNSEPBLSCHEME,MYNNPBLSCHEME2,MYNNPBLSCHEME3,BOULACSCHEME,&
+                   QNSEPBLSCHEME,MYNNPBLSCHEME,BOULACSCHEME,&
                    CAMUWPBLSCHEME,BEPSCHEME,BEP_BEMSCHEME,MYJSFCSCHEME, &
                    SURFDRAGSCHEME, TEMFPBLSCHEME, &
                    p_qi,param_first_scalar

--- a/wrftladj/module_pbl_driver_tl.F
+++ b/wrftladj/module_pbl_driver_tl.F
@@ -64,7 +64,7 @@ SUBROUTINE G_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 
    USE module_state_description, ONLY :                            &
                    YSUSCHEME,MRFSCHEME,GFSSCHEME,MYJPBLSCHEME,ACMPBLSCHEME,&
-                   QNSEPBLSCHEME,MYNNPBLSCHEME2,MYNNPBLSCHEME3,BOULACSCHEME,&
+                   QNSEPBLSCHEME,MYNNPBLSCHEME,BOULACSCHEME,&
                    CAMUWPBLSCHEME,BEPSCHEME,BEP_BEMSCHEME,MYJSFCSCHEME, &
                    SURFDRAGSCHEME, TEMFPBLSCHEME, &
                    p_qi,param_first_scalar 

--- a/wrftladj/module_pbl_driver_tl.F
+++ b/wrftladj/module_pbl_driver_tl.F
@@ -45,7 +45,7 @@ SUBROUTINE G_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 &  mf_temf, thup_temf, qtup_temf, qlup_temf, exch_temf, cf3d_temf, &
 &  cfm_temf, flhc, flqc, qke, qke_adv, bl_mynn_tkeadvect, tsq, qsq, cov, &
 &  rmol, ch, qcg, grav_settling, el_mynn, dqke, qwt, qshear, qbuoy, qdiss&
-&  , bl_mynn_tkebudget, ids, ide, jds, jde, kds, kde, ims, ime, jms, jme&
+&  , tke_budget, ids, ide, jds, jde, kds, kde, ims, ime, jms, jme&
 &  , kms, kme, i_start, i_end, j_start, j_end, kts, kte, num_tiles, hol, &
 &  mol, regime, gwd_opt, dtaux3d, dtaux3dd, dtauy3d, dtauy3dd, dusfcg, &
 &  dusfcgd, dvsfcg, dvsfcgd, var2d, oc12d, oa1, oa2, oa3, oa4, ol1, ol2, &
@@ -311,7 +311,7 @@ SUBROUTINE G_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 !,k_m,k_h,k_q &
   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT) ::&
 &  tsq, qsq, cov, qke, el_mynn, dqke, qwt, qshear, qbuoy, qdiss
-  INTEGER, OPTIONAL, INTENT(IN) :: bl_mynn_tkebudget, grav_settling
+  INTEGER, OPTIONAL, INTENT(IN) :: tke_budget, grav_settling
 !ACF-QKE advection start
   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT) ::&
 &  qke_adv

--- a/wrftladj/module_physics_addtendc_tl.F
+++ b/wrftladj/module_physics_addtendc_tl.F
@@ -636,7 +636,7 @@ SUBROUTINE g_phy_bl_ten(config_flags,rk_step,n_moist,n_scalar,   &
                 its, ite, jts, jte, kts, kte                     )
        ENDIF
 
-      CASE (MYNNPBLSCHEME2,MYNNPBLSCHEME3)
+      CASE (MYNNPBLSCHEME)
 
            CALL add_a2a(rt_tendf,RTHBLTEN,config_flags,          &
                 ids,ide, jds, jde, kds, kde,                     &

--- a/wrftladj/solve_em_ad.F
+++ b/wrftladj/solve_em_ad.F
@@ -691,8 +691,7 @@ BENCH_END(set_phys_bc_tim)
                             )
 
 #ifdef DM_PARALLEL
-       IF ( config_flags%bl_pbl_physics == MYNNPBLSCHEME2 .OR. &
-            config_flags%bl_pbl_physics == MYNNPBLSCHEME3 ) THEN
+       IF ( config_flags%bl_pbl_physics == MYNNPBLSCHEME ) THEN
 #        include "HALO_EM_SCALAR_E_5.inc"
        ENDIF
 #endif

--- a/wrftladj/solve_em_tl.F
+++ b/wrftladj/solve_em_tl.F
@@ -669,8 +669,7 @@ BENCH_END(g_set_phys_bc_tim)
                              )
 
 #ifdef DM_PARALLEL
-       IF ( config_flags%bl_pbl_physics == MYNNPBLSCHEME2 .OR. &
-            config_flags%bl_pbl_physics == MYNNPBLSCHEME3 ) THEN
+       IF ( config_flags%bl_pbl_physics == MYNNPBLSCHEME ) THEN
 #        include "HALO_EM_SCALAR_E_5.inc"
        ENDIF
 #endif


### PR DESCRIPTION
MYNN-EDMF Update from CCPP to WRF

TYPE: bug fix/enhancement/new feature

KEYWORDS: MYNN EDMF closure subgrid clouds CCPP universalization 

SOURCE: Joseph Olson (NOAA-GSL), Wayne Angevine (NOAA-CSL)

DESCRIPTION OF CHANGES:

- Vacate bl_pbl_physics = 6; will instead regulate the closure level with new namelist variable “bl_mynn_closure”; now has 3 options: level 2.5, 2.6, 3.0. This alone required changes in many files beyond the MYNN code.
- TKE budget fix; change bl_mynn_tkebudget to tke_budget (logical), so it’s a generic flag for other schemes to use
- Universalization of MYNN-EDMF for CCPP and WRF-ARW/MPAS
- Added a new WRF-specific wrapper called in module_pbl_driver.F
- Added a new WRF-specific module for defining constants
- Reordering of subroutines; bring driver to the top
- Improved conservation of heat/moisture
- Greatly improved global/medium-range performance
- Improved performance for hurricanes - but still not directly tuned for hurricanes
- New higher-order moment cloud PDF; improved SGS clouds
- New downdraft MF option for turbulence related to cloud-top cooling (still work in progress)
- Many misc tuning
- Many updated comments
- Bug fix for mixing in WRF_CHEM applications
- Merged in new qnbca additions since last update  - will probably need to modify again soon
- Lingering (but not required for this commit): 
    - Kind_physics (still different between WRF and CCPP)

LIST OF MODIFIED FILES:
M       Registry/Registry.EM_COMMON
M       Registry/registry.chem
M       dyn_em/module_big_step_utilities_em.F
M       dyn_em/module_first_rk_step_part1.F
M       dyn_em/solve_em.F
M       main/depend.common
M       phys/Makefile
M       phys/module_bl_fogdes.F
M       phys/module_bl_mynn.F
M       phys/module_pbl_driver.F
M       phys/module_physics_addtendc.F
M       phys/module_physics_init.F
M       phys/module_sf_fogdes.F
M       phys/module_shcu_camuwshcu.F
M       share/module_check_a_mundo.F
M       wrftladj/module_pbl_driver_ad.F
M       wrftladj/module_pbl_driver_tl.F
M       wrftladj/module_physics_addtendc_tl.F
M       wrftladj/solve_em_ad.F
M       wrftladj/solve_em_tl.F
M      chem/chemics_init.F
M      chem/dry_dep_driver.F
A       phys/module_bl_mynn_common.F
A       phys/module_bl_mynn_wrapper.F


TESTS CONDUCTED: 
1. Most of the rigorous scientific testing was done in the CCPP framework before merging into WRF
2. Several case studies in WRF were performed after merging with strict debugging
2. All regression tests have now passed.

RELEASE NOTE: overview of changes:
A substantial update to the MYNN-EDMF, including a reorganization of the subroutines, as part of the “universalization efforts” which are meant to keep the scheme similar in all dycores. The major physics changes include (1) improved conservation of scalars which improves performance in medium-range global forecasting, (2) revised subgrid clouds which leverages the prognostic q’2, (3) vacate bl_pbl_physics = 6 (now only run with bl_pbl_physics = 5); will instead regulate the closure level with new namelist variable “bl_mynn_closure” set to 2.5, 2.6, or 3.0, (4) important bug fixes for the TKE budget and the bl_mynn_tkebudget flag is not renamed to tke_budget for use in other schemes (although may not be hooked up for other schemes yet), (5) new downdraft option (hidden hard-coded flag in module_bl_mynn.F) but still under development to best fit within the MYNN-EDMF, (6) and many miscellaneous tuning/minor bug fixes. For its performance evaluation, please see the following: [Examples of MYNN improvements.pdf](https://github.com/wrf-model/WRF/files/10125487/Examples.of.MYNN.improvements.pdf)