### PR TITLE
Fix declaration for QSFC to INOUT variable

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -326,13 +326,12 @@ CONTAINS
 
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(INOUT)   ::                                 &
-                                                              QGH
+                                                         QSFC,QGH
 
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(OUT)     ::                        U10,V10, &
-                                                TH2,T2,Q2,QSFC,LH
+                                                     TH2,T2,Q2,LH
 
-                                    
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV
 
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::      DX

--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -138,14 +138,12 @@ CONTAINS
                                                             XLAND, &
                                                               TSK
 
-!
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)               ::             REGIME, &
                                                               HFX, &
                                                               QFX, &
                                                                LH, &
                                                           MOL,RMOL
-!m the following 5 are change to memory size
 !
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)   ::                 GZ1OZ0,WSPD,BR, &

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -143,15 +143,14 @@ CONTAINS
                                                               V10, &
                                                               TH2, &
                                                                T2, &
-                                                               Q2, &
-                                                             QSFC
+                                                               Q2
 
-!
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)               ::             REGIME, &
                                                               HFX, &
                                                               QFX, &
                                                                LH, &
+                                                             QSFC, &
                                                           MOL,RMOL
 !m the following 5 are change to memory size
 !
@@ -320,11 +319,11 @@ CONTAINS
 
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(INOUT)   ::                                 &
-                                                              QGH
+                                                         QSFC,QGH
 
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(OUT)     ::                        U10,V10, &
-                                                TH2,T2,Q2,QSFC,LH
+                                                     TH2,T2,Q2,LH
 
                                     
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: sfclay, sfclayrev, qsfc

SOURCE: Reported by Laura Fowler, NCAR/MMM, internal

DESCRIPTION OF CHANGES:
Problem:
QSFC variable in sfclay and sfclayrev modules was declared as an OUT variable, but it is only calculated conditionally. For some grid points, it takes the input value. This has caused compilation issue in MPAS.

Solution:
Change the declaration for QSFC from OUT to INOUT variable.

LIST OF MODIFIED FILES: 
M     phys/module_sf_sfclay.F
M     phys/module_sf_sfclayrev.F

TESTS CONDUCTED: 
1. It fixed the compilation problem in MPAS.
2. The Jenkins tests have passed.

RELEASE NOTE: 
