### PR TITLE
Add scale-aware to the new Tiedtke cu scheme as an option

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2447,6 +2447,7 @@ rconfig   integer cu_diag                 namelist,physics      max_domains    0
 rconfig   integer kf_edrates              namelist,physics      max_domains    0       rh   "kf_edrates"           "output entrainment/detrainment rates and convective timescale for KF schemes"      ""
 rconfig   integer kfeta_trigger           namelist,physics	1              1       rh   "KFETA Trigger function"    ""    ""
 rconfig   integer nsas_dx_factor          namelist,physics	1              0       rh   "NSAS DX-dependent option"    ""    ""
+rconfig   integer ntiedtke_dx_opt         namelist,physics	1              0       rh   "nTiedtke DX-dependent option"    ""    ""
 rconfig   real    CUDT                    namelist,physics	max_domains    0       h    "CUDT"          ""      ""
 rconfig   real    GSMDT                   namelist,physics	max_domains    0       h    "GSMDT"          ""      ""
 rconfig   integer ISFFLX                  namelist,physics 	1             1       irh    "ISFFLX"                        ""      ""

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1474,6 +1474,7 @@ BENCH_START(cu_driver_tim)
      !BSINGH -ENDS
      &             ,KFETA_TRIGGER=config_flags%kfeta_trigger              &
      &             ,NSAS_DX_FACTOR=config_flags%nsas_dx_factor            &
+     &             ,NTIEDTKE_DX_OPT=config_flags%ntiedtke_dx_opt          &
                  ! Dimension arguments
      &             ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde     &
      &             ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme     &

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -150,6 +150,7 @@ contains
                 ,u3d,v3d,w,t3d,qv3d,qc3d,qi3d,pi3d,rho3d        &
                 ,qvften,thften                                  &
                 ,dz8w,pcps,p8w,xland,cu_act_flag,dx             &
+                ,ntiedtke_dx_opt                                &
                 ,ids,ide, jds,jde, kds,kde                      &
                 ,ims,ime, jms,jme, kms,kme                      &
                 ,its,ite, jts,jte, kts,kte                      &
@@ -191,6 +192,7 @@ contains
 !-- dz8w        dz between full levels (m)
 !-- qfx         upward moisture flux at the surface (kg/m^2/s)
 !-- hfx         upward heat flux at the surface (w/m^2) 
+!-- ntiedtke_dx_opt   whether the schemem is scale-aware
 !-- dt          time step (s)
 !-- ids         start index for i in domain
 !-- ide         end index for i in domain
@@ -216,6 +218,8 @@ contains
                                         its,ite, jts,jte, kts,kte,      &
                                         itimestep,                      &
                                         stepcu
+
+      integer, intent(in) ::            ntiedtke_dx_opt
 
       real,    intent(in) ::                                            &
                                         dt
@@ -426,7 +430,7 @@ contains
 !
 !########################################################################
       call tiecnvn(u1,v1,t1,q1,q2,q3,q1b,t1b,ghtl,ghti,omg,prsl,prsi,evap,heatflux,  &
-                  rn,slimsk,im,kx,kx1,delt,dx2d)
+                  rn,slimsk,im,kx,kx1,delt,dx2d,ntiedtke_dx_opt)
 
       do i=its,ite
          raincv(i,j)=rn(i)/stepcu
@@ -555,7 +559,7 @@ contains
 !          level 1 subroutine 'tiecnvn'
 !-----------------------------------------------------------------
       subroutine tiecnvn(pu,pv,pt,pqv,pqc,pqi,pqvf,ptf,poz,pzz,pomg, &
-     &         pap,paph,evap,hfx,zprecc,lndj,lq,km,km1,dt,dx)
+     &         pap,paph,evap,hfx,zprecc,lndj,lq,km,km1,dt,dx,ntiedtke_dx_opt)
 !-----------------------------------------------------------------
 !  this is the interface between the model and the mass 
 !  flux convection module
@@ -577,6 +581,7 @@ contains
      &     zqsat(lq,km),   pqc(lq,km),   pqi(lq,km),   zrain(lq)
       real pqvf(lq,km),    ptf(lq,km)
       real dx(lq)
+      integer ntiedtke_dx_opt
 
       integer icbot(lq),   ictop(lq),     ktype(lq),   lndj(lq)
       logical locum(lq)
@@ -585,6 +590,18 @@ contains
       integer i,j,k,lq,km,km1
       real dt,ztpp1
       real zew,zqs,zcor
+      real scale_fac(lq), dxref
+!
+!  set scale-dependency factor when dx is < 15 km
+!
+      dxref = 15000.
+      do j=1,lq
+      if (dx(j).lt.dxref .and. ntiedtke_dx_opt.eq.1) then
+          scale_fac(j) = (1.+log(dxref/dx(j)))**3
+      else
+          scale_fac(j) = 1.+1.33e-5*dx(j)
+      end if 
+      end do
 !
       ztmst=dt
 !
@@ -638,7 +655,8 @@ contains
      &     pssfc,    locum,                             &
      &     ktype,    icbot,    ictop,    ztu,     zqu,  &
      &     zlu,      zlude,    zmfu,     zmfd,    zrain,&
-     &     pcte,     phhfl,    lndj,     pgeoh,   dx)
+     &     pcte,     phhfl,    lndj,     pgeoh,   dx,   &
+     &     scale_fac, ntiedtke_dx_opt )
 !
 !     to include the cloud water and cloud ice detrained from convection
 !
@@ -693,7 +711,8 @@ contains
      &     pssfc,    ldcum,                              &
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
-     &     pcte,     phhfl,    lndj,     zgeoh,   dx)
+     &     pcte,     phhfl,    lndj,     zgeoh,    dx,   &
+     &     scale_fac,  ntiedtke_dx_opt )
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme
@@ -801,6 +820,8 @@ contains
      &         ktype(klon),            lndj(klon)
       logical  ldcum(klon)
       logical  loddraf(klon),          llo1,   llo2(klon)
+      real     scale_fac(klon)
+      integer  ntiedtke_dx_opt
 
 !  local varaiables
       real     zcons,zcons2,zqumqe,zdqmin,zdh,zmfmax
@@ -901,7 +922,8 @@ contains
      &     zuu,      zvu,      pmfu,     zmfub,&
      &     zmfus,    zmfuq,    zmful,    plude,    zdmfup,&
      &     kcbot,    kctop,    ictop0,   icum,     ztmst,&
-     &     zqsenh,   zlglac,   lndj,     wup,      wbase,   kdpl,  pmfude_rate )
+     &     zqsenh,   zlglac,   lndj,     wup,      wbase,   kdpl,  pmfude_rate,&
+     &     scale_fac,  ntiedtke_dx_opt )
 
 !*     (b) check cloud depth and change entrainment rate accordingly
 !          calculate precipitation rate (for downdraft calculation)
@@ -1017,10 +1039,14 @@ contains
        if(ldcum(jl).and.ktype(jl).eq.1) then
            ikb = kcbot(jl)
            ikt = kctop(jl)
-           ztau = ztauc(jl) * (1.+1.33e-5*dx(jl))
+           ztau = ztauc(jl) * scale_fac(jl)
            ztau = max(ztmst,ztau)
            ztau = max(360.,ztau)
+           if(ntiedtke_dx_opt.eq.1) then
+           ztau = min(43200.,ztau)
+           else
            ztau = min(10800.,ztau)
+           end if
            if(nonequil) then
              zcape2(jl)= max(0.,zcape2(jl))
              zcape(jl) = max(0.,min(zcape1(jl)-zcape2(jl),5000.))
@@ -1060,6 +1086,9 @@ contains
              zmfub1(jl) = zmfub(jl)
            end if
            zmfub1(jl) = min(zmfub1(jl),zmfmax)
+           if(ntiedtke_dx_opt.eq.1) then
+              zmfub1(jl) = zmfub1(jl)/(scale_fac(jl))**(.5)
+           end if
          end if
 
 !*  6.3   mid-level convection - nothing special
@@ -2102,7 +2131,8 @@ contains
      &     puu,      pvu,      pmfu,     pmfub,    &
      &     pmfus,    pmfuq,    pmful,    plude,    pdmfup,&
      &     kcbot,    kctop,    kctop0,   kcum,     ztmst,&
-     &     pqsenh,   plglac,   lndj,     wup,      wbase,   kdpl, pmfude_rate)
+     &     pqsenh,   plglac,   lndj,     wup,      wbase,   kdpl, pmfude_rate,&
+     &     scale_fac,  ntiedtke_dx_opt )
       implicit none
 !     this routine does the calculations for cloud ascents
 !     for cumulus parameterization
@@ -2223,12 +2253,18 @@ contains
       real     zrnew,zz,zdmfeu,zdmfdu,dp
       real     zfac,zbuoc,zdkbuo,zdken,zvv,zarg,zchange,zxe,zxs,zdshrd
       real     atop1,atop2,abot
+      real     scale_fac(klon)
+      integer  ntiedtke_dx_opt
 !--------------------------------
 !*    1.       specify parameters
 !--------------------------------
       zcons2=3./(g*ztmst)
       zfacbuo = 0.5/(1.+0.5)
+      if(ntiedtke_dx_opt.eq.1) then
+      zprcdgw = cprcon*zrg/(scale_fac(jl)**(1./3.))
+      else
       zprcdgw = cprcon*zrg
+      end if
       z_cldmax = 5.e-3
       z_cwifrac = 0.5
       z_cprc2 = 0.5
@@ -2307,7 +2343,7 @@ contains
      &     pgeo,     pgeoh,    ldcum,   ktype,   klab,  zlrain,&
      &     pmfu,     pmfub,    kcbot,   ptu,&
      &     pqu,      plu,      puu,     pvu,      pmfus,&
-     &     pmfuq,    pmful,    pdmfup)
+     &     pmfuq,    pmful,    pdmfup,  ntiedtke_dx_opt )
       is = 0
       jlm = 0
       do jl = 1,klon
@@ -3709,7 +3745,7 @@ contains
      &     pgeo,     pgeoh,    ldcum,   ktype,  klab,  plrain,&
      &     pmfu,     pmfub,    kcbot,   ptu,&
      &     pqu,      plu,      puu,     pvu,    pmfus,&
-     &     pmfuq,    pmful,    pdmfup)
+     &     pmfuq,    pmful,    pdmfup,  ntiedtke_dx_opt )
       implicit none
 !      m.tiedtke         e.c.m.w.f.     12/89
 !      c.zhang           iprc           05/2012
@@ -3746,9 +3782,38 @@ contains
 ! local variabels
       integer  jl,kk,klev,klon,klevp1,klevm1
       real     zzzmb
+      integer  ntiedtke_dx_opt
 !--------------------------------------------------------
 !*    1.      calculate entrainment and detrainment rates
 ! -------------------------------------------------------
+       if(ntiedtke_dx_opt.eq.1) then
+         do jl=1,klon
+          if(.not.ldcum(jl) .and. klab(jl,kk+1).eq.0) then
+            if(lmfmid .and. pqen(jl,kk) .gt. 0.80*pqsen(jl,kk).and. &
+! ww (no mid level conv, if the air is saturated)
+              pqen(jl,kk) .le. pqsen(jl,kk).and. &
+              pgeo(jl,kk)*zrg .gt. 5.0e2  .and.  &
+     &        pgeo(jl,kk)*zrg .lt. 1.0e4 )  then
+            ptu(jl,kk+1)=(cpd*pten(jl,kk)+pgeo(jl,kk)-pgeoh(jl,kk+1))&
+     &                          *rcpd
+            pqu(jl,kk+1)=pqen(jl,kk)
+            plu(jl,kk+1)=0.
+            zzzmb=max(cmfcmin,-pverv(jl,kk)*zrg)
+            zzzmb=min(zzzmb,cmfcmax)
+            pmfub(jl)=zzzmb
+            pmfu(jl,kk+1)=pmfub(jl)
+            pmfus(jl,kk+1)=pmfub(jl)*(cpd*ptu(jl,kk+1)+pgeoh(jl,kk+1))
+            pmfuq(jl,kk+1)=pmfub(jl)*pqu(jl,kk+1)
+            pmful(jl,kk+1)=0.
+            pdmfup(jl,kk+1)=0.
+            kcbot(jl)=kk
+            klab(jl,kk+1)=1
+            plrain(jl,kk+1)=0.0
+            ktype(jl)=3
+          end if
+         end if
+        end do
+       else
          do jl=1,klon
           if(.not.ldcum(jl) .and. klab(jl,kk+1).eq.0) then
             if(lmfmid .and. pqen(jl,kk) .gt. 0.80*pqsen(jl,kk).and. &
@@ -3773,6 +3838,7 @@ contains
           end if
          end if
         end do
+      end if
       return
       end subroutine cubasmcn
 !---------------------------------------------------------

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -1043,9 +1043,9 @@ contains
            ztau = max(ztmst,ztau)
            ztau = max(360.,ztau)
            if(ntiedtke_dx_opt.eq.1) then
-           ztau = min(43200.,ztau)
+             ztau = min(43200.,ztau)
            else
-           ztau = min(10800.,ztau)
+             ztau = min(10800.,ztau)
            end if
            if(nonequil) then
              zcape2(jl)= max(0.,zcape2(jl))
@@ -2261,7 +2261,7 @@ contains
       zcons2=3./(g*ztmst)
       zfacbuo = 0.5/(1.+0.5)
       if(ntiedtke_dx_opt.eq.1) then
-      zprcdgw = cprcon*zrg/(scale_fac(jl)**(1./3.))
+        zprcdgw = cprcon*zrg/(scale_fac(jl)**(1./3.))
       else
       zprcdgw = cprcon*zrg
       end if

--- a/phys/module_cumulus_driver.F
+++ b/phys/module_cumulus_driver.F
@@ -125,6 +125,7 @@ CONTAINS
                  ! Optional trigger function activation variable
                      ,kfeta_trigger                                   &
                      ,nsas_dx_factor                                  &
+                     ,ntiedtke_dx_opt                                 &
 #if ( WRF_DFI_RADAR == 1 )
                  ! Optional CAP suppress option      --- 3.2 CLEANUP TODO -- THESE SHOULD BE OPTIONAL, NOT #IF/#ENDIF
                      ,do_capsuppress                                  &
@@ -324,6 +325,7 @@ CONTAINS
 !-- W0AVG         average vertical velocity, (for KF scheme) (m/s)
 !-- kfeta_trigger namelist for KF trigger (=1, default; =2, moisture-advection-dependent trigger)
 !-- nsas_dx_factor namelist for NSAS deep scheme to have some dependency on grid sizes
+!-- ntiedtke_dx_opt namelist for nTiedtke cu scheme to have some dependency on grid sizes
 !-- rho           density (kg/m^3)
 !-- CONVCLD       Convective cloud (for BMJ scheme) (kg/m^2)
 !-- CCLDFRA       convective cloud fraction (for BMJ scheme)
@@ -525,6 +527,7 @@ CONTAINS
 
    INTEGER, INTENT(IN   ), OPTIONAL        ::   kfeta_trigger
    INTEGER, INTENT(IN   ), OPTIONAL        ::   nsas_dx_factor
+   INTEGER, INTENT(IN   )                  ::   ntiedtke_dx_opt
 
    REAL,  INTENT(IN   ) :: DT, DX
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,               &    
@@ -1423,6 +1426,7 @@ CONTAINS
                ,QV3D=QV_CURR,QC3D=QC_CURR,QI3D=QI_CURR          &
                ,DZ8W=dz8w,PCPS=p,P8W=p8w,XLAND=XLAND,DX=dx2d    &
                ,CU_ACT_FLAG=CU_ACT_FLAG                         &
+               ,NTIEDTKE_DX_OPT=NTIEDTKE_DX_OPT                 &
                ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde &
                ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme &
                ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte &

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -852,6 +852,9 @@ Namelist variables for controlling the adaptive time step option:
                                      = 3, for small grid distances (DX < 5 km)
  nsas_dx_factor                      = 0, ! default option
                                      = 1,   NSAS grid-distance dependent option
+ ntiedtke_dx_opt                     = 0, default option
+                                     = 1, new Tiedtke grid-distance dependent option (scale-aware)
+                                          when grid size falls below 15 km
  For KF-CuP scheme: recommended to use with cu_rad_feedback
  shallowcu_forced_ra(max_dom)        radiative impact of shallow Cu by a prescribed maximum cloud fraction
                                      = .false., option off, default


### PR DESCRIPTION
Add scale-aware to the new Tiedtke scheme as an option

TYPE: new feature

KEYWORDS: new Tiedtke cu scheme, scale aware option

SOURCE: internal

DESCRIPTION OF CHANGES:
A scale-aware or grid-distance-dependent option is added to the new Tiedtke scheme. The code is based on the paper by Wang (2022), and can be turned on by using namelist option ntiedtke_dx_opt = 1. The option becomes active when grid sizes is less than 15 km.
Wang, W., 2022: Forecasting Convection with a “Scale-Aware” Tiedtke Cumulus Parameterization Scheme at Kilometer Scales. _Wea. Forecasting_, 37/8, 1491 - 1507, 10.1175/WAF-D-21-0179.1.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_cu_ntiedtke.F
M       phys/module_cumulus_driver.F
M       run/README.namelist

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. The Jenkins tests have passed.

RELEASE NOTE: A scale-aware or grid-distance-dependent option is added to the new Tiedtke scheme. The code is based on the paper by Wang (2022), and can be turned on by using namelist option ntiedtke_dx_opt = 1. The option becomes active when grid sizes is less than 15 km.
