### PR TITLE
Use GFS total column ozone in TUV photolysis 

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1235,6 +1235,8 @@ state integer   ncfrcv           ij     misc        1         -      -
 
 # new rad variables
 state    real   o3rad           ikj     misc        1         -      rdf=(p2c)      "o3rad"    "RADIATION 3D OZONE" "ppmv"
+# GFS Total ozone
+state   real    o3_gfs_du       ij      misc        1         -      i012rh         "o3_gfs_du"    "Total ozone from GFS" "Dobson Units"
 
 # incoming optical depth derived from aerosol data
 state  real   aerodm    i{lsa}jm{ty}    misc        1    -   -     -

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -4186,6 +4186,7 @@ rconfig   logical   has_o3_exo_coldens namelist,chem  1                  .false.
 rconfig   real      du_at_grnd      namelist,chem     1                  300.     rh     "O3 at ground"          "O3 at ground"                     "o3 Dobson units"
 rconfig   logical   scale_o3_to_grnd_exo_coldens namelist,chem  1  .false.  rh     "scale o3 column to exo_coldens"   "true = scale to exo model o3 column denisties"   ""
 rconfig   logical   scale_o3_to_du_at_grnd       namelist,chem  1  .false.  rh     "scale o3 column to du_at_grnd"    "true = scale to DU at ground"   ""
+rconfig   logical   scale_o3_to_gfs_tot          namelist,chem  1  .false.  rh     "gfs_ozone_scale_opt"              "true = scale to GFS DU at ground"               ""
 
 package  lnox_opt_none      lnox_opt==0    -   -
 package  lnox_opt_ott       lnox_opt==1    -   tracer:lnox_total

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -986,6 +986,7 @@
               grid%bscoef1,grid%bscoef2,grid%bscoef3,grid%bscoef4,                    &
               grid%l2aer,grid%l3aer,grid%l4aer,grid%l5aer,grid%l6aer,grid%l7aer,      &
               grid%pm2_5_dry,grid%pm2_5_water,grid%uvrad,grid%ivgtyp,                 &
+              grid%o3_gfs_du,                                                         &
               ids,ide, jds,jde, kds,kde,                                              &
               ims,ime, jms,jme, kms,kme,                                              &
               its,ite,jts,jte,kts,kte)

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -87,6 +87,7 @@
                ph_glyald,ph_mek,ph_gly,                                   &
                pm2_5_dry,pm2_5_water,uvrad,                               &
                dt_cld,af_dir,af_dn,af_up,par,erythema,                    &
+               o3_gfs_du,                                                 &
                ids,ide, jds,jde, kds,kde,                                 &
                ims,ime, jms,jme, kms,kme,                                 &
                its,ite, jts,jte, kts,kte )
@@ -155,6 +156,9 @@
    REAL,  DIMENSION( ims:ime , jms:jme )                   ,    &     
           INTENT(INOUT   ) ::                        uvrad
    REAL,     INTENT(IN   ) ::                        gmt
+
+   REAL, DIMENSION( ims:ime, jme:jme ),                         &
+         OPTIONAL,INTENT(IN ) ::                   o3_gfs_du
 
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 
@@ -570,6 +574,9 @@ has_daylight : &
          endif
          if( config_flags%scale_o3_to_grnd_exo_coldens ) then
            dobsi = real( o3_exo_col_at_grnd(i,j),4 )/2.687e16
+         endif
+         if (config_flags%scale_o3_to_gfs_tot ) then
+           dobsi = o3_gfs_du(i,j)
          endif
 
          so2col(:) = 0.

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -158,7 +158,7 @@
    REAL,     INTENT(IN   ) ::                        gmt
 
    REAL, DIMENSION( ims:ime, jme:jme ),                         &
-         OPTIONAL,INTENT(IN ) ::                   o3_gfs_du
+         OPTIONAL,INTENT(IN ) ::                    o3_gfs_du
 
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 

--- a/chem/photolysis_driver.F
+++ b/chem/photolysis_driver.F
@@ -29,6 +29,7 @@
                bscoef1,bscoef2,bscoef3,bscoef4,                          &
                l2aer,l3aer,l4aer,l5aer,l6aer,l7aer,                      &
                pm2_5_dry,pm2_5_water,uvrad,ivgtyp,                       &
+               o3_gfs_du,                                                &
                ids,ide, jds,jde, kds,kde,                                &
                ims,ime, jms,jme, kms,kme,                                &
                its,ite, jts,jte, kts,kte                                 )
@@ -134,6 +135,9 @@
           INTENT(IN   ) ::                                             &
                                                      xlat,             &
                                                      xlong
+   REAL,  DIMENSION( ims:ime, jms:jme ),                                & 
+          OPTIONAL, INTENT(IN ) :: o3_gfs_du
+
    TYPE(grid_config_rec_type),  INTENT(IN   )    :: config_flags
 
    LOGICAL, INTENT(IN)  :: haveaer
@@ -238,6 +242,7 @@
                ph_glyald,ph_mek,ph_gly,                                &
                pm2_5_dry, pm2_5_water, uvrad,                          &
                dt_cld,af_dir,af_dn,af_up,par,erythema,                 &
+               o3_gfs_du,                                              &
                ids,ide, jds,jde, kds,kde,                              &
                ims,ime, jms,jme, kms,kme,                              &
                its,ite, jts,jte, kts,kte                               )


### PR DESCRIPTION
This adds an option to use GFS total ozone (2D) in the TUV photolysis (phot_opt=4) to scale the simulated column to the GFS total column in the calculation of photolysis rates. This option requires the namelist option to be set (scale_o3_to_gfs_tot) as well as using the variable table Vtable.GFS_OZONE during the ungrib step. Alternatively, users could append the wrfinput file with a total ozone field (through e.g., ncks) with the name O3_GFS_DU.

TYPE: enhancement

SOURCE: Jordan Schnell (CIRES/NOAA)

DESCRIPTION OF CHANGES:
Problem: Only option to provide total ozone field in TUV was a single scalar value.
Solution:
This allows use of GFS total ozone (not time varying)

LIST OF MODIFIED FILES:
M       Registry/Registry.EM_COMMON
M       Registry/registry.chem
M       chem/chem_driver.F
M       chem/module_phot_tuv.F
M       chem/photolysis_driver.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Use GFS total column ozone in TUV photolysis 
