### PR TITLE
Correcting the equation that calculates the net longwave fluxes in single layer UCM. 

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1297,7 +1297,7 @@ ENDIF
        RB2=EPSB*( (1.-EPSG)*VFWG*VFGS*RX                          &
        +(1.-EPSG)*EPSB*VFGW*VFWG*SIG*(TBP**4.)/60.                &
        +(1.-EPSB)*VFWS*(1.-2.*VFWS)*RX                            &
-       +(1.-EPSB)*VFWG*(1.-2.*VFWS)*EPSG*SIG*EPSG*TGP**4./60.     &
+       +(1.-EPSB)*VFWG*(1.-2.*VFWS)*SIG*EPSG*TGP**4./60.     &
        +EPSB*(1.-EPSB)*(1.-2.*VFWS)*(1.-2.*VFWS)*SIG*TBP**4./60. )
 
        RG=RG1+RG2
@@ -1416,7 +1416,7 @@ ENDIF
        RB2=EPSB*( (1.-EPSG)*VFWG*VFGS*RX                          &
        +(1.-EPSG)*EPSB*VFGW*VFWG*SIG*(TBP**4.)/60.                &
        +(1.-EPSB)*VFWS*(1.-2.*VFWS)*RX                            &
-       +(1.-EPSB)*VFWG*(1.-2.*VFWS)*EPSG*SIG*EPSG*TGP**4./60.     &
+       +(1.-EPSB)*VFWG*(1.-2.*VFWS)*SIG*EPSG*TGP**4./60.     &
        +EPSB*(1.-EPSB)*(1.-2.*VFWS)*(1.-2.*VFWS)*SIG*TBP**4./60. )
 
        RG=RG1+RG2


### PR DESCRIPTION
To correct for the underestimation of net longwave flux absorbed by the building wall, RB2, in module_sf_urban.F

TYPE: Bug fix

KEYWORDS: Longwave flux, radiation/energy balance, Surface temperature, Urban climate, SLUCM

SOURCE: Parag Joshi (Brookhaven National Lab), Katia Lamer (Brookhaven National Lab)

DESCRIPTION OF CHANGES:
Problem:
The net long wave fluxes absorbed by the building walls is being underestimated due to multiplication of the emissivity twice in the equation. The command/lines that evaluate RB2 in the module_sf_urban.F (Lines 1300 and 1419 of WRF version-4.5.2) reflect the net long wave fluxes absorbed by building walls. 

Solution:
The code has been corrected by referring to the equation A9 of in the article, Kusaka & Kimora 2004, Journal of Applied Meteorology. 

ISSUE: For use when this PR closes an issue.
Fixes #2011 

LIST OF MODIFIED FILES: module_sf_urban.F

TESTS CONDUCTED: 
1. The test can be conducted by running WRF with SLUCM with and without corrected module and quantify the values of RB2. 
2. It passed Jenkins tests.

RELEASE NOTE: Correcting the net long wave fluxes for application in modeling urban climate using Single Layer Urban Canopy Model (SLUCM). It slightly improved 2-m temperature in urban area.
