### PR TITLE
Fix issue with generalized compiler version output using the wrong flags

### DIFF
--- a/compile
+++ b/compile
@@ -410,11 +410,11 @@ else
   set comp = ( `grep "^SFC" configure.wrf | cut -d"#" -f1 | cut -d"=" -f2-` )
   $comp[1] -V >& /dev/null
   if ( $status == 0 ) then
-    $comp[1] --version
+    $comp[1] -V
   else
     $comp[1] --version >& /dev/null
     if ( $status == 0 ) then
-      $comp[1] -V
+      $comp[1] --version
     else
       echo "Not sure how to figure out the version of this compiler: $comp[1]"
     endif


### PR DESCRIPTION
Fix issue with generalized compiler version output using the wrong flags

TYPE: bug fix

KEYWORDS: compile, version

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
A generalized compile version check was proposed in #1987. This logic was implemented in #1942 but the originating logic contains a bug where the `-V` and `--version` flag commands' output is flipped.

Solution:
Use `-V` in the appropriate spot when `$status` is zero for the `-V` check, and respectively for the `--version` check.

LIST OF MODIFIED FILES: 
M       compile

TESTS CONDUCTED: 
1. With previous bad logic the compile log output shows a compiler error as the wrong flag is used to output version info. With the fix, the correct output now shows in the compile log.

