### PR TITLE
Make sure that USENETCDFPAR is not undefined

### DIFF
--- a/configure
+++ b/configure
@@ -219,6 +219,8 @@ if [ -n "$NETCDFPAR" ] ; then
   export NETCDF
   export NETCDF4
   export USENETCDFPAR
+else
+  export USENETCDFPAR=0
 fi
 
 if  test -z "$NETCDF"  ; then
@@ -292,7 +294,6 @@ if [ -z "$HDF5_PATH" ] ; then HDF5_PATH=''; fi
 if [ -z "$ZLIB_PATH" ] ; then ZLIB_PATH=''; fi
 if [ -z "$GPFS_PATH" ] ; then GPFS_PATH=''; fi
 if [ -z "$CURL_PATH" ] ; then CURL_PATH=''; fi
-
 if [ -n "$NETCDF4" ] ; then
   if [ $NETCDF4 -eq 1 ] ; then
     NETCDF4_DEP_LIB=''

--- a/configure
+++ b/configure
@@ -294,6 +294,7 @@ if [ -z "$HDF5_PATH" ] ; then HDF5_PATH=''; fi
 if [ -z "$ZLIB_PATH" ] ; then ZLIB_PATH=''; fi
 if [ -z "$GPFS_PATH" ] ; then GPFS_PATH=''; fi
 if [ -z "$CURL_PATH" ] ; then CURL_PATH=''; fi
+
 if [ -n "$NETCDF4" ] ; then
   if [ $NETCDF4 -eq 1 ] ; then
     NETCDF4_DEP_LIB=''


### PR DESCRIPTION
Some versions of make appear to fail on the USENETCDFPAR logic in the top level Makefile if the variable is undefined. Making sure it is at least set to 0 by the configure script fixes the issue.

TYPE: bug fix

KEYWORDS:  make

SOURCE: Ted Mansell (NOAA/NSSL)

DESCRIPTION OF CHANGES:
Problem: Logic failure in top level Makefile with some versions of make (don't remember which) if USENETCDFPAR is undefined

Solution:
Making sure that at USENETCDFPAR is set to either 0 or 1 in the configure script fixes the issue.

LIST OF MODIFIED FILES: configure

TESTS: it passed regression tests.