### PR TITLE
add compilation stanza for Intel oneAPI for 4.5.2

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -2125,6 +2125,52 @@ NETCDFPAR_BUILD =       CONFIGURE_NETCDFPAR_BUILD
 #insert new stanza here
 
 ###########################################################
+#ARCH    Linux x86_64 ppc64le i486 i586 i686, Intel oneAPI compiler with icx #serial smpar dmpar dm+sm
+# This mirrors the above Intel build but changes ifort=>ifx icc=>icx
+
+DESCRIPTION     =       INTEL ($SFC/$SCC) : oneAPI LLVM
+DMPARALLEL      =       # 1
+OMPCPP          =       # -D_OPENMP
+OMP             =       # -qopenmp -fpp -auto
+OMPCC           =       # -qopenmp -auto
+SFC             =       ifx
+SCC             =       icx
+CCOMP           =       icx
+DM_FC           =       mpif90 -f90=$(SFC)
+DM_CC           =       mpicc -cc=$(SCC)
+FC              =       CONFIGURE_FC
+CC              =       CONFIGURE_CC
+LD              =       $(FC)
+RWORDSIZE       =       CONFIGURE_RWORDSIZE
+PROMOTION       =       -real-size `expr 8 \* $(RWORDSIZE)` -i4
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_FUNC  CONFIGURE_D_CTSM
+CFLAGS_LOCAL    =       -w -O3 -ip #-xHost -fp-model fast=2 -no-prec-div -no-prec-sqrt -ftz -no-multibyte-chars # -DRSL0_ONLY
+LDFLAGS_LOCAL   =       -ip #-xHost -fp-model fast=2 -no-prec-div -no-prec-sqrt -ftz -align all -fno-alias -fno-common
+CPLUSPLUSLIB    =
+ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
+FCOPTIM         =       -O3
+FCREDUCEDOPT	=       $(FCOPTIM)
+FCNOOPT		=       -O0 -fno-inline -no-ip
+FCDEBUG         =       # -g $(FCNOOPT) -traceback # -fpe0 -check noarg_temp_created,bounds,format,output_conversion,pointers,uninit -ftrapuv -unroll0 -u
+FORMAT_FIXED    =       -FI
+FORMAT_FREE     =       -FR
+FCSUFFIX        =
+BYTESWAPIO      =       -convert big_endian
+RECORDLENGTH    =       -assume byterecl
+FCBASEOPTS_NO_G =       -ip -fp-model precise -w -ftz -align all -fno-alias $(FORMAT_FREE) $(BYTESWAPIO) #-xHost -fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt -fno-common
+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
+MODULE_SRCH_FLAG =
+TRADFLAG        =      CONFIGURE_TRADFLAG
+CPP             =      /lib/cpp CONFIGURE_CPPFLAGS
+AR              =      ar
+ARFLAGS         =      ru
+M4              =      m4
+RANLIB          =      ranlib
+RLFLAGS		=
+CC_TOOLS        =      $(SCC)
+NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
+
+###########################################################
 #ARCH    Linux aarch64, GCC compiler OpenMPI # serial smpar dmpar dm+sm
 #
 DESCRIPTION     =      GCC ($SFC/$SCC): Aarch64


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Intel, LLVM, oneAPI, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Addressing issue #1884 for Intel oneAPI ifx/icx builds

Solution:
Add configuration to `configure.defaults` mirroring original Intel ifort/icc build with minor tweaking.

ISSUE: For use when this PR closes an issue.
Fixes #1884

LIST OF MODIFIED FILES: 
M       arch/configure.defaults

TESTS CONDUCTED: 
1. WRF core em_real compiles with ifx/icx
2. Are the Jenkins tests all passing?
3. Note that this is the same PR as in [#1893](https://github.com/wrf-model/WRF/pull/1893), but commited to release-v4.5.2 branch (instead of develop)

RELEASE NOTE: Added build configuration for new Intel oneAPI LLVM ifx/icx compilers, which will be available on NCAR's new computer, Derecho.
