### PR TITLE
Remove arbitrary limiting of heat fluxes

### DIFF
--- a/phys/module_sf_sfclay.F
+++ b/phys/module_sf_sfclay.F
@@ -892,7 +892,7 @@ CONTAINS
 !                                                                               
       DO 370 I=its,ite
         QFX(I)=FLQC(I)*(QSFC(I)-QX(I))                                     
-        QFX(I)=AMAX1(QFX(I),0.)                                            
+!       QFX(I)=AMAX1(QFX(I),0.)                                            
         LH(I)=XLV*QFX(I)
   370 CONTINUE                                                                 
                                                                                 
@@ -910,7 +910,7 @@ CONTAINS
 !         ENDIF
         ELSEIF(XLAND(I)-1.5.LT.0.)THEN                                       
           HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
-          HFX(I)=AMAX1(HFX(I),-250.)                                       
+!         HFX(I)=AMAX1(HFX(I),-250.)                                       
         ENDIF                                                                  
   400 CONTINUE                                                                 
 

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1041,7 +1041,7 @@ CONTAINS
 
       DO 370 I=its,ite
         QFX(I)=FLQC(I)*(QSFC(I)-QX(I))                                     
-        QFX(I)=AMAX1(QFX(I),0.)                                            
+!       QFX(I)=AMAX1(QFX(I),0.)                                            
         LH(I)=XLV*QFX(I)
   370 CONTINUE                                                                 
                                                                                 
@@ -1059,7 +1059,7 @@ CONTAINS
 !         ENDIF 
         ELSEIF(XLAND(I)-1.5.LT.0.)THEN                                       
           HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
-          HFX(I)=AMAX1(HFX(I),-250.)                                       
+!         HFX(I)=AMAX1(HFX(I),-250.)                                       
         ENDIF                                                                  
   400 CONTINUE                                                                 
 

--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -1701,6 +1701,8 @@ SUBROUTINE open_hist_w ( grid , config_flags, stream, alarm_id, &
    ENDIF
 
    ierr = 0
+   fname = ""
+   n2 = ""
 
    ! Note that computation of fname and n2 are outside of the oid IF statement 
    ! since they are OUT args and may be used by callers even if oid/=0.  

--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -1701,8 +1701,6 @@ SUBROUTINE open_hist_w ( grid , config_flags, stream, alarm_id, &
    ENDIF
 
    ierr = 0
-   fname = ""
-   n2 = ""
 
    ! Note that computation of fname and n2 are outside of the oid IF statement 
    ! since they are OUT args and may be used by callers even if oid/=0.  


### PR DESCRIPTION
Arbitrary limitation in the computation of **QFX** and **HFX**.

TYPE: bug fix

KEYWORDS: SBL

SOURCE: David Robertson, Rutgers University

DESCRIPTION OF CHANGES:
Problem:

- Arbitrary limitation in the computation of **QFX** and **HFX** in modules  **`module_sf_sfclay.F`** and **`module_sf_sfclayrev.F`** that affects the computation latent heat fluxes and sensible heat flux in coastal areas that limit fog layers.

Solution:
- Comment out the lines in **`phys/module_sf_sfclay.F`** :
 ```f90
       DO 370 I=its,ite
         QFX(I)=FLQC(I)*(QSFC(I)-QX(I))
!       QFX(I)=AMAX1(QFX(I),0.)
         LH(I)=XLV*QFX(I)
  370 CONTINUE

...

        ELSEIF(XLAND(I)-1.5.LT.0.)THEN
          HFX(I)=FLHC(I)*(THGB(I)-THX(I))
!        HFX(I)=AMAX1(HFX(I),-250.)
        ENDIF
  400 CONTINUE
```
 - Similar changes in **`phys/module_sf_sfclayrev.F`**.

LIST OF MODIFIED FILES: 
M       phys/module_sf_sfclay.F
M       phys/module_sf_sfclayrev.F

TESTS CONDUCTED: 
1. Ran the coupled WRF-ROMS standard test case for Hurricane Irene.
2. It passed regression tests.

RELEASE NOTE: This PR removed zero negative latent heat flux limit (atmosphere to water) in the revised MM5 and original MM5 surface layer schemes.
