### PR TITLE
Add missing bcast for stc2 in module_wind_fitch.F

### DIFF
--- a/phys/module_wind_fitch.F
+++ b/phys/module_wind_fitch.F
@@ -518,6 +518,7 @@ CONTAINS
         CALL wrf_dm_bcast_real(hubheight,nt)
         CALL wrf_dm_bcast_real(diameter,nt)
         CALL wrf_dm_bcast_real(stc,nt)
+        CALL wrf_dm_bcast_real(stc2,nt)
         CALL wrf_dm_bcast_real(npower,nt)
         CALL wrf_dm_bcast_real(cutin,nt)
         CALL wrf_dm_bcast_real(cutout,nt)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: wind, fitch, standing thrust coefficient, broadcast, mpi

SOURCE: Marc Imberger, Technical University of Denmark, Denmark

DESCRIPTION OF CHANGES:
Problem:
Curently, the standing thrust coefficient above cut-out wind speed ('stc2') is not broadcasted from the master node in the fitch wind farm parameterization scheme. This has the consequence that any wind turbine that (1) exceeds the cut-out wind speed at hub-height and that (2) is not located in a WRF tile associated with the MPI master process will have a non-deterministic standing thrust coefficient. Since stc2 is also not initialized within the code, this value could be in principle anything (I guess this also depends on how the compiler deals with unitinialized arrays). This affects mostly 'thrcof' which modifies the horizontal velocity tendencies and can thus yield to unphysical feedback to the rest of the model or even model crash (CFL violations).

Solution:
Adding stc2 to the list of variables to broadcast (see l. 516 in WRF/phys/module_wind_fitch.F) using CALL wrf_dm_bcast_real(stc2,nt) addresses this issue.

ISSUE: For use when this PR closes an issue.
This PR fixes issue #1865

LIST OF MODIFIED FILES:
- WRF/phys/module_wind_fitch.F

TESTS CONDUCTED:
- Flawed broadcasting could in principle be demonstrated by printing the values of 'stc2' by each MPI process.
- Issue has been found by running a simulation with windfarm_opt=1 for a short episode where wind speeds at hub-height exceed cut-out wind speed and where the turbine is not located in the tile assocated with the master process. In my case, model crash due unreasonably high velocity tendencies (CFL violation) has been observed.
- In less extreme cases (e.g. when stc2 contains 0 as described in issue #1865), 'thrcof' is set to 0 causing no turbine feedback to the velocity tendencies (while typical standing thrust coefficients are larger 0)

RELEASE NOTE:
Add missing wrf_dm_bcast_real for stc2 in fitch parameterization scheme affecting standing thrust coefficients for wind speeds at turbine hub-heights above cut-out.