### PR TITLE
Correct diffusion coefficients for tke in LES

### DIFF
--- a/dyn_em/module_diffusion_em.F
+++ b/dyn_em/module_diffusion_em.F
@@ -3023,7 +3023,7 @@ SUBROUTINE horizontal_diffusion_2 ( rt_tendf, ru_tendf, rv_tendf, rw_tendf,    &
                                    config_flags,                           &
                                    tke(ims,kms,jms),                       & 
                                    msftx, msfty, msfux, msfuy,             &
-                                   msfvx, msfvy, xkhh, rdx, rdy,           &
+                                   msfvx, msfvy, xkmh, rdx, rdy,           &
                                    fnm, fnp, cf1, cf2, cf3,                &
                                    zx, zy, rdz, rdzw, dnw, dn, rho,        &
                                    .true.,                                 &
@@ -4332,7 +4332,7 @@ SUBROUTINE vertical_diffusion_2   ( ru_tendf, rv_tendf, rw_tendf, rt_tendf,   &
    If (km_opt .eq. 2) then
    CALL vertical_diffusion_s( tke_tendf(ims,kms,jms),               &
                               config_flags, tke(ims,kms,jms),       &
-                              xkhv,                                 &
+                              xkmv,                                 &
                               dn, dnw, rdz, rdzw, fnm, fnp, rho,    &
                               .true.,                               &
                               ids, ide, jds, jde, kds, kde,         &


### PR DESCRIPTION

TYPE: bug-fix

KEYWORDS: Diffusion of tke

SOURCE: internal (issue raised by Branko Kosovic)

DESCRIPTION OF CHANGES:
Problem:
Reported in #2026 tke diffusion should be twice momentum diffusion, but was twice heat diffusion (three times larger).

Solution:
xkmv and xkmh passed into diffusion routines for tke calls instead of xkhv and xkhh.

ISSUE: For use when this PR closes an issue.
Fixes #2026 

LIST OF MODIFIED FILES: 
modified:   dyn_em/module_diffusion_em.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: km_opt=2 tke diffusion was reduced to one third its value to match theory.
