### PR TITLE
Bug Fix: Overflow in MYNN PBL with WRF_CHEM==1

### DIFF
--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -1061,10 +1061,8 @@ CONTAINS
              if  ( mix_chem ) then
                 do ic = 1,ndvel
                    vd1(ic) = vdep(i,ic) ! dry deposition velocity
-                   chem1(kts,ic) = chem3d(i,kts,ic)
-                   s_awchem1(kts,ic)=0.
                 enddo
-                do k = kts+1,kte
+                do k = kts,kte
                    do ic = 1,nchem
                       chem1(k,ic) = chem3d(i,k,ic)
                       s_awchem1(k,ic)=0.
@@ -1073,10 +1071,8 @@ CONTAINS
              else
                 do ic = 1,ndvel
                    vd1(ic) = 0. ! dry deposition velocity
-                   chem1(kts,ic) = 0.
-                   s_awchem1(kts,ic)=0.
                 enddo
-                do k = kts+1,kte
+                do k = kts,kte
                    do ic = 1,nchem
                       chem1(k,ic) = 0.
                       s_awchem1(k,ic)=0.


### PR DESCRIPTION
Fixes loop index for nchem/ndvel in MYNN. When NDVEL > NCHEM, loops w…ould overflow, causing intent (IN) variables to change.

TYPE: bug fix

KEYWORDS: MYNN, WRF_CHEM, loop overflow

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Abort due to overflow changing intent IN variables.

Solution:
Change so chem variables only loop over nchem.

ISSUE: Introduced with PR#1788

LIST OF MODIFIED FILES:
M       phys/module_bl_mynn.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?

RELEASE NOTE: 
