### PR TITLE
Adjust #defines to accommodate future CMake build

### DIFF
--- a/dyn_em/module_advect_em.F
+++ b/dyn_em/module_advect_em.F
@@ -1,7 +1,7 @@
 
 !WRF:MODEL_LAYER:DYNAMICS
 !
-#if ( defined(ADVECT_KERNEL) )
+#ifdef ADVECT_KERNEL
 ! cpp -traditional-cpp -P -DADVECT_KERNEL module_advect_em.F > advection_kernel.f90
 ! gfortran -ffree-form -ffree-line-length-none advection_kernel.f90
 ! ./a.out
@@ -111,7 +111,7 @@ SUBROUTINE column (loop , data_list, its,ite)
    
 END SUBROUTINE column
 !----------------------------------------------------------------
-#elif ( ! defined(ADVECT_KERNEL) )
+#else
 
 MODULE module_advect_em
 
@@ -4357,7 +4357,7 @@ SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
    ENDIF vert_order_test
 
 END SUBROUTINE advect_scalar
-#if ( ! defined(ADVECT_KERNEL) )
+#ifndef ADVECT_KERNEL
 
 !---------------------------------------------------------------------------------
 
@@ -10543,7 +10543,7 @@ END SUBROUTINE advect_scalar_mono
 
 !-----------------------------------------------------------
 
-#if ( defined(ADVECT_KERNEL) )
+#ifdef ADVECT_KERNEL
 
 END MODULE advection_kernel
 !================================================================
@@ -10851,7 +10851,7 @@ PROGRAM feeder
 
 END PROGRAM feeder
 #endif
-#if ( !defined(ADVECT_KERNEL) )
+#ifndef ADVECT_KERNEL
 
 !---------------------------------------------------------------------------------
 

--- a/external/atm_ocn/cmpcomm.F
+++ b/external/atm_ocn/cmpcomm.F
@@ -1,4 +1,4 @@
-#if defined( DM_PARALLEL ) 
+#ifdef DM_PARALLEL
       MODULE CMP_COMM
 
       implicit none

--- a/external/io_adios2/wrf_io.F90
+++ b/external/io_adios2/wrf_io.F90
@@ -702,9 +702,9 @@ module ext_adios2_support_routines
  
    call LowerCase(MemoryOrder,MemOrd)
    select case (MemOrd)
- 
- !#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
- ! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
+! Cannot use following define due to gfortran cpp traditional mode concatenation limitations 
+!#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
+! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
      case ('xzy')
 #undef  DFIELD
 #define DFIELD XField(1:di,XDEX(i,k,j))

--- a/external/io_netcdf/wrf_io.F90
+++ b/external/io_netcdf/wrf_io.F90
@@ -754,7 +754,7 @@ subroutine Transpose(IO,MemoryOrder,di, Field,l1,l2,m1,m2,n1,n2 &
 
   call LowerCase(MemoryOrder,MemOrd)
   select case (MemOrd)
-
+! Cannot use following define due to gfortran cpp traditional mode concatenation limitations
 !#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
 ! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
 
@@ -940,7 +940,7 @@ subroutine TransposeToR4(IO,MemoryOrder,di, Field,l1,l2,m1,m2,n1,n2 &
 
   call LowerCase(MemoryOrder,MemOrd)
   select case (MemOrd)
-
+! Cannot use following define due to gfortran cpp traditional mode concatenation limitations
 !#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
 ! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
 

--- a/external/io_netcdfpar/wrf_io.F90
+++ b/external/io_netcdfpar/wrf_io.F90
@@ -767,7 +767,7 @@ subroutine Transpose(IO,MemoryOrder,di, Field,l1,l2,m1,m2,n1,n2 &
 
   call LowerCase(MemoryOrder,MemOrd)
   select case (MemOrd)
-
+! Cannot use following define due to gfortran cpp traditional mode concatenation limitations
 !#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
 ! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
 
@@ -953,7 +953,7 @@ subroutine TransposeToR4a(IO,MemoryOrder,di, Field,l1,l2,m1,m2,n1,n2 &
 
   call LowerCase(MemoryOrder,MemOrd)
   select case (MemOrd)
-
+! Cannot use following define due to gfortran cpp traditional mode concatenation limitations
 !#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
 ! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
 

--- a/external/io_pnetcdf/wrf_io.F90
+++ b/external/io_pnetcdf/wrf_io.F90
@@ -740,7 +740,7 @@ subroutine Transpose(IO,MemoryOrder,di, Field,l1,l2,m1,m2,n1,n2 &
 
   call LowerCase(MemoryOrder,MemOrd)
   select case (MemOrd)
-
+! Cannot use following define due to gfortran cpp traditional mode concatenation limitations
 !#define XDEX(A,B,C) A-A ## 1+1+(A ## 2-A ## 1+1)*((B-B ## 1)+(C-C ## 1)*(B ## 2-B ## 1+1))
 ! define(`XDEX',($1-``$1''1+1+(``$1''2-``$1''1+1)*(($2-``$2''1)+($3-``$3''1)*(``$2''2-``$2''1+1))))
 

--- a/frame/module_configure.F
+++ b/frame/module_configure.F
@@ -15,7 +15,8 @@ CONTAINS
   END SUBROUTINE init_module_scalar_tables
 END MODULE module_scalar_tables
 
-#if( WRF_CHEM == 1 && WRF_KPP == 1 )
+#ifdef WRF_CHEM
+#ifdef WRF_KPP
 MODULE module_irr_diag
 
    INTEGER, parameter :: max_eqn = 1200
@@ -44,6 +45,7 @@ CONTAINS
   END SUBROUTINE init_module_irr_diag
 
 END MODULE module_irr_diag
+#endif
 #endif
 
 MODULE module_configure

--- a/phys/module_mp_SBM_polar_radar.F
+++ b/phys/module_mp_SBM_polar_radar.F
@@ -6,6 +6,11 @@
          dummy = 1
       END SUBROUTINE SBM_polar_radar
       END MODULE module_mp_SBM_polar_radar
+
+! Stub module
+module scatt_tables
+end module scatt_tables
+
 #else
 !******************
 module scatt_tables

--- a/phys/module_mp_fast_sbm.F
+++ b/phys/module_mp_fast_sbm.F
@@ -6,6 +6,20 @@
          dummy = 1
       END SUBROUTINE SBM_fast
       END MODULE module_mp_fast_sbm
+
+! Stub modules
+module module_mp_SBM_BreakUp
+end module module_mp_SBM_BreakUp
+
+module module_mp_SBM_Collision
+end module module_mp_SBM_Collision
+
+module module_mp_SBM_Auxiliary
+end module module_mp_SBM_Auxiliary
+
+module module_mp_SBM_Nucleation
+end module module_mp_SBM_Nucleation
+
 #else
 ! +-----------------------------------------------------------------------------+
 ! +-----------------------------------------------------------------------------+


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: defines, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Certain #define constructs prove to be challenging for CMake to process automatically into a dependency graph. 

Solution:
Reduce complexity for #defines that can be rewritten. For those that cannot, create stub modules.

LIST OF MODIFIED FILES: 
M       dyn_em/module_advect_em.F
M       external/atm_ocn/cmpcomm.F
M       external/io_adios2/wrf_io.F90
M       external/io_netcdf/wrf_io.F90
M       external/io_netcdfpar/wrf_io.F90
M       external/io_pnetcdf/wrf_io.F90
M       frame/module_configure.F
M       phys/module_mp_SBM_polar_radar.F
M       phys/module_mp_fast_sbm.F


TESTS CONDUCTED: 
1. Do mods fix problem? Local tests demonstrate fixes satisfy new upcoming cmake build
2. Are the Jenkins tests all passing? Yes

RELEASE NOTE:
Adjust #defines to accommodate future CMake build
