### PR TITLE
Modified/Corrected LECH's stability functions in the SL Urban Canopy Model following the formulation. 

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -3053,13 +3053,13 @@ SUBROUTINE SFCDIF_URB (ZLM,Z0,THZ0,THLM,SFCSPD,AKANDA,AKMS,AKHS,RLMO,CD)
 ! LECH'S SURFACE FUNCTIONS
 ! ----------------------------------------------------------------------
       PSLMU (ZZ)= -0.96* log (1.0-4.5* ZZ)
-      PSLMS (ZZ)= ZZ * RRIC -2.076* (1. -1./ (ZZ +1.))
+      PSLMS (ZZ)= (ZZ/RFC) -2.076* (1. -1./ (ZZ +1.))
       PSLHU (ZZ)= -0.96* log (1.0-4.5* ZZ)
 
 ! ----------------------------------------------------------------------
 ! PAULSON'S SURFACE FUNCTIONS
 ! ----------------------------------------------------------------------
-      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. -1./ (ZZ +1.))
+      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. - exp(-1.2 * ZZ))
       PSPMU (XX)= -2.* log ( (XX +1.)*0.5) - log ( (XX * XX +1.)*0.5)   &
      &        +2.* ATAN (XX)                                            &
      &- PIHF

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -64,7 +64,6 @@ use module_wrf_error
    REAL, ALLOCATABLE, DIMENSION(:) :: TRLEND_TBL, TBLEND_TBL, TGLEND_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: AKANDA_URBAN_TBL
 !for BEP
-
    ! MAXDIRS :: The maximum number of street directions we're allowed to define
    INTEGER, PARAMETER :: MAXDIRS = 3
    ! MAXHGTS :: The maximum number of building height bins we're allowed to define


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: LECH stability functions, Latent heat flux, Sensible heat flux, SL Urban Canpy Model

SOURCE: Parag Joshi (Brookhaven National Lab), Katia Lamer (Brookhaven National Lab)

DESCRIPTION OF CHANGES:
Problem:
The stability functions originally proposed by Lech Lobocki which are used in calculating the exchange coefficients between surface layer and roof, building wall, Green roof, and ground are implemented incorrectly. The error surfaced while comparing the formulation suggested in Lobocki 1992 with the equations in commands/lines 3056 and 3062 (WRF-v4.5.2).

Solution:
The code has been corrected by referring to the equations 48 and 49 of the article "A procedure for the derivation of surface layer bulk relationships from simplified second-order closure models" by Lobocki 1992 (Journal of Applied Meteorology).

LIST OF MODIFIED FILES: 
M    phys/module_sf_urban.F

TESTS CONDUCTED: 
1. The significance of the corrections can be highlighted by comparing a test run with the corrected module and current version of the WRF model. 
2. The fix will correct the evaluation of the exchange coefficients between the ground, roof, green roof etc and air. 
3. The Jenkins tests are all passing.

RELEASE NOTE: Lech's stability functions are corrected following the original formulation. 
