### PR TITLE
Bug fix in gen_allocs to use correct conditional compilation logic on allocatables vs pointers

### DIFF
--- a/tools/gen_allocs.c
+++ b/tools/gen_allocs.c
@@ -659,7 +659,7 @@ gen_dealloc2 ( FILE * fp , char * structname , node_t * node )
         fprintf(fp, 
 "  DEALLOCATE(%s%s,STAT=ierr)\n if (ierr.ne.0) then\n CALL wrf_error_fatal ( &\n'frame/module_domain.f: Failed to deallocate %s%s. ')\n endif\n",
 structname, fname, structname, fname ) ;
-#ifdef USE_ALLOCATABLES
+#ifndef USE_ALLOCATABLES
         fprintf(fp,
 "  NULLIFY(%s%s)\n",structname, fname ) ;
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: gen_allocs, registry, defines

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Conditionally compiled code in `gen_allocs` is flipped to use wrong `#define` for when to use allocatables or pointers

Solution:
Flip logic of `#ifdef` to `#ifndef` to avoid using Fortran `nullify()` statement on allocatables

LIST OF MODIFIED FILES: 
M tools/gen_allocs.c

RELEASE NOTE: 
Bug fix in gen_allocs to use correct conditional compilation logic on allocatables vs pointers
