### PR TITLE
Add if test for ftn compiler version (for derecho) in compile file

### DIFF
--- a/compile
+++ b/compile
@@ -414,6 +414,8 @@ else
     pgf90 --version
   else if ( "$comp[1]" == "ifort" ) then
     ifort -V
+  else if ( "$comp[1]" == "ftn" ) then
+    ftn -V
   else
     echo "Not sure how to figure out the version of this compiler: $comp[1]"
   endif


### PR DESCRIPTION
TYPE: no impact

KEYWORDS: compile, version, compiler, ftn, derecho

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When compiling WRF on NCAR's Derecho HPC, and choosing a Cray option during configuration (for e.g., "INTEL (ftn/icc): Cray XC"), the compile script isn't able to determine the compiler version because "ftn" is not included in the "if" test to checks versions in the "compile" script. This means the compiler version is not printed in the compile log, which could be problematic for several reasons.

Solution:
Added a line to the "compile" file compiler version "if" test to print out the compiler version information when "ftn" is used.

LIST OF MODIFIED FILES: 
M    compile

TESTS CONDUCTED: 
1. Tested a compile when choosing "INTEL (ftn/icc): Cray XC" during configuration. Now the compiler version prints out to the compile log.
2. Are the Jenkins tests all passing?