### PR TITLE
Test for RPC instead of checking hardcoded paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1095,6 +1095,10 @@ fortran_2003_fflush_test:
 fortran_2008_gamma_test:
 	@cd tools ; /bin/rm -f fortran_2008_gamma_test.{exe,o} ; $(SFC) -o fortran_2008_gamma_test.exe fortran_2008_gamma_test.F ; cd ..
 
+# rule used by configure to test for RPC support
+rpc_test:
+	@cd tools ; /bin/rm -f rpc_test.exe ; $(SCC) -DUSE_TIRPC -o rpc_test.exe rpc_test.c ; $(SCC) -o rpc_test.exe rpc_test.c; cd ..
+
 toolsdir :
 	@ echo '--------------------------------------'
 	if [ $(WRF_PLUS_CORE) -eq 0 ] ; then \

--- a/configure
+++ b/configure
@@ -1038,11 +1038,16 @@ if [ $retval -ne 0 ] ; then
 fi
 
 # testing for location of rpc/types.h file, used in landuse
-if [ -f /usr/include/rpc/types.h ] ; then
-  sed -e '/^CFLAGS_LOCAL/s/#/-DRPC_TYPES=1 &/' configure.wrf > configure.wrf.edit
-  mv configure.wrf.edit configure.wrf
-elif [ -f /usr/include/tirpc/rpc/types.h ] ; then
-  sed -e '/^CFLAGS_LOCAL/s/#/-DRPC_TYPES=2 &/' configure.wrf > configure.wrf.edit
+make rpc_test > tools/rpc_test.log 2>&1
+rm -f tools/rpc_test.log
+
+if [ -f tools/rpc_test.exe ] ; then
+  rpc_type=`tools/rpc_test.exe`
+  if [ $rpc_type == "rpc" ]; then
+    sed -e '/^CFLAGS_LOCAL/s/#/-DRPC_TYPES=1 &/' configure.wrf > configure.wrf.edit
+  else
+    sed -e '/^CFLAGS_LOCAL/s/#/-DRPC_TYPES=2 &/' configure.wrf > configure.wrf.edit
+  fi
   mv configure.wrf.edit configure.wrf
 else
   echo "************************** W A R N I N G ************************************"

--- a/tools/rpc_test.c
+++ b/tools/rpc_test.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+#ifdef USE_TIRPC
+#include <tirpc/rpc/types.h>
+#else
+#include <rpc/types.h>
+#endif
+
+/* Should confirm type to avoid symlink hack false positivies */
+int main()
+{
+#ifdef _RPC_TYPES_H
+    printf("rpc\n");
+#endif
+
+#ifdef _TIRPC_TYPES_H
+    printf("tirpc\n");
+#endif
+    return 0;
+}


### PR DESCRIPTION
Change to configure to test for RPC package instead of checking hardcoded paths, so that non-standard RPC installs can still be found.

TYPE: enhancement

KEYWORDS: configure, build, rpc, make, test

SOURCE: Brian Vanderwende (NCAR)

DESCRIPTION OF CHANGES:
Problem:
If an RPC library is installed in a non-standard prefix with a package manager like Spack, WRF will not be able to find it.

Solution:
Instead of checking hardcoded locations for `rpc/types.h`, compile a test program to check for one of the variants. Since symbolic linking hacks are occasionally done to make tirpc friendlier, it's also good to check constants to confirm the version used.

LIST OF MODIFIED FILES (from develop):
M       Makefile
M       configure
A       tools/rpc_test.c

TESTS CONDUCTED: 
1. The success is determined by running `configure` on a system that uses Spack to install libtirpc.
2. The Jenkins tests have passed - no impact on other part of code.

RELEASE NOTE: Test for RPC headers to support non-standard locations.
