### PR TITLE
Avoid re-initialization of time series for parent after child domain starts

### DIFF
--- a/frame/module_domain_type.F
+++ b/frame/module_domain_type.F
@@ -224,14 +224,14 @@ MODULE module_domain_type
       Type(WRFU_TimeInterval) :: last_dtInterval
 
       ! Time series location information
-      INTEGER :: ntsloc, ntsloc_domain
-      INTEGER :: next_ts_time
-      INTEGER, POINTER, DIMENSION(:) :: itsloc, jtsloc, id_tsloc
-      REAL, POINTER, DIMENSION(:) :: lattsloc, lontsloc
-      CHARACTER (LEN=5), POINTER, DIMENSION(:) :: nametsloc
-      CHARACTER (LEN=25), POINTER, DIMENSION(:) :: desctsloc
-      CHARACTER (LEN=256), POINTER, DIMENSION(:) :: ts_filename
-      LOGICAL :: have_calculated_tslocs
+      INTEGER :: ntsloc = 0, ntsloc_domain = 0
+      INTEGER :: next_ts_time = 0
+      INTEGER, POINTER, DIMENSION(:) :: itsloc => NULL(), jtsloc => NULL(), id_tsloc => NULL()
+      REAL, POINTER, DIMENSION(:) :: lattsloc => NULL(), lontsloc => NULL()
+      CHARACTER (LEN=5), POINTER, DIMENSION(:) :: nametsloc => NULL()
+      CHARACTER (LEN=25), POINTER, DIMENSION(:) :: desctsloc => NULL()
+      CHARACTER (LEN=256), POINTER, DIMENSION(:) :: ts_filename => NULL()
+      LOGICAL :: have_calculated_tslocs = .FALSE.
       LOGICAL :: have_displayed_alloc_stats   ! used in module_alloc_space to display alloc stats; only do it once.
 
 ! Track location information

--- a/share/wrf_tsin.F
+++ b/share/wrf_tsin.F
@@ -24,12 +24,17 @@ SUBROUTINE wrf_tsin ( grid , ierr )
 
     ierr = 0
 
+    !
+    ! If time series locations have already been computed by calc_ts_locations,
+    ! assume that we have already read the 'tslist' file for this domain and return
+    !
+    IF ( grid%have_calculated_tslocs ) RETURN
+
 #if ((EM_CORE == 1) && (DA_CORE != 1))
     IF ( grid%dfi_opt == DFI_NODFI .OR. (grid%dfi_opt /= DFI_NODFI .AND. grid%dfi_stage == DFI_SETUP) ) THEN
 #endif
     CALL model_to_grid_config_rec ( grid%id , model_config_rec , config_flags ) 
        grid%ntsloc = 0
-       grid%have_calculated_tslocs = .FALSE.
    
        IF ( grid%max_ts_locs <= 0 ) RETURN
    


### PR DESCRIPTION
This PR corrects an issue in which time series for a parent domain were re-initialized when a child domain started later than the initial time for a simulation.

TYPE: bug fix

KEYWORDS: time series, tslist, nest

SOURCE: Mathieu Landreau (LHEEA, Centrale Nantes, France), Michael Duda (NSF NCAR)

DESCRIPTION OF CHANGES:
Problem:
When running a simulation with a nest starting later than its parent and with the time series option activated, the parent domain time series is reinitialized when the nest starts.

Solution:
This issue is corrected by:

1) Initializing time series-specific members of the domain type, in particular, initializing `have_calculated_tslocs` to `.FALSE.`
    
2) Returning early from the wrf_tsin routine if `grid%have_calculated_tslocs` is `.TRUE.` (but avoiding changes to the value of `have_calculated_tslocs` otherwise).

ISSUE:
Fixes https://github.com/wrf-model/WRF/issues/1927

LIST OF MODIFIED FILES:
M       frame/module_domain_type.F
M       share/wrf_tsin.F

TESTS CONDUCTED:
- The problem was observed on a personal test case and the modifications fixed it.
- It passes Jenkins tests.

RELEASE NOTE:
Fix an issue in which time series for a parent domain were re-initialized when a child domain started later than the initial time for a simulation