### PR TITLE
Updated heat transfer coefficient correlation parameters for horizontal and upward heat flow over PV panels. 

### DIFF
--- a/phys/module_sf_bem.F
+++ b/phys/module_sf_bem.F
@@ -889,7 +889,7 @@ use module_wrf_error
        uroof=(uout(n+1)**2+vout(n+1)**2)**0.5
       deltat=tpv-tair(n+1)
     hf=2.5*(40./100.*uroof)**(0.5)
-    hc=9.842*abs(deltat)**(1./3.)/(7.283-abs(cos(tiltangle)))
+    hc=9.482*abs(deltat)**(1./3.)/(7.238-abs(cos(tiltangle)))
     hup=sqrt(hc**2.+(hf)**2.)
     hc=1.810*abs(deltat)**(1./3.)/(1.382+abs(cos(tiltangle)))
     hdown=sqrt(hc**2.+(hf)**2.)


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: PV panels, Correlations, Upward heat flow, BEM (Building Energy Model). 

SOURCE: Parag Joshi (Brookhaven National Laboratory) 

DESCRIPTION OF CHANGES:
Problem:
A typographical mistake was identified within the correlations that evaluate heat transfer coefficient for the upward heat flow over PV panels in the Building Energy Model (BEM). 

Solution:
The parameters have been modified following the correlation expressions provided in the literature. Please refer to the equation J.2.2a (please see the attached screenshot) on page number 79 of the document below. 
https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nbsir83-2655.pdf

<img width="1058" alt="Screenshot 2024-05-14 at 5 07 59 PM" src="https://github.com/wrf-model/WRF/assets/160153650/94b0e141-1305-482e-a8a3-3abf36bb206b">

LIST OF MODIFIED FILES: 
M     phys/module_sf_bem.F

TESTS CONDUCTED: 
1. No test has been conducted as the parameters seems to have very small or insignificant impact on the results. However, the tests can be performed with and without correcting the parameters to quantify the role. 
2. The Jenkins tests are all passing.

RELEASE NOTE: Bug fixes for parameters associated with the heat transfer coefficient for the upward heat flow over PV panels. 