### PR TITLE
Add text to two routines in physics_mmm

### DIFF
--- a/phys/physics_mmm/cu_ntiedtke.F90
+++ b/phys/physics_mmm/cu_ntiedtke.F90
@@ -75,6 +75,9 @@
 
 
 !=================================================================================================================
+!>\section arg_table_cu_ntiedtke_init
+!!\html\include cu_ntiedtke_init.html
+!!
  subroutine cu_ntiedtke_init(con_cp,con_rd,con_rv,con_xlv,con_xls,con_xlf,con_grav,errmsg,errflg)
 !=================================================================================================================
 
@@ -120,6 +123,9 @@
  end subroutine cu_ntiedtke_init
 
 !=================================================================================================================
+!>\section arg_table_cu_ntiedtke_finalize
+!!\html\include cu_ntiedtke_finalize.html
+!!
  subroutine cu_ntiedtke_finalize(errmsg,errflg)
 !=================================================================================================================
 
@@ -135,6 +141,9 @@
  end subroutine cu_ntiedtke_finalize
 
 !=================================================================================================================
+!>\section arg_table_cu_ntiedtke_run
+!!\html\include cu_ntiedtke_run.html
+!!
 !     level 1 subroutine 'cu_ntiedkte_run'
       subroutine cu_ntiedtke_run(pu,pv,pt,pqv,pqc,pqi,pqvf,ptf,poz,pzz,pomg, &
      &         pap,paph,evap,hfx,zprecc,lndj,lq,km,km1,dt,dx,errmsg,errflg)

--- a/phys/physics_mmm/mp_wsm6_effectRad.F90
+++ b/phys/physics_mmm/mp_wsm6_effectRad.F90
@@ -17,6 +17,9 @@
 
 
 !=================================================================================================================
+!>\section arg_table_mp_wsm6_effectRad_init
+!!\html\include mp_wsm6_effectRad_init.html
+!!
  subroutine mp_wsm6_effectRad_init(errmsg,errflg)
 !=================================================================================================================
 
@@ -32,6 +35,9 @@
  end subroutine mp_wsm6_effectRad_init
 
 !=================================================================================================================
+!>\section arg_table_mp_wsm6_effectRad_finalize
+!!\html\include mp_wsm6_effectRad_finalize.html
+!!
  subroutine mp_wsm6_effectRad_finalize(errmsg,errflg)
 !=================================================================================================================
 
@@ -47,6 +53,9 @@
  end subroutine mp_wsm6_effectRad_finalize
 
 !=================================================================================================================
+!>\section arg_table_mp_wsm6_effectRad_run
+!!\html\include mp_wsm6_effectRad_run.html
+!!
  subroutine mp_wsm6_effectRad_run(do_microp_re,t,qc,qi,qs,rho,qmin,t0c,re_qc_bg,re_qi_bg,re_qs_bg, &
                                   re_qc_max,re_qi_max,re_qs_max,re_qc,re_qi,re_qs,its,ite,kts,kte, &
                                   errmsg,errflg)


### PR DESCRIPTION
TYPE:  text only

KEYWORDS: doxygen comments, shared physics routines

SOURCE: internal

DESCRIPTION OF CHANGES:
Added some doxygen comments to make routines in physics_mmm/ the same as those in future MMM shared physics repository.

LIST OF MODIFIED FILES:
M       phys/physics_mmm/cu_ntiedtke.F90
M       phys/physics_mmm/mp_wsm6_effectRad.F90

TESTS CONDUCTED: 
The Jenkins tests are all passing.
