### PR TITLE
Bug fix for erroneous syntax in dyn_em/module_first_rk_step_part1.F

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -925,7 +925,7 @@ BENCH_START(surf_driver_tim)
      &        ,iopt_crop=config_flags%opt_crop, iopt_irr=config_flags%opt_irr    &
      &        ,iopt_irrm=config_flags%opt_irrm                                   &
      &        ,iopt_infdv=config_flags%opt_infdv,iopt_tdrn=config_flags%opt_tdrn &
-     &        ,soiltstep=config_flags%soiltstep
+     &        ,soiltstep=config_flags%soiltstep                                      &
      &        , isnowxy=grid%isnowxy  ,    tvxy=grid%tvxy    ,    tgxy=grid%tgxy     &
      &        ,canicexy=grid%canicexy ,canliqxy=grid%canliqxy,   eahxy=grid%eahxy    &
      &        ,   tahxy=grid%tahxy    ,    cmxy=grid%cmxy    ,    chxy=grid%chxy     &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: syntax

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Wrong Fortran syntax most likely being corrected by standard.exe

Solution:
Fix the syntax error

LIST OF MODIFIED FILES: 
M       dyn_em/module_first_rk_step_part1.F

RELEASE NOTE: 
Bug fix for erroneous syntax in dyn_em/module_first_rk_step_part1.F
