### PR TITLE
Remove unneeded depends

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -389,7 +389,6 @@ module_bl_camuwpbl_driver.o: \
 
 
 module_sf_mynn.o: \
-	module_sf_sfclay.o \
 	module_bl_mynn.o \
 	../share/module_model_constants.o \
 	../frame/module_wrf_error.o 
@@ -928,7 +927,6 @@ module_physics_init.o: \
 	module_ra_hs.o \
 	module_ra_flg.o \
 	module_sf_sfclay.o \
-	module_sf_sfclayrev.o \
 	physics_mmm/sf_sfclayrev.o \
 	module_sf_slab.o \
 	module_sf_myjsfc.o \
@@ -1415,10 +1413,6 @@ module_fdda_spnudging.o: \
 	../frame/module_state_description.o \
 	../frame/module_domain.o \
 	../frame/module_wrf_error.o 
-
-
-module_sf_bep.o: \
-	module_sf_urban.o 
 
 
 module_mp_wsm5.o: \


### PR DESCRIPTION
TYPE: bug fix, clean up

KEYWORDS: dependencies, unused

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Some dependency is declared twice, some are no longer needed.

Solution:
Remove un-used depends.

LIST OF MODIFIED FILES: 
M      main/depend.common

TESTS CONDUCTED: 
1. Tested on Derecho with 6 proc to compile
2. The Jenkins tests are all passing.

RELEASE NOTE:
