### PR TITLE
Bug fix for N2O5 heterogenous chemistry namelist for MADE

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -3905,7 +3905,7 @@ rconfig   real        af_lambda_start     namelist,chem          max_domains    
 rconfig   real        af_lambda_end       namelist,chem          max_domains    340.    rh    "end   wavelength for AF output" "nm"      ""
 # Control for ISORROPIA in MADE/SORGAM schemes
 rconfig   logical     do_isorropia        namelist,chem          1              .false. rh    "flag to use ISORROPIA"
-rconfig   logical     do_n2o5het          namelsit,chem          1              .false. rh    "flag to do n2o5 heterogenous chemistry via chlorine pathway"
+rconfig   logical     do_n2o5het          namelist,chem          1              .false. rh    "flag to do n2o5 heterogenous chemistry via chlorine pathway"
 
 # CHEMISTRY PACKAGE DEFINITIONS
 #


### PR DESCRIPTION
FIx typo in Registry for N2O5 heterogenous chemistry namelist for MADE

TYPE: Bug Fix

KEYWORDS: N2O5 het, MADE

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem: Error when trying to use namelist option

Solution:
Fix Typo

LIST OF MODIFIED FILES:
M Registry/registry.chem

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Fixes n2o5 heterogenous namelist option for MADE schemes
