### PR TITLE
Fix two numeric operators are consecutive

### DIFF
--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -7556,9 +7556,9 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
          dummy_0=(1.-am_unst*zet)          ! parentesis arg
          dummy_1=dummy_0**0.333333         ! y
-         dummy_11=-0.33333*am_unst*dummy_0**-0.6666667 ! dy/dzet
-         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
-         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
+         dummy_11=-0.33333*am_unst*dummy_0**(-0.6666667) ! dy/dzet
+         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)      ! f
+         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)      ! df/dzet
          dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
          dummy_33 = 1.1547*dummy_11        ! dg/dzet
          dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
@@ -7608,9 +7608,9 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
          dummy_0=(1.-ah_unst*zet)          ! parentesis arg
          dummy_1=dummy_0**0.333333         ! y
-         dummy_11=-0.33333*ah_unst*dummy_0**-0.6666667 ! dy/dzet
-         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
-         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
+         dummy_11=-0.33333*ah_unst*dummy_0**(-0.6666667) ! dy/dzet
+         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)      ! f
+         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)      ! df/dzet
          dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
          dummy_33 = 1.1547*dummy_11        ! dg/dzet
          dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic


### PR DESCRIPTION
Fix two numeric operators are consecutive

TYPE: bug fix

KEYWORDS: Fortran, Precedence of operators

SOURCE: Kengo Miyamoto (RIST)

DESCRIPTION OF CHANGES:
Problem:
In fortran, the formation rules do not permit expressions containing two consecutive numeric operators, such as A ** –B, while an expression such as A ** (–B) is permitted. This cause errors for Fujitsu Fortran compiler when building WRF load module files. gfortran warns to use parentheses.

Solution:
Adding parentheses

LIST OF MODIFIED FILES: phys/module_bl_mynn.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
   I checked whether Fujitsu compiler could make WRF and WPS load module files and a tutorial case (Nested Model Run: 2-way with 2 Input Files) could be completed successfully on a Fujitsu computer system.