### PR TITLE
Two small fixes in Thompson MP based on CCPP code with UFS testing

### DIFF
--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -837,7 +837,7 @@
 
 !..Create bins of cloud ice (from min diameter up to 5x min snow size).
       xDx(1) = D0i*1.0d0
-      xDx(nbi+1) = 5.0d0*D0s
+      xDx(nbi+1) = 2.0d0*D0s
       do n = 2, nbi
          xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbi) &
                   *DLOG(xDx(nbi+1)/xDx(1)) +DLOG(xDx(1)))
@@ -2542,7 +2542,7 @@
             png_rcg(k) = MIN(DBLE(ng(k)*odts), png_rcg(k))
             pbg_rcg(k) = prg_rcg(k)/rho_g(idx_bg(k))
 !..Put in explicit drop break-up due to collisions.
-            pnr_rcg(k) = -5.*tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  ! RAIN2M
+            pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  ! RAIN2M
            endif
           endif
          endif


### PR DESCRIPTION
Based on testing within CCPP for UFS (both RRFS and GFS), two minor updates to the Thompson microphysics scheme.

TYPE: bug fix

KEYWORDS: microphysics, Thompson, CCPP

SOURCE: gthompsn

DESCRIPTION OF CHANGES:

As described in [UFS PR69](https://github.com/ufs-community/ccpp-physics/pull/69) there are two changes for Thompson-MP:

1. The minimum size of snow was increased (some months ago) but it was noted that the min size of snow is used to determine the upper-most size bin of cloud ice. It was set to 5 times the min size of snow, which is exceedingly large for the cloud ice category. Therefore, the constant was reduced to 2 - making cloud ice largest size bin of 600 microns which is plenty big enough, giving more resolution to all the ice size bins.

2. In testing RRFS with @ericaligo-NOAA and @RuiyuSun for a specific case study, it was noted that rain was evaporating with a large rate producing a temperature tendency of 27C/hour. We traced the issue to an extremely large number of rain drops that appears to be produced by colliding rain and graupel - which has an explicit drop breakup (splash if you will) from the collisions making 5 drops per collision. This was forcing the rain (formed by melting graupel) to tends towards 500 microns (0.5 mm) which is too small. So the constant used for collisions was reduced to 1.5 in an effort to keep rain larger (thus reducing evaporation).
 
The third bullet of the referenced UFS PR is irrelevant because the values of `prr_sml` and `prr_gml` are held to zero instead of negative with the `MAX` statement.

LIST OF MODIFIED FILES:   `module_mp_thompson.F` only

TESTS CONDUCTED: 

Tested in RRFS and GFS but not in WRF.  The result of bullet 2 above will cause large rain drops so changes to simulations are expected.

RELEASE NOTE:  Minor changes to Thompson-MP aligning with changes made in CCPP for use in UFS.
