### PR TITLE
Fix Lightning Potential Index calculation failure

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3310,7 +3310,7 @@ package	ltng_none           lightning_option==0            -       -
 package	ltng_crm_PR92w      lightning_option==1            -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
 package ltng_crm_PR92z      lightning_option==2            -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
 package	ltng_cpm_PR92z      lightning_option==11           -       state:ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
-package	ltng_lpi            lightning_option==3           -        state:lpi
+package	ltng_lpi            lightning_option==3           -        state:lpi,ic_flashcount,ic_flashrate,cg_flashcount,cg_flashrate
 # only need to specify these once; not for every io_form* variable
 package   io_intio    io_form_restart==1                     -             -
 package   io_netcdf   io_form_restart==2                     -             -

--- a/phys/module_lightning_driver.F
+++ b/phys/module_lightning_driver.F
@@ -413,22 +413,21 @@
                   )
 
     ! LPI lightning options
-#if (EM_CORE==1)
     CASE( ltng_lpi )
         CALL wrf_debug ( 100, ' lightning_driver: calling Light Potential Index' )
         IF(F_QG) THEN
         CALL   calclpi(W=w,                              &
-                     Z=z,                              &
-                     PI_PHY=pi_phy, RHO_PHY=rho,             &
-                     TH_PHY=TH_PHY,P_PHY=p_phy,                  &
+                     Z=z,                                &
+                     PI_PHY=pi_phy, RHO_PHY=rho,         &
+                     TH_PHY=TH_PHY,P_PHY=p_phy,          &
                      DZ8w=dz8w,                          &
-                     QV=moist(ims,kms,jms,P_QV),         &   !Qv=qv_curr,                         &
-                     QC=moist(ims,kms,jms,P_QC),         &   !Qc=qc_curr,                         &
-                     QR=moist(ims,kms,jms,P_QR),         &   !QR=qr_curr,                         &
-                     QI=moist(ims,kms,jms,P_QI),         &   !QI=qi_curr,                         &
-                     QS=moist(ims,kms,jms,P_QS),         &   !qs_curr,                         &
-                     QG=moist(ims,kms,jms,P_QG),         &   !qg_curr,                         &
-                     QH=moist(ims,kms,jms,P_QH),         &   !qh_curr,                         &
+                     QV=moist(ims,kms,jms,P_QV),         &   !Qv=qv_curr
+                     QC=moist(ims,kms,jms,P_QC),         &   !Qc=qc_curr
+                     QR=moist(ims,kms,jms,P_QR),         &   !QR=qr_curr
+                     QI=moist(ims,kms,jms,P_QI),         &   !QI=qi_curr
+                     QS=moist(ims,kms,jms,P_QS),         &   !qs_curr
+                     QG=moist(ims,kms,jms,P_QG),         &   !qg_curr
+!                    QH=moist(ims,kms,jms,P_QH),         &   !qh_curr
                   lpi=lpi &
                  ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde &
                  ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme &
@@ -437,7 +436,7 @@
         WRITE(wrf_err_message, * ) ' lightning_driver: LPI option needs Microphysics Option with Graupel '
         CALL wrf_error_fatal ( wrf_err_message )
         ENDIF
-#endif
+
 !   CASE ( another_cpm_option)
 
     ! Invalid lightning options
@@ -446,6 +445,8 @@
         CALL wrf_error_fatal ( wrf_err_message )
 
  END SELECT flashrate_select
+
+ IF (lightning_option.eq.3) GOTO 100
 
 !-----------------------------------------------------------------
 
@@ -584,6 +585,7 @@
  ic_flashcount(its:ite,jts:jte) = ic_flashcount(its:ite,jts:jte) + ic_flashrate(its:ite,jts:jte) * lightning_dt
  cg_flashcount(its:ite,jts:jte) = cg_flashcount(its:ite,jts:jte) + cg_flashrate(its:ite,jts:jte) * lightning_dt
  
+ 100  CONTINUE
  do
    if( REAL(ltngacttime,8) <= nextTime ) then
      ltngacttime = ltngacttime + lightning_dt

--- a/phys/module_ltng_lpi.F
+++ b/phys/module_ltng_lpi.F
@@ -7,15 +7,15 @@ MODULE module_ltng_lpi
 ! However, we don't check for collapsing cell (so as not to require use of halo).
 ! This means that lpi is also calculated in cells that are no longer (on average) growing
 ! For a "complete" lightning forecast scheme, please see:
-!http://journals.ametsoc.org/doi/abs/10.1175/WAF-D-11-00144.1
+!https://doi.org/10.1175/WAF-D-11-00144.1
 !(Predicting Cloud-to-Ground and Intracloud Lightning in Weather Forecast Models)
 
 CONTAINS
 !===================================================================
 !
-  SUBROUTINE calclpi(qv,qc, qr, qi, qs, qg, qh                            &
-                 ,w,z,dz8w,pi_phy,th_phy,p_phy,rho_phy                    &
-                 ,lpi&
+  SUBROUTINE calclpi(qv,qc, qr, qi, qs, qg                         &
+                 ,w,z,dz8w,pi_phy,th_phy,p_phy,rho_phy             &
+                 ,lpi                                              &
                  ,ids,ide, jds,jde, kds,kde                        &
                  ,ims,ime, jms,jme, kms,kme                        &
                  ,its,ite, jts,jte, kts,kte                        &
@@ -35,7 +35,7 @@ CONTAINS
                                                               qi, &
                                                               qr, &
                                                               qs, &
-                                                              qg,qh
+                                                              qg
 
       REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                  &
          INTENT(IN ) ::  w, z
@@ -85,7 +85,7 @@ CONTAINS
           qc1d(k)=qc(i,k,j)
           ql1d(k)=qc(i,k,j)+qr(i,k,j)
           qi1d(k)=qi(i,k,j)
-          qti1d(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)+qh(i,k,j)
+          qti1d(k)=qi(i,k,j)+qs(i,k,j)+qg(i,k,j)
           qs1d(k)=qs(i,k,j)
 !         qg1d(k)=qg(i,k,j)+qh(i,k,j)
 ! Hail doesn't usually charge
@@ -103,6 +103,7 @@ CONTAINS
       END DO
       return
       end subroutine calclpi
+
       subroutine &
      &  calc_lpi(ql3d,qi3d,qs3d,qg3d,w3d,t3d,height,lpi,t_base,t_top,nk,nke)
       implicit none
@@ -125,6 +126,9 @@ CONTAINS
       real num_s,den_s
       real num_i,den_i
       real q_isg
+      real small_num
+
+      small_num=1.e-10
       icnt=0
       do k=1,nke
         top=height(k)
@@ -138,18 +142,19 @@ CONTAINS
       ave_z=0
       del_z_tot=0
       lpi=0
+
       do k=1,nke-1
        if (t3d(k).le.t_base.and.t3d(k).gt.t_top)then ! set temp range
         
         den_i = qi3d(k)+qg3d(k)     
         den_s = qs3d(k)+qg3d(k)
-        if (qs3d(k).eq.0.or.qg3d(k).eq.0.)then !checks for zeroes
+        if (qs3d(k).le.small_num.or.qg3d(k).le.small_num)then !checks for zeroes
          den_s=10000.
          num_s = 0.
         else
          num_s = sqrt(qs3d(k)*qg3d(k))   
         end if
-        if (qi3d(k).eq.0.or.qg3d(k).eq.0.)then  ! checks for zeroes
+        if (qi3d(k).le.small_num.or.qg3d(k).le.small_num)then  ! checks for zeroes
          den_i=10000.
          num_i = 0.
         else
@@ -157,7 +162,7 @@ CONTAINS
         end if
         q_isg = qg3d(k)*(num_i/den_i+num_s/den_s)  ! ice "fract"-content
 
-        if (ql3d(k).eq.0.or.q_isg.eq.0)then
+        if (ql3d(k).le.small_num.or.q_isg.eq.0)then
           num=0
           den=10000.
         else
@@ -173,7 +178,6 @@ CONTAINS
 !
       if (del_z_tot.eq.0)del_z_tot=100000
       lpi=ave_z/del_z_tot
-       
 !
       return
       end subroutine calc_lpi


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: LPI, malloc error, NaNs

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The model stops right away with malloc error (with gfortran) when using lightning_option = 3, the option to compute lightning potential index (the problem occurred only with a 2 domain test). The error is due to variable packaging for this option. Once this error is fixed, the model can run but produces NaNs in the diagnostics. Array for hail mixing ratio is removed from the call as well, as it is not used.

Solution:
Add additional variables for packaging, and limit hydrometeors to a number that is not smaller than 1.e-10, which eliminates the NaNs.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       phys/module_lightning_driver.F
M       phys/module_ltng_lpi.F

TESTS CONDUCTED: 
1. The model ran with 2 domain test, and do not produce NaNs.
2. The Jenkins tests are all passing.

RELEASE NOTE: Fixed a bug for lightning diagnostic option 3, an option for lightning potential index calculation. The bug prevented nested case to run, and may produce NaNs in the diagnostics.
