### PR TITLE
Enable WRFDA's compilation with RTTOV and HDF5 libs on Derecho

### DIFF
--- a/compile
+++ b/compile
@@ -351,7 +351,7 @@ else
              setenv BUFR 1
           endif
           if ( -e ${RTTOV}/lib/librttov12_main.a ) then
-             setenv RTTOV_LIB "-L${hdf5path}/lib -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -L${RTTOV}/lib -lrttov12_coef_io -lrttov12_emis_atlas -lrttov12_main -lrttov12_hdf"
+             setenv RTTOV_LIB "-L${hdf5path}/lib -lhdf5_hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lhdf5_hl_f90cstub -lhdf5_f90cstub -lhdf5_hl_cpp -L${RTTOV}/lib -lrttov12_coef_io -lrttov12_emis_atlas -lrttov12_main -lrttov12_hdf"
           else
              echo "Can not find a compatible RTTOV library! Please ensure that your RTTOV build was successful,"
              echo "your 'RTTOV' environment variable is set correctly, and you are using a supported version of RTTOV."


### PR DESCRIPTION
Enable WRFDA's compilation with RTTOV and HDF5 libs on Derecho

TYPE: maintenance

KEYWORDS: HDF5, RTTOV, WRFDA

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
HDF5 lib on derecho is changed, which makes WRFDA compilation failed when including RTTOV lib with HDF5.
By default, HDF5 and RTTOV libs are turned off when building WRFDA.

Solution:
Change an existing HDF5 lib name and add additional HDF5 libs. For gcc:

setenv HDF5 /glade/u/apps/derecho/23.06/spack/opt/spack/hdf5/1.12.2/cray-mpich/8.1.25/gcc/12.2.0/wjdl
setenv RTTOV /glade/work/liuz/RTTOVv12.1/hdf5/gnu_12.2.0

before configure/compile WRFDA.

LIST OF MODIFIED FILES:
M       compile

TESTS CONDUCTED: 
1. Build successfully with gnu on Derecho

RELEASE NOTE: None
