### PR TITLE
Changing how Config.pl looks for the HDF5 high-level fortran library.

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -49,6 +49,7 @@ $sw_usenetcdf = "" ;
 $sw_time = "" ;          # name of a timer to time fortran compiles, e.g. timex or time
 $sw_ifort_r8 = 0 ;
 $sw_hdf5 = "-lhdf5_hl -lhdf5";
+$sw_hdf5_hl_fortran="-lhdf5_hl_fortran";
 $sw_zlib = "-lz";
 $sw_dep_lib_path = "";
 $sw_gpfs_path = "";
@@ -349,6 +350,15 @@ if ( $ENV{WRF_CTSM_MKFILE} ) {
    $sw_ctsm_mkfile_path = $ENV{WRF_CTSM_MKFILE};
 }
 
+if ( $sw_hdf5_path ) {
+  opendir(my $dh, "$sw_hdf5_path/lib");
+  ($hl) = grep(/hdf5hl_fortran/i, readdir $dh);
+  closedir($dh);
+  if ($hl ne "") {
+    $sw_hdf5_hl_fortran="-lhdf5hl_fortran";
+  }
+}
+
 # parse the configure.wrf file
 
 $validresponse = 0 ;
@@ -453,6 +463,7 @@ if ( $response == 2 || $response == 3 ) {
 } else {
   $sw_terrain_and_landuse =" -DLANDREAD_STUB=1" ;
 } 
+
 open CONFIGURE_DEFAULTS, "cat ./arch/configure.defaults |"  ;
 $latchon = 0 ;
 while ( <CONFIGURE_DEFAULTS> )
@@ -732,7 +743,7 @@ while ( <CONFIGURE_DEFAULTS> )
       }
 
     if ( $sw_hdf5_path ) 
-      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
+      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib $sw_hdf5_hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
         $_ =~ s:CONFIGURE_HDF5_FLAG:-DHDF5: ;
          }
     else
@@ -1120,7 +1131,7 @@ while ( <ARCH_PREAMBLE> )
       }
 
     if ( $sw_hdf5_path )
-      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
+      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib $sw_hdf5_hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
         $_ =~ s:CONFIGURE_HDF5_FLAG:-DHDF5: ;
          }
     else

--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -1211,4 +1211,3 @@ close CONFIGURE_WRF ;
 printf "Configuration successful! \n" ;
 printf "------------------------------------------------------------------------\n" ;
 
-


### PR DESCRIPTION
Changing how Config.pl looks for the HDF5 high-level fortran library.

TYPE: enhancement
KEYWORDS: HDF5, high-level, fortran, library

SOURCE: Timothy Brown (AWS)

DESCRIPTION OF CHANGES:
Problem:
Depending on the installation type (autotools or cmake) of HDF5 the high-level fortran library can be either `hdf5_hl_fortran` or `hdf5hl_fortran`.

Solution:
In `Config.pl` we now check the HDF5 library directory for the high-level fortran library.

ISSUE:
Fixes [manual WRF build with Spack](https://github.com/aws-samples/aws-hpc-tutorials/issues/452)

LIST OF MODIFIED FILES:

- arch/Config.pl

TESTS CONDUCTED:

1. Yes. I have configured and built WRF against installs of HDF5 where the high-level fortran library has been
    a. hdf5_hl_fortran
    b. hdf5hl_fortran
    c. hdf5_hl_fortran and hdf5hl_fortran
2. Passed the Jenkins tests.

RELEASE NOTE: Config.pl now tests for the HDF5 high-level fortran library.
