### PR TITLE
Fix exponent letter

### DIFF
--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -339,7 +339,7 @@
       ENDDO
       UL = (1.-DERF(5.D+0/DSQRT(2.D+0)))*0.5                            ! after 5 sigma, x1mfrc will < 2.86E-7
       X1MAFRC = 1.D+0-XAFRC
-      IF (XAFRC.LT.1.E-10) THEN
+      IF (XAFRC.LT.1.D-10) THEN
          RC = RC_MIN
          RETURN
       ENDIF
@@ -352,7 +352,7 @@
       DO I = 1,ITERMAX
          Y  = Y0
          DY = DYEQU(DRC,DWMAS,DMODE,DSTDV)
-         IF (DY.LE.1.E-50) THEN
+         IF (DY.LE.1.D-50) THEN
             PRINT *,'IN FIND_RC0.F DY IS',DY
             PRINT *,I,DX,Y,DY,DEXP(DRC),DRC,XAFRC,X1MAFRC,DMODE,DSTDV, &
                     CMODE,CSTDV


### PR DESCRIPTION
Bug fix in exponent letters

TYPE: bug fix

KEYWORDS: exponent letter, double precision, default real, Fortran, underflow

SOURCE: Kengo Miyamoto (RIST)

DESCRIPTION OF CHANGES:
Problem: 
In Fortran, the exponent letter for double precision numbers should be ‘D’, while the exponent letter ‘E' is used for default real numbers. Furthermore, the value 1.0E-50 is less than the value of ‘tiny', which is the smallest positive number, of default real numbers. This causes error for Fujitsu Fortran compiler when building WRF load module files.

Solution:
Changing the exponent letters of the constants those are compared to double precision variables in SUBROUTINE FIND_RC0 from ‘E’ to ‘D’.

LIST OF MODIFIED FILES: 
M     phys/module_mp_ntu.F

TESTS CONDUCTED: 
1. I checked whether Fujitsu compiler could make WRF and WPS load module files and two tutorial cases (Single Domain Case and Nested Model Run: 2-way with 2 Input Files) could be completed successfully on a Fujitsu computer system.
2. The regression tests have passed, meaning the compilation of the changed code is ok.
