### PR TITLE
correction to bl_pbl_physics=17, K-epsilon-theta, to avoid instabilities over water surfaces

### DIFF
--- a/phys/module_bl_keps.F
+++ b/phys/module_bl_keps.F
@@ -1166,7 +1166,7 @@ real b_t(kms:kme),th0(kms:kme),tpe(kms:kme)
        dphidz(iz)=0.5*(dphidz1+dphidz2)
      enddo
       dphidz(kte)=0.
-      
+      dphidz(kts)=0. 
      do iz=kts,kte
       b_t(iz)=b_t(iz)-dphidz(iz)
      enddo


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: bug fix, k-epsilon counter-gradient term

SOURCE: Andrea Zonato,  Koninklijk Nederlands Meteorologisch Instituut

DESCRIPTION OF CHANGES:
Problem:
The counter-gradient term for temperature equation at the first level is creating instabilities over water surfaces.
Solution:
The counter gradient has been set =0 for the first atmospheric level.

LIST OF MODIFIED FILES: modue_bl_keps.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Correction for the counter-gradient term which causes instabilities and large biases at the first model level over water surfaces. 