### PR TITLE
Move shalwater_init to physics_init

### DIFF
--- a/phys/module_physics_init.F
+++ b/phys/module_physics_init.F
@@ -3137,11 +3137,14 @@ CHARACTER(LEN=8) :: name
            CALL sfclayinit( allowed_to_read )
            isfc = 1
       CASE (SFCLAYREVSCHEME)
-            CALL sfclayrevinit(ims,ime,jms,jme,                &
-                         its,ite,jts,jte,                      &
-                         bathymetry_flag, shalwater_z0,        &
-                         shalwater_depth, water_depth,         &
-                         xland,LakeModel,lake_depth,lakemask   )
+           CALL sfclayrevinit
+           IF ( shalwater_z0 .EQ. 1 ) THEN
+              CALL shalwater_init(ims,ime,jms,jme,            &  
+                        its,ite,jts,jte,                      &  
+                        bathymetry_flag, shalwater_z0,        &  
+                        shalwater_depth, water_depth,         &  
+                        xland,LakeModel,lake_depth,lakemask   )
+           END IF
            isfc = 1
       CASE (PXSFCSCHEME)
            CALL pxsfclayinit( allowed_to_read )
@@ -5657,5 +5660,63 @@ subroutine interp_vec_cu(locvec,locwant,periodic,loc1,loc2,wght1,wght2)
 #endif
 
   end subroutine compute_2d_dx_area
+
+  SUBROUTINE shalwater_init(ims,ime,jms,jme,                     &
+                             its,ite,jts,jte,                    &
+                             bathymetry_flag, shalwater_z0,      &
+                             shalwater_depth, water_depth,       &
+                             xland,LakeModel,lake_depth,lakemask )
+
+   INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
+   INTEGER, INTENT(IN)      ::   shalwater_z0
+   REAL,    INTENT(IN)      ::   shalwater_depth
+   INTEGER, INTENT(IN)      ::   bathymetry_flag
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  xland
+   INTEGER         ::     LakeModel
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  lake_depth
+   REAL,    DIMENSION( ims:ime, jms:jme )                   ::  lakemask
+               
+   ! Local  
+   LOGICAL :: overwrite_water_depth
+      
+   overwrite_water_depth = .False.
+                         
+   IF ( bathymetry_flag .eq. 1 ) THEN
+      IF ( shalwater_depth .LE. 0.0 ) THEN
+         IF ( LakeModel .ge. 1 ) THEN
+
+            DO j = jts,jte
+               DO i = its,ite
+                  IF ( lakemask(i,j) .EQ. 1 ) THEN
+                     water_depth(i,j) = lake_depth(i,j)
+                  END IF
+               END DO
+            END DO
+         END IF
+      ELSE
+         overwrite_water_depth = .True.
+      END IF
+   ELSE
+      IF ( shalwater_depth .GT. 0.0 ) THEN
+         overwrite_water_depth = .True.
+      ELSE
+         CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not greater than 0.0. Re-run WPS to get bathymetry data or set shalwater_depth > 0.0')
+      END IF
+   END IF
+
+   IF (overwrite_water_depth) THEN
+      DO j = jts,jte
+         DO i = its,ite
+            IF((XLAND(i,j)-1.5).GE.0)THEN
+               water_depth(i,j) = shalwater_depth
+            ELSE
+               water_depth(i,j) = -2.0
+            END IF
+         END DO
+      END DO
+   END IF
+
+  END SUBROUTINE shalwater_init
 
 END MODULE module_physics_init

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1107,24 +1107,10 @@ CONTAINS
    END SUBROUTINE SFCLAYREV1D
 
 !====================================================================
-   SUBROUTINE sfclayrevinit(ims,ime,jms,jme,                    &
-                            its,ite,jts,jte,                    &
-                            bathymetry_flag, shalwater_z0,      &
-                            shalwater_depth, water_depth,       &
-                            xland,LakeModel,lake_depth,lakemask )
+   SUBROUTINE sfclayrevinit
 
     INTEGER                   ::      N
     REAL                      ::      zolf
-
-   INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
-   INTEGER, INTENT(IN)      ::   shalwater_z0 
-   REAL,    INTENT(IN)      ::   shalwater_depth 
-   INTEGER, INTENT(IN)      ::   bathymetry_flag 
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  xland 
-   INTEGER         ::     LakeModel
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  lake_depth
-   REAL,    DIMENSION( ims:ime, jms:jme )                   ::  lakemask  
 
     DO N=0,1000
 ! stable function tables
@@ -1138,72 +1124,8 @@ CONTAINS
        psih_unstab(n)=psih_unstable_full(zolf)
 
     ENDDO
-    IF ( shalwater_z0 .EQ. 1 ) THEN
-       CALL shalwater_init(ims,ime,jms,jme,            &
-                 its,ite,jts,jte,                      &
-                 bathymetry_flag, shalwater_z0,        &
-                 shalwater_depth, water_depth,         &
-                 xland,LakeModel,lake_depth,lakemask   )
-    END IF
 
    END SUBROUTINE sfclayrevinit
-
-   SUBROUTINE shalwater_init(ims,ime,jms,jme,                    &
-                             its,ite,jts,jte,                    &
-                             bathymetry_flag, shalwater_z0,      &
-                             shalwater_depth, water_depth,       &
-                             xland,LakeModel,lake_depth,lakemask )
-
-   INTEGER, INTENT(IN)      ::   ims,ime,jms,jme,its,ite,jts,jte
-   INTEGER, INTENT(IN)      ::   shalwater_z0 
-   REAL,    INTENT(IN)      ::   shalwater_depth 
-   INTEGER, INTENT(IN)      ::   bathymetry_flag 
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)    ::  water_depth
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  xland 
-   INTEGER         ::     LakeModel
-   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN   )    ::  lake_depth
-   REAL,    DIMENSION( ims:ime, jms:jme )                   ::  lakemask  
-
-   ! Local 
-   LOGICAL :: overwrite_water_depth
-
-   overwrite_water_depth = .False.
-
-   IF ( bathymetry_flag .eq. 1 ) THEN
-      IF ( shalwater_depth .LE. 0.0 ) THEN
-         IF ( LakeModel .ge. 1 ) THEN
-            DO j = jts,jte
-               DO i = its,ite
-                  IF ( lakemask(i,j) .EQ. 1 ) THEN
-                     water_depth(i,j) = lake_depth(i,j)
-                  END IF
-               END DO
-            END DO
-         END IF
-      ELSE
-         overwrite_water_depth = .True.
-      END IF
-   ELSE
-      IF ( shalwater_depth .GT. 0.0 ) THEN
-         overwrite_water_depth = .True.
-      ELSE
-         CALL wrf_error_fatal('No bathymetry data detected and shalwater_depth not greater than 0.0. Re-run WPS to get bathymetry data or set shalwater_depth > 0.0')
-      END IF
-   END IF
-
-   IF (overwrite_water_depth) THEN 
-      DO j = jts,jte
-         DO i = its,ite
-            IF((XLAND(i,j)-1.5).GE.0)THEN
-               water_depth(i,j) = shalwater_depth
-            ELSE
-               water_depth(i,j) = -2.0 
-            END IF
-         END DO
-      END DO
-   END IF
-
-   END SUBROUTINE shalwater_init
 
       function zolri(ri,z,z0)
 !


### PR DESCRIPTION
TYPE: code clean up

KEYWORDS: shalwater_init

SOURCE: internal

DESCRIPTION OF CHANGES:
Move the call to shallow water roughness length initialization routine from module_sf_sfclayrev.F to module_physics_init.F

This is in preparation to make sfclayrev module ccpp-compliant, and potential make the initialization and physics available to other surface layer modules.

LIST OF MODIFIED FILES: 
M       phys/module_physics_init.F
M       phys/module_sf_sfclayrev.F

TESTS CONDUCTED: 
1. Should not change how the variable is initialized.
2. The Jenkins tests are all passing.

RELEASE NOTE: This PR moves the call to shalwater_init from module_sf_sfclayrev.F to module_physics_init.F.
