### PR TITLE
change wrf_error_fatal and wrf_message calls to macros to remain unif…

### DIFF
--- a/phys/module_sf_bem.F
+++ b/phys/module_sf_bem.F
@@ -1,4 +1,11 @@
 MODULE module_sf_bem
+#if defined(mpas)
+use mpas_atmphys_utilities, only: physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal( M )
+#else
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#endif
 ! -----------------------------------------------------------------------
 !  Variables and constants used in the BEM module
 ! -----------------------------------------------------------------------
@@ -2459,7 +2466,7 @@ MODULE module_sf_bem
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     CALL wrf_error_fatal('singular matrix in gaussjbem')
+                     FATAL_ERROR('singular matrix in gaussjbem')
                   endif
                enddo
             endif
@@ -2480,7 +2487,7 @@ MODULE module_sf_bem
           
          endif
          
-         if(a(icol,icol).eq.0) CALL wrf_error_fatal('singular matrix in gaussjbem')
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussjbem')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1

--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -3722,7 +3722,7 @@ do iz= kts,kte
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     CALL wrf_error_fatal('singular matrix in gaussj')
+                     FATAL_ERROR('singular matrix in gaussj')
                   endif
                enddo
             endif
@@ -3743,7 +3743,7 @@ do iz= kts,kte
           
          endif
          
-         if(a(icol,icol).eq.0) CALL wrf_error_fatal('singular matrix in gaussj')
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussj')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -2161,9 +2161,9 @@ ENDIF
             ALLOCATE( HSESF_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) FATAL_ERROR('Error allocating HSESF_TBL in urban_param_init')
             ALLOCATE( PV_FRAC_ROOF_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating PV_FRAC_ROOF_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating PV_FRAC_ROOF_TBL in urban_param_init')
             ALLOCATE( GR_FRAC_ROOF_TBL(ICATE), stat=allocate_status )
-            if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating GR_FRAC_ROOF_TBL in urban_param_init')
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating GR_FRAC_ROOF_TBL in urban_param_init')
 
          endif
          numdir_tbl = 0
@@ -2889,7 +2889,7 @@ ENDIF
       IF (CHECK.EQ.0)THEN
       IF(IVGTYP(I,J).EQ.1)THEN
         write(mesg,*) 'Sample of Urban settings'
-        call wrf_message(mesg)
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TSURFACE0_URB',TSURFACE0_URB(I,J)
         WRITE_MESSAGE(mesg)
         write(mesg,*) 'TDEEP0_URB', TDEEP0_URB(I,J)


### PR DESCRIPTION
TYPE:  text only

KEYWORDS: urban schemes, message calls

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The three urban scheme routines have a few wrf_message and wrf_error_fatal calls that should be replaced by macros defined at the top of modules so that the code maintains consistency with those in MPAS.

Solution:
The calls are replaced by the macros.

LIST OF MODIFIED FILES: 
M       phys/module_sf_bem.F
M       phys/module_sf_bep_bem.F
M       phys/module_sf_urban.F

TESTS CONDUCTED: 
1. The code compiles.
2. The Jenkins tests are all passing.