### PR TITLE
Fix an error with O31D exceeding vertical dimension kte

### DIFF
--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11647,10 +11647,9 @@ CONTAINS
          INTENT(IN   )  ::                                 XLAND, &
                                                             XICE, &
                                                             SNOW
-!ccc Added for time-varying trace gases.
+! Added for time-varying trace gases.
    INTEGER, INTENT(IN    ) ::                                 yr
    REAL, INTENT(IN    ) ::                                julian
-!ccc
 
 !
 ! Optional

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -12414,7 +12414,7 @@ CONTAINS
         else
          do k = kts, nlayers
             o3vmr(ncol,k) = o3mmr(k) * amdo
-            o31d(k) = o3vmr(ncol,k)
+            if (k.le.kte) o31d(k) = o3vmr(ncol,k)
          enddo
         endif
 

--- a/phys/module_ra_rrtmg_lw.F
+++ b/phys/module_ra_rrtmg_lw.F
@@ -11962,7 +11962,7 @@ CONTAINS
 ! Pressures are in mb
 !
 
-!ccc Read time-varying trace gases concentrations and interpolate them to run date.
+! Read time-varying trace gases concentrations and interpolate them to run date.
 !
    IF ( GHG_INPUT .EQ. 1 ) THEN 
       CALL read_CAMgases(yr,julian,.false.,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
@@ -11982,8 +11982,6 @@ CONTAINS
       cfc11 = 0.251e-9
       cfc12 = 0.538e-9
    END IF
-
-!ccc
 
 ! latitude loop
   j_loop: do j = jts,jte

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -10932,7 +10932,7 @@ CONTAINS
         else
          do k = kts, kte+1
             o3vmr(ncol,k) = o3mmr(k) * amdo
-            o31d(k) = o3vmr(ncol,k)
+            if (k.le.kte) o31d(k) = o3vmr(ncol,k)
          enddo
         endif
 

--- a/phys/module_ra_rrtmg_sw.F
+++ b/phys/module_ra_rrtmg_sw.F
@@ -10932,7 +10932,7 @@ CONTAINS
         else
          do k = kts, kte+1
             o3vmr(ncol,k) = o3mmr(k) * amdo
-            if (k.le.kte) o31d(k) = o3vmr(ncol,k)
+            o31d(k) = o3vmr(ncol,k)
          enddo
         endif
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: O3 output, o3input=0, RRTMG-LW

SOURCE: Reported by Samm Elliott, fixed internally

DESCRIPTION OF CHANGES:
Problem:
In 4.4, we introduced ozone output o3rad when o3input = 0, that is to use ozone profile provided by the RRTMG code. But the use of output array accessed memory with the vertical dimension > kte. This can cause segmentation fault on some systems.

Solution:
The array is now limited to use only when vertical dimension is less than kte.

LIST OF MODIFIED FILES: 
M     phys/module_ra_rrtmg_lw.F

TESTS CONDUCTED: 
1. Yes
2. Are the Jenkins tests all passing?

RELEASE NOTE: 