### PR TITLE
Fix Triggering Condition Bug for CAPE Calculation

### DIFF
--- a/phys/module_diag_functions.F
+++ b/phys/module_diag_functions.F
@@ -760,9 +760,10 @@ CONTAINS
             flag = .false.
          END IF
       END DO
-      IF (ellev >= 0) THEN !Modified by Zhixiao
-         pel = p(ellev) !Modified by Zhixiao
-         CIN=REAL ( 0 ) !Modified by Zhixiao
+      IF ((ellev >= 0) .and. (lfclev >= 0)) THEN !Modified by Zhixiao
+         plfc = p (lfclev)
+         pel = p (ellev)
+         CIN=REAL ( 0 )
          DO k = sfc+1, nz
             ! Make CAPE and CIN consistent with AMS definition
             ! https://glossary.ametsoc.org/wiki/Convective_available_potential_energy


### PR DESCRIPTION
Assign PLFC before calculating CAPE since PLFC is the triggering condition for the CAPE calculation

TYPE: bug fix

KEYWORDS: CAPE, PLFC

SOURCE: Zhixiao Zhang (University of Oxford)

DESCRIPTION OF CHANGES:
Problem:
CAPE can't be updated

Solution:
Assign PLFC value before calculating CAPE because PLFC is the triggering condition for CAPE calculation.

ISSUE: Fixes #1903

LIST OF MODIFIED FILES: WRF/phys/module_diag_functions.F

RELEASE NOTE: Fix triggering condition code bug for CAPE calculation