### PR TITLE
Add the ability for registry code generation to be out of source

### DIFF
--- a/tools/gen_streams.c
+++ b/tools/gen_streams.c
@@ -607,12 +607,14 @@ gen_med_find_esmf_coupling ( FILE *fp )
    for each stream.  This file is then included by the registry.io_boilerplate file when the
    registry actually runs.  As with the other mods above, this allows a variable, compile-time
    number of io streams. Note that this one is self contained and dirname is hard-coded.
+   AI: In an effort to delineate true source files from autogen stuff this is now not going into hard-coded
+   Registry so that we can use ./ as an alternate include location
 */
 int
 gen_io_boilerplate ()
 {
   FILE * fp ;
-  char * dirname = "Registry" ;
+  char * dirname = "./" ;
   char  fname[NAMELEN] ;
   char * fn ;
   char * aux , *streamtype , streamno[5]  ;

--- a/tools/gen_streams.c
+++ b/tools/gen_streams.c
@@ -607,14 +607,12 @@ gen_med_find_esmf_coupling ( FILE *fp )
    for each stream.  This file is then included by the registry.io_boilerplate file when the
    registry actually runs.  As with the other mods above, this allows a variable, compile-time
    number of io streams. Note that this one is self contained and dirname is hard-coded.
-   AI: In an effort to delineate true source files from autogen stuff this is now not going into hard-coded
-   Registry so that we can use ./ as an alternate include location
 */
 int
 gen_io_boilerplate ()
 {
   FILE * fp ;
-  char * dirname = "./" ;
+  char * dirname = "Registry" ;
   char  fname[NAMELEN] ;
   char * fn ;
   char * aux , *streamtype , streamno[5]  ;

--- a/tools/reg_parse.c
+++ b/tools/reg_parse.c
@@ -116,21 +116,28 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
     for ( p = inln ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
     if ( !strncmp( p , "include", 7 ) &&  ! ( ifdef_stack_ptr >= 0 && ! ifdef_stack[ifdef_stack_ptr] ) ) {
       FILE *include_fp ;
+      char include_file_name_dir[128] ;
       char include_file_name[128] ;
       p += 7 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       if ( strlen( p ) > 127 ) { fprintf(stderr,"Registry warning: invalid include file name: %s\n", p ) ; }
       else {
-        sprintf( include_file_name , "%s/%s", dir , p ) ;
+        
+        sprintf( include_file_name,     "%s", p ) ;
         if ( (p=index(include_file_name,'\n')) != NULL ) *p = '\0' ;
+        sprintf( include_file_name_dir, "%s/%s", dir , include_file_name ) ;
+        
         fprintf(stderr,"opening %s\n",include_file_name) ;
-        if (( include_fp = fopen( include_file_name , "r" )) != NULL ) {
+        if ( ( ( include_fp = fopen( include_file_name,     "r" ) ) != NULL ) || // Use short circuit logic here to try both sequentially
+             ( ( include_fp = fopen( include_file_name_dir, "r" ) ) != NULL ) )
+        {
 
           fprintf(stderr,"including %s\n",include_file_name ) ;
           pre_parse( dir , include_fp , outfile ) ;
 
           fclose( include_fp ) ;
-        } else {
-          fprintf(stderr,"Registry warning: cannot open %s. Ignoring.\n", include_file_name ) ;
+        } 
+        else {
+          fprintf(stderr,"Registry warning: cannot open %s. Tried %s and %s Ignoring.\n", include_file_name, include_file_name, include_file_name_dir ) ;
         } 
       }
     }

--- a/tools/reg_parse.c
+++ b/tools/reg_parse.c
@@ -116,19 +116,21 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
     for ( p = inln ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
     if ( !strncmp( p , "include", 7 ) &&  ! ( ifdef_stack_ptr >= 0 && ! ifdef_stack[ifdef_stack_ptr] ) ) {
       FILE *include_fp ;
-      char include_file_name_dir[128] ;
+      char include_file_name_local_registry[128] ;
       char include_file_name[128] ;
       p += 7 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       if ( strlen( p ) > 127 ) { fprintf(stderr,"Registry warning: invalid include file name: %s\n", p ) ; }
       else {
         
-        sprintf( include_file_name,     "%s", p ) ;
+        sprintf( include_file_name_local_registry, "./Registry/%s", p ) ;
+        sprintf( include_file_name, "%s/%s", dir , p ) ;
+
+        if ( (p=index(include_file_name_local_registry,'\n')) != NULL ) *p = '\0' ;
         if ( (p=index(include_file_name,'\n')) != NULL ) *p = '\0' ;
-        sprintf( include_file_name_dir, "%s/%s", dir , include_file_name ) ;
-        
+
         fprintf(stderr,"opening %s\n",include_file_name) ;
-        if ( ( ( include_fp = fopen( include_file_name,     "r" ) ) != NULL ) || // Use short circuit logic here to try both sequentially
-             ( ( include_fp = fopen( include_file_name_dir, "r" ) ) != NULL ) )
+        if ( ( ( include_fp = fopen( include_file_name_local_registry, "r" ) ) != NULL ) || // Use short circuit logic here to try both sequentially
+             ( ( include_fp = fopen( include_file_name, "r" ) ) != NULL ) )
         {
 
           fprintf(stderr,"including %s\n",include_file_name ) ;
@@ -137,7 +139,7 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
           fclose( include_fp ) ;
         } 
         else {
-          fprintf(stderr,"Registry warning: cannot open %s. Tried %s and %s Ignoring.\n", include_file_name, include_file_name, include_file_name_dir ) ;
+          fprintf(stderr,"Registry warning: cannot open %s. Tried %s and %s Ignoring.\n", include_file_name, include_file_name, include_file_name_local_registry ) ;
         } 
       }
     }


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: registry, code generation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The current registry generated code assumes generating the autogenerated code should be placed within the WRF repository alongside true source code that is committed to the repository. This leads to a cluttered source tree with hundreds of files that were autogenerated, and relies on various stopgaps (unintuitive ignores, specific path and wildcard `rm` commands within source folders, run code generation from specific location).

In preparation for the future cmake build, it would be ideal to not inherit these limitations of the registry code registration, allowing the source tree to be pristine while autogenerated code is placed in an alternate build directory.

Solution:
Add the potential for out-of-source code generation of the registry code. This can be achieved by adding the ability search a relative directory for the `io_boiler_plate_temporary.inc`. This would allow the registry generation to occur in an alternate directory but still source the Regsitry/ config files. This is because the boiler plate is generated relative to the execution path, but Registry config files are sourced via the provided command line path. 

Without this change, while the makefile system would run as before registry code generation outside the WRF directory structure would place the boiler plate and Registry config files in two different locations and thus fail to find the core template file. Since the relative directory of the boiler plate output is `./Registry`, by searching for that as the alternate relative directory we would find both Registry config files and the generated boiler plate. This would be able to accommodate different locations while for  the makefile build system there would be no change to the way code is generated and searched as `./Registry` and path to the Registry config files are the same when at the top-level WRF directory.


LIST OF MODIFIED FILES: 
M tools/reg_parse.c

TESTS CONDUCTED: 
1. Out-of-source builds work for cmake (experimental at the moment) and no impact on make builds

RELEASE NOTE: 
Add the ability for registry code generation to be out of source
