### PR TITLE
make configure script more portable 

### DIFF
--- a/configure
+++ b/configure
@@ -1043,7 +1043,7 @@ rm -f tools/rpc_test.log
 
 if [ -f tools/rpc_test.exe ] ; then
   rpc_type=`tools/rpc_test.exe`
-  if [ $rpc_type == "rpc" ]; then
+  if [ $rpc_type = "rpc" ]; then
     sed -e '/^CFLAGS_LOCAL/s/#/-DRPC_TYPES=1 &/' configure.wrf > configure.wrf.edit
   else
     sed -e '/^CFLAGS_LOCAL/s/#/-DRPC_TYPES=2 &/' configure.wrf > configure.wrf.edit


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: configure script, use '=' vs '=='

SOURCE: Chris Bridgham

DESCRIPTION OF CHANGES:
Problem:
The newly added test in v4.5 in configure script could fail due to less portable use '==' as in 
```
if [ $rpc_type == "rpc" ]; then
```

Solution:
Change the above to
```
if [ $rpc_type = "rpc" ]; then
```

ISSUE: For use when this PR closes an issue.
Fixes #1869

LIST OF MODIFIED FILES: 
M     configure

TESTS CONDUCTED: 
1. Yes.
2. The Jenkins tests are all passing.

RELEASE NOTE:
