### PR TITLE
WRF-urban bug fix for roof longwave calculation in bep_bem

### DIFF
--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -5316,7 +5316,7 @@ do iz= kts,kte
                      (1-emr_u)*rld*(1.-pv_frac_roof)+(1-0.79)*pv_frac_roof*rld)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
              rl_inc=rl_inc+rld*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
              rs_abs=rs_abs+((1.-albr_u)*rs*(1.-pv_frac_roof)+(1.-0.11)*rs*pv_frac_roof)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-             gfl=(1.-albr_u)*rs*(1-pv_frac_roof)+emr_u*rld*((1-pv_frac_roof)+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4) &
+             gfl=(1.-albr_u)*rs*(1-pv_frac_roof)+emr_u*rld*(1-pv_frac_roof)+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4 &
                 -emr_u*sigma*(tr_av(id,iz)**4.)+(1-gr_frac_roof)*sfr(id,iz)+(sfrv(id,iz)+lfrv(id,iz))*gr_frac_roof+(1.-gr_frac_roof)*lfr(id,iz)
              grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu  
          enddo


### PR DESCRIPTION
Bug fix for the roof longwave calculation in bep_bem urban code

TYPE: bug fix

KEYWORDS: bep_bem, longwave calculation, urban

SOURCE: Cenlin He (NCAR)

DESCRIPTION OF CHANGES:
Problem:
One of the parenthesis in the roof longwave radiation ("gfl" variable) calculation in module_sf_bep_bem.F was misplaced.

Solution:
Correct the misplaced parenthesis in the "gfl" variable calculation in module_sf_bep_bem.F

ISSUE: #1804 

LIST OF MODIFIED FILES:
/phys/module_sf_bep_bem.F

TESTS CONDUCTED: 
The modification fixes the problem.

RELEASE NOTE: This is the bug fix for the roof longwave calculation in bep_bem urban code.

