### PR TITLE
CMake build of diffwrf binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,6 +725,7 @@ target_include_directories(
                               $<TARGET_PROPERTY:io_grib1,Fortran_MODULE_DIRECTORY>
                               $<TARGET_PROPERTY:fftpack5,Fortran_MODULE_DIRECTORY>
                               $<TARGET_PROPERTY:io_netcdf,Fortran_MODULE_DIRECTORY>
+                              $<TARGET_PROPERTY:io_int,Fortran_MODULE_DIRECTORY>
 
                               $<TARGET_PROPERTY:${PROJECT_NAME}_Core,Fortran_MODULE_DIRECTORY>
 
@@ -744,7 +745,6 @@ target_include_directories(
                               $<INSTALL_INTERFACE:include/frame>
                               $<INSTALL_INTERFACE:include/external/ioapi_share>
 
-                            PRIVATE
                               # May or may not exist
                               $<$<TARGET_EXISTS:atm_ocn>:$<TARGET_PROPERTY:atm_ocn,Fortran_MODULE_DIRECTORY>>
                               $<$<TARGET_EXISTS:io_adios2>:$<TARGET_PROPERTY:io_adios2,Fortran_MODULE_DIRECTORY>>
@@ -755,6 +755,8 @@ target_include_directories(
                               $<$<TARGET_EXISTS:io_phdf5>:$<TARGET_PROPERTY:io_phdf5,Fortran_MODULE_DIRECTORY>>
                               $<$<TARGET_EXISTS:g2lib>:$<TARGET_PROPERTY:g2lib,Fortran_MODULE_DIRECTORY>>
                               $<$<TARGET_EXISTS:bacio-1.3>:$<TARGET_PROPERTY:bacio-1.3,Fortran_MODULE_DIRECTORY>>
+
+                            PRIVATE
                               
                               ${PROJECT_SOURCE_DIR}/dyn_em
 
@@ -844,6 +846,7 @@ target_link_libraries(  ${PROJECT_NAME}_Core
                             $<TARGET_NAME_IF_EXISTS:io_adios2>
                             $<TARGET_NAME_IF_EXISTS:io_esmf>
                             $<TARGET_NAME_IF_EXISTS:io_pio>
+                            io_int
                             io_netcdf
                             $<TARGET_NAME_IF_EXISTS:io_netcdfpar>
                             $<TARGET_NAME_IF_EXISTS:io_pnetcdf>

--- a/external/io_int/CMakeLists.txt
+++ b/external/io_int/CMakeLists.txt
@@ -1,51 +1,83 @@
 # WRF CMake Build
-# get_filename_component( FOLDER_COMPILE_TARGET ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component( FOLDER_COMPILE_TARGET ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-# add_library(
-#             ${FOLDER_COMPILE_TARGET}
-#               STATIC
-#               )
+add_library(
+            ${FOLDER_COMPILE_TARGET}
+              STATIC
+              )
 
-# target_sources(
-#                 ${FOLDER_COMPILE_TARGET}
-#                 PRIVATE
 target_sources(
-                ${PROJECT_NAME}_Core
+                ${FOLDER_COMPILE_TARGET}
                 PRIVATE
                   io_int.F90
                   io_int_idx.c
                   module_io_int_idx.F90
                   module_io_int_read.F90
+                  ${PROJECT_SOURCE_DIR}/frame/module_internal_header_util.F
                   )
 
-# set_target_properties( 
-#                       ${FOLDER_COMPILE_TARGET} 
-#                         PROPERTIES
-#                           Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${FOLDER_COMPILE_TARGET}
-#                           Fortran_FORMAT           FREE                          
-#                       )
+set_target_properties( 
+                      ${FOLDER_COMPILE_TARGET} 
+                        PROPERTIES
+                          Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${FOLDER_COMPILE_TARGET}
+                          EXPORT_PROPERTIES        Fortran_MODULE_DIRECTORY
+                          Fortran_FORMAT           FREE                          
+                      )
 
+target_link_libraries(  ${FOLDER_COMPILE_TARGET}
+                          PUBLIC
+                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
+                        )
 
-# target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-#                           PRIVATE
-#                             ${netCDF_LIBRARIES}
-#                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-#                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-#                         )
+target_include_directories( ${FOLDER_COMPILE_TARGET}
+                            PUBLIC
+                              $<TARGET_PROPERTY:${FOLDER_COMPILE_TARGET},Fortran_MODULE_DIRECTORY>
+                              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/ioapi_share>
+                              $<INSTALL_INTERFACE:include/external/ioapi_share>
+                              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/inc>
+                              $<INSTALL_INTERFACE:include/inc>
+                            PRIVATE
+                              ${CMAKE_CURRENT_SOURCE_DIR}
+                            )
 
-# target_include_directories( ${FOLDER_COMPILE_TARGET}
-#                             PRIVATE
-#                               ${netCDF_INCLUDE_DIRS}
-#                               ${CMAKE_CURRENT_SOURCE_DIR}
-#                               #!TODO Fix duplicates of wrf_[io|status]_flags.h
-#                               # ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share 
-#                               ${CMAKE_CURRENT_SOURCE_DIR}/../io_grib_share
-#                               ${CMAKE_CURRENT_SOURCE_DIR}/../../inc
-#                             )
+# Now build diffwrf
+set( DIFFWRF_TARGET diffwrf_int )
+add_executable(
+                ${DIFFWRF_TARGET}
+                diffwrf.F90
+                ${PROJECT_SOURCE_DIR}/frame/module_machine.F
+                ${PROJECT_SOURCE_DIR}/frame/module_driver_constants.F
+                ${PROJECT_SOURCE_DIR}/frame/pack_utils.c
+                ${PROJECT_SOURCE_DIR}/frame/module_wrf_error.F
+                ${PROJECT_SOURCE_DIR}/frame/wrf_debug.F
+                )
 
-# install(
-#         TARGETS ${FOLDER_COMPILE_TARGET}
-#         RUNTIME DESTINATION bin/
-#         ARCHIVE DESTINATION lib/
-#         LIBRARY DESTINATION lib/
-#         )
+target_link_libraries(
+                      ${DIFFWRF_TARGET}
+                        PRIVATE
+                          ${FOLDER_COMPILE_TARGET}
+                      )
+
+target_include_directories(
+                            ${DIFFWRF_TARGET}
+                            PRIVATE
+                              ${CMAKE_BINARY_DIR}/inc
+                            )
+
+set_target_properties( 
+                        ${DIFFWRF_TARGET}
+                          PROPERTIES
+                            # Just dump everything in here
+                            Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/${DIFFWRF_TARGET}
+                            Fortran_FORMAT           FREE
+                        )
+
+add_dependencies( ${DIFFWRF_TARGET} registry_code )
+
+install(
+        TARGETS ${FOLDER_COMPILE_TARGET} ${DIFFWRF_TARGET}
+        EXPORT  ${EXPORT_NAME}Targets
+        RUNTIME DESTINATION bin/
+        ARCHIVE DESTINATION lib/
+        LIBRARY DESTINATION lib/
+        )

--- a/external/io_netcdf/CMakeLists.txt
+++ b/external/io_netcdf/CMakeLists.txt
@@ -80,8 +80,32 @@ target_sources(
                   field_routines.F90
                   )
 
+# Now build diffwrf
+set( DIFFWRF_TARGET diffwrf_nc )
+add_executable(
+                ${DIFFWRF_TARGET}
+                diffwrf.F90
+                ${PROJECT_SOURCE_DIR}/frame/clog.c
+                ${PROJECT_SOURCE_DIR}/frame/module_wrf_error.F
+                ${PROJECT_SOURCE_DIR}/frame/wrf_debug.F
+                )
+
+target_link_libraries(
+                      ${DIFFWRF_TARGET}
+                        PRIVATE
+                          ${FOLDER_COMPILE_TARGET}
+                      )
+set_target_properties( 
+                      ${DIFFWRF_TARGET}
+                        PROPERTIES
+                          # Just dump everything in here
+                          Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/${DIFFWRF_TARGET}
+                          Fortran_FORMAT           FREE
+                      )
+
+
 install(
-        TARGETS ${FOLDER_COMPILE_TARGET}
+        TARGETS ${FOLDER_COMPILE_TARGET} ${DIFFWRF_TARGET}
         EXPORT  ${EXPORT_NAME}Targets
         RUNTIME DESTINATION bin/
         ARCHIVE DESTINATION lib/

--- a/external/io_netcdf/CMakeLists.txt
+++ b/external/io_netcdf/CMakeLists.txt
@@ -16,21 +16,33 @@ set_target_properties(
                       )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PUBLIC
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
+target_link_libraries(
+                      ${FOLDER_COMPILE_TARGET}
+                        PUBLIC
+                          $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
+                          $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
+                          ${netCDF_LIBRARIES}
+                          ${netCDF-Fortran_LIBRARIES}
+                      )
+
+# Because of the way netCDF provides its info and the way cmake auto-gens RPATH, we need to help it along
+target_link_directories(
+                        ${FOLDER_COMPILE_TARGET}
+                        PUBLIC
+                          ${netCDF_LIBRARY_DIR}
+                          ${netCDF-Fortran_LIBRARY_DIR}
                         )
 
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
+target_include_directories(
+                            ${FOLDER_COMPILE_TARGET}
+                            PUBLIC
+                              $<TARGET_PROPERTY:${FOLDER_COMPILE_TARGET},Fortran_MODULE_DIRECTORY>
+                              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/ioapi_share>
+                              $<INSTALL_INTERFACE:include/external/ioapi_share>
                               ${netCDF_INCLUDE_DIRS}
                               ${netCDF-Fortran_INCLUDE_DIRS}
+                            PRIVATE
                               ${CMAKE_CURRENT_SOURCE_DIR}
-                              ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share
-                              ${CMAKE_INSTALL_PREFIX}/${FOLDER_COMPILE_TARGET}
                             )
 
 

--- a/external/io_netcdfpar/CMakeLists.txt
+++ b/external/io_netcdfpar/CMakeLists.txt
@@ -16,19 +16,33 @@ set_target_properties(
                       )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
+target_link_libraries(
+                      ${FOLDER_COMPILE_TARGET}
+                        PUBLIC
+                          $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
+                          $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
+                          ${netCDF_LIBRARIES}
+                          ${netCDF-Fortran_LIBRARIES}
+                      )
+
+# Because of the way netCDF provides its info and the way cmake auto-gens RPATH, we need to help it along
+target_link_directories(
+                        ${FOLDER_COMPILE_TARGET}
+                        PUBLIC
+                          ${netCDF_LIBRARY_DIR}
+                          ${netCDF-Fortran_LIBRARY_DIR}
                         )
 
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
+target_include_directories(
+                            ${FOLDER_COMPILE_TARGET}
+                            PUBLIC
+                              $<TARGET_PROPERTY:${FOLDER_COMPILE_TARGET},Fortran_MODULE_DIRECTORY>
+                              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/ioapi_share>
+                              $<INSTALL_INTERFACE:include/external/ioapi_share>
                               ${netCDF_INCLUDE_DIRS}
+                              ${netCDF-Fortran_INCLUDE_DIRS}
+                            PRIVATE
                               ${CMAKE_CURRENT_SOURCE_DIR}
-                              ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share
-                              ${CMAKE_INSTALL_PREFIX}/${FOLDER_COMPILE_TARGET}
                             )
 
 

--- a/external/io_netcdfpar/CMakeLists.txt
+++ b/external/io_netcdfpar/CMakeLists.txt
@@ -80,8 +80,32 @@ target_sources(
                   field_routines.F90
                   )
 
+# Now build diffwrf
+set( DIFFWRF_TARGET diffwrf_ncpar )
+add_executable(
+                ${DIFFWRF_TARGET}
+                diffwrf.F90
+                ${PROJECT_SOURCE_DIR}/frame/clog.c
+                ${PROJECT_SOURCE_DIR}/frame/module_wrf_error.F
+                ${PROJECT_SOURCE_DIR}/frame/wrf_debug.F
+                )
+
+target_link_libraries(
+                      ${DIFFWRF_TARGET}
+                        PRIVATE
+                          ${FOLDER_COMPILE_TARGET}
+                      )
+set_target_properties( 
+                      ${DIFFWRF_TARGET}
+                        PROPERTIES
+                          # Just dump everything in here
+                          Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/${DIFFWRF_TARGET}
+                          Fortran_FORMAT           FREE
+                      )
+
+
 install(
-        TARGETS ${FOLDER_COMPILE_TARGET}
+        TARGETS ${FOLDER_COMPILE_TARGET} ${DIFFWRF_TARGET}
         EXPORT  ${EXPORT_NAME}Targets
         RUNTIME DESTINATION bin/
         ARCHIVE DESTINATION lib/


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, diffwrf

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
New CMake build did not create binaries for io_* `diffwrf`

Solution:
Slight restructure of certain targets to allow for easy creation of the diffwrf executables. Since previously all `diffwrf` binaries were named the same, to house them int the same `install/bin/` location they have been prefix with the type of io or shorthand of that option ( io_int -> `diffwrf_int`, io_netcdf -> `diffwrf_nc`, io_netcdfpar -> `diffwrf_ncpar` ). 

LIST OF MODIFIED FILES: 
M       CMakeLists.txt
M       external/io_int/CMakeLists.txt
M       external/io_netcdf/CMakeLists.txt
M       external/io_netcdfpar/CMakeLists.txt

TESTS CONDUCTED: 
1. Diffwrf execs should now be located in cmake install location

RELEASE NOTE: 
CMake build of diffwrf binaries
