### PR TITLE
User-friendly error messages for missing files associated with aercu_opt=[12] initialization

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -5528,8 +5528,14 @@ subroutine aerosol_in_cu(aeromcu,alevsiz,no_months,no_src_types,XLAT,XLONG,aerop
                READ(UNIT=iunit)  lon_aer
                READ(UNIT=iunit)  aeropin
                READ(UNIT=iunit)  aeroin
+            ELSE
+               CALL wrf_error_fatal('Unable to open file "CESM_RCP4.5_Aerosol_Data.dat" (required for aercu_opt = 1 or 2). ' // &
+                  'Please refer to the run/README.namelist file for more information.')
             END IF
           CLOSE(iunit)
+      ELSE
+          CALL wrf_error_fatal('Missing file "CESM_RCP4.5_Aerosol_Data.dat" (required for aercu_opt = 1 or 2). ' // &
+              'Please refer to the run/README.namelist file for more information.')
       END IF
 !---------------------------------------------------------------------------
 !-- latitudinally interpolate ozone data (and extend longitudinally)

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -902,6 +902,11 @@ Namelist variables for controlling the adaptive time step option:
                                      = 0: no aerosol interaction
                                      = 1: aerosol interaction with MSKF only
                                      = 2: aerosol interaction with both MSKF and Morrison
+                                     ! aercu_opt = 1 and 2 both require the "CESM_RCP4.5_Aerosol_Data.dat" static runtime data 
+                                       file. This can be downloaded from:
+                                            http://www2.mmm.ucar.edu/wrf/src/wrf_files/CESM_RCP4.5_Aerosol_Data.tar.gz
+                                       Once unpacked link/copy either of the two files to CESM_RCP4.5_Aerosol_Data.dat in
+                                       your run directory prior to running wrf.exe
  aercu_fct                           factor to multiply with aerosol amount
                                      = 1.       ! default value
  no_src_types_cu                     = 1        ! number of aerosol species in global aerosol data: 10 for CESM input,


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: aercu_opt, morrison aerosol aware

SOURCE: Samm Elliott (TempoQuest Inc.)

DESCRIPTION OF CHANGES:
Problem: see #924

Solution: added appropriate calls to `wrf_error_fatal()`

ISSUE: Fixes #924

TESTS CONDUCTED: 
Tested with valid/invalid/missing CESM_RCP4.5_Aerosol_Data.dat for jan2000 test case 

RELEASE NOTE: User-friendly fatal error messages have been added to inform the user if the optional CESM aerosol data files required for the MSKF cumulus/Morrison microphysics aerosol interaction option (aercu_opt = 1 or 2) are missing.
