### PR TITLE
Bug fix: iccg_crm_pr93

### DIFF
--- a/phys/module_ltng_crmpr92.F
+++ b/phys/module_ltng_crmpr92.F
@@ -252,7 +252,7 @@
  IMPLICIT NONE
 !-----------------------------------------------------------------
 ! Inputs
- REAL,    DIMENSION( ims:ims, kms:kme, jms:jme ), INTENT(IN   ) :: refl, t, z
+ REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN   ) :: refl, t, z
  REAL,                                            INTENT(IN   ) :: reflthreshold
 
 ! Order dependent args for domain, mem, and tile dims
@@ -292,7 +292,7 @@
         enddo
 
         kfreeze = ktop
-        DO WHILE ( t(i,kfreeze,j) .lt. 273.15 .and. ktop .gt. kps )
+        DO WHILE ( t(i,kfreeze,j) .lt. 273.15 .and. kfreeze .gt. kps )
             kfreeze = kfreeze - 1
         ENDDO
 


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: dimension and loop condition error in subroutine iccg_crm_pr93

SOURCE: J. Wong <johnwong@ucar.edu>

DESCRIPTION OF CHANGES: 
1. A dimension error was found in subroutine iccg_pr93 in module_ltng_crmpr92.F. The arrays should be dimensioned by ims:ime, instead it is dimensioned by ims:ims.
2. The DO WHILE loop to calculate freezing level height after cloud top height should be replaced from ktop to kfreeze. Otherwise, it might cause a Segmentation fault.

LIST OF MODIFIED FILES:
phys/module_ltng_crmpr92.F

TESTS CONDUCTED:
The regression tests have passed.

RELEASE NOTE: Fixed a dimension error for arrays refl, t and z. 