### PR TITLE
update reference and remove out of date contact info

### DIFF
--- a/phys/module_ltng_cpmpr92z.F
+++ b/phys/module_ltng_cpmpr92z.F
@@ -6,10 +6,9 @@
 ! Price, C., and D. Rind (1992), A Simple Lightning Parameterization for Calculating
 !   Global Lightning Distributions, J. Geophys. Res., 97(D9), 9919-9933, doi:10.1029/92JD00719.
 !
-! Wong, J., M. Barth, and D. Noone (2012), Evaluating a Lightning Parameterization
-!   at Resolutions with Partially-Resolved Convection, GMDD, in preparation.
-!
-! Contact: J. Wong <johnwong@ucar.edu>
+! Wong, J., M. Barth, and D. Noone, 2013: Evaluating a lightning parameterization 
+!   based on cloud-top height for mesoscale numerical model simulations, 
+!   Geosci. Model Dev., 6, 429–443, https://doi.org/10.5194/gmd-6-429-2013.
 !
 !**********************************************************************
 

--- a/phys/module_ltng_crmpr92.F
+++ b/phys/module_ltng_crmpr92.F
@@ -6,14 +6,13 @@
 ! Price, C., and D. Rind (1992), A Simple Lightning Parameterization for Calculating
 !   Global Lightning Distributions, J. Geophys. Res., 97(D9), 9919-9933, doi:10.1029/92JD00719.
 !
-! Wong, J., M. Barth, and D. Noone (2012), Evaluating a Lightning Parameterization
-!   at Resolutions with Partially-Resolved Convection, GMDD, in preparation.
+! Wong, J., M. Barth, and D. Noone, 2013: Evaluating a lightning parameterization 
+!   based on cloud-top height for mesoscale numerical model simulations, 
+!   Geosci. Model Dev., 6, 429–443, https://doi.org/10.5194/gmd-6-429-2013.
 !
 ! Unlike previous implementation, this version will produce slightly inconsistent
 ! IC and CG grid-flash rates against NO emission after production via calling
 ! lightning_nox_decaria.
-!
-! Contact: J. Wong <johnwong@ucar.edu>
 !
 !**********************************************************************
 

--- a/phys/module_ltng_iccg.F
+++ b/phys/module_ltng_iccg.F
@@ -8,8 +8,6 @@
 !
 ! See comments preceeding each method for details
 !
-! Contact: J. Wong <johnwong@ucar.edu>
-!
 !**********************************************************************
 
 


### PR DESCRIPTION
TYPE:  text only

KEYWORDS: reference, lightning options

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
A reference for lightning options (lightning_option = 1 and 2) and contact info in the modules are out of date.

Solution:
Update the reference and remove out of date contact info.

LIST OF MODIFIED FILES: 
M       phys/module_ltng_cpmpr92z.F
M       phys/module_ltng_crmpr92.F
M       phys/module_ltng_iccg.F

TESTS CONDUCTED: 
1. Text change only
2. Are the Jenkins tests all passing?

RELEASE NOTE: 
