### PR TITLE
Bug fix and rework the scale-aware code

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2458,7 +2458,6 @@ rconfig   integer cu_diag                 namelist,physics      max_domains    0
 rconfig   integer kf_edrates              namelist,physics      max_domains    0       rh   "kf_edrates"           "output entrainment/detrainment rates and convective timescale for KF schemes"      ""
 rconfig   integer kfeta_trigger           namelist,physics	1              1       rh   "KFETA Trigger function"    ""    ""
 rconfig   integer nsas_dx_factor          namelist,physics	1              0       rh   "NSAS DX-dependent option"    ""    ""
-rconfig   integer ntiedtke_dx_opt         namelist,physics	1              0       rh   "nTiedtke DX-dependent option"    ""    ""
 rconfig   real    CUDT                    namelist,physics	max_domains    0       h    "CUDT"          ""      ""
 rconfig   real    GSMDT                   namelist,physics	max_domains    0       h    "GSMDT"          ""      ""
 rconfig   integer ISFFLX                  namelist,physics 	1             1       irh    "ISFFLX"                        ""      ""

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1480,7 +1480,6 @@ BENCH_START(cu_driver_tim)
      !BSINGH -ENDS
      &             ,KFETA_TRIGGER=config_flags%kfeta_trigger              &
      &             ,NSAS_DX_FACTOR=config_flags%nsas_dx_factor            &
-     &             ,NTIEDTKE_DX_OPT=config_flags%ntiedtke_dx_opt          &
                  ! Dimension arguments
      &             ,IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde     &
      &             ,IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme     &

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -150,7 +150,6 @@ contains
                 ,u3d,v3d,w,t3d,qv3d,qc3d,qi3d,pi3d,rho3d        &
                 ,qvften,thften                                  &
                 ,dz8w,pcps,p8w,xland,cu_act_flag,dx             &
-                ,ntiedtke_dx_opt                                &
                 ,ids,ide, jds,jde, kds,kde                      &
                 ,ims,ime, jms,jme, kms,kme                      &
                 ,its,ite, jts,jte, kts,kte                      &
@@ -192,7 +191,6 @@ contains
 !-- dz8w        dz between full levels (m)
 !-- qfx         upward moisture flux at the surface (kg/m^2/s)
 !-- hfx         upward heat flux at the surface (w/m^2) 
-!-- ntiedtke_dx_opt   whether the schemem is scale-aware
 !-- dt          time step (s)
 !-- ids         start index for i in domain
 !-- ide         end index for i in domain
@@ -219,8 +217,6 @@ contains
                                         itimestep,                      &
                                         stepcu
 
-      integer, intent(in) ::            ntiedtke_dx_opt
-
       real,    intent(in) ::                                            &
                                         dt
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
@@ -234,7 +230,6 @@ contains
 
       logical, dimension(ims:ime,jms:jme), intent(inout) ::             &
                                         cu_act_flag
-
 
       real,    dimension(ims:ime, kms:kme, jms:jme), intent(in) ::      &
                                         dz8w,                           &
@@ -430,7 +425,7 @@ contains
 !
 !########################################################################
       call tiecnvn(u1,v1,t1,q1,q2,q3,q1b,t1b,ghtl,ghti,omg,prsl,prsi,evap,heatflux,  &
-                  rn,slimsk,im,kx,kx1,delt,dx2d,ntiedtke_dx_opt)
+                  rn,slimsk,im,kx,kx1,delt,dx2d)
 
       do i=its,ite
          raincv(i,j)=rn(i)/stepcu
@@ -559,7 +554,7 @@ contains
 !          level 1 subroutine 'tiecnvn'
 !-----------------------------------------------------------------
       subroutine tiecnvn(pu,pv,pt,pqv,pqc,pqi,pqvf,ptf,poz,pzz,pomg, &
-     &         pap,paph,evap,hfx,zprecc,lndj,lq,km,km1,dt,dx,ntiedtke_dx_opt)
+     &         pap,paph,evap,hfx,zprecc,lndj,lq,km,km1,dt,dx)
 !-----------------------------------------------------------------
 !  this is the interface between the model and the mass 
 !  flux convection module
@@ -581,7 +576,6 @@ contains
      &     zqsat(lq,km),   pqc(lq,km),   pqi(lq,km),   zrain(lq)
       real pqvf(lq,km),    ptf(lq,km)
       real dx(lq)
-      integer ntiedtke_dx_opt
 
       integer icbot(lq),   ictop(lq),     ktype(lq),   lndj(lq)
       logical locum(lq)
@@ -590,19 +584,20 @@ contains
       integer i,j,k,lq,km,km1
       real dt,ztpp1
       real zew,zqs,zcor
-      real scale_fac(lq), dxref
-      integer  scale_aware(lq)
+      real scale_tau(lq), scale_mf(lq), relax_t_limit(lq), dxref
 !
 !  set scale-dependency factor when dx is < 15 km
 !
-      scale_aware = 0
       dxref = 15000.
       do j=1,lq
-      if (dx(j).lt.dxref .and. ntiedtke_dx_opt.eq.1) then
-          scale_fac(j) = (1.+log(dxref/dx(j)))**3
-          scale_aware(j) = 1
+      if (dx(j).lt.dxref) then
+          scale_tau(j) = (1.+log(dxref/dx(j)))**3
+          scale_mf(j) = scale_tau(j)**0.5
+          relax_t_limit(j) = 43200.
       else
-          scale_fac(j) = 1.+1.33e-5*dx(j)
+          scale_tau(j) = 1.+1.33e-5*dx(j)
+          scale_mf(j) = 1.
+          relax_t_limit(j) = 10800.
       end if 
       end do
 !
@@ -659,7 +654,7 @@ contains
      &     ktype,    icbot,    ictop,    ztu,     zqu,  &
      &     zlu,      zlude,    zmfu,     zmfd,    zrain,&
      &     pcte,     phhfl,    lndj,     pgeoh,   dx,   &
-     &     scale_fac, scale_aware )
+     &     scale_tau, scale_mf, relax_t_limit )
 !
 !     to include the cloud water and cloud ice detrained from convection
 !
@@ -715,7 +710,7 @@ contains
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
      &     pcte,     phhfl,    lndj,     zgeoh,    dx,   &
-     &     scale_fac,  scale_aware )
+     &     scale_tau,  scale_mf, relax_t_limit )
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme
@@ -823,8 +818,7 @@ contains
      &         ktype(klon),            lndj(klon)
       logical  ldcum(klon)
       logical  loddraf(klon),          llo1,   llo2(klon)
-      real     scale_fac(klon)
-      integer  scale_aware(klon)
+      real     scale_tau(klon), scale_mf(klon), relax_t_limit(klon)
 
 !  local varaiables
       real     zcons,zcons2,zqumqe,zdqmin,zdh,zmfmax
@@ -925,8 +919,7 @@ contains
      &     zuu,      zvu,      pmfu,     zmfub,&
      &     zmfus,    zmfuq,    zmful,    plude,    zdmfup,&
      &     kcbot,    kctop,    ictop0,   icum,     ztmst,&
-     &     zqsenh,   zlglac,   lndj,     wup,      wbase,   kdpl,  pmfude_rate,&
-     &     scale_fac,  scale_aware )
+     &     zqsenh,   zlglac,   lndj,     wup,      wbase,   kdpl,  pmfude_rate)
 
 !*     (b) check cloud depth and change entrainment rate accordingly
 !          calculate precipitation rate (for downdraft calculation)
@@ -1042,14 +1035,10 @@ contains
        if(ldcum(jl).and.ktype(jl).eq.1) then
            ikb = kcbot(jl)
            ikt = kctop(jl)
-           ztau = ztauc(jl) * scale_fac(jl)
+           ztau = ztauc(jl) * scale_tau(jl)
            ztau = max(ztmst,ztau)
            ztau = max(360.,ztau)
-           if(scale_aware(jl).eq.1) then
-             ztau = min(43200.,ztau)
-           else
-             ztau = min(10800.,ztau)
-           end if
+           ztau = min(relax_t_limit(jl),ztau)
            if(nonequil) then
              zcape2(jl)= max(0.,zcape2(jl))
              zcape(jl) = max(0.,min(zcape1(jl)-zcape2(jl),5000.))
@@ -1088,10 +1077,8 @@ contains
            else
              zmfub1(jl) = zmfub(jl)
            end if
+           zmfub1(jl) = zmfub1(jl)/scale_mf(jl)
            zmfub1(jl) = min(zmfub1(jl),zmfmax)
-           if(scale_aware(jl).eq.1) then
-              zmfub1(jl) = zmfub1(jl)/(scale_fac(jl))**(.5)
-           end if
          end if
 
 !*  6.3   mid-level convection - nothing special
@@ -2134,8 +2121,7 @@ contains
      &     puu,      pvu,      pmfu,     pmfub,    &
      &     pmfus,    pmfuq,    pmful,    plude,    pdmfup,&
      &     kcbot,    kctop,    kctop0,   kcum,     ztmst,&
-     &     pqsenh,   plglac,   lndj,     wup,      wbase,   kdpl, pmfude_rate,&
-     &     scale_fac,  scale_aware )
+     &     pqsenh,   plglac,   lndj,     wup,      wbase,   kdpl, pmfude_rate) 
       implicit none
 !     this routine does the calculations for cloud ascents
 !     for cumulus parameterization
@@ -2256,8 +2242,6 @@ contains
       real     zrnew,zz,zdmfeu,zdmfdu,dp
       real     zfac,zbuoc,zdkbuo,zdken,zvv,zarg,zchange,zxe,zxs,zdshrd
       real     atop1,atop2,abot
-      real     scale_fac(klon)
-      integer  scale_aware(klon)
 !--------------------------------
 !*    1.       specify parameters
 !--------------------------------
@@ -2342,7 +2326,7 @@ contains
      &     pgeo,     pgeoh,    ldcum,   ktype,   klab,  zlrain,&
      &     pmfu,     pmfub,    kcbot,   ptu,&
      &     pqu,      plu,      puu,     pvu,      pmfus,&
-     &     pmfuq,    pmful,    pdmfup,  scale_aware )
+     &     pmfuq,    pmful,    pdmfup  )
       is = 0
       jlm = 0
       do jl = 1,klon
@@ -2562,9 +2546,6 @@ contains
             ikb=kcbot(jl)
             if ( plu(jl,jk) > zdshrd )then
               zwu = min(15.0,sqrt(2.*max(0.1,kup(jl,jk+1))))
-              if(scale_aware(jl).eq.1) then
-                 zprcdgw = cprcon*zrg/(scale_fac(jl)**(1./3.))
-              end if
               zprcon = zprcdgw/(0.75*zwu)
 ! PARAMETERS FOR BERGERON-FINDEISEN PROCESS (T < -5C)
               zdt = min(rtber-rtice,max(rtber-ptu(jl,jk),0.))
@@ -3747,7 +3728,7 @@ contains
      &     pgeo,     pgeoh,    ldcum,   ktype,  klab,  plrain,&
      &     pmfu,     pmfub,    kcbot,   ptu,&
      &     pqu,      plu,      puu,     pvu,    pmfus,&
-     &     pmfuq,    pmful,    pdmfup,  scale_aware )
+     &     pmfuq,    pmful,    pdmfup  )
       implicit none
 !      m.tiedtke         e.c.m.w.f.     12/89
 !      c.zhang           iprc           05/2012
@@ -3784,36 +3765,11 @@ contains
 ! local variabels
       integer  jl,kk,klev,klon,klevp1,klevm1
       real     zzzmb
-      integer  scale_aware(klon)
 !--------------------------------------------------------
 !*    1.      calculate entrainment and detrainment rates
 ! -------------------------------------------------------
          do jl=1,klon
           if(.not.ldcum(jl) .and. klab(jl,kk+1).eq.0) then
-           if(scale_aware(jl).eq.1) then
-            if(lmfmid .and. pqen(jl,kk) .gt. 0.80*pqsen(jl,kk).and. &
-! ww (no mid level conv, if the air is saturated)
-              pqen(jl,kk) .lt. pqsen(jl,kk).and. &
-              pgeo(jl,kk)*zrg .gt. 5.0e2  .and.  &
-     &        pgeo(jl,kk)*zrg .lt. 1.0e4 )  then
-            ptu(jl,kk+1)=(cpd*pten(jl,kk)+pgeo(jl,kk)-pgeoh(jl,kk+1))&
-     &                          *rcpd
-            pqu(jl,kk+1)=pqen(jl,kk)
-            plu(jl,kk+1)=0.
-            zzzmb=max(cmfcmin,-pverv(jl,kk)*zrg)
-            zzzmb=min(zzzmb,cmfcmax)
-            pmfub(jl)=zzzmb
-            pmfu(jl,kk+1)=pmfub(jl)
-            pmfus(jl,kk+1)=pmfub(jl)*(cpd*ptu(jl,kk+1)+pgeoh(jl,kk+1))
-            pmfuq(jl,kk+1)=pmfub(jl)*pqu(jl,kk+1)
-            pmful(jl,kk+1)=0.
-            pdmfup(jl,kk+1)=0.
-            kcbot(jl)=kk
-            klab(jl,kk+1)=1
-            plrain(jl,kk+1)=0.0
-            ktype(jl)=3
-          end if
-         else
             if(lmfmid .and. pqen(jl,kk) .gt. 0.80*pqsen(jl,kk).and. &
               pgeo(jl,kk)*zrg .gt. 5.0e2  .and.  &
      &        pgeo(jl,kk)*zrg .lt. 1.0e4 )  then
@@ -3834,7 +3790,6 @@ contains
             plrain(jl,kk+1)=0.0
             ktype(jl)=3
           end if
-         end if
          end if
         end do
       return

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -591,13 +591,16 @@ contains
       real dt,ztpp1
       real zew,zqs,zcor
       real scale_fac(lq), dxref
+      integer  scale_aware(lq)
 !
 !  set scale-dependency factor when dx is < 15 km
 !
+      scale_aware = 0
       dxref = 15000.
       do j=1,lq
       if (dx(j).lt.dxref .and. ntiedtke_dx_opt.eq.1) then
           scale_fac(j) = (1.+log(dxref/dx(j)))**3
+          scale_aware(j) = 1
       else
           scale_fac(j) = 1.+1.33e-5*dx(j)
       end if 
@@ -656,7 +659,7 @@ contains
      &     ktype,    icbot,    ictop,    ztu,     zqu,  &
      &     zlu,      zlude,    zmfu,     zmfd,    zrain,&
      &     pcte,     phhfl,    lndj,     pgeoh,   dx,   &
-     &     scale_fac, ntiedtke_dx_opt )
+     &     scale_fac, scale_aware )
 !
 !     to include the cloud water and cloud ice detrained from convection
 !
@@ -712,7 +715,7 @@ contains
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
      &     pcte,     phhfl,    lndj,     zgeoh,    dx,   &
-     &     scale_fac,  ntiedtke_dx_opt )
+     &     scale_fac,  scale_aware )
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme
@@ -821,7 +824,7 @@ contains
       logical  ldcum(klon)
       logical  loddraf(klon),          llo1,   llo2(klon)
       real     scale_fac(klon)
-      integer  ntiedtke_dx_opt
+      integer  scale_aware(klon)
 
 !  local varaiables
       real     zcons,zcons2,zqumqe,zdqmin,zdh,zmfmax
@@ -923,7 +926,7 @@ contains
      &     zmfus,    zmfuq,    zmful,    plude,    zdmfup,&
      &     kcbot,    kctop,    ictop0,   icum,     ztmst,&
      &     zqsenh,   zlglac,   lndj,     wup,      wbase,   kdpl,  pmfude_rate,&
-     &     scale_fac,  ntiedtke_dx_opt )
+     &     scale_fac,  scale_aware )
 
 !*     (b) check cloud depth and change entrainment rate accordingly
 !          calculate precipitation rate (for downdraft calculation)
@@ -1042,7 +1045,7 @@ contains
            ztau = ztauc(jl) * scale_fac(jl)
            ztau = max(ztmst,ztau)
            ztau = max(360.,ztau)
-           if(ntiedtke_dx_opt.eq.1) then
+           if(scale_aware(jl).eq.1) then
              ztau = min(43200.,ztau)
            else
              ztau = min(10800.,ztau)
@@ -1086,7 +1089,7 @@ contains
              zmfub1(jl) = zmfub(jl)
            end if
            zmfub1(jl) = min(zmfub1(jl),zmfmax)
-           if(ntiedtke_dx_opt.eq.1) then
+           if(scale_aware(jl).eq.1) then
               zmfub1(jl) = zmfub1(jl)/(scale_fac(jl))**(.5)
            end if
          end if
@@ -2132,7 +2135,7 @@ contains
      &     pmfus,    pmfuq,    pmful,    plude,    pdmfup,&
      &     kcbot,    kctop,    kctop0,   kcum,     ztmst,&
      &     pqsenh,   plglac,   lndj,     wup,      wbase,   kdpl, pmfude_rate,&
-     &     scale_fac,  ntiedtke_dx_opt )
+     &     scale_fac,  scale_aware )
       implicit none
 !     this routine does the calculations for cloud ascents
 !     for cumulus parameterization
@@ -2254,17 +2257,13 @@ contains
       real     zfac,zbuoc,zdkbuo,zdken,zvv,zarg,zchange,zxe,zxs,zdshrd
       real     atop1,atop2,abot
       real     scale_fac(klon)
-      integer  ntiedtke_dx_opt
+      integer  scale_aware(klon)
 !--------------------------------
 !*    1.       specify parameters
 !--------------------------------
       zcons2=3./(g*ztmst)
       zfacbuo = 0.5/(1.+0.5)
-      if(ntiedtke_dx_opt.eq.1) then
-        zprcdgw = cprcon*zrg/(scale_fac(jl)**(1./3.))
-      else
       zprcdgw = cprcon*zrg
-      end if
       z_cldmax = 5.e-3
       z_cwifrac = 0.5
       z_cprc2 = 0.5
@@ -2343,7 +2342,7 @@ contains
      &     pgeo,     pgeoh,    ldcum,   ktype,   klab,  zlrain,&
      &     pmfu,     pmfub,    kcbot,   ptu,&
      &     pqu,      plu,      puu,     pvu,      pmfus,&
-     &     pmfuq,    pmful,    pdmfup,  ntiedtke_dx_opt )
+     &     pmfuq,    pmful,    pdmfup,  scale_aware )
       is = 0
       jlm = 0
       do jl = 1,klon
@@ -2563,6 +2562,9 @@ contains
             ikb=kcbot(jl)
             if ( plu(jl,jk) > zdshrd )then
               zwu = min(15.0,sqrt(2.*max(0.1,kup(jl,jk+1))))
+              if(scale_aware(jl).eq.1) then
+                 zprcdgw = cprcon*zrg/(scale_fac(jl)**(1./3.))
+              end if
               zprcon = zprcdgw/(0.75*zwu)
 ! PARAMETERS FOR BERGERON-FINDEISEN PROCESS (T < -5C)
               zdt = min(rtber-rtice,max(rtber-ptu(jl,jk),0.))
@@ -3745,7 +3747,7 @@ contains
      &     pgeo,     pgeoh,    ldcum,   ktype,  klab,  plrain,&
      &     pmfu,     pmfub,    kcbot,   ptu,&
      &     pqu,      plu,      puu,     pvu,    pmfus,&
-     &     pmfuq,    pmful,    pdmfup,  ntiedtke_dx_opt )
+     &     pmfuq,    pmful,    pdmfup,  scale_aware )
       implicit none
 !      m.tiedtke         e.c.m.w.f.     12/89
 !      c.zhang           iprc           05/2012
@@ -3782,16 +3784,16 @@ contains
 ! local variabels
       integer  jl,kk,klev,klon,klevp1,klevm1
       real     zzzmb
-      integer  ntiedtke_dx_opt
+      integer  scale_aware(klon)
 !--------------------------------------------------------
 !*    1.      calculate entrainment and detrainment rates
 ! -------------------------------------------------------
-       if(ntiedtke_dx_opt.eq.1) then
          do jl=1,klon
           if(.not.ldcum(jl) .and. klab(jl,kk+1).eq.0) then
+           if(scale_aware(jl).eq.1) then
             if(lmfmid .and. pqen(jl,kk) .gt. 0.80*pqsen(jl,kk).and. &
 ! ww (no mid level conv, if the air is saturated)
-              pqen(jl,kk) .le. pqsen(jl,kk).and. &
+              pqen(jl,kk) .lt. pqsen(jl,kk).and. &
               pgeo(jl,kk)*zrg .gt. 5.0e2  .and.  &
      &        pgeo(jl,kk)*zrg .lt. 1.0e4 )  then
             ptu(jl,kk+1)=(cpd*pten(jl,kk)+pgeo(jl,kk)-pgeoh(jl,kk+1))&
@@ -3811,11 +3813,7 @@ contains
             plrain(jl,kk+1)=0.0
             ktype(jl)=3
           end if
-         end if
-        end do
-       else
-         do jl=1,klon
-          if(.not.ldcum(jl) .and. klab(jl,kk+1).eq.0) then
+         else
             if(lmfmid .and. pqen(jl,kk) .gt. 0.80*pqsen(jl,kk).and. &
               pgeo(jl,kk)*zrg .gt. 5.0e2  .and.  &
      &        pgeo(jl,kk)*zrg .lt. 1.0e4 )  then
@@ -3837,8 +3835,8 @@ contains
             ktype(jl)=3
           end if
          end if
+         end if
         end do
-      end if
       return
       end subroutine cubasmcn
 !---------------------------------------------------------

--- a/phys/module_cu_ntiedtke.F
+++ b/phys/module_cu_ntiedtke.F
@@ -584,20 +584,18 @@ contains
       integer i,j,k,lq,km,km1
       real dt,ztpp1
       real zew,zqs,zcor
-      real scale_tau(lq), scale_mf(lq), relax_t_limit(lq), dxref
+      real scale_fac(lq), scale_fac2(lq), dxref
 !
 !  set scale-dependency factor when dx is < 15 km
 !
       dxref = 15000.
       do j=1,lq
       if (dx(j).lt.dxref) then
-          scale_tau(j) = (1.+log(dxref/dx(j)))**3
-          scale_mf(j) = scale_tau(j)**0.5
-          relax_t_limit(j) = 43200.
+          scale_fac(j) = (1.06133+log(dxref/dx(j)))**3
+          scale_fac2(j) = scale_fac(j)**0.5
       else
-          scale_tau(j) = 1.+1.33e-5*dx(j)
-          scale_mf(j) = 1.
-          relax_t_limit(j) = 10800.
+          scale_fac(j) = 1.+1.33e-5*dx(j)
+          scale_fac2(j) = 1.
       end if 
       end do
 !
@@ -654,7 +652,7 @@ contains
      &     ktype,    icbot,    ictop,    ztu,     zqu,  &
      &     zlu,      zlude,    zmfu,     zmfd,    zrain,&
      &     pcte,     phhfl,    lndj,     pgeoh,   dx,   &
-     &     scale_tau, scale_mf, relax_t_limit )
+     &     scale_fac, scale_fac2)
 !
 !     to include the cloud water and cloud ice detrained from convection
 !
@@ -710,7 +708,7 @@ contains
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
      &     pcte,     phhfl,    lndj,     zgeoh,    dx,   &
-     &     scale_tau,  scale_mf, relax_t_limit )
+     &     scale_fac,  scale_fac2)
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme
@@ -818,7 +816,7 @@ contains
      &         ktype(klon),            lndj(klon)
       logical  ldcum(klon)
       logical  loddraf(klon),          llo1,   llo2(klon)
-      real     scale_tau(klon), scale_mf(klon), relax_t_limit(klon)
+      real     scale_fac(klon), scale_fac2(klon)
 
 !  local varaiables
       real     zcons,zcons2,zqumqe,zdqmin,zdh,zmfmax
@@ -1035,10 +1033,10 @@ contains
        if(ldcum(jl).and.ktype(jl).eq.1) then
            ikb = kcbot(jl)
            ikt = kctop(jl)
-           ztau = ztauc(jl) * scale_tau(jl)
-           ztau = max(ztmst,ztau)
-           ztau = max(360.,ztau)
-           ztau = min(relax_t_limit(jl),ztau)
+           ztauc(jl) = max(ztmst,ztauc(jl))
+           ztauc(jl) = max(360.,ztauc(jl))
+           ztauc(jl) = min(10800.,ztauc(jl))
+           ztau = ztauc(jl) * scale_fac(jl)
            if(nonequil) then
              zcape2(jl)= max(0.,zcape2(jl))
              zcape(jl) = max(0.,min(zcape1(jl)-zcape2(jl),5000.))
@@ -1077,7 +1075,7 @@ contains
            else
              zmfub1(jl) = zmfub(jl)
            end if
-           zmfub1(jl) = zmfub1(jl)/scale_mf(jl)
+           zmfub1(jl) = zmfub1(jl)/scale_fac2(jl)
            zmfub1(jl) = min(zmfub1(jl),zmfmax)
          end if
 

--- a/phys/module_cumulus_driver.F
+++ b/phys/module_cumulus_driver.F
@@ -125,7 +125,6 @@ CONTAINS
                  ! Optional trigger function activation variable
                      ,kfeta_trigger                                   &
                      ,nsas_dx_factor                                  &
-                     ,ntiedtke_dx_opt                                 &
 #if ( WRF_DFI_RADAR == 1 )
                  ! Optional CAP suppress option      --- 3.2 CLEANUP TODO -- THESE SHOULD BE OPTIONAL, NOT #IF/#ENDIF
                      ,do_capsuppress                                  &
@@ -325,7 +324,6 @@ CONTAINS
 !-- W0AVG         average vertical velocity, (for KF scheme) (m/s)
 !-- kfeta_trigger namelist for KF trigger (=1, default; =2, moisture-advection-dependent trigger)
 !-- nsas_dx_factor namelist for NSAS deep scheme to have some dependency on grid sizes
-!-- ntiedtke_dx_opt namelist for nTiedtke cu scheme to have some dependency on grid sizes
 !-- rho           density (kg/m^3)
 !-- CONVCLD       Convective cloud (for BMJ scheme) (kg/m^2)
 !-- CCLDFRA       convective cloud fraction (for BMJ scheme)
@@ -527,7 +525,6 @@ CONTAINS
 
    INTEGER, INTENT(IN   ), OPTIONAL        ::   kfeta_trigger
    INTEGER, INTENT(IN   ), OPTIONAL        ::   nsas_dx_factor
-   INTEGER, INTENT(IN   )                  ::   ntiedtke_dx_opt
 
    REAL,  INTENT(IN   ) :: DT, DX
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,               &    
@@ -1416,8 +1413,6 @@ CONTAINS
 ! NEW TIEDTKE SCHEME - ZCX&YQW (U of Hawaii)
      CASE (NTIEDTKESCHEME)
 
-        IF ( PRESENT ( QFX ) .AND. PRESENT( HFX )) THEN
-
           CALL wrf_debug(100,'in cu_ntiedtke')
           CALL CU_NTIEDTKE(                                      &
                 DT=dt,ITIMESTEP=itimestep,STEPCU=STEPCU,HFX=hfx  &
@@ -1426,7 +1421,6 @@ CONTAINS
                ,QV3D=QV_CURR,QC3D=QC_CURR,QI3D=QI_CURR          &
                ,DZ8W=dz8w,PCPS=p,P8W=p8w,XLAND=XLAND,DX=dx2d    &
                ,CU_ACT_FLAG=CU_ACT_FLAG                         &
-               ,NTIEDTKE_DX_OPT=NTIEDTKE_DX_OPT                 &
                ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde &
                ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme &
                ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte &
@@ -1438,9 +1432,6 @@ CONTAINS
                ,F_QV=f_qv,F_QC=f_qc,F_QR=f_qr                   &
                ,F_QI=f_qi,F_QS=f_qs                             &
                                                              )
-        ELSE
-          CALL wrf_error_fatal('Lacking arguments for CU_NTIEDTKE in cumulus driver')
-        ENDIF
 
 ! New KIM SAS SCHEME - (KIAPS, South Korea)
      CASE (KSASSCHEME)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: scale-aware ntiedtke

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The original PR to add scale-awareness to the new Tiedtke scheme had a bug: the introduction of the namelist control didn't work correctly. Also the introduction of the namelist control made the code look ugly. After discussing with the original developer, we agreed if the changes to scale the cloud to rain conversion coefficient (which helps to reduce very light precip), and saturation check as a condition for triggering mid-level convection (which helps to the number of grid points that are classified as mid-level convection) are removed, the rest of the code can be added without a namelist control. 

Solution:
Removing the namelist introduced in PR#1806, and the changes related to cloud-to-rain conversion coefficient and saturation check for mid-level convection, and only keeping the scale-awareness only for convective adjustment time scale and shallow mass fluxes.

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_cu_ntiedtke.F
M       phys/module_cumulus_driver.F

TESTS CONDUCTED: 
1. Works as expected in two cases.
2. The Jenkins tests have passed.
