### PR TITLE
Stop intentionally removing OpenMP flags

### DIFF
--- a/arch/noopt_exceptions
+++ b/arch/noopt_exceptions
@@ -138,13 +138,7 @@ wrf_tsin.o :
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	if $(FGREP) '!$$OMP' $*.f90 ; then \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITH OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(OMP) $(FCSUFFIX) $*.f90 ; \
-        else \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITHOUT OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $*.f90 ; \
-        fi
+	$(FC) -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(OMP) $(FCSUFFIX) $*.f90
 
 module_sf_ruclsm.o : module_sf_ruclsm.F
 
@@ -153,15 +147,8 @@ module_sf_ruclsm.o :
 	$(CPP) -I$(WRF_SRC_ROOT_DIR)/inc $(CPPFLAGS) $(OMPCPP) $*.F  > $*.bb
 	$(SED_FTN) $*.bb | $(CPP) $(TRADFLAG) > $*.f90
 	$(RM) $*.b $*.bb
-	if $(FGREP) '!$$OMP' $*.f90 ; then \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITH OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCREDUCEDOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(OMP) $(FCSUFFIX) $*.f90 ; \
-        else \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITHOUT OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCREDUCEDOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $*.f90 ; \
-        fi
+	$(FC) -c $(PROMOTION) $(FCREDUCEDOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(OMP) $(FCSUFFIX) $*.f90
 
-# compile without OMP
 input_wrf.o \
 module_io.o \
 module_domain.o \
@@ -249,4 +236,4 @@ module_configure.o :
           mv $*.f90.tmp $*.f90 ; \
         fi
 	$(RM) $*.b $*.bb
-	$(FC) -c $(PROMOTION) $(FCSUFFIX) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $*.f90
+	$(FC) -c $(PROMOTION) $(FCSUFFIX) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(OMP) $*.f90

--- a/arch/noopt_exceptions_f
+++ b/arch/noopt_exceptions_f
@@ -90,13 +90,7 @@ wrf_tsin.o :
           $(WRF_SRC_ROOT_DIR)/var/build/da_name_space.pl $*.f90 > $*.f90.tmp ; \
           mv $*.f90.tmp $*.f90 ; \
         fi
-	if $(FGREP) '!$$OMP' $*.f90 ; then \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITH OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $(OMP) $*.f90 ; \
-        else \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITHOUT OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $*.f90 ; \
-        fi
+	$(FC) -c $(PROMOTION) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $(OMP) $*.f90
 
 #solve_em.o :
 #	$(RM) $@
@@ -112,16 +106,8 @@ module_sf_ruclsm.o :
 	$(SED_FTN) $*.F > $*.b 
 	$(CPP) -I$(WRF_SRC_ROOT_DIR)/inc $(CPPFLAGS) $(OMPCPP) $*.b  > $*.f90
 	$(RM) $*.b
-	if $(FGREP) '!$$OMP' $*.f90 ; then \
-          echo COMPILING $*.F WITH OMP ; \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITH OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCREDUCEDOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $(OMP) $*.f90 ; \
-        else \
-          if [ -n "$(OMP)" ] ; then echo COMPILING $*.F WITHOUT OMP ; fi ; \
-	  $(FC) -c $(PROMOTION) $(FCREDUCEDOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $*.f90 ; \
-        fi
+	$(FC) -c $(PROMOTION) $(FCREDUCEDOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(FCSUFFIX) $(OMP) $*.f90
 
-# compile without OMP
 input_wrf.o \
 module_domain.o \
 module_domain_type.o \
@@ -165,4 +151,4 @@ module_configure.o :
           mv $*.f90.tmp $*.f90 ; \
         fi
 	$(RM) $*.b $*.bb
-	$(FC) -c $(PROMOTION) $(FCSUFFIX) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $*.f90
+	$(FC) -c $(PROMOTION) $(FCSUFFIX) $(FCNOOPT) $(FCBASEOPTS) $(MODULE_DIRS) $(OMP) $*.f90


### PR DESCRIPTION
Stop intentionally removing OpenMP flags

TYPE: no impact

KEYWORDS: Compile, OpenMP flag

SOURCE: Kengo Miyamoto (RIST)

DESCRIPTION OF CHANGES:
Problem:
Some source program files are compiled without OpenMP flags, even though those refer to a variable in the source program file that is compiled with OpenMP flag. This causes errors for Fujitsu Fortran compiler when building WRF load module files. We don’t anticipate any issues if we also compile those files with OpenMP flags when we select 'smpar' or 'sm+dm’ configuration option.

Solution:
Stop intentionally removing OpenMP flags when compiling certain listed source program files. This also might make it easier to maintain building environment (e.g., The time of someone adds new source program files).

ISSUE:
https://forum.mmm.ucar.edu/threads/compiler-option-for-openmp-parallelization.12638/

LIST OF MODIFIED FILES:
arch/noopt_exception
arch/noopt_exception_f

TESTS CONDUCTED: 
1. In the eight cases below, I checked whether Fujitsu compiler could make WRF load module files and a tutorial case (Nested Model Run: 2-way with 2 Input Files) could be completed successfully on a Fujitsu computer system:
(opt_level=“-f”) x {serial, smpar, dmpar, sm+dm}
                          +
(opt_level=“”) x {serial, smpar, dmpar, sm+dm}

2. The regression tests have passed - no impact generally.

RELEASE NOTE: Stop intentionally removing OpenMP flags when compiling certain listed source program files, which causes problems with a Fujitsu Fortran compiler.