### PR TITLE
Stability function correction for momentum in mos subroutine of SLUCM.

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1133,7 +1133,7 @@ use module_wrf_error
           
        CALL TDFCND (DF1,SMR(KZ), QUARTZ, SMCMAX )
        DF1 = DF1 * EXP(-2.0 * SHDFAC)  
-       RGR = EPSV*(RX-SIG*(TGRP**4.)/60.)
+       RGR = EPSV*(RX-SIG*(TA**4.)/60.)
        RGRR= (SGR+RGR) * 697.7 * 60.
        RCH = RHOO*CPP*CHGR
        RR1 = EPSV*(TA**4) * 6.48E-8 / (PS* CHGR) + 1.0
@@ -1635,7 +1635,7 @@ ENDIF
         PSIM=ALOG((Z+Z0)/Z0) &
             -ALOG((X+1.)**2.*(X**2.+1.)) &
             +2.*ATAN(X) &
-            +ALOG((X+1.)**2.*(X0**2.+1.)) &
+            +ALOG((X0+1.)**2.*(X0**2.+1.)) &
             -2.*ATAN(X0)
         FAIH=1./SQRT(1.-16.*XXX)
         PSIH=ALOG((Z+Z0)/Z0)+0.4*B1 &


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: Stability function, Urban canopy model, surface energy balance, Green roof temperature. 

SOURCE: Parag Joshi (Brookhaven National Laboratory), Katia Lamer (Brookhaven National Laboratory)

DESCRIPTION OF CHANGES:
Problem: The earlier equations has a typo where X (= (1-16\zeta)^1/4) is mentioned instead of X0. In addition, following the formulation of surface energy balance of OSU1DPBL scheme by Ek and Mahrt 1991, it appears that when the following definition is used $\sigma * \theta_s^4 = \sigma T_0^4 (1 + 4((\theta_s - T_0)/T_0)))$ is used, the temperature in the calculations of net flux at the surface should use T_0 (temperature at first atmospheric level). However, in the module TGRP (temperature of the green roof surface at previous time step is used)is used instead of T_0 (please refer to the attached screenshots of the formulation).

Also I am not sure why the term (\theta_0 - T_0) is neglected in the definition of YY (Line/command 1145 WRFv-4.5.2) whereas the equation for the $\theta_s$ in attached screenshot shows the term. Due to insignficant impact?

Solution:
Following the formulation, the temperature variable has been updated according. Moreover, the mos subroutine is also corrected by replacing X by X0 where X0 is =X*z0/(z+z0) (as per the WRF/phys/module_sf_urban.F).

LIST OF MODIFIED FILES: 
M     phys/module_sf_urban.F

TESTS CONDUCTED: 
1. No tests are conducted. A test case could be run to compare the impact of changes in the TGR and stability parameter value as well as CD, US, and ALPHA. 
2. The Jenkins tests are all passing.

For more details, refer to the pages # 47-50 of the document link in the release note.

RELEASE NOTE: Fixes for the calculations for PSIM in the mos subroutine and the temperature used in surface energy balance for the green roof. The later follows the OSU1DPBL document located at:  
[https://ftp.emc.ncep.noaa.gov/mmb/gcp/ldas/nceplsm/OSU1DPBL/OSU1DPBL-userguide.pdf]

<img width="1003" alt="Screenshot 2024-04-17 at 2 20 50 PM" src="https://github.com/wrf-model/WRF/assets/160153650/417467a2-fb3e-48db-88ec-fa9908c7ed6a">
<img width="1012" alt="Screenshot 2024-04-17 at 2 38 26 PM" src="https://github.com/wrf-model/WRF/assets/160153650/22b2891c-f4b8-491a-899c-c6605bbb4f43">
]
