### PR TITLE
Remove print from microphysics driver

### DIFF
--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -806,7 +806,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
    ENDIF
 
 ! set this to true to print out the global max/min for W on each time step.
-   IF ( .true. ) THEN
+   IF ( .false. ) THEN
       wmax = maxval( w(ips:ipe,kps:kpe,jps:jpe) )
       wmin = minval( w(ips:ipe,kps:kpe,jps:jpe) )
 #if ( defined(DM_PARALLEL)  &&   ! defined(STUBMPI) )


### PR DESCRIPTION
TYPE: almost text only

KEYWORDS: extra print, microphysics driver

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR-1876 accidentally turned on a diagnostic print for max and min vertical motions

Solution:
The print is removed as in previous code.

LIST OF MODIFIED FILES: 
M       phys/module_microphysics_driver.F

TESTS CONDUCTED: 
The Jenkins tests are all passing.

RELEASE NOTE: 