### PR TITLE
Changed 'grid spaces' to 'grid points' for e_we/sn description in namelist.input.default

### DIFF
--- a/test/em_real/namelist.input.default
+++ b/test/em_real/namelist.input.default
@@ -30,8 +30,8 @@
  time_step_fract_num                 = 0,			! Numerator if using fractional time step. DO NOT ADD ADDITIONAL COLUMNS.
  time_step_fract_den                 = 1,			! Denomenator if using fractional time step. DO NOT ADD ADDITIONAL COLUMNS.
  max_dom                             = 1,			! Total number of domains for the simulation. DO NOT ADD ADDITIONAL COLUMNS.
- e_we                                = 150,    220,   200,	! Number of grid spaces in the x direction (west-east).
- e_sn                                = 130,    214,   210,	! Number of grid spaces in the y direction (south-north).
+ e_we                                = 150,    220,   200,	! Number of grid points in the x direction (west-east).
+ e_sn                                = 130,    214,   210,	! Number of grid points in the y direction (south-north).
  e_vert                              = 45,     45,    45,	! Number of full vertical levels. must be the same for all domains.
  dzstretch_s                         = 1.1			! Surface stretch factor when auto_levels_opt = 2 (which is default). DO NOT ADD ADDITIONAL COLUMNS.
  p_top_requested                     = 5000,			! Pressure top (in Pa) to use for the simulation. The input data must go up to this value. DO NOT ADD ADDITIONAL COLUMNS.


### PR DESCRIPTION
TYPE: text only

KEYWORDS: grid spaces, grid points, namelist.input.default

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
In namelist.input.default, for the values e_we and e_sn, the description referred to them as the number of "grid spaces," and this should be "grid points."

Solution:
Changed the descriptions to say "grid points."

LIST OF MODIFIED FILES: 
M  test/em_real/namelist.input.default

TESTS CONDUCTED: 
1. Text only - no tests necessary
2. Are the Jenkins tests all passing?
