### PR TITLE
Update g2lib png encode/decode to use correct png_voidp define

### DIFF
--- a/external/io_grib2/g2lib/dec_png.c
+++ b/external/io_grib2/g2lib/dec_png.c
@@ -88,7 +88,7 @@ int DEC_PNG(unsigned char *pngbuf,g2int *width,g2int *height,char *cout)
 
 /*    Set new custom read function    */
 
-    png_set_read_fn(png_ptr,(voidp)&read_io_ptr,(png_rw_ptr)user_read_data);
+    png_set_read_fn(png_ptr,(png_voidp)&read_io_ptr,(png_rw_ptr)user_read_data);
 /*     png_init_io(png_ptr, fptr);   */
 
 /*     Read and decode PNG stream   */

--- a/external/io_grib2/g2lib/enc_png.c
+++ b/external/io_grib2/g2lib/enc_png.c
@@ -88,7 +88,7 @@ int ENC_PNG(char *data,g2int *width,g2int *height,g2int *nbits,char *pngbuf)
 
 /*    Set new custom write functions    */
 
-    png_set_write_fn(png_ptr,(voidp)&write_io_ptr,(png_rw_ptr)user_write_data,
+    png_set_write_fn(png_ptr,(png_voidp)&write_io_ptr,(png_rw_ptr)user_write_data,
                     (png_flush_ptr)user_flush_data);
 /*    png_init_io(png_ptr, fptr);   */
 /*    png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);  */


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: png

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:

Incorrect define type used for png void type when compared to libpng functions and NCEP g2lib source code.

While `voidp` does exist, compile may fail when enabling GRIB2 I/O and enabling libpng compression in the makefiles. Additionally no version of libpng (back to 0.89) ever had those functions explicitly compatibly with `voidp`  - likewise the ncep g2 lib version of these files (back to v2.5.0) never has `voidp` in the modified code.

This will __NOT__ affect out-of-the-box native builds of WRF, grib2 enabled or not. One must enable the source code manually to exercise PNG compression and then this issue may appear.

Solution:
Switch to the appropriate define `png_voidp`, as can be seen here : 
https://github.com/weathersource/g2clib/blob/24bcccafb8088f4b5918a878e6b8daf7acc86275/src/dec_png.c#L91
https://github.com/weathersource/g2clib/blob/24bcccafb8088f4b5918a878e6b8daf7acc86275/src/enc_png.c#L91

or here:
https://github.com/NOAA-EMC/NCEPLIBS-g2/blob/1dcdfb0d8db0caf2f31b5631abcf1ca04402a0aa/dec_png.c#L104
https://github.com/NOAA-EMC/NCEPLIBS-g2/blob/1dcdfb0d8db0caf2f31b5631abcf1ca04402a0aa/enc_png.c#L103

Note that NCEP's github version does not goes as far back as version 1.0.7 which WRF uses

LIST OF MODIFIED FILES: 
M       external/io_grib2/g2lib/dec_png.c
M       external/io_grib2/g2lib/enc_png.c

RELEASE NOTE: 
Update g2lib png encode/decode to use correct png_voidp define
