### PR TITLE
BUG FIX: chem_opt = 201, 202 ph_diag

### DIFF
--- a/chem/aerosol_driver.F
+++ b/chem/aerosol_driver.F
@@ -195,6 +195,7 @@
 
 !  output of aerosol pH from MOSAIC 4-bin
    REAL,  DIMENSION( ims:ime , kms:kme , jms:jme )         ,        &
+          OPTIONAL, &
           INTENT(OUT  ) ::                                          &
                                ph_aer01, ph_aer02, ph_aer03, ph_aer04
 !

--- a/chem/cloudchem_driver.F
+++ b/chem/cloudchem_driver.F
@@ -171,6 +171,7 @@
          INTENT(INOUT ) ::                                gas_aqfrac
 
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                    &
+         OPTIONAL, &
          INTENT(OUT) ::                            ph_cw            ! ph_cw - pH of cloud water
 
 ! LOCAL  VAR

--- a/chem/module_mosaic_cloudchem.F
+++ b/chem/module_mosaic_cloudchem.F
@@ -108,6 +108,7 @@
 !   gas_aqfrac - fraction (0-1) of gas that is dissolved in cloud water
 
         real, intent(out),   &
+                OPTIONAL,    &
                 dimension( ims:ime, kms:kme, jms:jme ) :: &
                 ph_cw 
 
@@ -148,7 +149,7 @@
 	end if
 !   following line turns aqueous radical chem off unconditionally
 	iradical_onoff = 0
-
+    if ( config_flags%mozart_ph_diag .eq. 1 ) then
 !   Initialize pH of CW ph_cw to a FillValue value
         do jt = jts, jte
           do kt = kts, kte
@@ -157,7 +158,7 @@
             end do
           end do
         end do
-
+     end if
 	do 3920 jt = jts, jte
 	do 3910 it = its, ite
 
@@ -214,9 +215,10 @@
 		num_moist, num_chem, moist, chem,             &
 		t_phy, p_phy, rho_phy                         )
 
-	gas_aqfrac(it,kt,jt,:) = gas_aqfrac_box(:) 
+	gas_aqfrac(it,kt,jt,:) = gas_aqfrac_box(:)
+        if ( config_flags%mozart_ph_diag .eq. 1 ) then 
         ph_cw(it,kt,jt)        = ph_aq_box
-
+        end if
 3800	continue
 
 3910	continue

--- a/chem/module_mosaic_driver.F
+++ b/chem/module_mosaic_driver.F
@@ -237,6 +237,7 @@
 !	(ug/kg for mass species, #/kg for number species)
 
         real, intent(out),   &
+                optional,    &
                 dimension( ims:ime, kms:kme, jms:jme ) :: &
                 ph_aer01, ph_aer02, ph_aer03, ph_aer04
 
@@ -456,7 +457,8 @@
 	call aerchemistry( it, jt, kclm_calcbgn, kclm_calcend,   &
                            dtchem, idiagaa_dum, vbs_nbin,        &
                            ph_aer01(it,kms:kme,jt), ph_aer02(it,kms:kme,jt), &
-                           ph_aer03(it,kms:kme,jt), ph_aer04(it,kms:kme,jt), kms,kme  )
+                           ph_aer03(it,kms:kme,jt), ph_aer04(it,kms:kme,jt), &
+                           kms,kme,config_flags%mozart_ph_diag  )
 
 !  note units for aerosol is now ug/m3
 

--- a/chem/module_mosaic_therm.F
+++ b/chem/module_mosaic_therm.F
@@ -92,7 +92,7 @@
 !-----------------------------------------------------------------------
       subroutine aerchemistry( iclm, jclm, kclm_calcbgn, kclm_calcend,    &
                                dtchem_sngl, idiagaa,vbs_nbin,             &
-                               ph_aer1, ph_aer2, ph_aer3, ph_aer4,kms,kme )
+                               ph_aer1, ph_aer2, ph_aer3, ph_aer4,kms,kme,do_ph )
 
       use module_data_mosaic_asect
       use module_data_mosaic_other
@@ -107,7 +107,8 @@
       integer iclm, jclm, kclm_calcbgn, kclm_calcend, idiagaa,vbs_nbin(1)
       real dtchem_sngl
       integer kms, kme
-      real, intent(out), dimension(kms:kme) ::                       &
+      integer, intent(in) :: do_ph
+      real, optional, intent(out), dimension(kms:kme) ::                       &
             ph_aer1, ph_aer2, ph_aer3, ph_aer4       ! pH of the aerosols
 !   local variables
       real(kind=8) :: dtchem
@@ -157,11 +158,12 @@
           call specialoutaa( iclm, jclm, k, m, 'befor_movesect' )
           call move_sections( 1, iclm, jclm, k, m)
           call specialoutaa( iclm, jclm, k, m, 'after_movesect' )
-
+          if ( do_ph .eq. 1 ) then
           ph_aer1(k) = mc(1,1)
           ph_aer2(k) = mc(1,2)
           ph_aer3(k) = mc(1,3)
           ph_aer4(k) = mc(1,4)
+          end if
 
 100     continue	! k levels
 


### PR DESCRIPTION
Fixed a bug for chem_opt = 201, 202.

TYPE: bug fix

KEYWORDS: MOZART_MOSAIC_4BIN, mozart_pH_diag, bug fix

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem: 
Users will experience a stalled simulation upon writing history files. This was caused by the pH diagnostics added in v4.3 (https://github.com/wrf-model/WRF/pull/1342) not being activated with the namelist option mozart_ph_diag = 1. 

Solution:
Add as optional arguments only filled if the namelist is activated.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M       chem/aerosol_driver.F
M       chem/cloudchem_driver.F
M       chem/module_mosaic_cloudchem.F
M       chem/module_mosaic_driver.F
M       chem/module_mosaic_therm.F

TESTS CONDUCTED: 
1. Yes, the fix remedies the problem.
2. The Jenkins tests have passed.

RELEASE NOTE: This PR addresses a bug introduced in WRF v4.3 that affects users using chem_opts = 201 (MOZART_MOSAIC_4BIN_KPP) and 202 (MOZART_MOSAIC_4BIN_AQ_KPP).