### PR TITLE
Runtime checks on registry file generation and add ability to run out-of-source

### DIFF
--- a/tools/gen_allocs.c
+++ b/tools/gen_allocs.c
@@ -659,7 +659,7 @@ gen_dealloc2 ( FILE * fp , char * structname , node_t * node )
         fprintf(fp, 
 "  DEALLOCATE(%s%s,STAT=ierr)\n if (ierr.ne.0) then\n CALL wrf_error_fatal ( &\n'frame/module_domain.f: Failed to deallocate %s%s. ')\n endif\n",
 structname, fname, structname, fname ) ;
-#ifdef USE_ALLOCATABLES
+#ifndef USE_ALLOCATABLES
         fprintf(fp,
 "  NULLIFY(%s%s)\n",structname, fname ) ;
 #endif

--- a/tools/gen_streams.c
+++ b/tools/gen_streams.c
@@ -607,12 +607,14 @@ gen_med_find_esmf_coupling ( FILE *fp )
    for each stream.  This file is then included by the registry.io_boilerplate file when the
    registry actually runs.  As with the other mods above, this allows a variable, compile-time
    number of io streams. Note that this one is self contained and dirname is hard-coded.
+   AI: In an effort to delineate true source files from autogen stuff this is now not going into hard-coded
+   Registry so that we can use ./ as an alternate include location
 */
 int
 gen_io_boilerplate ()
 {
   FILE * fp ;
-  char * dirname = "Registry" ;
+  char * dirname = "./" ;
   char  fname[NAMELEN] ;
   char * fn ;
   char * aux , *streamtype , streamno[5]  ;

--- a/tools/reg_parse.c
+++ b/tools/reg_parse.c
@@ -116,21 +116,28 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
     for ( p = inln ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
     if ( !strncmp( p , "include", 7 ) &&  ! ( ifdef_stack_ptr >= 0 && ! ifdef_stack[ifdef_stack_ptr] ) ) {
       FILE *include_fp ;
+      char include_file_name_dir[128] ;
       char include_file_name[128] ;
       p += 7 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       if ( strlen( p ) > 127 ) { fprintf(stderr,"Registry warning: invalid include file name: %s\n", p ) ; }
       else {
-        sprintf( include_file_name , "%s/%s", dir , p ) ;
+        
+        sprintf( include_file_name,     "%s", p ) ;
         if ( (p=index(include_file_name,'\n')) != NULL ) *p = '\0' ;
+        sprintf( include_file_name_dir, "%s/%s", dir , include_file_name ) ;
+        
         fprintf(stderr,"opening %s\n",include_file_name) ;
-        if (( include_fp = fopen( include_file_name , "r" )) != NULL ) {
+        if ( ( ( include_fp = fopen( include_file_name,     "r" ) ) != NULL ) || // Use short circuit logic here to try both sequentially
+             ( ( include_fp = fopen( include_file_name_dir, "r" ) ) != NULL ) )
+        {
 
           fprintf(stderr,"including %s\n",include_file_name ) ;
           pre_parse( dir , include_fp , outfile ) ;
 
           fclose( include_fp ) ;
-        } else {
-          fprintf(stderr,"Registry warning: cannot open %s. Ignoring.\n", include_file_name ) ;
+        } 
+        else {
+          fprintf(stderr,"Registry warning: cannot open %s. Tried %s and %s Ignoring.\n", include_file_name, include_file_name, include_file_name_dir ) ;
         } 
       }
     }

--- a/tools/registry.c
+++ b/tools/registry.c
@@ -237,7 +237,7 @@ main( int argc, char *argv[], char *env[] )
 
   fclose(fp_tmp) ;
 
-  NON_ZERO_RETURN( check_dimspecs() );
+  check_dimspecs();
 
   NON_ZERO_RETURN( gen_state_struct( "inc" ) );
   NON_ZERO_RETURN( gen_state_subtypes( "inc" ) );

--- a/tools/registry.c
+++ b/tools/registry.c
@@ -18,6 +18,9 @@
 #include "data.h"
 #include "sym.h"
 
+// Helper macro to actually do return checks
+#define NON_ZERO_RETURN( A ) { int result = A; if ( result != 0 ) { printf( "Error in %s, non-zero return expected", #A ); exit(result); } }
+
 /* SamT: bug fix: main returns int */
 int
 main( int argc, char *argv[], char *env[] )
@@ -132,11 +135,11 @@ main( int argc, char *argv[], char *env[] )
     argv++ ;
   }
 
-  gen_io_boilerplate() ;  /* 20091213 jm.  Generate the io_boilerplate_temporary.inc file */
+  NON_ZERO_RETURN( gen_io_boilerplate() );  /* 20091213 jm.  Generate the io_boilerplate_temporary.inc file */
 
-  init_parser() ;
-  init_type_table() ;
-  init_dim_table() ;
+  NON_ZERO_RETURN( init_parser() );
+  NON_ZERO_RETURN( init_type_table() );
+  NON_ZERO_RETURN( init_dim_table() );
 //
 //  possible IRR diagnostcis?
 //
@@ -230,45 +233,45 @@ main( int argc, char *argv[], char *env[] )
   }
 
 
-  reg_parse(fp_tmp) ;
+  NON_ZERO_RETURN( reg_parse(fp_tmp) );
 
   fclose(fp_tmp) ;
 
-  check_dimspecs() ;
+  NON_ZERO_RETURN( check_dimspecs() );
 
-  gen_state_struct( "inc" ) ;
-  gen_state_subtypes( "inc" ) ;
-  gen_alloc( "inc" ) ;
+  NON_ZERO_RETURN( gen_state_struct( "inc" ) );
+  NON_ZERO_RETURN( gen_state_subtypes( "inc" ) );
+  NON_ZERO_RETURN( gen_alloc( "inc" ) );
   /* gen_alloc_count( "inc" ) ; */
-  gen_dealloc( "inc" ) ;
-  gen_scalar_indices( "inc" ) ;
-  gen_module_state_description( "frame" ) ;
-  gen_actual_args( "inc" ) ;
-  gen_actual_args_new( "inc" ) ;
-  gen_dummy_args( "inc" ) ;
-  gen_dummy_args_new( "inc" ) ;
-  gen_dummy_decls( "inc" ) ;
-  gen_dummy_decls_new( "inc" ) ;
-  gen_i1_decls( "inc" ) ;
-  gen_namelist_statements("inc") ;
-  gen_namelist_defines ( "inc", 0 ) ;  /* without dimension statements  */
-  gen_namelist_defines ( "inc", 1 ) ;  /* with dimension statements     */
-  gen_namelist_defaults ( "inc" ) ;
-  gen_namelist_script ( "inc" ) ;
-  gen_get_nl_config( "inc" ) ;
-  gen_config_assigns( "inc" ) ;
-  gen_config_reads( "inc" ) ;
-  gen_wrf_io( "inc" ) ;
-  gen_model_data_ord( "inc" ) ;
-  gen_nest_interp( "inc" ) ;
-  gen_nest_v_interp( "inc") ; /*KAL added this for vertical interpolation*/
-  gen_scalar_derefs( "inc" ) ;
-  gen_streams("inc") ;
+  NON_ZERO_RETURN( gen_dealloc( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_scalar_indices( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_module_state_description( "frame" ) ) ;
+  NON_ZERO_RETURN( gen_actual_args( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_actual_args_new( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_dummy_args( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_dummy_args_new( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_dummy_decls( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_dummy_decls_new( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_i1_decls( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_namelist_statements("inc") ; )
+  NON_ZERO_RETURN( gen_namelist_defines ( "inc", 0 ) ) ;  /* without dimension statements  */
+  NON_ZERO_RETURN( gen_namelist_defines ( "inc", 1 ) ) ;  /* with dimension statements     */
+  NON_ZERO_RETURN( gen_namelist_defaults ( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_namelist_script ( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_get_nl_config( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_config_assigns( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_config_reads( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_wrf_io( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_model_data_ord( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_nest_interp( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_nest_v_interp( "inc") ; ) /*KAL added this for vertical interpolation*/
+  NON_ZERO_RETURN( gen_scalar_derefs( "inc" ) ) ;
+  NON_ZERO_RETURN( gen_streams("inc") ; )
 
 /* this has to happen after gen_nest_interp, which adds halos to the AST */
-  gen_comms( "inc" ) ;    /* this is either package supplied (by copying a */
-                          /* gen_comms.c file into this directory) or a    */
-                          /* stubs routine.                                */
+  NON_ZERO_RETURN( gen_comms( "inc" ) );    /* this is either package supplied (by copying a */
+                                            /* gen_comms.c file into this directory) or a    */
+                                            /* stubs routine.                                */
 
 cleanup:
 #ifdef _WIN32


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: registry, out-of-source

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Registry code generation continues regardless of errors and missing fields are not caught until sometimes ~40 minutes into compilation when a subsequent source file is missing registry-generated fields. Additionally, the generated code clutters the source development environment with hundreds of files, requiring many .gitignore entries that seem counterintuitive (e,g. ignoring all *.f90 source files). Finally, there is a bug in the the gen_allocs conditionally compiled code

Solution:
Check returns of `gen_...()` functions that create files to output if respective call failed to generate the registry code
Add the ability to supply a root registry directory to utilize instead of assumed relative directories to allow out-of-source registry code generation outside of the WRF repo. Make assumed relative still the default method so previous builds not using this new capability still work.
Fix gen_allocs.c define macro

LIST OF MODIFIED FILES: 
M tools/gen_allocs.c
M tools/gen_streams.c
M tools/reg_parse.c
M tools/registry.c

TESTS CONDUCTED: 
1. Do mods fix problem? Local compilation demonstrates fixes working as expected
2. Are the Jenkins tests all passing? Yes

RELEASE NOTE: 
Runtime checks on registry file generation and add ability to run out-of-source. Minor bug fix in gen_allocs.c
