### PR TITLE
Quiet compiler warnings for registry.exe

### DIFF
--- a/configure
+++ b/configure
@@ -641,7 +641,7 @@ fi
 #Checking cross-compiling capability for some particular environment 
 #on Linux and Mac box
 
-if [ $os = "Linux" -o $os = "Darwin" ]; then
+if [ $os = "Linux" -o $os = "Darwin" -o $os = "CYGWIN_NT" ]; then
 
   SFC=`grep '^SFC' configure.wrf | awk '{print $3}'`
   SCC=`grep '^SCC' configure.wrf | awk '{print $3}'`

--- a/doc/README.cygwin.md
+++ b/doc/README.cygwin.md
@@ -19,6 +19,8 @@
 		- libnetcdf-fortran-devel
 		- openmpi (MPI for dmpar)
 		- libopenmpi-devel (MPI for dmpar)
+		- libhwloc-devel (needed by MPI)
+		- libevent-devel (needed by MPI)
 		- libjasper-devel (GRIB)
 		- perl
 		- tcsh

--- a/inc/streams.h
+++ b/inc/streams.h
@@ -1,5 +1,11 @@
 #ifndef MAX_HISTORY
-# define MAX_HISTORY 12
+# include <stdint.h>
+# define MAX_HISTORY (UINT8_C(12))
+# if (MAX_HISTORY > 120)
+#  warning If changing MAX_HISTORY to be above 120, check uses, loop variables,
+#  warning and destination string buffers to ensure the types used are wide
+#  warning enough.  Enabling compiler warnings for format strings should help.
+# endif
 #endif
 #ifndef IWORDSIZE
 # define IWORDSIZE 4

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,14 +1,21 @@
 .SUFFIXES: .c .o
 
-CC_TOOLS = cc
+CC_TOOLS = $(CC)
 CFLAGS = $(CC_TOOLS_CFLAGS) #-ansi
 LDFLAGS =
-DEBUG = -g 
+DEBUG = -g3 -ggdb3 -Og -fvar-tracking -fvar-tracking-assignments -gcolumn-info -fbounds-check -fstack-protector-all -fstack-protector-strong -fstack-check
+DEBUG = -Og -g -fuse-linker-plugin -flto=3
+WARNING = -Wall -Wextra  # -Werror
+GCC_WARNING = -Wno-unused-variable -Wno-unused-but-set-variable	\
+    -Wno-unused-parameter -Wformat=2 -Wformat-truncation=2		\
+    -Wformat-overflow=2 -Wno-format-security -Wno-format-nonliteral	\
+    -Wno-sign-compare -Wno-misleading-indentation
 OBJ = registry.o my_strtok.o reg_parse.o data.o type.o misc.o \
       gen_defs.o gen_allocs.o gen_mod_state_descr.o gen_scalar_indices.o \
       gen_args.o gen_config.o sym.o symtab_gen.o gen_irr_diag.o \
       gen_model_data_ord.o gen_interp.o gen_comms.o gen_scalar_derefs.o set_dim_strs.o gen_wrf_io.o\
       gen_streams.o
+DEBUG += $(WARNING) $(GCC_WARNING)
 
 registry : $(OBJ) standard.exe
 	$(CC_TOOLS) -o registry $(DEBUG) $(LDFLAGS) $(OBJ)
@@ -30,21 +37,22 @@ gen_comms.c : gen_comms.stub
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
-data.o: registry.h protos.h data.h
-gen_allocs.o: protos.h registry.h data.h
-gen_args.o: protos.h registry.h data.h
-gen_scalar_derefs.o: protos.h registry.h data.h
-gen_config.o: protos.h registry.h data.h
-gen_defs.o: protos.h registry.h data.h
-gen_mod_state_descr.o: protos.h registry.h data.h
-gen_model_data_ord.o: protos.h registry.h data.h
-gen_scalar_indices.o: protos.h registry.h data.h
-gen_wrf_io.o: protos.h registry.h data.h
-misc.o: protos.h registry.h data.h
-my_strtok.o: registry.h protos.h data.h
-reg_parse.o: registry.h protos.h data.h
-registry.o: protos.h registry.h data.h
+data.o: registry.h protos.h data.h ../inc/streams.h
+gen_allocs.o: protos.h registry.h data.h ../inc/streams.h sym.h
+gen_args.o: protos.h registry.h data.h ../inc/streams.h
+gen_config.o: protos.h registry.h data.h ../inc/streams.h sym.h
+gen_defs.o: protos.h registry.h data.h ../inc/streams.h
+gen_interp.o: protos.h registry.h data.h ../inc/streams.h
+gen_mod_state_descr.o: protos.h registry.h data.h ../inc/streams.h
+gen_model_data_ord.o: protos.h registry.h data.h ../inc/streams.h
+gen_scalar_derefs.o: protos.h registry.h data.h ../inc/streams.h
+gen_scalar_indices.o: protos.h registry.h data.h ../inc/streams.h
+gen_streams.o: protos.h registry.h data.h ../inc/streams.h sym.h
+gen_wrf_io.o: protos.h registry.h data.h ../inc/streams.h sym.h
+misc.o: protos.h registry.h data.h ../inc/streams.h
+my_strtok.o: registry.h protos.h data.h ../inc/streams.h
+reg_parse.o: registry.h protos.h data.h ../inc/streams.h sym.h
+registry.o: protos.h registry.h data.h ../inc/streams.h sym.h
+set_dim_strs.o: protos.h registry.h data.h ../inc/streams.h sym.h
 sym.o: sym.h
-type.o: registry.h protos.h data.h
-gen_interp.o: registry.h protos.h data.h
-gen_streams.o: registry.h protos.h data.h
+type.o: registry.h protos.h data.h ../inc/streams.h

--- a/tools/data.h
+++ b/tools/data.h
@@ -119,7 +119,7 @@ EXTERN node_t * Cycles ;
 
 EXTERN node_t Domain ;
 
-EXTERN char t1[NAMELEN], t2[NAMELEN], t3[NAMELEN], t4[NAMELEN], t5[NAMELEN], t6[NAMELEN] ;
+EXTERN char t1[NAMELEN], t2[NAMELEN], t3[NAMELEN], t4[NAMELEN + 11], t5[NAMELEN], t6[NAMELEN] ;
 EXTERN char thiscom[4*NAMELEN] ;
 EXTERN int  model_order[3] ;
 

--- a/tools/fseek_test.c
+++ b/tools/fseek_test.c
@@ -8,7 +8,7 @@ main()
   FILE *fp ;
   long long y ;
   int retval ;
-  int result1 ;
+  int result1 = 0 ;
 #ifdef TEST_FSEEKO
   off_t x ;
   off_t result2 ;

--- a/tools/gen_allocs.c
+++ b/tools/gen_allocs.c
@@ -80,13 +80,13 @@ int
 gen_alloc2 ( FILE * fp , char * structname , char * structname2 , node_t * node, int *j, int *iguy, int *fraction, int numguys, int frac, int sw ) /* 1 = allocate, 2 = just count */
 {
   node_t * p ;
-  int tag ;
+  int tag = 0 ;
   char post[NAMELEN], post_for_count[NAMELEN] ;
-  char fname[NAMELEN], dname[NAMELEN], dname_tmp[NAMELEN] ;
-  char x[NAMELEN] ;
-  char x2[NAMELEN], fname2[NAMELEN] ;
-  char dimname[3][NAMELEN] ;
-  char tchar ;
+  char fname[NAMELEN], dname[NAMELEN + 11], dname_tmp[NAMELEN] ;
+  char x[NAMELEN + 4] ;
+  char x2[NAMELEN + 2], fname2[2 * NAMELEN + 1] ;
+  char dimname[3][NAMELEN + 12] ;
+  char tchar = '\0';
   unsigned int *io_mask ;
   int nd ;
   int restart ;
@@ -120,7 +120,7 @@ gen_alloc2 ( FILE * fp , char * structname , char * structname2 , node_t * node,
 */
 if ( tag == 1 )
 {
-     char dname_symbol[128] ;
+     char dname_symbol[NAMELEN + 7] ;
      sym_nodeptr sym_node ;
 
      sprintf(dname_symbol, "DNAME_%s", dname_tmp ) ;
@@ -607,7 +607,7 @@ gen_dealloc2 ( FILE * fp , char * structname , node_t * node )
   int tag ;
   char post[NAMELEN] ;
   char fname[NAMELEN] ;
-  char x[NAMELEN] ;
+  char x[NAMELEN + 4] ;
 
   if ( node == NULL ) return(1) ;
 

--- a/tools/gen_args.c
+++ b/tools/gen_args.c
@@ -88,7 +88,7 @@ gen_args1 ( FILE * fp , char * outstr , char * structname ,
   int tag ;
   char post[NAMELEN] ;
   char fname[NAMELEN] ;
-  char x[NAMELEN], y[NAMELEN] ;
+  char x[NAMELEN + 4], y[NAMELEN] ;
   char indices[NAMELEN] ;
   int lenarg ; 
   int only4d = 0 ;

--- a/tools/gen_config.c
+++ b/tools/gen_config.c
@@ -14,12 +14,16 @@ int
 gen_namelist_defines ( char * dirname , int sw_dimension )
 {
   FILE * fp ;
-  char  fname[NAMELEN] ;
+  char  fname[NAMELEN + 4] ;
   char  fn[NAMELEN] ;
   node_t *p ;
   
   sprintf( fn, "namelist_defines%s.inc", sw_dimension?"":"2" ) ;
-  if ( strlen(dirname) > 0 ) { sprintf(fname,"%s/%s",dirname,fn) ; }
+  if ( strlen(dirname) > 0 ) {
+    sprintf(fname,"%s/%s",dirname,fn) ;
+  } else {
+    sprintf(fname, "%s", fn) ;
+  }
   if ((fp = fopen( fname , "w" )) == NULL ) return(1) ;
   print_warning(fp,fname) ;
 
@@ -55,7 +59,11 @@ gen_namelist_defaults ( char * dirname )
   char  *fn = "namelist_defaults.inc" ;
   node_t *p ;
 
-  if ( strlen(dirname) > 0 ) { sprintf(fname,"%s/%s",dirname,fn) ; }
+  if ( strlen(dirname) > 0 ) {
+    sprintf(fname,"%s/%s",dirname,fn) ;
+  } else {
+    sprintf(fname, "%s", fn) ;
+  }
   if ((fp = fopen( fname , "w" )) == NULL ) return(1) ;
   print_warning(fp,fname) ;
 
@@ -129,7 +137,11 @@ gen_namelist_script ( char * dirname )
   char  howset1[NAMELEN] ;
   char  howset2[NAMELEN] ;
 
-  if ( strlen(dirname) > 0 ) { sprintf(fname,"%s/%s",dirname,fn) ; }
+  if ( strlen(dirname) > 0 ) {
+    sprintf(fname,"%s/%s",dirname,fn) ;
+  } else {
+    sprintf(fname, "%s", fn) ;
+  }
   if ((fp = fopen( fname , "w" )) == NULL ) return(1) ;
 
   sym_forget() ;

--- a/tools/gen_defs.c
+++ b/tools/gen_defs.c
@@ -90,7 +90,7 @@ int
 gen_i1_decls ( char * dn )
 {
   FILE * fp ;
-  char  fname[NAMELEN], post[NAMELEN] ;
+  char  fname[NAMELEN+6], post[NAMELEN+6] ;
   char * fn = "i1_decl.inc" ;
   char * dimspec ;
   node_t * p ; 
@@ -140,7 +140,7 @@ gen_decls ( FILE * fp , node_t * node , int sw_ranges, int sw_point , int mask ,
   node_t * p ; 
   int tag, ipass ;
   char fname[NAMELEN], post[NAMELEN] ;
-  char * dimspec ;
+  char * dimspec = "";
   int bdyonly = 0 ;
 
   if ( node == NULL ) return(1) ;

--- a/tools/gen_interp.c
+++ b/tools/gen_interp.c
@@ -66,7 +66,7 @@ int contains_tok( char *s1, char *s2, char *delims )
   
 
  /* Had to increase size for SOA from 4*4096 to 4*7000 */
-char halo_define[4*7000], halo_use[NAMELEN], halo_id[NAMELEN], x[NAMELEN] ;
+char halo_define[4*7000], halo_use[NAMELEN] = {'\0'}, halo_id[NAMELEN], x[2 * NAMELEN + 1] ;
 
 /*KAL added this for vertical interpolation */
 /*DJW 131202 modified to create files required for vertical interpolation from parent to nest */
@@ -130,7 +130,7 @@ else if ( down_path[ipath] == FORCE_DOWN  ) { sprintf(halo_id,"HALO_FORCE_DOWN")
 else if ( down_path[ipath] == INTERP_UP   ) { sprintf(halo_id,"HALO_INTERP_UP") ; }
 else if ( down_path[ipath] == SMOOTH_UP   ) { sprintf(halo_id,"HALO_INTERP_SMOOTH") ; }
 sprintf(halo_define,"80:") ;
-sprintf(halo_use,"") ;
+ halo_use[0] = '\0' ;
       gen_nest_interp1 ( fp , Domain.fields, NULL, down_path[ipath], (down_path[ipath]==FORCE_DOWN)?2:2 ) ;
 {
   node_t * comm_struct ;
@@ -168,8 +168,8 @@ gen_nest_interp1 ( FILE * fp , node_t * node, char * fourdname, int down_path , 
   char nddim2[3][2][NAMELEN] ;
   char nmdim2[3][2][NAMELEN] ;
   char npdim2[3][2][NAMELEN] ;
-  char vname[NAMELEN], vname2[NAMELEN] ; 
-  char tag[NAMELEN], tag2[NAMELEN] ; 
+  char vname[3 * NAMELEN + 88], vname2[3 * NAMELEN + 88] ;
+  char tag[NAMELEN] = {'\0'}, tag2[NAMELEN] = {'\0'} ;
   char fcn_name[NAMELEN] ;
   char xstag[NAMELEN], ystag[NAMELEN] ;
   char dexes[NAMELEN] ;
@@ -200,7 +200,7 @@ gen_nest_interp1 ( FILE * fp , node_t * node, char * fourdname, int down_path , 
     if ( nest_mask & down_path )
     {
         if ( p->ntl > 1 ) { sprintf(tag,"_2") ; sprintf(tag2,"_%d", use_nest_time_level) ; }
-        else              { sprintf(tag,"")   ; sprintf(tag2,"")                         ; }
+        else              { tag[0] = '\0'; tag2[0] = '\0'; }
 
         /* construct variable name */
         if ( p->node_kind & FOURD ) {
@@ -359,7 +359,7 @@ fprintf(fp,"                  ngrid%%i_parent_start, ngrid%%j_parent_start,     
 fprintf(fp,"                  ngrid%%parent_grid_ratio, ngrid%%parent_grid_ratio                &\n") ;
    
         {
-           char tmpstr[NAMELEN], *p1 ;
+           char tmpstr[2 * NAMELEN + 8], *p1 ;
            node_t * nd, * pp  ;
            pp = NULL ;
            if ( p->node_kind & FOURD ) {
@@ -377,10 +377,10 @@ fprintf(fp,"                  ngrid%%parent_grid_ratio, ngrid%%parent_grid_ratio
                strcpy( tmpstr , pp->interpu_aux_fields ) ;
 	     } else if ( down_path & FORCE_DOWN ) {
                /* by default, add the boundary and boundary tendency fields to the arg list */
-               if ( ! p->node_kind & FOURD ) {
-                 sprintf( tmpstr , "%s_b,%s_bt,", pp->name, pp->name )  ;
+               if ( ! (p->node_kind & FOURD) ) {
+                 snprintf( tmpstr , 2 * NAMELEN + 8, "%s_b,%s_bt,", pp->name, pp->name )  ;
                } else {
-                 sprintf( tmpstr , "%s_b,%s_bt,", p->name, p->name )  ;
+                 snprintf( tmpstr , 2 * NAMELEN + 8, "%s_b,%s_bt,", p->name, p->name )  ;
                }
                strcat( tmpstr , pp->force_aux_fields ) ;
 	     } else if ( down_path & INTERP_DOWN ) {
@@ -507,7 +507,7 @@ gen_nest_interp2 ( FILE * fp , node_t * node, char * fourdname, int down_path , 
   char ddim[3][2][NAMELEN] ;
   char mdim[3][2][NAMELEN] ;
   char pdim[3][2][NAMELEN] ;
-  char vname[NAMELEN], vname2[NAMELEN] ; 
+  char vname[3 * NAMELEN + 88], vname2[3 * NAMELEN + 88] ;
   char tag[NAMELEN], tag2[NAMELEN] ; 
   char dexes[NAMELEN] ;
   char ndexes[NAMELEN] ;
@@ -546,11 +546,11 @@ gen_nest_interp2 ( FILE * fp , node_t * node, char * fourdname, int down_path , 
           set_dim_strs2 ( p , ddim , mdim , pdim , "", 1 ) ;
         } 
         if ( !strcmp ( ddim[0][1], "kde") ||
-	             ( ddim[1][1], "kde") ||
-		         ( ddim[2][1], "kde")) {	
+	     !strcmp ( ddim[1][1], "kde") ||
+	     !strcmp ( ddim[2][1], "kde")) {
     
             if ( p->ntl > 1 ) { sprintf(tag,"_2") ; sprintf(tag2,"_%d", use_nest_time_level) ; }
-            else              { sprintf(tag,"")   ; sprintf(tag2,"")                         ; }
+            else              { tag[0] = '\0'; tag2[0] = '\0'; }
 
             /* construct variable name */
             if ( p->node_kind & FOURD ) {

--- a/tools/gen_irr_diag.c
+++ b/tools/gen_irr_diag.c
@@ -5,11 +5,12 @@
 #include <unistd.h>
 #include <string.h>
 #include <strings.h>
+#include <ctype.h>
 
-int  nChmOpts = 0;
-char rxt_tbl[5][1000][128];
-char chm_scheme[5][128];
-int  rxt_cnt[5];
+short int  nChmOpts = 0;
+char rxt_tbl[5][1000][128] = { '\0' };
+char chm_scheme[5][128] = { '\0' };
+short int  rxt_cnt[5];
 
 void strip_blanks( char *instring, char *outstring )
 {
@@ -38,7 +39,7 @@ int AppendReg( char *chem_opt, int ndx )
    char *strt, *end;
    char *token;
    char *wstrg1;
-   char path[256];
+   char path[256 * 2 + 25];
    char fname[256];
    char inln[1024],winln[1024],s[1024];
    char rxtstr[128];
@@ -71,6 +72,7 @@ int AppendReg( char *chem_opt, int ndx )
 
    if( fp_reg == NULL ) {
      fprintf(stderr,"Can not open registry.irr_diag for writing\n");
+     fclose(fp_eqn);
      return(-2);
    }
    strcpy( buffer,"\"Integrated Reaction Rate\"  \"\"");
@@ -175,7 +177,7 @@ int AppendReg( char *chem_opt, int ndx )
           for( i=0; i < slen; i++ )
           {
             if( ! strncmp( rxtsym+i, "+", 1 ) )
-              strncpy( rxtsym+i, "_", 1 );
+              strncpy( rxtsym+i, "_", 2 );
           }
           strcat( rxtsym,"_IRR" );
 //
@@ -201,11 +203,11 @@ int AppendReg( char *chem_opt, int ndx )
 int irr_diag_scalar_indices( char *dirname )
 {
    int Nrxt;
-   int i, j;
+   short int i, j;
    int first, flush, s1;
    char fname[256];
-   char line[132];
-   char piece[132];
+   char line[135];
+   char piece[135];
    char *blank = "                                                           ";
    FILE *fp_inc;
 
@@ -266,18 +268,18 @@ int irr_diag_scalar_indices( char *dirname )
    sprintf( line,"  chm_opts_ndx(:nchm_opts) = (/ ");
    for( i = 0; i < nChmOpts; i++ ) {
      if( i == 0 ) 
-       sprintf( piece,"%s_kpp",chm_scheme[i]);
+       snprintf( piece,135,"%.128s_kpp",chm_scheme[i]);
      else
-       sprintf( piece," ,%s_kpp",chm_scheme[i]);
+       snprintf( piece,135," ,%.128s_kpp",chm_scheme[i]);
      strcat( line,piece );
    }
    strcat( line," /)\n" );
    fprintf( fp_inc,line );
    fprintf( fp_inc," \n");
 
-   for( i = 0; i < nChmOpts,rxt_cnt[i] > 0; i++ ) {
+   for( i = 0; /*i < nChmOpts &&*/ rxt_cnt[i] > 0; i++ ) {
      for( j = 0; j < rxt_cnt[i]; j++ ) {
-       sprintf( line,"     rxtsym(%d,%d) = '%s'\n",j+1,i+1,rxt_tbl[i][j]);
+       snprintf( line,132,"     rxtsym(%d,%d) = '%s'\n",j+1,i+1,rxt_tbl[i][j]);
        fprintf( fp_inc,"%s",line);
      }
      fprintf( fp_inc," \n");

--- a/tools/gen_scalar_indices.c
+++ b/tools/gen_scalar_indices.c
@@ -14,18 +14,24 @@
 
 #define NULLCHARPTR   (char *) 0
 
+/* About the only place the stringify macro is useful is in the
+   definition of the stringify_const macro.  Most other places, you
+   can put the quotes on yourself.  */
+#define stringify_const(value) stringify(value)
+#define stringify(value) #value
+
 int
 gen_scalar_indices ( char * dirname )
 {
   FILE * fp, *fp5[26] ;
-  char  fname[NAMELEN], fname5[NAMELEN] ;
+  char  fname[NAMELEN], fname5[2 * NAMELEN + 1] ;
   char * fn = "scalar_indices.inc" ;
   char * fn2 = "scalar_tables.inc" ;
   char * fn3 = "scalar_tables_init.inc" ;
   char * fn4 = "scalar_indices_init.inc" ;
   int i ;
 
-  char fn5[26][NAMELEN] ;
+  char fn5[26][NAMELEN] = { '\0' } ;
 
   strcpy( fname, fn ) ;
   if ( strlen(dirname) > 0 ) { sprintf(fname,"%s/%s",dirname,fn) ; }
@@ -37,7 +43,14 @@ gen_scalar_indices ( char * dirname )
   { 
     sprintf(fn5[i],"in_use_for_config_%c.inc",'a'+i) ;
     strcpy( fname5, fn5[i] ) ;
-    if ( strlen(dirname) > 0 ) { sprintf(fname5,"%s/%s",dirname,fn5[i]) ; }
+    if ( strlen(dirname) > 0 ) {
+      /* The stringify_const(NAMELEN) is to get something like %.512s
+	 in the format string, so snprintf won't copy more than
+	 NAMELEN elements of the entry of fn5 (each NAMELEN chars long) */
+      snprintf(fname5,sizeof(fname5),"%s/%." stringify_const(NAMELEN) "s",dirname,fn5[i]) ;
+    } else {
+      sprintf(fname5,"%s", fn5[i]);
+    }
     if ((fp5[i] = fopen( fname5 , "w" )) == NULL ) return(1) ;
     print_warning(fp5[i],fname5) ;
   }
@@ -117,7 +130,7 @@ gen_scalar_indices1 ( FILE * fp, FILE ** fp2 )
   node_t * p, * memb , * pkg, * rconfig, * fourd, *x ; 
   char * c , *pos1, *pos2 ;
   char assoc_namelist_var[NAMELEN], assoc_namelist_choice[NAMELEN], assoc_4d[NAMELEN_LONG], fname[NAMELEN_LONG] ;
-  char fname2[NAMELEN], tmp1[NAMELEN], tmp2[NAMELEN] ;
+  char fname2[NAMELEN], tmp1[NAMELEN + 5], tmp2[NAMELEN + 4] ;
   char scalars_str[NAMELEN_LONG] ;
   char * scalars ;
   int i ;
@@ -128,8 +141,11 @@ gen_scalar_indices1 ( FILE * fp, FILE ** fp2 )
 
   for ( p = FourD ; p != NULL ; p = p->next ) {
     if( strncmp( p->name,"irr_diag",8 ) ) {
-      for ( memb = p->members ; memb != NULL ; memb = memb->next )
-        if ( strcmp(memb->name,"-") ) fprintf(fp,"  P_%s = 1 ; F_%s = .FALSE. \n", memb->name, memb->name ) ; 
+      for ( memb = p->members ; memb != NULL ; memb = memb->next ) {
+        if ( strcmp(memb->name,"-") ) {
+	  fprintf(fp,"  P_%s = 1 ; F_%s = .FALSE. \n", memb->name, memb->name);
+	}
+      }
     }
   }
 
@@ -171,11 +187,11 @@ gen_scalar_indices1 ( FILE * fp, FILE ** fp2 )
                 fprintf(fp,"     P_%s = %s_index_table( PARAM_%s , idomain )\n",c,assoc_4d,c)  ;
                 fprintf(fp,"   END IF\n") ;
                 {
-                  char fourd_bnd[NAMELEN] ;
+                  char fourd_bnd[NAMELEN_LONG + 3] = { '\0' } ;
                   /* check for the existence of a fourd boundary array associated with this 4D array */
                   /* set io_mask accordingly for gen_wrf_io to know that it should generate i/o for _b and _bt */
                   /* arrays */
-                  sprintf(fourd_bnd,"%s_b",assoc_4d) ;
+                  snprintf(fourd_bnd, NAMELEN_LONG + 3,"%s_b",assoc_4d) ;
                   if ( get_entry_r( fourd_bnd, NULL, Domain.fields) != NULL ) {
                      x->boundary = 1 ;
                   }

--- a/tools/gen_streams.c
+++ b/tools/gen_streams.c
@@ -10,6 +10,25 @@
 #include "data.h"
 #include "sym.h"
 
+int gen_io_domain_defs ( FILE * fp );
+int gen_io_boilerplate ();
+int gen_med_find_esmf_coupling ( FILE *fp );
+int gen_shutdown_closes ( FILE *fp );
+int gen_med_open_esmf_calls ( FILE *fp );
+int gen_med_last_solve_io ( FILE *fp );
+int gen_med_auxinput_in_closes ( FILE *fp );
+int gen_med_hist_out_closes ( FILE *fp );
+int gen_med_hist_out_opens ( FILE *fp );
+int gen_med_auxinput_in ( FILE *fp );
+int gen_fine_stream_input ( FILE *fp );
+int gen_check_auxstream_alarms ( FILE *fp );
+int gen_switches_and_alarms ( FILE *fp );
+int gen_io_form_for_stream ( FILE *fp );
+int gen_io_form_for_dataset ( FILE *fp );
+int gen_set_timekeeping_alarms ( FILE * fp );
+int gen_set_timekeeping_defs ( FILE *fp );
+
+
 int gen_streams(  char * dirname ) 
 {
   FILE * fp ;
@@ -160,7 +179,7 @@ gen_io_domain_defs ( FILE * fp )
     for ( i = 0 ; i < 2*MAX_HISTORY ; i++ ) 
     {
       if ( i % MAX_HISTORY == 0 ) { aux = ""  ; streamno[0] = '\0' ; }
-      else                        { aux="aux" ; sprintf(streamno,"%d",i%MAX_HISTORY) ; }
+      else                        { aux="aux" ; sprintf(streamno,"%d",(signed char) i%MAX_HISTORY) ; }
       if ( i < MAX_HISTORY )      { streamtype = "input" ; }
       else                        { streamtype = ( i%MAX_HISTORY == 0 )?"history":"hist" ; }
 
@@ -188,7 +207,7 @@ gen_set_timekeeping_defs ( FILE *fp )
   for ( i = 0 ; i < 2*MAX_HISTORY ; i++ ) 
   {
     if ( i % MAX_HISTORY == 0 ) { aux = ""  ; streamno[0] = '\0' ; }
-    else                        { aux="aux" ; sprintf(streamno,"%d",i%MAX_HISTORY) ; }
+    else                        { aux="aux" ; sprintf(streamno,"%d",(signed char) i%MAX_HISTORY) ; }
     if ( i < MAX_HISTORY )      { streamtype = "input" ; }
     else                        { streamtype = ( i%MAX_HISTORY == 0 )?"history":"hist" ; }
 
@@ -222,7 +241,7 @@ gen_set_timekeeping_alarms ( FILE * fp )
   for ( i = 0 ; i < 2*MAX_HISTORY ; i++ )
   {
     if ( i % MAX_HISTORY == 0 ) { aux = ""  ; streamno[0] = '\0' ; }
-    else                        { aux="aux" ; sprintf(streamno,"%d",i%MAX_HISTORY) ; }
+    else                        { aux="aux" ; sprintf(streamno,"%d",(signed char) i%MAX_HISTORY) ; }
     if ( i < MAX_HISTORY )      { streamtype = "input" ; }
     else                        { streamtype = ( i%MAX_HISTORY == 0 )?"history":"hist" ; }
     if ( i == 0 ) continue ;  /* skip just input */
@@ -305,7 +324,7 @@ int
 gen_io_form_for_dataset ( FILE *fp )
 {
   char * aux , *streamtype , streamno[5]  ;
-  int i ;
+  unsigned char i ;
 
   fprintf(fp,"    IF      ( DataSet .eq. 'RESTART' ) THEN\n") ;
   fprintf(fp,"      CALL nl_get_io_form_restart( 1, io_form )\n") ;
@@ -333,7 +352,7 @@ int
 gen_io_form_for_stream ( FILE *fp )
 {
   char * aux , *streamtype , streamno[5]  ;
-  int i ;
+  unsigned char i ;
 
   fprintf(fp,"    IF      ( stream .eq. restart_only ) THEN\n") ;
   fprintf(fp,"      CALL nl_get_io_form_restart( 1, io_form )\n") ;
@@ -539,7 +558,7 @@ gen_shutdown_closes ( FILE *fp )
 }
 
 /* generate the calls that main/wrf_ESMFMod.F uses in wrf_state_populate() */
-gen_med_open_esmf_calls ( FILE *fp )
+int gen_med_open_esmf_calls ( FILE *fp )
 {
   int i ;
   for ( i = 1 ; i < MAX_HISTORY ; i++ )
@@ -569,7 +588,7 @@ gen_med_open_esmf_calls ( FILE *fp )
 }
 
 /* generate the calls that main/wrf_ESMFMod.F uses in wrf_state_populate() */
-gen_med_find_esmf_coupling ( FILE *fp )
+int gen_med_find_esmf_coupling ( FILE *fp )
 {
   int i ;
   for ( i = 1 ; i < MAX_HISTORY ; i++ )

--- a/tools/gen_wrf_io.c
+++ b/tools/gen_wrf_io.c
@@ -50,7 +50,7 @@ gen_wrf_io2 ( FILE * fp , char * fname, char * structname , char * fourdname, no
   node_t * p ;
   int i , ii  ;
   char x[NAMELEN], tag[NAMELEN], dexes[NAMELEN] ;
-  char dname[NAMELEN], dname_tmp[NAMELEN] ; 
+  char dname[NAMELEN + 6], dname_tmp[NAMELEN] ;
   char vname[NAMELEN], vname_x[NAMELEN],vname_1[NAMELEN], vname_2[NAMELEN], memord[NAMELEN] ;
   char ddim[3][2][NAMELEN] ;
   char mdim[3][2][NAMELEN] ;
@@ -58,7 +58,7 @@ gen_wrf_io2 ( FILE * fp , char * fname, char * structname , char * fourdname, no
   char ddim_no[3][2][NAMELEN] ;
   char mdim_no[3][2][NAMELEN] ;
   char pdim_no[3][2][NAMELEN] ;
-  char dimname[3][NAMELEN] ;
+  char dimname[3][NAMELEN + 6] ;
   char stagstr[NAMELEN] ;
   char * tend_tag ;
 
@@ -85,7 +85,7 @@ gen_wrf_io2 ( FILE * fp , char * fname, char * structname , char * fourdname, no
   {
 
 
-    if ( p->ndims > 3 && ! p->node_kind & FOURD ) continue ; /* short circuit anything with more than 3 dims, (not counting 4d arrays) */
+    if ( p->ndims > 3 && ! (p->node_kind & FOURD) ) continue ; /* short circuit anything with more than 3 dims, (not counting 4d arrays) */
 
     if ( p->node_kind & I1 ) continue ;  /* short circuit anything that's not a state var */
 
@@ -115,8 +115,8 @@ gen_wrf_io2 ( FILE * fp , char * fname, char * structname , char * fourdname, no
         int ibdy ;
         int idx ;
         node_t *fourd_bound_array ;
-        char *bdytag, *xdomainend, *ydomainend, *zdomainend, bdytag2[10],fourd_bnd[NAMELEN] ;
-        char *ds1,*de1,*ds2,*de2,*ds3,*de3,*ms1,*me1,*ms2,*me2,*ms3,*me3,*ps1,*pe1,*ps2,*pe2,*ps3,*pe3 ;
+        char *bdytag="", *xdomainend="", *ydomainend="", *zdomainend="", bdytag2[10],fourd_bnd[NAMELEN + 2] ;
+        char *ds1="",*de1="",*ds2="",*de2="",*ds3="",*de3="",*ms1="",*me1="",*ms2="",*me2="",*ms3="",*me3="",*ps1="",*pe1="",*ps2="",*pe2="",*ps3="",*pe3="" ;
 
 #if ( WRFPLUS == 1 )
 /*  adjoint and perturbation variables should not be inputed*/
@@ -276,12 +276,12 @@ fprintf(fp, "ENDDO\n") ;
 
 /* ////////  BOUNDARY ///////////////////// */
 
-      if (  p->boundary && strcmp( p->use, "_4d_bdy_array_" ) || ( p->boundary && fourdname ) )
+      if (  (p->boundary && strcmp( p->use, "_4d_bdy_array_" )) || ( p->boundary && fourdname ) )
       {
         int ibdy ;
         int idx ;
-        char *bdytag, *xdomainend, *ydomainend, *zdomainend ;
-        char *ds1,*de1,*ds2,*de2,*ds3,*de3,*ms1,*me1,*ms2,*me2,*ms3,*me3,*ps1,*pe1,*ps2,*pe2,*ps3,*pe3 ;
+        char *bdytag="", *xdomainend="", *ydomainend="", *zdomainend="" ;
+        char *ds1="",*de1="",*ds2="",*de2="",*ds3="",*de3="",*ms1="",*me1="",*ms2="",*me2="",*ms3="",*me3="",*ps1="",*pe1="",*ps2="",*pe2="",*ps3="",*pe3="" ;
 	char t1[64], t2[64] ;
 
 #if ( WRFPLUS == 1 )

--- a/tools/misc.c
+++ b/tools/misc.c
@@ -15,7 +15,7 @@
 char *
 dimension_with_colons( char * pre , char * tmp , node_t * p , char * post )
 {
-  int i ;
+  unsigned int i ;
   if ( p == NULL ) return("") ;
   if ( p->ndims <= 0 && ! p->boundary_array ) return("") ;
   strcpy(tmp,"") ;
@@ -42,8 +42,8 @@ dimension_with_colons( char * pre , char * tmp , node_t * p , char * post )
 char *
 dimension_with_ones( char * pre , char * tmp , node_t * p , char * post )
 {
-  int i ;
-  char r[NAMELEN],s[NAMELEN],four_d[NAMELEN] ;
+  unsigned int i ;
+  char r[NAMELEN + 12],s[NAMELEN],four_d[NAMELEN + 6] ;
   char *pp ;
   if ( p == NULL ) return("") ;
   if ( p->ndims <= 0 && ! p->boundary_array ) return("") ;
@@ -88,10 +88,10 @@ dimension_with_ranges( char * refarg , char * pre ,
 						   which a namelist supplied dimension
                                                    should be dereference from, or ""  */
 {
-  int i ;
-  char tx[NAMELEN] ;
-  char r[NAMELEN],s[NAMELEN],four_d[NAMELEN] ;
-  int   bdex, xdex, ydex, zdex ;
+  unsigned int i ;
+  char tx[6 * NAMELEN + 82] ;
+  char r[NAMELEN],s[NAMELEN],four_d[NAMELEN + 5] ;
+  int   bdex = 0, xdex, ydex, zdex ;
   node_t *xdim, *ydim, *zdim ;
   char *pp ;
   if ( p == NULL ) return("") ;
@@ -178,11 +178,11 @@ char *
 index_with_firstelem( char * pre , char * dref , int bdy ,  /* as defined in data.h */
                       char * tmp , node_t * p , char * post )
 {
-  int i ;
-  char tx[NAMELEN] ;
+  unsigned int i ;
+  char tx[NAMELEN * 3] = {'\0'} ;
   char tmp2[NAMELEN] ;
   /* SamT: bug fix: zdex is used but never set */
-  int  bdex, xdex, ydex, zdex=-999 ;
+  int  bdex = 0, xdex, ydex, zdex=-999 ;
   node_t *xdim, *ydim, *zdim ;
   char r[NAMELEN] ;
 
@@ -260,7 +260,7 @@ int
 get_elem ( char * structname , char * nlstructname , char * tx , int i , node_t * p , int first_last )
 {
    char dref[NAMELEN], nlstruct[NAMELEN] ;
-   char d, d1 ;
+   char d, d1 = '\0' ;
 
    if ( structname == NULL ) { strcpy( dref, "" ) ;}
    else                      { strcpy( dref, structname ) ; }
@@ -288,25 +288,27 @@ get_elem ( char * structname , char * nlstructname , char * tx , int i , node_t 
            if ( p->dims[i]->subgrid ) 
            {
              if ( first_last == 0 ) { /*first*/
-               sprintf(tx,"(%ssm3%d%s-1)*%ssr_%c+1",dref,p->dims[i]->dim_order,ornt,dref,d1) ;
+               snprintf(tx, 3 * NAMELEN, "(%ssm3%d%s-1)*%ssr_%c+1",dref,p->dims[i]->dim_order,ornt,dref,d1) ;
              }else{                   /*last*/
-               sprintf(tx,"%sem3%d%s*%ssr_%c"      ,dref,p->dims[i]->dim_order,ornt,dref,d1) ;
+               snprintf(tx, 3 * NAMELEN, "%sem3%d%s*%ssr_%c"      ,dref,p->dims[i]->dim_order,ornt,dref,d1) ;
              }
            }
            else
            {
-             sprintf(tx,"%s%cm3%d%s",dref,first_last==0?'s':'e',p->dims[i]->dim_order,ornt) ;
+             snprintf(tx, 3 * NAMELEN, "%s%cm3%d%s",dref,first_last==0?'s':'e',p->dims[i]->dim_order,ornt) ;
            }
          }
          break ;
        case (NAMELIST) :
-         if ( first_last == 0 ) { if ( !strcmp( p->dims[i]->assoc_nl_var_s , "1" ) ) {
-                                    sprintf(tx,"%s",p->dims[i]->assoc_nl_var_s) ;
-                                  } else {
-                                    sprintf(tx,"%s%s%s",nlstructname,structname,p->dims[i]->assoc_nl_var_s) ; 
-                                  }
-                                }
-         else                   { sprintf(tx,"%s%s%s",nlstructname,structname,p->dims[i]->assoc_nl_var_e) ; }
+         if ( first_last == 0 ) {
+	   if ( !strcmp( p->dims[i]->assoc_nl_var_s , "1" ) ) {
+	     snprintf(tx, 3 * NAMELEN,"%s",p->dims[i]->assoc_nl_var_s) ;
+	   } else {
+	     snprintf(tx, 3 * NAMELEN, "%s%s%s",nlstructname,structname,p->dims[i]->assoc_nl_var_s) ;
+	   }
+	 } else {
+	   snprintf(tx, 3 * NAMELEN, "%s%s%s",nlstructname,structname,p->dims[i]->assoc_nl_var_e) ;
+	 }
          break ;
        case (CONSTANT) :
          if ( first_last == 0 ) { sprintf(tx,"%d",p->dims[i]->coord_start) ; }
@@ -558,10 +560,10 @@ array_size_expression ( char * refarg , char * pre ,
 						   which a namelist supplied dimension
                                                    should be dereference from, or ""  */
 {
-  int i ;
-  char tx[NAMELEN] ;
-  char r[NAMELEN],s[NAMELEN],four_d[NAMELEN] ;
-  int   bdex, xdex, ydex, zdex ;
+  unsigned int i ;
+  char tx[6 * NAMELEN + 87] ;
+  char r[NAMELEN],s[NAMELEN],four_d[NAMELEN + 6] ;
+  int   bdex = 0, xdex, ydex, zdex ;
   node_t *xdim, *ydim, *zdim ;
   char *pp ;
   if ( p == NULL ) return("") ;

--- a/tools/protos.h
+++ b/tools/protos.h
@@ -4,7 +4,12 @@
 
 int init_dim_table()   ;
 int make_lower( char * s1 ) ;
+char *make_lower_case ( char * str ) ;
+char *make_upper_case ( char * str ) ;
 int reg_parse( FILE * infile ) ;
+int init_parser() ;
+int pre_parse( char * dir, FILE * infile, FILE * outfile ) ;
+int check_dimspecs() ;
 int set_dim_len ( char * dimspec , node_t * dim_entry ) ;
 int set_dim_order ( char * dimorder , node_t * dim_entry ) ;
 int set_dim_orient ( char * dimorient , node_t * dim_entry ) ;
@@ -68,16 +73,25 @@ char * get_typename_i(int i) ;
 int gen_alloc ( char * dirname ) ;
 int gen_alloc1 ( char * dirname ) ;
 int gen_alloc2 ( FILE * fp , char * structname , char * structname2 , node_t * node, int *j, int *iguy, int *fraction, int numguys, int frac, int sw );
+int gen_comms ( char * dirname );
+int gen_streams(  char * dirname );
+int gen_io_boilerplate ();
 
 int gen_module_state_description ( char * dirname ) ;
 int gen_module_state_description1 ( FILE * fp , node_t * node ) ;
 
 int gen_scalar_indices ( char * dirname ) ;
 int gen_scalar_indices1 ( FILE * fp, FILE ** fp2 ) ;
+int gen_nest_interp ( char * dirname );
+int gen_nest_v_interp ( char * dirname );
+int gen_nest_interp2(FILE *fp, node_t *node, char *fourdname, int down_path, int use_nest_time_level);
 
 int gen_actual_args ( char * dirname ) ;
+int gen_actual_args_new ( char * dirname ) ;
 int gen_dummy_args ( char * dirname ) ;
+int gen_dummy_args_new ( char * dirname ) ;
 int gen_dummy_decls ( char * dn ) ;
+int gen_dummy_decls_new ( char * dn ) ;
 int gen_args ( char * dirname , int sw ) ;
 int gen_args1 ( FILE * fp , char * outstr, char * structname , node_t * node , int *linelen , int sw , int deep ) ;
 
@@ -105,6 +119,7 @@ int gen_wrf_io2 ( FILE * fp , char * fname , char * structname , char * fourdnam
 int gen_namelist_defines ( char * dirname , int sw_dimension ) ;
 int gen_namelist_defaults ( char * dirname ) ;
 int gen_namelist_script ( char * dirname ) ;
+int gen_namelist_statements ( char * dirname ) ;
 
 int gen_model_data_ord ( char * dirname ) ;
 
@@ -119,6 +134,9 @@ int range_of_dimension ( char *, char * , int, node_t *, char * );
 int dimension_size_expression ( char *, char *, int, node_t *, char *);
 int gen_alloc_count ( char *);
 int gen_alloc_count1 ( char *);
+int gen_comms ( char * dirname );
+int gen_streams(  char * dirname );
+int gen_io_boilerplate ();
 int gen_ddt_write ( char * );
 int gen_ddt_write1 ( FILE *, char *, node_t *);
 int gen_dealloc ( char * );
@@ -130,13 +148,14 @@ int irr_diag_scalar_indices ( char * );
 int gen_scalar_tables_init ( FILE *);
 int gen_scalar_indices_init ( FILE *);
 int hash(char *);
+int gen_nest_interp ( char * dirname );
 int gen_nest_interp1 ( FILE *, node_t *, char *, int, int );
 #if ( WRFPLUS == 1 )
-int gen_packs_halo ( FILE *fp , node_t *p, char *shw, int xy /* 0=y,1=x */ , int pu /* 0=pack,1=unpack */, int nta /* 0=NLM,1=TLM,2=ADM */, char * packname, char * commname, int always_interp_mp /* 1 for ARW, varies for NMM */ );
+void gen_packs_halo ( FILE *fp , node_t *p, char *shw, int xy /* 0=y,1=x */ , int pu /* 0=pack,1=unpack */, int nta /* 0=NLM,1=TLM,2=ADM */, char * packname, char * commname, int always_interp_mp /* 1 for ARW, varies for NMM */ );
 #else
-int gen_packs_halo ( FILE *fp , node_t *p, char *shw, int xy /* 0=y,1=x */ , int pu /* 0=pack,1=unpack */, char * packname, char * commname, int always_interp_mp /* 1 for ARW, varies for NMM */ );
+void gen_packs_halo ( FILE *fp , node_t *p, char *shw, int xy /* 0=y,1=x */ , int pu /* 0=pack,1=unpack */, char * packname, char * commname, int always_interp_mp /* 1 for ARW, varies for NMM */ );
 #endif
-int gen_packs ( FILE *fp , node_t *p, int shw, int xy /* 0=y,1=x */ , int pu /* 0=pack,1=unpack */, char * packname, char * commname );
+void gen_packs ( FILE *fp , node_t *p, int shw, int xy /* 0=y,1=x */ , int pu /* 0=pack,1=unpack */, char * packname, char * commname );
 int gen_periods ( char * dirname , node_t * periods );
 int gen_swaps ( char * dirname , node_t * swaps );
 int gen_cycles ( char * dirname , node_t * cycles );

--- a/tools/reg_parse.c
+++ b/tools/reg_parse.c
@@ -84,22 +84,23 @@
 #define COMM_USE           2
 #define COMM_DEFINE        3
 
-static int ntracers = 0 ;
+static unsigned int ntracers = 0 ;
 static char tracers[1000][100] ;
 
 int
 pre_parse( char * dir, FILE * infile, FILE * outfile )
 {
   /* Decreased size for SOA from 8192 to 8000--double check if necessary, Manish Shrivastava 2010 */
-  char inln[8000], parseline[8000], parseline_save[8000] ;
+  char inln[8000], parseline[8000] = {'\0'}, parseline_save[8000] ;
   int found ; 
   char *p, *q ;
   char *tokens[MAXTOKENS], *toktmp[MAXTOKENS], newdims[NAMELEN_LONG], newdims4d[NAMELEN_LONG],newname[NAMELEN_LONG] ;
-  int i, ii, len_of_tok ;
+  unsigned int i, ii;
+  ssize_t len_of_tok = 0;
   char x, xstr[NAMELEN_LONG] ;
-  int is4d, wantstend, wantsbdy ;
-  int ifdef_stack_ptr = 0 ;
-  int ifdef_stack[100] ;
+  unsigned char is4d = 0, wantstend = 0, wantsbdy = 0 ;
+  signed char ifdef_stack_ptr = 0 ;
+  int ifdef_stack[100] = {1} ;
   int inquote, retval ;
 
   ifdef_stack[0] = 1 ;
@@ -139,7 +140,13 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
       p += 5 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       strncpy(value, p, 31 ) ; value[31] = '\0' ;
       if ( (p=index(value,'\n')) != NULL ) *p = '\0' ;
-      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ; 
+      /* I have no clue what the next line was trying to say */
+      if ( (p=index(value,' ')) != NULL ) {
+	*p = '\0' ;
+      }
+      if ( (p=index(value,'	')) != NULL ) {
+	*p = '\0' ;
+      }
       ifdef_stack_ptr++ ;
       ifdef_stack[ifdef_stack_ptr] = ( sym_get(value) != NULL && ifdef_stack[ifdef_stack_ptr-1] ) ;
       if ( ifdef_stack_ptr >= 100 ) { fprintf(stderr,"Registry fatal: too many nested ifdefs\n") ; exit(1) ; }
@@ -150,7 +157,13 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
       p += 6 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       strncpy(value, p, 31 ) ; value[31] = '\0' ;
       if ( (p=index(value,'\n')) != NULL ) *p = '\0' ;
-      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ; 
+      /* I have no idea what the next line was trying to accomplish */
+      if ( (p=index(value,' ')) != NULL ) {
+	*p = '\0' ;
+      }
+      if ( (p=index(value,'	')) != NULL ) {
+	*p = '\0' ;
+      }
       ifdef_stack_ptr++ ;
       ifdef_stack[ifdef_stack_ptr] = ( sym_get(value) == NULL && ifdef_stack[ifdef_stack_ptr-1] ) ;
       if ( ifdef_stack_ptr >= 100 ) { fprintf(stderr,"Registry fatal: too many nested ifdefs\n") ; exit(1) ; }
@@ -166,7 +179,13 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
       p += 6 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       strncpy(value, p, 31 ) ; value[31] = '\0' ;
       if ( (p=index(value,'\n')) != NULL ) *p = '\0' ;
-      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ; 
+      /* Another instance of this distinctly odd pattern */
+      if ( (p=index(value,' ')) != NULL ) {
+	*p = '\0' ;
+      }
+      if ( (p=index(value,'	')) != NULL ) {
+	*p = '\0' ;
+      }
       sym_add( value ) ;
       continue ;
     }
@@ -236,7 +255,7 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
           }
           sprintf(xstr,"%c",x) ;
           if ( x != 'b' || inbrace ) strcat ( newdims , xstr ) ;
-          if ( x != 'f' && x != 't' || inbrace ) strcat( newdims4d , xstr ) ;
+          if ( (x != 'f' && x != 't') || inbrace ) strcat( newdims4d , xstr ) ;
 
         }
         if ( wantsbdy ) {
@@ -255,7 +274,7 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
 	        if ( !strcmp( tokens[F_USE] , tracers[i] ) ) found = 1 ; 
               }
 	      if ( found == 0 ) {
-	        sprintf(tracers[ntracers],tokens[F_USE]) ;
+	        snprintf(tracers[ntracers], 100, tokens[F_USE]) ;
 	        ntracers++ ;
 
 /* add entries for _b and _bt arrays */
@@ -305,7 +324,8 @@ reg_parse( FILE * infile )
   char inln[7000], parseline[7000] ;
   char *p, *q ;
   char *tokens[MAXTOKENS], *toktmp[MAXTOKENS] ; 
-  int i, ii, idim ;
+  unsigned int i, ii;
+  int idim ;
   int defining_state_field, defining_rconfig_field, defining_i1_field ;
 
   parseline[0] = '\0' ;
@@ -477,7 +497,7 @@ reg_parse( FILE * infile )
 	char prev = '\0' ;
 	char x ;
         char tmp[NAMELEN], tmp1[NAMELEN], tmp2[NAMELEN] ;
-	int len_of_tok ;
+	ssize_t len_of_tok = 0 ;
         char fcn_name[2048], aux_fields[2048] ;
 
         strcpy(tmp,tokens[FIELD_IO]) ;
@@ -508,7 +528,7 @@ reg_parse( FILE * infile )
                 if (( pp = index(tmp2,'}') ) != NULL ) {
                   *pp = '\0' ;
                   unitid = atoi(tmp2) ;  /* JM 20100416 */
-                  if ( unitid >= 0  || unitid < MAX_STREAMS && stream + unitid < MAX_HISTORY ) {
+                  if ( unitid >= 0  || (unitid < MAX_STREAMS && stream + unitid < MAX_HISTORY) ) {
                     set_mask( mask , stream + unitid   ) ;
                   }
                   p = p + strlen(tmp2) + 1 ;
@@ -535,7 +555,7 @@ reg_parse( FILE * infile )
               *pp = '\0' ;
               iii = pp - (tmp + i + 1) ;
               unitid = atoi(tmp+i+1) ;  /* JM 20091102 */
-              if ( unitid >= 0  || unitid < MAX_STREAMS  && unitid < MAX_HISTORY ) {
+              if ( unitid >= 0  || (unitid < MAX_STREAMS  && unitid < MAX_HISTORY) ) {
                 if        ( prev == 'i' ) {
                   set_mask( field_struct->io_mask , unitid + MAX_HISTORY  ) ;
                 } else if ( prev == 'h' ) {
@@ -566,7 +586,8 @@ reg_parse( FILE * infile )
 
 	                       if ( tokens[FIELD_IO][i+1] == '=' ) 
 			       {
-				 int ii, jj, state ;
+				 unsigned int ii;
+				 int jj, state ;
 				 state = 0 ;
 				 jj = 0 ;
 				 for ( ii = i+3 ; ii < len_of_tok ; ii++ )
@@ -1057,7 +1078,7 @@ check_dimspecs()
 		  p->assoc_nl_var_s,p->name ) ;
 	  return(1) ;
         }
-        if ( ! q->node_kind & RCONFIG )
+        if ( ! (q->node_kind & RCONFIG) )
         {
 	  fprintf(stderr,"WARNING: no namelist variable %s defined for dimension %s\n",
 		  p->assoc_nl_var_s,p->name ) ;
@@ -1082,7 +1103,7 @@ check_dimspecs()
 		p->assoc_nl_var_e,p->name ) ;
 	return(1) ;
       }
-      if ( ! q->node_kind & RCONFIG )
+      if ( ! (q->node_kind & RCONFIG) )
       {
 	fprintf(stderr,"WARNING: no namelist variable %s defined for dimension %s\n",
 		p->assoc_nl_var_e,p->name ) ;

--- a/tools/registry.c
+++ b/tools/registry.c
@@ -1,16 +1,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef _WIN32
+#define rindex(X,Y) strrchr(X,Y)
+#define index(X,Y) strchr(X,Y)
+#endif
 # include <io.h>
-# define rindex(X,Y) strrchr(X,Y)
-# define index(X,Y) strchr(X,Y)
-#else
 # include <sys/time.h>
 # include <sys/resource.h>
 # include <unistd.h>
 # include <string.h>
 # include <strings.h>
-#endif
 
 #define DEFINE_GLOBALS
 #include "protos.h"
@@ -20,13 +19,14 @@
 
 /* SamT: bug fix: main returns int */
 int
-main( int argc, char *argv[], char *env[] )
+main( int argc, char *argv[] )
 {
-  char fname_in[NAMELEN], dir[NAMELEN], fname_tmp[NAMELEN], command[NAMELEN] ;
-  char fname_wrk[NAMELEN] ;
+  char fname_in[NAMELEN] = {'\0'}, dir[NAMELEN] = {'\0'};
+  char fname_tmp[NAMELEN] = {'\0'}, command[2 * NAMELEN + 32] = {'\0'};
+  char fname_wrk[NAMELEN + 18] = {'\0'};
   FILE * fp_in, *fp_tmp ;
-  char * thisprog  ;
-  char *env_val ;
+  char * thisprog = "";
+  char *env_val = "";
   int mypid ;
   int do_irr_diag ;
 #ifndef _WIN32
@@ -34,7 +34,7 @@ main( int argc, char *argv[], char *env[] )
 #endif
 
   mypid = (int) getpid() ;
-  strcpy( thiscom, argv[0] ) ;
+  strncpy( thiscom, argv[0], 4 * NAMELEN - 1) ;
   argv++ ;
 
   sw_deref_kludge           = 0 ;
@@ -157,7 +157,23 @@ main( int argc, char *argv[], char *env[] )
       sprintf( fname_wrk,"%s/Registry_irr_diag",dir ) ;
     }
 //  fprintf(stderr,"Registry tmp file = %s\n",fname_wrk);
-    sprintf(command,"/bin/cp %s %s\n",fname_in,fname_wrk);
+    /* we should be able to implement this using posix_spawn */
+    /*
+      #include <spawn.h>
+      extern char **environ;
+      pid_t child_pid;
+      // There doesn't seem to be a way to specify the length, so I'm
+      // assuming it's null-terminated
+      char *command_argv[4] = {"/bin/cp", NULL, NULL, NULL};
+      command_argv[1] = fname_in;
+      command_argv[2] = fname_wrk;
+
+      if (posix_spawn(&child_pid, command_argv[0], NULL, NULL, command_argv, environ)) {
+        fprintf(stderr, "Could not copy %s to %s\n", fname_in, fname_wrk);
+	exit(2);
+      }
+     */
+    sprintf(command,"/bin/cp \'%s\' \'%s\'\n",fname_in,fname_wrk);
 //  fprintf(stderr,"Command = %s\n",command);
     if( system( command ) ) {
       fprintf(stderr,"Could not copy %s to %s\n",fname_in,fname_wrk);
@@ -169,6 +185,15 @@ main( int argc, char *argv[], char *env[] )
       exit(2) ;
     }
     if( !access( "Registry/registry.irr_diag",F_OK ) ) {
+      /*
+	command_argv[0] = "/bin/rm";
+	command_argv[1] = "-f";
+	command_argv[2] = "Registry/registry.irr_diag";
+	if (posix_spawn(&child_pid, command_argv[0], NULL, NULL, command_argv, environ)) {
+          fprintf(stderr, "Could not remove Registry/registry.irr_diag\n", fname_in, fname_wrk);
+	  exit(2);
+	}
+      */
       sprintf(command,"/bin/rm -f Registry/registry.irr_diag\n");
       if( system( command ) ) {
         fprintf(stderr,"Could not remove Registry/registry.irr_diag\n");
@@ -279,6 +304,15 @@ cleanup:
    sprintf(command,"del /F /Q %s\n",fname_tmp );
 #else
    if( do_irr_diag ) {
+      /*
+	command_argv[0] = "/bin/rm";
+	command_argv[1] = "-f";
+	command_argv[2] = fname_wrk;
+	if (posix_spawn(&child_pid, command_argv[0], NULL, NULL, command_argv, environ)) {
+          fprintf(stderr, "Could not remove %s\n", fname_wrk);
+	  exit(2);
+	}
+      */
      sprintf(command,"/bin/rm -f %s\n",fname_wrk );
      system( command ) ;
    }

--- a/tools/registry.h
+++ b/tools/registry.h
@@ -1,4 +1,8 @@
 #ifndef REGISTRY_H
+#include <stdlib.h>
+#include <ctype.h>
+#include <sys/unistd.h>
+
 #define NAMELEN 512
 #define NAMELEN_LONG 125000
 #define MAXDIMS 21

--- a/tools/set_dim_strs.c
+++ b/tools/set_dim_strs.c
@@ -18,7 +18,7 @@ set_dim_strs_x ( node_t *node , char ddim[3][2][NAMELEN], char mdim[3][2][NAMELE
 {
   int i, j, ii ;
   node_t *p ;
-  char d, d1 ;
+  char d = '\0', d1 = '\0' ;
   char * stag ;
   char r1[NAMELEN] ;
 

--- a/tools/sym.c
+++ b/tools/sym.c
@@ -150,6 +150,7 @@ sym_nodeptr x ;
 int
 sym_forget() 
 {
+  /* for (int i = 0; i < SIZEOF_SYMTAB; i++); free(symtab[i]); free(symtab); */
   create_ht( &symtab ) ;
   if (symtab == NULL)
   {

--- a/tools/sym.h
+++ b/tools/sym.h
@@ -55,6 +55,7 @@
 ***************************************************************************/
 #ifndef SYM_H
 #define SYM_H
+#include <stdlib.h>
 
 /* file: sym.h
 
@@ -91,5 +92,8 @@ struct sym_node
 
 sym_nodeptr sym_add() ;
 sym_nodeptr sym_get() ;
+int sym_forget();
+int create_ht( char *** p ) ;
+
 
 #endif

--- a/tools/symtab_gen.c
+++ b/tools/symtab_gen.c
@@ -36,8 +36,14 @@ For a sample main or calling program see the end of this file.
 #ifndef _WIN32
 # include <strings.h>
 #endif
+#include <stdlib.h>
 
 #define HASHSIZE 1024
+
+#include "sym.h"
+int sym_forget();
+int create_ht( char *** p ) ;
+int hash(char * name);
 
 /*  commented out 2-29-90
 static char * symtab[HASHSIZE] ;	
@@ -46,7 +52,7 @@ static char * symtab[HASHSIZE] ;
 void * malloc() ;
 void * calloc() ;
 
-char * symget(name,newnode,nodename,nodenext,symtab,flag)
+sym_nodeptr symget(name,newnode,nodename,nodenext,symtab,flag)
 char *name ;
 char *(*newnode)(), **(*nodename)(), **(*nodenext)() ;
 char *symtab[] ;
@@ -91,7 +97,7 @@ int flag ;		/* 1 is create if not there, 0 return NULL if not there */
       }
     }
 
-    return(p) ;
+    return ((sym_nodeptr) p) ;
 }
 
 int

--- a/tools/type.c
+++ b/tools/type.c
@@ -230,7 +230,7 @@ get_entry_r ( char * name , char * use , node_t * node )
 node_t *
 get_dimnode_for_coord ( node_t * node , int coord_axis )
 {
-  int i ;
+  unsigned int i ;
   if ( node == NULL ) return(NULL) ;
   for ( i = 0 ; i < node->ndims ; i++ )
   {
@@ -246,7 +246,7 @@ get_dimnode_for_coord ( node_t * node , int coord_axis )
 int 
 get_index_for_coord ( node_t * node , int coord_axis )
 {
-  int i ;
+  unsigned int i ;
   if ( node == NULL ) return( -1 ) ;
   for ( i = 0 ; i < node->ndims ; i++ )
   {
@@ -263,7 +263,7 @@ get_index_for_coord ( node_t * node , int coord_axis )
 char *
 set_mem_order( node_t * node , char * str , int n )
 {
-  int i ;
+  unsigned int i ;
   node_t * p ;
   
   if ( str == NULL || node == NULL ) return(NULL) ;


### PR DESCRIPTION
Quiet the compiler warnings in registry.exe

TYPE: bug fix

KEYWORDS: compiler warnings, snprintf, initial values, string length

SOURCE: Either "Daniel Wesloh (Pennsylvania State University Department of Meteorology and Atmospheric Science)"

DESCRIPTION OF CHANGES:
Problem:
Generally or specifically, what was wrong and needed to be addressed?
A few years ago, `registry.exe` was segfaulting while compiling WRF.  I enabled every compiler warning for that build process I could find, and tried to fix every one I saw.  The problem ended up being insufficient stack space (fix merged a few years ago), but fixing the warnings probably won't hurt.

Solution:
What was down algorithmically and in the source code to address the problem?
- make sure string buffers are large enough for the contents put in them
- don't use larger types than necessary (i.e. use `short` instead of `int` for numbers in the 300--16,000 range, so printf knows that five characters will be enough)
- Specify maximum lengths to copy using `snprintf` and friends
- Make sure all variables are initialized.

ISSUE: None

LIST OF MODIFIED FILES: list of changed files <!--(use `git diff --name-status master` to get formatted list)-->
```
M       configure
M       doc/README.cygwin.md
M       inc/streams.h
M       tools/Makefile
M       tools/data.h
M       tools/fseek_test.c
M       tools/gen_allocs.c
M       tools/gen_args.c
M       tools/gen_config.c
M       tools/gen_defs.c
M       tools/gen_interp.c
M       tools/gen_irr_diag.c
M       tools/gen_scalar_indices.c
M       tools/gen_streams.c
M       tools/gen_wrf_io.c
M       tools/misc.c
M       tools/protos.h
M       tools/reg_parse.c
M       tools/registry.c
M       tools/registry.h
M       tools/set_dim_strs.c
M       tools/sym.c
M       tools/sym.h
M       tools/symtab_gen.c
M       tools/type.c
```

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
   - DWesl/WRF#3
   - WRF compile finishes with this patch
2. Are the Jenkins tests all passing?
   - I have no idea how to run those

RELEASE NOTE: Eliminate some compiler warnings when building registry.exe
