### PR TITLE
Fix a logic for using specific humidity or mixing ratio directly

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -1110,6 +1110,7 @@ integer::oops1,oops2
             ELSE
                k = num_metgrid_levels
             END IF
+            config_flags%use_sh_qv = .FALSE.
 
             IF      ( config_flags%rh2qv_method .eq. 1 ) THEN
                CALL rh_to_mxrat1(grid%rh_gc, grid%t_gc, grid%p_gc, grid%qv_gc ,         &
@@ -1821,7 +1822,7 @@ integer::oops1,oops2
          END IF
 
          ! do not compute qv from RH if flag_sh or flag_qv = 1, or use_sh_qv = F
-         IF      ( flag_sh .ne. 1 .or. flag_qv .ne. 1 .or. .not. config_flags%use_sh_qv ) THEN
+         IF      ( .not.config_flags%use_sh_qv ) THEN
          IF      ( config_flags%rh2qv_method .eq. 1 ) THEN
             CALL rh_to_mxrat1(grid%u_1, grid%v_1, grid%p , moist(:,:,:,P_QV) ,       &
                               config_flags%rh2qv_wrt_liquid ,                        &
@@ -4100,7 +4101,7 @@ endif
                         ims , ime , jms , jme , kms , kme , &
                         its , ite , jts , jte , kts , kte )
 
-      IF      ( flag_sh .ne. 1 .or. flag_qv .ne. 1 .or. .not. config_flags%use_sh_qv ) THEN
+      IF      ( .not.config_flags%use_sh_qv ) THEN
       IF      ( config_flags%rh2qv_method .eq. 1 ) THEN
          CALL rh_to_mxrat1(grid%u_1, grid%v_1, grid%p_hyd , moist(:,:,:,P_QV) ,       &
                            config_flags%rh2qv_wrt_liquid ,                        &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: real, use_sh_qv

SOURCE: internal

DESCRIPTION OF CHANGES:
The logic to control whether specific humidity or mixing ratio is used instead of RH is wrong (PR-1959). It is corrected in this PR.

LIST OF MODIFIED FILES: 
M     dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. Tested before and after this change. The data without SH is not affected, and the data with SH (EC model level data) is now used directly if use_sh_qv is set to true.
2. The Jenkins tests are all passing.

RELEASE NOTE: 
