### PR TITLE
Revised MM5 - Limit zolri convergence loop to a maximum of 10 iterations

### DIFF
--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1212,7 +1212,9 @@ CONTAINS
 !
       fx1=zolri2(x1,ri,z,z0)
       fx2=zolri2(x2,ri,z,z0)
+      iter = 0
       Do While (abs(x1 - x2) > 0.01)
+      if (iter .eq. 10) return
 ! check added for potential divide by zero (2019/11)
       if(fx1.eq.fx2)return
       if(abs(fx2).lt.abs(fx1))then
@@ -1225,6 +1227,7 @@ CONTAINS
         zolri=x2
       endif
 !
+      iter = iter + 1
       enddo
 !
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Revised MM5 surface layer

SOURCE: Samm Elliott (TempoQuest Inc.)

DESCRIPTION OF CHANGES:
Problem: see https://github.com/wrf-model/WRF/issues/1859

Solution:
Limit the maximum iterations of the `zolri` loop to 10 if the solution does not converge due to fp roundoff error.

ISSUE:
Fixes #1859

LIST OF MODIFIED FILES:
phys/module_sf_sfclayrev.F

TESTS CONDUCTED: 
Fixed the issue for the test case discussed in https://github.com/wrf-model/WRF/issues/1859 for AceCAST (GPU-accelerated version of WRF developed by TQI). The same case produced B4B results on CPU (when compared to a run using https://github.com/wrf-model/WRF/commit/755fc49834471330496892e760fb05951b361360).

RELEASE NOTE: Fixed an issue in Revised MM5 (sf_sfclay_physics=1) where the model could potentially encounter an infinite loop. In specific conditions floating point roundoff errors were preventing a convergence condition from ever being met.
