### PR TITLE
Add missing dependency module_wind_mav to module_physics_init

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -989,6 +989,7 @@ module_physics_init.o: \
 	module_cam_mp_modal_aero_initialize_data_phys.o \
 	module_cam_support.o \
 	module_wind_fitch.o \
+	module_wind_mav.o \
 	module_gocart_coupling.o \
 	module_data_gocart_dust.o \
 	../frame/module_state_description.o \


### PR DESCRIPTION
TYPE: bug

KEYWORDS: make, dependency

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #1944 adds `module_wind_mav` to `module_physics_init`, but does not update the `main/depend.common` file to add the dependency during compilation

Solution:
Add `module_wind_mav.o` as a dependency to `module_physics_init.o` in the `main/depend.common` file

ISSUE: 
Fixes [comment](https://github.com/wrf-model/WRF/pull/1944#issuecomment-1917898723) noted in #1944 

LIST OF MODIFIED FILES: 
M main/depend.common

TESTS CONDUCTED: 
1. Local compilation in single job mode `-j 1` should work now

RELEASE NOTE: 
Add missing dependency module_wind_mav to module_physics_init
