### PR TITLE
Fix AHE option 2 and a problem with mosaic

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -850,6 +850,7 @@ BENCH_START(surf_driver_tim)
      &        ,LF_URB2D=grid%lf_urb2d                                           & 
      &        ,lf_urb2d_s=grid%lf_urb2d_s, z0_urb2d=grid%z0_urb2d               &
      &        ,GMT=grid%gmt,XLAT=grid%xlat,XLONG=grid%xlong,JULDAY=grid%julday  &
+     &        ,distributed_ahe_opt=grid%distributed_ahe_opt, ahe=grid%ahe       & !For anthropogenic heat
      &        ,A_U_BEP=grid%a_u_bep,A_V_BEP=grid%a_v_bep,A_T_BEP=grid%a_t_bep   &
      &        ,A_Q_BEP=grid%a_q_bep                                             &
      &        ,B_U_BEP=grid%b_u_bep,B_V_BEP=grid%b_v_bep,B_T_BEP=grid%b_t_bep   &

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3135,9 +3135,10 @@ integer::oops1,oops2
       !  Split NUDAPT  Urban Parameters
 
       distributed_aerodynamics_if: IF (config_flags%sf_urban_physics == 1 .AND. config_flags%slucm_distributed_drag) THEN
+         CALL nl_get_isurban ( grid%id , grid%isurban )
          DO j = jts , MIN(jde-1,jte)
             DO i = its , MIN(ide-1,ite)
-              IF (grid%ivgtyp(i, j) == model_config_rec%isurban(grid%id)) THEN
+              IF (grid%landusef(i, grid%isurban, j) > 0) THEN
                 grid%frc_urb2d(i, j) = MAX(0.1, MIN(0.9, 1 - grid%shdavg(i, j) / 100.))
               END IF
             END DO

--- a/main/depend.common
+++ b/main/depend.common
@@ -1139,6 +1139,7 @@ module_pbl_driver.o: \
 	module_bl_gwdo_gsl.o \
 	module_bl_temf.o \
 	module_bl_mfshconvpbl.o \
+	module_ra_gfdleta.o \
 	$(PHYS_BL) \
 	module_wind_fitch.o \
 	../frame/module_state_description.o \
@@ -1186,6 +1187,7 @@ module_radiation_driver.o: \
 
 
 module_surface_driver.o: \
+	module_ra_gfdleta.o \
 	module_sf_noahlsm.o \
 	module_sf_sfclay.o \
 	module_sf_sfclayrev.o \

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -2269,23 +2269,15 @@ CONTAINS
               ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte)
           ENDIF
 
-     IF (distributed_ahe_opt > 0) THEN
+     IF (distributed_ahe_opt == 1) THEN
        call cal_mon_day(julday, julyr, jmonth, jday)
        ihour = (jmonth - 1) * 24 + MOD(INT(gmt + xtime / 60.0), 24)
-       IF (distributed_ahe_opt == 1) THEN
-         DO j = jts, jte
-         DO i = its, ite
-           ! Volumetric heat capacity of air = 1200 J/(K m3)
-           RTHBLTEN(i, 1, j) = RTHBLTEN(i, 1, j) + ahe(i, ihour, j) / 1200 / DZ8W(i, 1, j)
-         END DO
-         END DO
-       ELSE IF (distributed_ahe_opt == 2) THEN
-         DO j = jts, jte
-         DO i = its, ite
-           HFX(i, j) = HFX(i, j) + ahe(i, ihour, j)
-         END DO
-         END DO
-       END IF
+       DO j = jts, jte
+       DO i = its, ite
+         ! Volumetric heat capacity of air = 1200 J/(K m3)
+         RTHBLTEN(i, 1, j) = RTHBLTEN(i, 1, j) + ahe(i, ihour, j) / 1200 / DZ8W(i, 1, j)
+       END DO
+       END DO
      END IF
 
    ENDDO

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -2896,7 +2896,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: AKMS_URB2D
 !
      REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: UST_URB2D
-     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FRC_URB2D                ! change this to inout, danli mosaic
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: FRC_URB2D
      INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
 
 ! output variables urban --> lsm
@@ -3745,7 +3745,6 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   IF (slucm_distributed_drag) THEN
                     IF (IVGTYP(I, J) == ISURBAN) THEN
                       UTYPE_URB = 2
-                      FRC_URB2D(I, J) = MAX(0.1, MIN(0.9, 1 - shdavg(I, J) / 100.))
                     END IF
                   ELSE IF (use_wudapt_lcz == 1) THEN
                     IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=5
@@ -3760,28 +3759,11 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                     IF(IVGTYP(I,J)==LCZ_9) UTYPE_URB=9
                     IF(IVGTYP(I,J)==LCZ_10) UTYPE_URB=10
                     IF(IVGTYP(I,J)==LCZ_11) UTYPE_URB=11
-
-
-                    IF(UTYPE_URB==1) FRC_URB2D(I,J)=1.
-                    IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.99
-                    IF(UTYPE_URB==3) FRC_URB2D(I,J)=1.00
-                    IF(UTYPE_URB==4) FRC_URB2D(I,J)=0.65
-                    IF(UTYPE_URB==5) FRC_URB2D(I,J)=0.7
-                    IF(UTYPE_URB==6) FRC_URB2D(I,J)=0.65
-                    IF(UTYPE_URB==7) FRC_URB2D(I,J)=0.3
-                    IF(UTYPE_URB==8) FRC_URB2D(I,J)=0.85
-                    IF(UTYPE_URB==9) FRC_URB2D(I,J)=0.3
-                    IF(UTYPE_URB==10) FRC_URB2D(I,J)=0.55
-                    IF(UTYPE_URB==11) FRC_URB2D(I,J)=1.
                   ELSE
                     IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
                     IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1 ! LOW_DENSITY_RESIDENTIAL
                     IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2 ! HIGH_DENSITY_RESIDENTIAL
                     IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3 ! HIGH_INTENSITY_INDUSTRIAL
-
-                    IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.5
-                    IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
-                    IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.95
                   END IF
 
                   TA_URB    = SFCTMP           ! [K]

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -2896,7 +2896,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: AKMS_URB2D
 !
      REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: UST_URB2D
-     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: FRC_URB2D                ! change this to inout, danli mosaic
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FRC_URB2D                ! change this to inout, danli mosaic
      INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
 
 ! output variables urban --> lsm
@@ -3740,7 +3740,49 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                      IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
                      IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
 
-                  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+                  !  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+                  !  this need to be changed in the mosaic danli
+                  IF (slucm_distributed_drag) THEN
+                    IF (IVGTYP(I, J) == ISURBAN) THEN
+                      UTYPE_URB = 2
+                      FRC_URB2D(I, J) = MAX(0.1, MIN(0.9, 1 - shdavg(I, J) / 100.))
+                    END IF
+                  ELSE IF (use_wudapt_lcz == 1) THEN
+                    IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=5
+                    IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1
+                    IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2
+                    IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3
+                    IF(IVGTYP(I,J)==LCZ_4) UTYPE_URB=4
+                    IF(IVGTYP(I,J)==LCZ_5) UTYPE_URB=5
+                    IF(IVGTYP(I,J)==LCZ_6) UTYPE_URB=6
+                    IF(IVGTYP(I,J)==LCZ_7) UTYPE_URB=7
+                    IF(IVGTYP(I,J)==LCZ_8) UTYPE_URB=8
+                    IF(IVGTYP(I,J)==LCZ_9) UTYPE_URB=9
+                    IF(IVGTYP(I,J)==LCZ_10) UTYPE_URB=10
+                    IF(IVGTYP(I,J)==LCZ_11) UTYPE_URB=11
+
+
+                    IF(UTYPE_URB==1) FRC_URB2D(I,J)=1.
+                    IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.99
+                    IF(UTYPE_URB==3) FRC_URB2D(I,J)=1.00
+                    IF(UTYPE_URB==4) FRC_URB2D(I,J)=0.65
+                    IF(UTYPE_URB==5) FRC_URB2D(I,J)=0.7
+                    IF(UTYPE_URB==6) FRC_URB2D(I,J)=0.65
+                    IF(UTYPE_URB==7) FRC_URB2D(I,J)=0.3
+                    IF(UTYPE_URB==8) FRC_URB2D(I,J)=0.85
+                    IF(UTYPE_URB==9) FRC_URB2D(I,J)=0.3
+                    IF(UTYPE_URB==10) FRC_URB2D(I,J)=0.55
+                    IF(UTYPE_URB==11) FRC_URB2D(I,J)=1.
+                  ELSE
+                    IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
+                    IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1 ! LOW_DENSITY_RESIDENTIAL
+                    IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2 ! HIGH_DENSITY_RESIDENTIAL
+                    IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3 ! HIGH_INTENSITY_INDUSTRIAL
+
+                    IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.5
+                    IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
+                    IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.95
+                  END IF
 
                   TA_URB    = SFCTMP           ! [K]
                   QA_URB    = Q2K              ! [kg/kg]

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -257,6 +257,7 @@ CONTAINS
      &          ,bldt,curr_secs,adapt_step_flag,bldtacttime           & 
          ! Optional urban with BEP
      &          ,sf_urban_physics,gmt,xlat,xlong,julday               &
+     &          ,distributed_ahe_opt, ahe                             & !For anthropogenic heat
      &          ,num_urban_ndm                                        & !multi-layer urban
      &          ,urban_map_zrd                                        & !multi-layer urban
      &          ,urban_map_zwd                                        & !multi-layer urban
@@ -395,6 +396,7 @@ CONTAINS
    USE module_sf_tmnupdate
    USE module_sf_lake
    USE module_cpl, ONLY : coupler_on, cpl_rcv
+   use module_ra_gfdleta, only: cal_mon_day
 !
 !  This driver calls subroutines for the surface parameterizations.
 !
@@ -1455,14 +1457,10 @@ CONTAINS
 
    real,    optional,  dimension(ims:ime,jms:jme ),intent(inout) :: XLAIDYN
 ! IRRIGATION
-   INTEGER :: tloc, jmonth,timing  
-   REAL, PARAMETER    :: PI_GRECO=3.14159 
-   INTEGER  :: end_hour, irr_start,xt24,irr_day  
-   REAL :: constants_irrigation   
+   INTEGER :: ihour, jmonth, jday
    REAL, DIMENSION( ims:ime, jms:jme ) :: IRRIGATION_CHANNEL      
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)   , OPTIONAL::   IRRIGATION
    REAL,  INTENT(IN),OPTIONAL::  irr_daily_amount     
-   INTEGER :: phase
    INTEGER, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT),OPTIONAL :: irr_rand_field
    INTEGER, INTENT(IN ),OPTIONAL:: sf_surf_irr_scheme,irr_start_hour,irr_num_hours,irr_start_julianday,irr_end_julianday,irr_freq,irr_ph
 
@@ -4481,6 +4479,21 @@ CONTAINS
 
        ENDIF
      ENDIF
+
+     IF (distributed_ahe_opt == 2) THEN
+       call cal_mon_day(julday, julyr, jmonth, jday)
+       ihour = (jmonth - 1) * 24 + MOD(INT(gmt + xtime / 60.0), 24)
+       !$OMP PARALLEL DO   &
+       !$OMP PRIVATE ( ij, i, j, k )
+       DO ij = 1, num_tiles
+         DO j = j_start(ij), j_end(ij)
+         DO i = i_start(ij), i_end(ij)
+           HFX(i, j) = HFX(i, j) + ahe(i, ihour, j)
+         END DO
+         END DO
+       END DO
+       !$OMP END PARALLEL DO
+     END IF
 
    ENDIF run_param_if
 

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -944,6 +944,8 @@ CONTAINS
 ! Variables for multi-layer UCM
    REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
    INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
+   INTEGER, INTENT(IN) :: distributed_ahe_opt
+   REAL, OPTIONAL, DIMENSION( ims:ime, 0:287, jms:jme ), INTENT(IN)  :: ahe
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
    INTEGER , INTENT(IN)        ::     num_urban_ndm
    INTEGER , INTENT(IN)        ::     urban_map_zrd


### PR DESCRIPTION
Related to PR#1881.

TYPE: bug fix

KEYWORDS: anthropogenic heat, mosaic

SOURCE: Do Ngoc Khanh (Tokyo Institute of Technology)

DESCRIPTION OF CHANGES:
Problem 1:
* In https://github.com/wrf-model/WRF/pull/1881#discussion_r1446523703, @cenlinhe said that `FRC_URB2D` should be `IN` (not `INOUT`) and removed a portion of code. See https://github.com/wrf-model/WRF/pull/1986/files#diff-4cf900c383221426961400b9c706d4a7f551833ccff64af20fef15ef6bdc0f1bL3721.
* However, that change causes `UTYPE_URB` passed to urban module to become 0 when mosaic is turn on, and array index out of bound error occurs.

Solution 1:
* As I said before, I don't know why FRC_URB2D and UTYPE should be set there. But apparently the model does not work if they are not set there (even when the new options are turned off and only standard SLUCM is used).
* In this PR, I revert that portion of change. Converting `FRC_URB2D` back to `INOUT`. 

Problem 2:
* @weiwangncar said that adding AH to HFX after PBL driver has no effect. https://github.com/wrf-model/WRF/pull/1986#discussion_r1480479849

Solution 2:
* I moved the addition part to surface driver, right after the computation of HFX.

This PR also removes a few unused variables in their declaration.

LIST OF MODIFIED FILES:
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_pbl_driver.F
M       phys/module_sf_noahdrv.F
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
The Jenkins tests are all passing.

RELEASE NOTE: Fix AHE option 2 and a problem with mosaic
