### PR TITLE
fix a typo in the single-layer urban canopy model 

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1279,7 +1279,7 @@ ENDIF
        ES=6.11*EXP( (2.5*10.**6./461.51)*(TGP-273.15)/(273.15*TGP) ) 
        DESDT=(2.5*10.**6./461.51)*ES/(TGP**2.)
        QS0G=0.622*ES/(PS-0.378*ES)        
-       DQS0GDTG=DESDT*0.22*PS/((PS-0.378*ES)**2.) 
+       DQS0GDTG=DESDT*0.622*PS/((PS-0.378*ES)**2.) 
 
        RG1=EPSG*( RX*VFGS          &
        +EPSB*VFGW*SIG*TBP**4./60.  &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: single-layer urban canopy model, saturated specific humidity for ground

SOURCE: Dan Li (Boston University)

DESCRIPTION OF CHANGES:
Problem:
When computing the derivative of the saturated specific humidity with respect to surface temperature for the ground in single-layer urban canopy model, the equation had a typo which involved a coefficient. It should be 0.622 (as in for example the same calculations for roof and wall) instead of 0.22. 

Solution:
Change the coefficient from 0.22 to 0.622. 

LIST OF MODIFIED FILES: 
M    phys/module_sf_urban.F

TESTS CONDUCTED: 
1. case study.
2. The Jenkins tests are all passing.

RELEASE NOTE: Fix a typo in computing the saturated specific humidity in the single-layer urban canopy model. The effect is likely small due to the calculation is relevant only in the case of rain and on impervious surfaces when using default evaporation scheme (which is set in URBPARM.TBL).