### PR TITLE
The WRF-SoilN-chem: a dynamic ammonia emission model 

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -98,6 +98,17 @@ state    real   sct_dom_gc     ij       dyn_em      1        -     i1  "SCT_DOM"
 state    real   scb_dom_gc     ij       dyn_em      1        -     i1  "SCB_DOM"  "Dominant soil (bottom) category from GEOGRID"  "cat"
 state    real   greenfrac      imj      dyn_em      1        Z     i1  "GREENFRAC" "monthly greenness fraction" "0 - 1 fraction"
 state    real   albedo12m      imj      dyn_em      1        Z     i1  "ALBEDO12M" "background albedo" "0 - 1 fraction"
+
+#renchuanhua rch added 2021/4/8
+state    real   actnh3         imj      misc      1        Z     i01rh01d  "ACTNH3"      "The activity of NH3" "0 - 1 fraction"
+state    real   agrisoil       ij       misc      1        Z     i01rh01d  "AGRISOIL"    "The activity of NH3" "0 - 1 fraction"
+state    real   fertilizer     imj      misc      1        Z     i01rh01d  "FERTILIZER"  "The activity of NH3" "0 - 1 fraction"
+state    real   freeinten      ij       misc      1        Z     i01rh01d  "FREEINTEN"   "The activity of NH3" "0 - 1 fraction"
+state    real   graze          ij       misc      1        Z     i01rh01d  "GRAZE"       "The activity of NH3" "0 - 1 fraction"
+state    real   industry       ij       misc      1        Z     i01rh01d  "INDUSTRY"    "The activity of NH3" "0 - 1 fraction"
+state    real   residential    ij       misc      1        Z     i01rh01d  "RESIDENTIAL" "The activity of NH3" "0 - 1 fraction"
+state    real   transport      ij       misc      1        Z     i01rh01d  "TRANSPORT"   "The activity of NH3" "0 - 1 fraction"
+
 state    real   lai12m         imj      dyn_em      1        Z     i1  "LAI12M" "monthly LAI" "m2/m2"
 state    real   pd_gc          igj      dyn_em      1        Z     -   "PD"    "dry pressure"        "Pa"
 state    real   pdrho_gc       igj      dyn_em      1        Z     -   "PDRHO"    "dry pressure for UM data for the variables U and V"   "Pa"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -99,16 +99,6 @@ state    real   scb_dom_gc     ij       dyn_em      1        -     i1  "SCB_DOM"
 state    real   greenfrac      imj      dyn_em      1        Z     i1  "GREENFRAC" "monthly greenness fraction" "0 - 1 fraction"
 state    real   albedo12m      imj      dyn_em      1        Z     i1  "ALBEDO12M" "background albedo" "0 - 1 fraction"
 
-#renchuanhua rch added 2021/4/8
-state    real   actnh3         imj      misc      1        Z     i01rh01d  "ACTNH3"      "The activity of NH3" "0 - 1 fraction"
-state    real   agrisoil       ij       misc      1        Z     i01rh01d  "AGRISOIL"    "The activity of NH3" "0 - 1 fraction"
-state    real   fertilizer     imj      misc      1        Z     i01rh01d  "FERTILIZER"  "The activity of NH3" "0 - 1 fraction"
-state    real   freeinten      ij       misc      1        Z     i01rh01d  "FREEINTEN"   "The activity of NH3" "0 - 1 fraction"
-state    real   graze          ij       misc      1        Z     i01rh01d  "GRAZE"       "The activity of NH3" "0 - 1 fraction"
-state    real   industry       ij       misc      1        Z     i01rh01d  "INDUSTRY"    "The activity of NH3" "0 - 1 fraction"
-state    real   residential    ij       misc      1        Z     i01rh01d  "RESIDENTIAL" "The activity of NH3" "0 - 1 fraction"
-state    real   transport      ij       misc      1        Z     i01rh01d  "TRANSPORT"   "The activity of NH3" "0 - 1 fraction"
-
 state    real   lai12m         imj      dyn_em      1        Z     i1  "LAI12M" "monthly LAI" "m2/m2"
 state    real   pd_gc          igj      dyn_em      1        Z     -   "PD"    "dry pressure"        "Pa"
 state    real   pdrho_gc       igj      dyn_em      1        Z     -   "PDRHO"    "dry pressure for UM data for the variables U and V"   "Pa"

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -670,8 +670,17 @@ state    real  pftp_hb        ij      misc        1         -      i06r     "pft
 state    real  mtsa           ijm     misc        1         Z      i06r     "mtsa"             "Monthly surface air temp"  "K"
 state    real  mswdown        ijm     misc        1         Z      i06r     "mswdown"          "Monthly SWdown"  "W/m2"
 state    real  EFmegan        ij{nm}     misc        1         -      -        "EFmegan"          "MEGAN2 Emis Factor"       "ug m^-2 hr^-1"
-#renchuanhua rch added
-state    real  EFnh3          ij      misc        1         -      i01rh01        "EFNH3"          "NH3 Emis Factor"       "ug m^-2 hr^-1"
+# Arrays for online ammonia emissions
+state    real   EFnh3          ij       misc      1        -     i01rh01   "EFNH3"       "NH3 Emis Factor"       "ug m^-2 hr^-1"
+state    real   actnh3         imj      misc      1        Z     i01rh01d  "ACTNH3"      "The activity of NH3" "0 - 1 fraction"
+state    real   agrisoil_nh3       ij       misc      1        Z     i01rh01d  "AGRISOIL_NH3"    "The activity of NH3" "0 - 1 fraction"
+state    real   fertilizer_nh3     imj      misc      1        Z     i01rh01d  "FERTILIZER_NH3"  "The activity of NH3" "0 - 1 fraction"
+state    real   freeinten_nh3      ij       misc      1        Z     i01rh01d  "FREEINTEN_NH3"   "The activity of NH3" "0 - 1 fraction"
+state    real   graze_nh3          ij       misc      1        Z     i01rh01d  "GRAZE_NH3"       "The activity of NH3" "0 - 1 fraction"
+state    real   industry_nh3       ij       misc      1        Z     i01rh01d  "INDUSTRY_NH3"    "The activity of NH3" "0 - 1 fraction"
+state    real   residential_nh3    ij       misc      1        Z     i01rh01d  "RESIDENTIAL_NH3" "The activity of NH3" "0 - 1 fraction"
+state    real   transport_nh3      ij       misc      1        Z     i01rh01d  "TRANSPORT_NH3"   "The activity of NH3" "0 - 1 fraction"
+
 # Input for GOCART: Background chemistry, erodible surface emissions map
 state    real  backg_oh       ikj     misc        1         -      i08r    "BACKG_OH"       "Background OH for Aerosol-GOcart option"       "volume mixing ratio"
 state    real  backg_h2o2     ikj     misc        1         -      i08r    "BACKG_H2O2"     "Background H2O2 for Aerosol-GOcart option"     "volume mixing ratio"
@@ -4093,7 +4102,7 @@ package   megan2_clm    bio_emiss_opt==4
 
 # renchuanhua rch added for online nh3 emissions
 package   offline       nh3emis_opt==0              -              -
-package   online        nh3emis_opt==1              -              state:EFnh3;emis_ant:e_nh3;chem:nh3
+package   online        nh3emis_opt==1              -              state:EFnh3,agrisoil_nh3,fertilizer_nh3,freeinten_nh3,graze_nh3,industry_nh3,residential_nh3,transport_nh3;emis_ant:e_nh3
 
 # Biospheric CO2 and CH4 emissions
 package   ebioco2       bio_emiss_opt==16            -             state:rad_vprm,lambda_vprm,alpha_vprm,resp_vprm;vprm_in:vegfra_vprm,evi,evi_min,evi_max,lswi,lswi_max,lswi_min;eghg_bio:ebio_gee,ebio_res,ebio_co2oce

--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -82,7 +82,7 @@ state    real  e_hcho         i+jf     emis_ant     1         Z      i5r    "E_H
 state    real  e_ald          i+jf     emis_ant     1         Z      i5r    "E_ALD"               "EMISSIONS"          "mol km^-2 hr^-1"
 state    real  e_ket          i+jf     emis_ant     1         Z      i5r    "E_KET"               "EMISSIONS"          "mol km^-2 hr^-1"
 state    real  e_ora2         i+jf     emis_ant     1         Z      i5r    "E_ORA2"              "EMISSIONS"          "mol km^-2 hr^-1"
-state    real  e_nh3          i+jf     emis_ant     1         Z      i5r    "E_NH3"               "EMISSIONS"          "mol km^-2 hr^-1"
+state    real  e_nh3          i+jf     emis_ant     1         Z      i5rh01    "E_NH3"               "EMISSIONS"          "mol km^-2 hr^-1"
 state    real  e_pm_25        i+jf     emis_ant     1         Z      i5r    "E_PM_25"             "EMISSIONS"          "ug/m3 m/s"
 state    real  e_pm_10        i+jf     emis_ant     1         Z      i5r    "E_PM_10"             "EMISSIONS"          "ug/m3 m/s"
 state    real  e_pm25i        i+jf     emis_ant     1         Z      i5r    "E_PM25I"             "EMISSION RATE OF UNIDEN. PM2.5 MASS"  "ug/m3 m/s"
@@ -670,6 +670,8 @@ state    real  pftp_hb        ij      misc        1         -      i06r     "pft
 state    real  mtsa           ijm     misc        1         Z      i06r     "mtsa"             "Monthly surface air temp"  "K"
 state    real  mswdown        ijm     misc        1         Z      i06r     "mswdown"          "Monthly SWdown"  "W/m2"
 state    real  EFmegan        ij{nm}     misc        1         -      -        "EFmegan"          "MEGAN2 Emis Factor"       "ug m^-2 hr^-1"
+#renchuanhua rch added
+state    real  EFnh3          ij      misc        1         -      i01rh01        "EFNH3"          "NH3 Emis Factor"       "ug m^-2 hr^-1"
 # Input for GOCART: Background chemistry, erodible surface emissions map
 state    real  backg_oh       ikj     misc        1         -      i08r    "BACKG_OH"       "Background OH for Aerosol-GOcart option"       "volume mixing ratio"
 state    real  backg_h2o2     ikj     misc        1         -      i08r    "BACKG_H2O2"     "Background H2O2 for Aerosol-GOcart option"     "volume mixing ratio"
@@ -3832,6 +3834,10 @@ rconfig   integer     emiss_opt           namelist,chem          max_domains    
 rconfig   integer     emiss_opt_vol       namelist,chem          max_domains    0       rh    "emiss_opt_vol"       ""      ""
 rconfig   integer     dust_opt            namelist,chem          1              0       rh    "dust_opt"            ""      ""
 rconfig   integer     dust_schme          namelist,chem          1              2       rh    "dust_schme"       ""      ""
+
+#renchuanhua rch added
+rconfig   integer     nh3emis_opt         namelist,chem          1              0       rh    "nh3emis_opt"         ""      ""
+
 rconfig   integer     dmsemis_opt         namelist,chem          1              0       rh    "dmsemis_opt"         ""      ""
 rconfig   integer     seas_opt            namelist,chem          1              0       rh    "seas_opt"            ""      ""
 rconfig   integer     bio_emiss_opt       namelist,chem          max_domains    0       rh    "bio_emiss_opt"       ""      ""
@@ -4084,6 +4090,10 @@ package   gunther1      bio_emiss_opt==1             -             -
 package   beis314       bio_emiss_opt==2             -             -
 package   megan2        bio_emiss_opt==3             -             state:mebio_isop,mebio_apin,mebio_bcar,mebio_acet,mebio_mbo,mebio_no,msebio_isop,mlai,pftp_bt,pftp_nt,pftp_sb,pftp_hb,mtsa,mswdown,EFmegan
 package   megan2_clm    bio_emiss_opt==4   
+
+# renchuanhua rch added for online nh3 emissions
+package   offline       nh3emis_opt==0              -              -
+package   online        nh3emis_opt==1              -              state:EFnh3;emis_ant:e_nh3;chem:nh3
 
 # Biospheric CO2 and CH4 emissions
 package   ebioco2       bio_emiss_opt==16            -             state:rad_vprm,lambda_vprm,alpha_vprm,resp_vprm;vprm_in:vegfra_vprm,evi,evi_min,evi_max,lswi,lswi_max,lswi_min;eghg_bio:ebio_gee,ebio_res,ebio_co2oce

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -878,6 +878,10 @@
               grid%biomt_par,grid%emit_par,grid%ebio_co2oce,                               &
               eghg_bio,                                                                    &
               grid%seas_flux,                                                              &
+         ! stuff for the online nh3-"WRF-NH3-CHEM" modified by renchuanhua
+              grid%actnh3, grid%EFnh3,                                                     &          
+              grid%agrisoil, grid%fertilizer, grid%freeinten, grid%graze, grid%industry,   &
+              grid%residential,  grid%transport, current_hour, grid%Q2,                    &
               ids,ide, jds,jde, kds,kde,                                                   &
               ims,ime, jms,jme, kms,kme,                                                   &
               its,ite,jts,jte,kts,kte)

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -282,6 +282,8 @@
       CHARACTER (LEN=1000) :: msg 
       CHARACTER (LEN=256) :: current_date_char 
       integer :: current_month
+!for the online nh3-"WRF-NH3-CHEM" modified by renchuanhua 
+      integer :: current_hour  
 ! ..
 ! .. Intrinsic Functions ..
       INTRINSIC max, min

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -882,11 +882,12 @@
               grid%seas_flux,                                                              &
          ! stuff for the online nh3-"WRF-NH3-CHEM" modified by renchuanhua
               grid%actnh3, grid%EFnh3,                                                     &          
-              grid%agrisoil, grid%fertilizer, grid%freeinten, grid%graze, grid%industry,   &
-              grid%residential,  grid%transport, current_hour, grid%Q2,                    &
+              grid%agrisoil_nh3, grid%fertilizer_nh3, grid%freeinten_nh3,                  &
+              grid%graze_nh3, grid%industry_nh3,                                           &
+              grid%residential_nh3,  grid%transport_nh3, current_hour, grid%Q2,            &
               ids,ide, jds,jde, kds,kde,                                                   &
               ims,ime, jms,jme, kms,kme,                                                   &
-              its,ite,jts,jte,kts,kte)
+              its,ite,jts,jte,kts,kte                                                      )
               if( chm_is_mozart ) then
                  call mozcart_lbc_set( chem, num_chem, grid%id, &
                                        ims, ime, jms, jme, kms, kme,    &                  

--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -70,14 +70,15 @@ CONTAINS
          ! stuff for aircraft emissions
          emis_aircraft,                                                    &
          ! stuff for GHG fluxes
-         vprm_in,rad_vprm,lambda_vprm,alpha_vprm,resp_vprm,               &
+         vprm_in,rad_vprm,lambda_vprm,alpha_vprm,resp_vprm,                &
          xtime,tslb,wet_in,rainc,rainnc,potevp,sfcevp,lu_index,            &
          biomt_par,emit_par,ebio_co2oce,eghg_bio,                          &
          seas_flux,                                                        &
          ! stuff for online nh3 "WRF-NH3-CHEM" modified by renchuanhua
          actnh3,EFnh3,                                                     &
-         agrisoil, fertilizer, freeinten, graze, industry, residential,    &
-         transport, current_hour, Q2,                                      &         
+         agrisoil_nh3, fertilizer_nh3, freeinten_nh3, graze_nh3,           &
+         industry_nh3, residential_nh3,                                    &
+         transport_nh3, current_hour, Q2,                                  &         
          ids,ide, jds,jde, kds,kde,                                        &
          ims,ime, jms,jme, kms,kme,                                        &
          its,ite, jts,jte, kts,kte                                         )
@@ -344,13 +345,13 @@ CONTAINS
 ! stuff for online NH3  "WRF-NH3-CHEM" modified by renchuanhua
      REAL, DIMENSION( ims:ime,12,jms:jme ), OPTIONAL,  INTENT(IN   ) :: actnh3
      REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: EFnh3
-     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: agrisoil
-     REAL, DIMENSION( ims:ime,12,jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: fertilizer
-     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: freeinten
-     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: graze
-     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: industry
-     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: residential
-     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: transport
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: agrisoil_nh3
+     REAL, DIMENSION( ims:ime,12,jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: fertilizer_nh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: freeinten_nh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: graze_nh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: industry_nh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: residential_nh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: transport_nh3
      INTEGER, INTENT(IN   ) ::       current_hour
 
 
@@ -1008,11 +1009,11 @@ real, save :: freq_industry(24)    = &
  if( config_flags%nh3emis_opt == ONLINE) then      
   emis_ant(ims:ime , config_flags%kemit , jms:jme, p_e_nh3)=0.0
 
-  frin_house         =  freeinten*Factor_fihouse      ! house [in]
-  frin_sManure       =  freeinten*Factor_sManure      ! manure - field [out]
-  frin_manureStore   =  freeinten*Factor_manureStore  ! manure - store [none]
-  graze_house        =  graze*Factor_grhouse          ! graze [in]
-  graze_out          =  graze*(1.0-Factor_grhouse)    ! graze [out]
+  frin_house         =  freeinten_nh3*Factor_fihouse      ! house [in]
+  frin_sManure       =  freeinten_nh3*Factor_sManure      ! manure - field [out]
+  frin_manureStore   =  freeinten_nh3*Factor_manureStore  ! manure - store [none]
+  graze_house        =  graze_nh3*Factor_grhouse          ! graze [in]
+  graze_out          =  graze_nh3*(1.0-Factor_grhouse)    ! graze [out]
 
   GF_Thouse =1.0
 
@@ -1036,8 +1037,8 @@ real, save :: freq_industry(24)    = &
   end where
 
 
-     do 200 j=jts,jte  
-     do 200 i=its,ite  
+     do j=jts,jte  
+     do i=its,ite  
     
 
      CFwind  =exp(0.0419*(u10(i,j)*u10(i,j)+v10(i,j)*v10(i,j))**0.5)
@@ -1053,7 +1054,7 @@ real, save :: freq_industry(24)    = &
  ! for store
      emis_store(i,j) = frin_manureStore(i,j)
  ! for outside soil
-     emis_fert(i,j)  = EFnh3(i,j)*(fertilizer(i,current_month,j)+frin_sManure(i,j)+ graze_out(i,j)+agrisoil(i,j))
+     emis_fert(i,j)  = EFnh3(i,j)*(fertilizer_nh3(i,current_month,j)+frin_sManure(i,j)+ graze_out(i,j)+agrisoil_nh3(i,j))
 
 
 ! fertilizer and freeinten .... units is kg/km2/month
@@ -1062,11 +1063,12 @@ real, save :: freq_industry(24)    = &
         h=MOD(current_hour+8,24)   !range 0-23
 
   emis_ant(i,1,j,p_e_nh3)=1000.0/(17.0*30.0*24.0)*(emis_house(i,j)+emis_store(i,j)+emis_fert(i,j))  &
-                  + freq_residential(h+1)*residential(i,j)*1000.0/(30.0*17.0)   &
-                  + freq_industry(h+1)   *industry(i,j)*1000.0/(30.0*17.0)   &
-                  + freq_transport(h+1)  *transport(i,j)*1000.0/(30.0*17.0)   
+                  + freq_residential(h+1)*residential_nh3(i,j)*1000.0/(30.0*17.0)   &
+                  + freq_industry(h+1)   *industry_nh3(i,j)*1000.0/(30.0*17.0)   &
+                  + freq_transport(h+1)  *transport_nh3(i,j)*1000.0/(30.0*17.0)   
+    enddo
+    enddo
                    
- 200 continue
  end if 
 
 

--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -135,7 +135,7 @@ CONTAINS
    REAL, DIMENSION( ims:ime, jms:jme, ne_area ),                           &
          INTENT(INOUT ) ::                               e_bio
    REAL, DIMENSION( ims:ime, 1:config_flags%kemit, jms:jme,num_emis_ant),&
-         INTENT(IN ) ::                                                    &
+         INTENT(INOUT ) ::                                                    &
          emis_ant
    REAL, DIMENSION( ims:ime,  kms:kme, jms:jme,num_emis_vol),              &
          INTENT(INOUT ) ::                                                 &

--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -74,6 +74,10 @@ CONTAINS
          xtime,tslb,wet_in,rainc,rainnc,potevp,sfcevp,lu_index,            &
          biomt_par,emit_par,ebio_co2oce,eghg_bio,                          &
          seas_flux,                                                        &
+         ! stuff for online nh3 "WRF-NH3-CHEM" modified by renchuanhua
+         actnh3,EFnh3,                                                     &
+         agrisoil, fertilizer, freeinten, graze, industry, residential,    &
+         transport, current_hour, Q2,                                      &         
          ids,ide, jds,jde, kds,kde,                                        &
          ims,ime, jms,jme, kms,kme,                                        &
          its,ite, jts,jte, kts,kte                                         )
@@ -290,7 +294,7 @@ CONTAINS
 
    real, dimension (ims:ime, jms:jme ) ,                               &
         intent(in) ::                                                  &
-        T2, swdown
+        T2, swdown, Q2  ! modifed by renchuanhua
 
    integer, intent(in) :: current_month
 
@@ -336,7 +340,53 @@ CONTAINS
      REAL, DIMENSION( ims:ime,          jms:jme ),           INTENT(IN   ) :: ht, ic_flashrate, cg_flashrate
      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),           INTENT(IN   ) :: refl_10cm
 ! end stuff for lightning NOx
-!
+
+! stuff for online NH3  "WRF-NH3-CHEM" modified by renchuanhua
+     REAL, DIMENSION( ims:ime,12,jms:jme ), OPTIONAL,  INTENT(IN   ) :: actnh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: EFnh3
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: agrisoil
+     REAL, DIMENSION( ims:ime,12,jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: fertilizer
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: freeinten
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: graze
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: industry
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: residential
+     REAL, DIMENSION( ims:ime,   jms:jme ), OPTIONAL,  INTENT(INOUT   ) :: transport
+     INTEGER, INTENT(IN   ) ::       current_hour
+
+
+     ! local variables
+     real,parameter :: EFstd =5.5
+     real :: CFwind,CFtemp,CFsmois_hus,CFrain  
+     integer :: h 
+     real, dimension (ims:ime, jms:jme ) ::   frin_house, frin_sManure,frin_manureStore  !renchuanhua
+     real, dimension (ims:ime, jms:jme ) ::   graze_house, graze_out 
+     real, dimension (ims:ime, jms:jme ) ::   CFsmois
+     real, dimension (ims:ime, jms:jme ) ::   T_house, V_house, GF_Thouse
+     real, parameter :: Factor_fihouse=0.156, Factor_sManure=0.774, Factor_manureStore=0.07 
+     real, parameter :: Factor_grhouse=0.226     
+
+     real, dimension (ims:ime, jms:jme ) ::   house, store ,outsoil
+     real, dimension (ims:ime, jms:jme ) ::   emis_house, emis_store ,emis_fert
+
+real, save :: freq_residential(24) = &
+                          (/0.0110, 0.0030, 0.0010, 0.0000, 0.0020, 0.0169, &
+                            0.0914, 0.2111, 0.1402, 0.0905, 0.0676, 0.0487, &
+                            0.0179, 0.0358, 0.0258, 0.0182, 0.0272, 0.0222, &
+                            0.0411, 0.0401, 0.0268, 0.0202, 0.0212, 0.0202/)
+real, save :: freq_transport(24)   = &
+              (/0.02, 0.01, 0.01, 0.00, 0.00, 0.00, &
+                0.01, 0.03, 0.06, 0.06, 0.06, 0.05, &
+                0.06, 0.06, 0.06, 0.07, 0.07, 0.08, &
+                0.08, 0.07, 0.05, 0.04, 0.03, 0.02/)
+real, save :: freq_industry(24)    = &
+              (/0.02, 0.01, 0.01, 0.00, 0.00, 0.00, &
+                0.01, 0.03, 0.06, 0.06, 0.06, 0.05, &
+                0.06, 0.06, 0.06, 0.07, 0.07, 0.08, &
+                0.08, 0.07, 0.05, 0.04, 0.03, 0.02/)
+
+! end stuff online NH3  
+
+
 ! Local variables...
 !
       INTEGER :: begday,endday,i, j, k, m, p_in_chem, ksub, dust_emiss_active, seasalt_emiss_active,emiss_ash_hgt
@@ -951,6 +1001,75 @@ CONTAINS
     END SELECT bioem_select
 
 !!! **************** END BIOGENICS, ADD EMISSIONS FOR VARIOUS PACKAGES
+
+
+!!! online nh3 "WRF-NH3-CHEM" modified by renchuanhua
+
+ if( config_flags%nh3emis_opt == ONLINE) then      
+  emis_ant(ims:ime , config_flags%kemit , jms:jme, p_e_nh3)=0.0
+
+  frin_house         =  freeinten*Factor_fihouse      ! house [in]
+  frin_sManure       =  freeinten*Factor_sManure      ! manure - field [out]
+  frin_manureStore   =  freeinten*Factor_manureStore  ! manure - store [none]
+  graze_house        =  graze*Factor_grhouse          ! graze [in]
+  graze_out          =  graze*(1.0-Factor_grhouse)    ! graze [out]
+
+  GF_Thouse =1.0
+
+! Animal house temperature and wind speed
+  where( T2.LT.273.15)
+    T_house = 287.15 + 0.5*(T2-(273.15+0))
+    V_house = 0.2
+  elsewhere(T2 .GE. 273.15 .and. T2 .LT. 285.65)
+    T_house = 287.15
+    V_house = 0.2 + T2*(0.405/12.5)
+  elsewhere(T2 .GE. 285.65) 
+    T_house = 287.15 + 1.4*(T2-(285.65))
+    V_house = 0.405  !0.5*(0.38+0.43)
+  end where
+    
+!  out field soil moisture correction factor
+  where( smois(:,1,:).LT.0.45)
+    CFsmois = 0.45*exp(-1.0*smois(:,1,:))+0.55
+  elsewhere(smois(:,1,:).GE.0.45)
+    CFsmois = 0.45*exp(smois(:,1,:))+0.6
+  end where
+
+
+     do 200 j=jts,jte  
+     do 200 i=its,ite  
+    
+
+     CFwind  =exp(0.0419*(u10(i,j)*u10(i,j)+v10(i,j)*v10(i,j))**0.5)
+     CFtemp  = (exp(0.093*(tsk(i,j)-T2(i,j))-0.57))*exp(0.018*(tsk(i,j)-273.15))
+     CFrain = 1/(3.2*rainnc(i,j)+1.0)
+     EFnh3(i,j)=CFsmois(i,j)*CFtemp*CFrain*CFwind
+
+     CFsmois_hus = 0.45*exp(-1.0*smois(i,1,j))+0.55
+     GF_Thouse  =exp((0.093*(T_house(i,j)-tsk(i,j)))-0.57)*exp(0.018*(tsk(i,j)-273.15))  
+
+ ! for house 
+     emis_house(i,j) = CFsmois_hus*GF_Thouse(i,j)*exp(0.0419*V_house(i,j))*(frin_house(i,j) + graze_house(i,j))        
+ ! for store
+     emis_store(i,j) = frin_manureStore(i,j)
+ ! for outside soil
+     emis_fert(i,j)  = EFnh3(i,j)*(fertilizer(i,current_month,j)+frin_sManure(i,j)+ graze_out(i,j)+agrisoil(i,j))
+
+
+! fertilizer and freeinten .... units is kg/km2/month
+! conv is used to change units from "mole/km2/hr" to "delta ppmv"
+  conv = 4.828e-4/rho_phy(i,1,j)*dtstep/(dz8w(i,1,j)*60.)
+        h=MOD(current_hour+8,24)   !range 0-23
+
+  emis_ant(i,1,j,p_e_nh3)=1000.0/(17.0*30.0*24.0)*(emis_house(i,j)+emis_store(i,j)+emis_fert(i,j))  &
+                  + freq_residential(h+1)*residential(i,j)*1000.0/(30.0*17.0)   &
+                  + freq_industry(h+1)   *industry(i,j)*1000.0/(30.0*17.0)   &
+                  + freq_transport(h+1)  *transport(i,j)*1000.0/(30.0*17.0)   
+                   
+ 200 continue
+ end if 
+
+
 !
     gas_addemiss_select: SELECT CASE(config_flags%chem_opt)
     CASE (RADM2, RADM2_KPP, RADM2SORG, RADM2SORG_AQ, RADM2SORG_AQCHEM, RADM2SORG_KPP, &


### PR DESCRIPTION
The WRF-SoilN-chem: a dynamic ammonia emission model capable of calculating NH3 emission rate interactively with time- and spatial-varying meteorological and soil conditions.

TYPE: enhancement

KEYWORDS: ammonia emission, soil, dynamic, chem, gas phase.

SOURCE: RenChuanhua and Huangxin, Nanjing University.

DESCRIPTION OF CHANGES:  Use a dynamic ammonia emission function instead of a static monthly emission inventory
Problem:
The traditional monthly emission inventory cannot characterize the variation of ammonia emission intensity under different meteorological conditions, which leads to the simulation bias of secondary inorganic aerosol (such as nitrate and sulfate).

Solution:
The meteorological dependent dynamic emission factor (empirical function) is added to the emission file, which can calculate the ammonia emission rate according to hourly meteorological conditions and soil conditions.

LIST OF MODIFIED FILES: list of changed files: 
Registry/Registry.EM_COMMON
Registry/registry.chem
chem/chem_driver.F
chem/emissions_driver.F

TESTS CONDUCTED: 
We compiled and ran the revised model to simulate 2019 East China region, and it can run smoothly, and the running speed has not decreased significantly. Compared with the traditional static emission inventory, the NH3 and nitrate concentrations obtained by dynamic model are obviously optimized.

The code has passed the regression tests.

RELEASE NOTE: 
the whole source code and input dataset (binary data needed to be embedded into WPS geog_data_path) and model userguide can be found in:
https://github.com/RenChuanhua/wrf-nh3-chem_v1.0

Ren, C., Huang, X., Liu, T., Song, Y., Wen, Z., Liu, X., Ding, A., and Zhu, T.: A dynamic ammonia emission model and the online coupling with WRF-Chem (WRF-SoilN-Chem v1.0): development and evaluation, Geosci. Model Dev. Discuss. [preprint], https://doi.org/10.5194/gmd-2022-231, 2022.
