### PR TITLE
Fix registry description for settling velocity of bin 5

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -213,7 +213,7 @@ state    real  setvel_1      ij       misc         1         -       r      "set
 state    real  setvel_2      ij       misc         1         -       r      "setvel_2"     "dust gravitational settling velocity for size 2"    "m/s"
 state    real  setvel_3      ij       misc         1         -       r      "setvel_3"     "dust gravitational settling velocity for size 3"    "m/s"
 state    real  setvel_4      ij       misc         1         -       r      "setvel_4"     "dust gravitational settling velocity for size 4"    "m/s"
-state    real  setvel_5      ij       misc         1         -       r      "setvel_5"     "effective gravitational settling velocity for total"    "m/s"
+state    real  setvel_5      ij       misc         1         -       r      "setvel_5"     "dust gravitational settling velocity for size 5"    "m/s"
 state    real  dustgraset_1  ij       misc         1         -       r      "graset_1"     "Accumulated dust gravitational settling  for size 1"        "kg/m2"
 state    real  dustgraset_2  ij       misc         1         -       r      "graset_2"     "Accumulated dust gravitational settling  for size 2"        "kg/m2"
 state    real  dustgraset_3  ij       misc         1         -       r      "graset_3"     "Accumulated dust gravitational settling  for size 3"        "kg/m2"


### PR DESCRIPTION
This updates the registry description for settling velocity of bin 5 for GOCART

TYPE: text only

KEYWORDS: GOCART settling, description of bin 5 settling

SOURCE: [encyclica](https://github.com/encyclica)

DESCRIPTION OF CHANGES:
Updated the registry to correct tezxt

Solution:
Text change

ISSUE: For use when this PR closes an issue.
Fixes #1982 

LIST OF MODIFIED FILES: 
M       Registry/registry.chem

TESTS CONDUCTED: 
None

RELEASE NOTE: Updates registry for variable description of settling velocity in bin 5
