### PR TITLE
io_adios2: update ADIOS2 init API

### DIFF
--- a/external/io_adios2/wrf_io.F90
+++ b/external/io_adios2/wrf_io.F90
@@ -1599,9 +1599,9 @@ subroutine ext_adios2_ioinit(SysDepInfo, Status)
   !look for adios2 xml runtime configuration
   INQUIRE(FILE="adios2.xml", EXIST=file_exists)  
   if(file_exists) then
-    call adios2_init(adios, 'adios2.xml', MPI_COMM_WORLD, adios2_debug_mode_on, stat)
+    call adios2_init(adios, 'adios2.xml', MPI_COMM_WORLD, stat)
   else
-    call adios2_init(adios, MPI_COMM_WORLD, adios2_debug_mode_on, stat)
+    call adios2_init(adios, MPI_COMM_WORLD, stat)
   endif
   call adios2_err(stat,Status)
   if(Status /= WRF_NO_ERR) then


### PR DESCRIPTION
Fixes ADIOS2 init API to support ADIOS2 v2.9.0.

TYPE: bug fix

KEYWORDS: ADIOS2, parallel I/O, in-situ I/O, API change

SOURCE: Michael Laufer, Israel

DESCRIPTION OF CHANGES:
Problem:
ADIOS2 init API was changed in v2.9.0, leading to compilation issues.

Solution:
Use equivalent init API that is backwards compatible with old ADIOS2 releases.

LIST OF MODIFIED FILES:
M external/io_adios2/wrf_io.F90

RELEASE NOTE: Fix ADIOS2 API to support v2.9.0
