### PR TITLE
Print parameters used in auto_levels_opt = 2

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -7867,6 +7867,7 @@ WRITE (*,FMT='("Full level index = ",I4,"     Height = ",F7.1," m")') k,phb(1)/g
 do k = 2 ,kte
 WRITE (*,FMT='("Full level index = ",I4,"     Height = ",F7.1," m      Thickness = ",F6.1," m")') k,phb(k)/g,(phb(k)-phb(k-1))/g
 end do
+WRITE (*,FMT='("p_top = ",F7.0," Pa, dzbot = ",F6.1," m, dzstretch_s/u = ",2F6.2)') p_top,dzbot,dzstretch_s,dzstretch_u
 
       END IF
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: auto_levels_opt, dzbot, dzstretch

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Lack of information in the standard output when running real.exe using auto_levels_opt = 2.

Solution:
Adds print for parameters used to define vertical levels.

LIST OF MODIFIED FILES: 
M     dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. Now print like the following is added to output from running real.exe:
   p_top =    1000. Pa, dzbot =   30.0 m, dzstretch_s/u =   1.20  1.02
2. The Jenkins tests are all passing.

RELEASE NOTE: This PR adds a print for parameters used when running real.exe using auto_levels_opt = 2 option, which is the default.
