### PR TITLE
Fixed small indexing error of rhoair in ISHMAEL MP scheme

### DIFF
--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -1381,7 +1381,7 @@ contains
                 if(temp.gt.T0) then
 
   !.. Melting: ice shapes become more spherical
-                   qmlt(cc)=2.*PI*(kt*fh(cc)*(T0-temp)+rhoair(cc)*xxlv*dv*fv(cc)*(qs0-qv(k)))/   & 
+                   qmlt(cc)=2.*PI*(kt*fh(cc)*(T0-temp)+rhoair(k)*xxlv*dv*fv(cc)*(qs0-qv(k)))/   & 
                         xxlf*(ni(cc,k)*NU*max(ani(cc),cni(cc))) - &
                         (CPW/xxlf*(temp-T0)*(rimetotal(cc)/rhoair(k) + dQImltri(cc)))
                    

--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -23,8 +23,8 @@ module module_mp_jensen_ishmael
   ! Last modified: 07 June 2019 (ISHMAEL version 0.1)                                                    !
   !------------------------------------------------------------------------------------------------------!
 
-  use module_wrf_error   
-
+  use module_wrf_error
+  
   implicit none !.. You are welcome
 
   !.. Constants
@@ -4709,4 +4709,3 @@ SUBROUTINE AVINT(X,Y,N,XLO,XUP,ANS)
 end module module_mp_jensen_ishmael
 
   !.. Full stop
-

--- a/phys/module_mp_jensen_ishmael.F
+++ b/phys/module_mp_jensen_ishmael.F
@@ -23,7 +23,7 @@ module module_mp_jensen_ishmael
   ! Last modified: 07 June 2019 (ISHMAEL version 0.1)                                                    !
   !------------------------------------------------------------------------------------------------------!
 
-  use module_wrf_error
+  use module_wrf_error   
   
   implicit none !.. You are welcome
 


### PR DESCRIPTION
Small indexing error of rhoair, old indexing used cc, everywhere else in code k is used.

TYPE: bug fix

KEYWORDS: Microphysics, ISHMAEL, indexing, minor

SOURCE: Dylan Reynolds (SLF)

DESCRIPTION OF CHANGES:
Problem:
indexing error

Solution:
changed index

TESTS CONDUCTED: 
None using WRF -- ISHMAEL is being tested in the HICAR model where this bug was found.
The Jenkins tests have passed.

RELEASE NOTE: very minor improvement to ISHMAEL MP.
