### PR TITLE
added model stop for ghg_input with nonsupported radiation options

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -928,7 +928,7 @@
 #endif
 
 !-----------------------------------------------------------------------
-! Climate GHG from an input file requires coordinated pairing of
+! Climatr GHG from an input file requires coordinated pairing of
 ! LW and SW schemes, and restricts which schemes are eligible.
 ! Only radiation schemes CAM, RRTM, RRTMG, RRTMG_fast may be used.
 ! CAM LW and CAM SW must be used together.
@@ -963,6 +963,7 @@
             CALL wrf_message ( TRIM( wrf_err_message ) )
             wrf_err_message = '           OK = RRTM, RRTMG LW or SW, RRTMG_fast LW or SW may be mixed'
             CALL wrf_message ( TRIM( wrf_err_message ) )
+            count_fatal_error = count_fatal_error + 1
          END IF
       END IF
 

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -928,7 +928,7 @@
 #endif
 
 !-----------------------------------------------------------------------
-! Climatr GHG from an input file requires coordinated pairing of
+! Climate GHG from an input file requires coordinated pairing of
 ! LW and SW schemes, and restricts which schemes are eligible.
 ! Only radiation schemes CAM, RRTM, RRTMG, RRTMG_fast may be used.
 ! CAM LW and CAM SW must be used together.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ghg_input, radiation, module_check_a_mundo

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
If a user had ghg_input turned on, but wasn't using one of the supported radiation physics options (i.e., not CAM, RRTM, RRTMG, or RRTMG_fast), the model would give an "ERROR" message, but wouldn't stop, nor would it make any changes to the settings. As long as everything else was correct, it would continue and write out the SUCCESS message at the end of the log files. 

Solution:
Added a "count_fatal_error = count_fatal_error + 1" to the check for this in module_check_a_mundo.F.  

LIST OF MODIFIED FILES: 
M   share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Now, if non-supported radiation options are used with ghg_input, the model stops with the following message:
                  --- ERROR: ghg_input available only for these radiation schemes: CAM, RRTM, RRTMG, RRTMG_fast 
                             And the LW and SW schemes must be reasonably paired together:
                             OK = CAM LW with CAM SW
                             OK = RRTM, RRTMG LW or SW, RRTMG_fast LW or SW may be mixed 
                  -------------- FATAL CALLED --------------- 
                  FATAL CALLED FROM FILE:  <stdin>  LINE:    2794 
                  NOTE:       1 namelist settings are wrong. Please check and reset these options 
                  -------------------------------------------

3. Are the Jenkins tests all passing?

RELEASE NOTE: A bug fix was added to ensure the model stops when using ghg_input and a non-supported radiation physics option (i.e., anything other than CAM, RRTM, RRTMG, or RRTMG_fast).
