### PR TITLE
Restructure netCDF find modules to use modern import target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,8 +426,18 @@ find_package( netCDF         REQUIRED )
 find_package( netCDF-Fortran REQUIRED )
 
 # Make use of version checking here and not in find_package for previous versions that did not use cmake
-if ( ( NOT netCDF_VERSION GREATER_EQUAL "4.1.3" ) OR ( NOT netCDF-Fortran_VERSION GREATER_EQUAL "4.1.3" ) )
-  message( FATAL "Please make sure NETCDF versions are 4.1.3 or later. " )
+if ( NOT ${FORCE_NETCDF_CLASSIC} )
+  if ( NOT netCDF_VERSION GREATER_EQUAL "4.1.3" )
+    set( NC4_MISSING_REASON "(version < 4.1.3)" )
+  elseif( NOT ${netCDF_HAS_NC4} )
+    set( NC4_MISSING_REASON "(not build with nc4)" )
+  endif()
+
+  if ( DEFINED NC4_MISSING_REASON )
+    message( STATUS "netCDF found does not support NC4 features ${NC4_MISSING_REASON}, forcing use of classic netcdf" )
+    message( STATUS "  To disable this message, make sure netCDF used has nc4 capabilities or specify FORCE_NETCDF_CLASSIC" )
+    set( FORCE_NETCDF_CLASSIC ON CACHE BOOL "Required by netCDF found" FORCE )
+  endif()
 endif()
 
 find_package( pnetCDF QUIET )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,7 @@ endif()
 find_package( netCDF         REQUIRED )
 find_package( netCDF-Fortran REQUIRED )
 
-# Make use of version checking here and not in find_package for previous versions that did not use cmake
+# Make use of version checking here and not in find_package for WRF control allowing older versions if requested
 if ( NOT ${FORCE_NETCDF_CLASSIC} )
   if ( NOT netCDF_VERSION GREATER_EQUAL "4.1.3" )
     set( NC4_MISSING_REASON "(version < 4.1.3)" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,7 +684,7 @@ else()
 endif()
 
 # If force classic or no nc-4 support enable classic
-if ( ${FORCE_NETCDF_CLASSIC} OR ( NOT ${netCDF_NC4} ) )
+if ( ${FORCE_NETCDF_CLASSIC} OR ( NOT ${netCDF_HAS_NC4} ) )
   list( APPEND PROJECT_COMPILE_DEFINITIONS NETCDF_classic=1 )
 endif()
 if ( ${WRFIO_NCD_NO_LARGE_FILE_SUPPORT} OR ( NOT ${netCDF_LARGE_FILE_SUPPORT} ) )
@@ -693,7 +693,7 @@ endif()
 # May need a check for WRFIO_ncdpar_LARGE_FILE_SUPPORT
 
 # Now set the opposite in different defines, because why not :)
-if ( ( NOT ${FORCE_NETCDF_CLASSIC} ) AND ${netCDF_NC4} )
+if ( ( NOT ${FORCE_NETCDF_CLASSIC} ) AND ${netCDF_HAS_NC4} )
   list( APPEND PROJECT_COMPILE_DEFINITIONS USE_NETCDF4_FEATURES=1 )
 endif()
 if ( ( NOT ${WRFIO_NCD_NO_LARGE_FILE_SUPPORT} ) AND ${netCDF_LARGE_FILE_SUPPORT} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -941,7 +941,7 @@ set_target_properties(
 
 target_link_libraries(  ${PROJECT_NAME}_Core
                           PUBLIC
-                            netCDF::netCDF-Fortran
+                            netCDF::netcdff
                             ${pnetCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,8 +897,6 @@ target_include_directories(
                               ${PROJECT_SOURCE_DIR}/external/io_int
 
                               # Found Packages not handled through :: imported target
-                              ${netCDF_INCLUDE_DIRS}
-                              ${netCDF-Fortran_INCLUDE_DIRS}
                               ${pnetCDF_INCLUDE_DIRS}
                             )
 
@@ -940,19 +938,10 @@ set_target_properties(
                           EXPORT_PROPERTIES        Fortran_MODULE_DIRECTORY
                       )
 
-# Because of the way netCDF provides its info and the way cmake auto-gens RPATH, we need to help it along
-target_link_directories(
-                        ${PROJECT_NAME}_Core
-                        PUBLIC
-                          ${netCDF_LIBRARY_DIR}
-                          ${netCDF-Fortran_LIBRARY_DIR}
-                        )
-
 
 target_link_libraries(  ${PROJECT_NAME}_Core
                           PUBLIC
-                            ${netCDF_LIBRARIES}
-                            ${netCDF-Fortran_LIBRARIES}
+                            netCDF::netCDF-Fortran
                             ${pnetCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>

--- a/cmake/modules/FindnetCDF-Fortran.cmake
+++ b/cmake/modules/FindnetCDF-Fortran.cmake
@@ -115,7 +115,7 @@ find_package_handle_standard_args(
                                   HANDLE_VERSION_RANGE
                                 )
 
-# Note that the name of the target is the project name as specified by the netCDF cmake build,
+# Note that the name of the target is the target library name as specified by the netCDF cmake build,
 # NOT the netCDF repository name, I've kept this consistent to the provided netCDF builds rather
 # than the convention of *_<LANG> to specify multiple components. This also helps account for the
 # fact that the netCDF langauge-specific projects are separate projects

--- a/cmake/modules/FindnetCDF-Fortran.cmake
+++ b/cmake/modules/FindnetCDF-Fortran.cmake
@@ -68,8 +68,6 @@ else()
       f03
       )
 
-  set( netCDF-Fortran_DEFINITIONS  )
-  set( netCDF-Fortran_LIBRARY_DIR  ${netCDF-Fortran_PREFIX}/lib )
   foreach( NF_QUERY ${netCDF-Fortran_QUERY_YES_OPTIONS} )
     execute_process( COMMAND ${NETCDF-FORTRAN_PROGRAM} --has-${NF_QUERY} OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE netCDF-Fortran_${NF_QUERY}_LOWERCASE )
     string( TOUPPER ${NF_QUERY}                     NF_QUERY_UPPERCASE )
@@ -78,6 +76,12 @@ else()
     set( netCDF-Fortran_HAS_${NF_QUERY_UPPERCASE} ${NF_ANSWER_UPPERCASE} )
   endforeach()
 
+
+  # A bug in previous netcdf-fortran cmake builds, extract from flibs
+  string( REGEX MATCH "^-L([^ ]*)" netCDF-Fortran_LIBRARY_LINK_LOCATION ${netCDF-Fortran_FLIBS} )
+  set( netCDF-Fortran_LIBRARY_DIR ${CMAKE_MATCH_1} )
+
+  set( netCDF-Fortran_DEFINITIONS  )
   set( netCDF-Fortran_LIBRARIES
       $<$<LINK_LANGUAGE:Fortran>:${netCDF-Fortran_FLIBS}>
       )

--- a/cmake/modules/FindnetCDF-Fortran.cmake
+++ b/cmake/modules/FindnetCDF-Fortran.cmake
@@ -70,6 +70,10 @@ else()
 
   foreach( NF_QUERY ${netCDF-Fortran_QUERY_YES_OPTIONS} )
     execute_process( COMMAND ${NETCDF-FORTRAN_PROGRAM} --has-${NF_QUERY} OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE netCDF-Fortran_${NF_QUERY}_LOWERCASE )
+    if ( NOT "${netCDF-Fortran_${NF_QUERY}_LOWERCASE}" )
+      # might be empty
+      set( netCDF-Fortran_${NF_QUERY}_LOWERCASE no )
+    endif()
     string( TOUPPER ${NF_QUERY}                     NF_QUERY_UPPERCASE )
     string( TOUPPER ${netCDF-Fortran_${NF_QUERY}_LOWERCASE} NF_ANSWER_UPPERCASE )
     # Convert to netCDF-Fortran_HAS_* = YES/NO - Note this cannot be generator expression if you want to use it during configuration time

--- a/cmake/modules/FindnetCDF-Fortran.cmake
+++ b/cmake/modules/FindnetCDF-Fortran.cmake
@@ -98,8 +98,6 @@ else()
                 )
 endif()
 
-find_package( PkgConfig )
-
 include(FindPackageHandleStandardArgs)
 
 # handle the QUIETLY and REQUIRED arguments and set netCDF-Fortran_FOUND to TRUE

--- a/cmake/modules/FindnetCDF.cmake
+++ b/cmake/modules/FindnetCDF.cmake
@@ -102,11 +102,33 @@ include(FindPackageHandleStandardArgs)
 
 # handle the QUIETLY and REQUIRED arguments and set netCDF_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args( netCDF  DEFAULT_MSG
-                                   netCDF_INCLUDE_DIRS
-                                   netCDF_LIBRARY_DIR
-                                   netCDF_CLIBS
-                                   netCDF_VERSION
-                                  )
+find_package_handle_standard_args(
+                                  netCDF
+                                  FOUND_VAR netCDF_FOUND
+                                  REQUIRED_VARS
+                                    netCDF_INCLUDE_DIRS
+                                    netCDF_LIBRARIES
+                                    netCDF_VERSION
+                                  VERSION_VAR netCDF_VERSION
+                                  HANDLE_VERSION_RANGE
+                                )
+
+# Note that the name of the target is the project name as specified by the netCDF cmake build,
+# NOT the netCDF repository name, I've kept this consistent to the provided netCDF builds rather
+# than the convention of *_<LANG> to specify multiple components. This also helps account for the
+# fact that the netCDF langauge-specific projects are separate projects
+if ( netCDF_FOUND AND NOT TARGET netCDF::netcdf )
+  add_library( netCDF::netcdf UNKNOWN IMPORTED )
+  set_target_properties(
+                        netCDF::netcdf
+                        PROPERTIES
+                          IMPORTED_LOCATION                   "${netCDF_LIBRARY}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES   C
+                          INTERFACE_INCLUDE_DIRECTORIES      "${netCDF_INCLUDE_DIRS}"
+                        )
+
+
+endif()
+
 
 mark_as_advanced( netCDF_CLIBS netCDF_PREFIX netCDF_LIBRARY_DIR )

--- a/cmake/modules/FindnetCDF.cmake
+++ b/cmake/modules/FindnetCDF.cmake
@@ -66,6 +66,10 @@ else()
 
   foreach( NC_QUERY ${netCDF_QUERY_YES_OPTIONS} )
     execute_process( COMMAND ${NETCDF_PROGRAM} --has-${NC_QUERY} OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE netCDF_${NC_QUERY}_LOWERCASE )
+    if ( NOT "${netCDF-Fortran_${NF_QUERY}_LOWERCASE}" )
+      # might be empty
+      set( netCDF-Fortran_${NF_QUERY}_LOWERCASE no )
+    endif()
     string( TOUPPER ${NC_QUERY}                     NC_QUERY_UPPERCASE )
     string( TOUPPER ${netCDF_${NC_QUERY}_LOWERCASE} NC_ANSWER_UPPERCASE )
     # Convert to netCDF_HAS_* = YES/NO - Note this cannot be generator expression if you want to use it during configuration time

--- a/cmake/modules/FindnetCDF.cmake
+++ b/cmake/modules/FindnetCDF.cmake
@@ -111,8 +111,6 @@ else()
   endif()
 endif()
 
-find_package( PkgConfig )
-
 include(FindPackageHandleStandardArgs)
 
 # handle the QUIETLY and REQUIRED arguments and set netCDF_FOUND to TRUE

--- a/cmake/modules/FindnetCDF.cmake
+++ b/cmake/modules/FindnetCDF.cmake
@@ -113,7 +113,7 @@ find_package_handle_standard_args(
                                   HANDLE_VERSION_RANGE
                                 )
 
-# Note that the name of the target is the project name as specified by the netCDF cmake build,
+# Note that the name of the target is the target library name as specified by the netCDF cmake build,
 # NOT the netCDF repository name, I've kept this consistent to the provided netCDF builds rather
 # than the convention of *_<LANG> to specify multiple components. This also helps account for the
 # fact that the netCDF langauge-specific projects are separate projects

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -54,7 +54,7 @@ add_subdirectory( esmf_time_f90    )
 add_subdirectory( io_netcdf        )
 #!TODO We should collapse all these files into #ifdefs even if they are compiled
 #      multiple times with different defs for the same configuration
-if ( ${netCDF_PARALLEL} AND ${USE_MPI} )
+if ( ${netCDF_HAS_PARALLEL} AND ${USE_MPI} )
   message( STATUS "Adding [io_netcdfpar] to configuration" )
   add_subdirectory( io_netcdfpar     )
 endif()

--- a/external/RSL_LITE/CMakeLists.txt
+++ b/external/RSL_LITE/CMakeLists.txt
@@ -32,15 +32,9 @@ set_target_properties(
 
 target_link_libraries(  ${FOLDER_COMPILE_TARGET}
                           PRIVATE
-                            ${netCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                         )
-
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                            )
 
 install(
         TARGETS ${FOLDER_COMPILE_TARGET}

--- a/external/atm_ocn/CMakeLists.txt
+++ b/external/atm_ocn/CMakeLists.txt
@@ -28,15 +28,9 @@ set_target_properties(
 
 target_link_libraries(  ${FOLDER_COMPILE_TARGET}
                           PRIVATE
-                            ${netCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                         )
-
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                            )
 
 install(
         TARGETS ${FOLDER_COMPILE_TARGET}

--- a/external/esmf_time_f90/CMakeLists.txt
+++ b/external/esmf_time_f90/CMakeLists.txt
@@ -42,15 +42,13 @@ set_target_properties(
 
 target_link_libraries(  ${FOLDER_COMPILE_TARGET}
                           PRIVATE
-                            ${netCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
+                          )
 
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_LIST_DIR}
+                              ${CMAKE_CURRENT_SOURCE_DIR}
                             )
 
 install(

--- a/external/fftpack/fftpack5/CMakeLists.txt
+++ b/external/fftpack/fftpack5/CMakeLists.txt
@@ -32,18 +32,6 @@ set_target_properties(
                           EXPORT_PROPERTIES        Fortran_MODULE_DIRECTORY
                       )
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                            )
-
 install(
         TARGETS ${FOLDER_COMPILE_TARGET}
         EXPORT  ${EXPORT_NAME}Targets

--- a/external/io_adios2/CMakeLists.txt
+++ b/external/io_adios2/CMakeLists.txt
@@ -18,15 +18,12 @@ set_target_properties(
 
 target_link_libraries(  ${FOLDER_COMPILE_TARGET}
                           PRIVATE
-                            ${netCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                         )
 
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_SOURCE_DIR}
                               ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share
                               ${CMAKE_INSTALL_PREFIX}/${FOLDER_COMPILE_TARGET}
                             )

--- a/external/io_esmf/CMakeLists.txt
+++ b/external/io_esmf/CMakeLists.txt
@@ -30,7 +30,6 @@ set_target_properties(
 
 target_link_libraries(  ${FOLDER_COMPILE_TARGET}
                           PRIVATE
-                            ${netCDF_LIBRARIES}
                             $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
                             $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                         )

--- a/external/io_grib1/CMakeLists.txt
+++ b/external/io_grib1/CMakeLists.txt
@@ -29,17 +29,8 @@ set_target_properties(
                       )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_SOURCE_DIR}
                               ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share 
                               ${CMAKE_CURRENT_SOURCE_DIR}/../io_grib_share
                               ${CMAKE_CURRENT_SOURCE_DIR}/grib1_util

--- a/external/io_grib1/MEL_grib1/CMakeLists.txt
+++ b/external/io_grib1/MEL_grib1/CMakeLists.txt
@@ -48,17 +48,9 @@ target_sources(
                   )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_SOURCE_DIR}
+                              # ${CMAKE_CURRENT_SOURCE_DIR}
                               ${CMAKE_CURRENT_SOURCE_DIR}/../../ioapi_share
                             )
 

--- a/external/io_grib1/WGRIB/CMakeLists.txt
+++ b/external/io_grib1/WGRIB/CMakeLists.txt
@@ -50,19 +50,6 @@ target_sources(
                   nceptab_131.c
                   )
 
-
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                            )
-
 install(
         TARGETS ${FOLDER_COMPILE_TARGET}
         EXPORT  ${EXPORT_NAME}Targets

--- a/external/io_grib1/grib1_util/CMakeLists.txt
+++ b/external/io_grib1/grib1_util/CMakeLists.txt
@@ -16,17 +16,9 @@ target_sources(
                   )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_SOURCE_DIR}
+                              # ${CMAKE_CURRENT_SOURCE_DIR}
                               ${CMAKE_CURRENT_SOURCE_DIR}/../MEL_grib1
                             )
 

--- a/external/io_grib2/bacio-1.3/CMakeLists.txt
+++ b/external/io_grib2/bacio-1.3/CMakeLists.txt
@@ -21,19 +21,6 @@ set_target_properties(
                           EXPORT_PROPERTIES        Fortran_MODULE_DIRECTORY
                       )
 
-
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
-target_include_directories( ${FOLDER_COMPILE_TARGET}
-                            PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                            )
-
 install(
         TARGETS ${FOLDER_COMPILE_TARGET}
         EXPORT  ${EXPORT_NAME}Targets

--- a/external/io_grib2/g2lib/CMakeLists.txt
+++ b/external/io_grib2/g2lib/CMakeLists.txt
@@ -83,20 +83,8 @@ set_target_properties(
                       )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                            $<TARGET_NAME_IF_EXISTS:Jasper::Jasper>
-                        )
-
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_SOURCE_DIR}
-                              #!TODO Fix duplicates of wrf_[io|status]_flags.h
-                              # ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share 
                               ${CMAKE_CURRENT_SOURCE_DIR}/../io_grib_share
                             )
 

--- a/external/io_grib_share/CMakeLists.txt
+++ b/external/io_grib_share/CMakeLists.txt
@@ -25,17 +25,8 @@ set_target_properties(
                       )
 
 
-target_link_libraries(  ${FOLDER_COMPILE_TARGET}
-                          PRIVATE
-                            ${netCDF_LIBRARIES}
-                            $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                            $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
-                        )
-
 target_include_directories( ${FOLDER_COMPILE_TARGET}
                             PRIVATE
-                              ${netCDF_INCLUDE_DIRS}
-                              ${CMAKE_CURRENT_SOURCE_DIR}
                               ${CMAKE_CURRENT_SOURCE_DIR}/../ioapi_share
                             )
 

--- a/external/io_netcdf/CMakeLists.txt
+++ b/external/io_netcdf/CMakeLists.txt
@@ -21,17 +21,8 @@ target_link_libraries(
                         PUBLIC
                           $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                           $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                          ${netCDF_LIBRARIES}
-                          ${netCDF-Fortran_LIBRARIES}
+                          netCDF::netCDF-Fortran
                       )
-
-# Because of the way netCDF provides its info and the way cmake auto-gens RPATH, we need to help it along
-target_link_directories(
-                        ${FOLDER_COMPILE_TARGET}
-                        PUBLIC
-                          ${netCDF_LIBRARY_DIR}
-                          ${netCDF-Fortran_LIBRARY_DIR}
-                        )
 
 target_include_directories(
                             ${FOLDER_COMPILE_TARGET}
@@ -39,8 +30,6 @@ target_include_directories(
                               $<TARGET_PROPERTY:${FOLDER_COMPILE_TARGET},Fortran_MODULE_DIRECTORY>
                               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/ioapi_share>
                               $<INSTALL_INTERFACE:include/external/ioapi_share>
-                              ${netCDF_INCLUDE_DIRS}
-                              ${netCDF-Fortran_INCLUDE_DIRS}
                             PRIVATE
                               ${CMAKE_CURRENT_SOURCE_DIR}
                             )

--- a/external/io_netcdf/CMakeLists.txt
+++ b/external/io_netcdf/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
                         PUBLIC
                           $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                           $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                          netCDF::netCDF-Fortran
+                          netCDF::netcdff
                       )
 
 target_include_directories(

--- a/external/io_netcdfpar/CMakeLists.txt
+++ b/external/io_netcdfpar/CMakeLists.txt
@@ -21,17 +21,9 @@ target_link_libraries(
                         PUBLIC
                           $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                           $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                          ${netCDF_LIBRARIES}
-                          ${netCDF-Fortran_LIBRARIES}
+                          netCDF::netCDF-Fortran
                       )
 
-# Because of the way netCDF provides its info and the way cmake auto-gens RPATH, we need to help it along
-target_link_directories(
-                        ${FOLDER_COMPILE_TARGET}
-                        PUBLIC
-                          ${netCDF_LIBRARY_DIR}
-                          ${netCDF-Fortran_LIBRARY_DIR}
-                        )
 
 target_include_directories(
                             ${FOLDER_COMPILE_TARGET}
@@ -39,8 +31,6 @@ target_include_directories(
                               $<TARGET_PROPERTY:${FOLDER_COMPILE_TARGET},Fortran_MODULE_DIRECTORY>
                               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/ioapi_share>
                               $<INSTALL_INTERFACE:include/external/ioapi_share>
-                              ${netCDF_INCLUDE_DIRS}
-                              ${netCDF-Fortran_INCLUDE_DIRS}
                             PRIVATE
                               ${CMAKE_CURRENT_SOURCE_DIR}
                             )

--- a/external/io_netcdfpar/CMakeLists.txt
+++ b/external/io_netcdfpar/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
                         PUBLIC
                           $<$<BOOL:${USE_OPENMP}>:$<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_Fortran>>
                           $<$<BOOL:${USE_MPI}>:$<TARGET_NAME_IF_EXISTS:MPI::MPI_Fortran>>
-                          netCDF::netCDF-Fortran
+                          netCDF::netcdff
                       )
 
 

--- a/hydro/CMakeLists.txt
+++ b/hydro/CMakeLists.txt
@@ -1,6 +1,6 @@
 # additions that WRF-Hydro's top CMakeLists.txt handles
-add_compile_options( ${PROJECT_COMPILE_OPTIONS} )
-add_compile_definitions( ${PROJECT_COMPILE_DEFINITIONS} )
+add_compile_options( "${PROJECT_COMPILE_OPTIONS}" )
+add_compile_definitions( "${PROJECT_COMPILE_DEFINITIONS}" )
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/hydro/mods)
 add_definitions(-DMPP_LAND)
 if (WRF_HYDRO_NUDGING STREQUAL "1")

--- a/hydro/HYDRO_drv/CMakeLists.txt
+++ b/hydro/HYDRO_drv/CMakeLists.txt
@@ -8,14 +8,11 @@ target_link_libraries(hydro_driver PUBLIC
         hydro_data_rec
         hydro_routing
         hydro_debug_utils
+        PRIVATE
+          netCDF::netcdff
 )
 
 if(WRF_HYDRO_NUDGING STREQUAL "1")
         target_link_libraries(hydro_driver PUBLIC hydro_nudging)
 endif()
 
-target_include_directories(hydro_driver
-        PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
-)

--- a/hydro/IO/CMakeLists.txt
+++ b/hydro/IO/CMakeLists.txt
@@ -5,10 +5,5 @@ add_library(hydro_netcdf_layer STATIC
 
 target_link_libraries(hydro_netcdf_layer
         MPI::MPI_Fortran
-)
-
-target_include_directories(hydro_netcdf_layer
-        PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
+        netCDF::netcdff
 )

--- a/hydro/Routing/CMakeLists.txt
+++ b/hydro/Routing/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(hydro_routing STATIC
 
 target_link_libraries(hydro_routing
        MPI::MPI_Fortran
+       netCDF::netcdff
        hydro_mpp
        hydro_utils
        hydro_orchestrator
@@ -29,10 +30,4 @@ target_link_libraries(hydro_routing
        hydro_routing_reservoirs_hybrid
        hydro_data_rec
        hydro_routing_reservoirs_rfc
-)
-
-target_include_directories(hydro_routing
-        PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
 )

--- a/hydro/Routing/Reservoirs/CMakeLists.txt
+++ b/hydro/Routing/Reservoirs/CMakeLists.txt
@@ -5,10 +5,9 @@ add_library(hydro_routing_reservoirs STATIC
         module_reservoir_utilities.F90
 )
 
-target_include_directories(hydro_routing_reservoirs
+target_link_libraries(hydro_routing_reservoirs
         PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
+        netCDF::netcdff
 )
 
 add_subdirectory("Level_Pool")

--- a/hydro/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/CMakeLists.txt
+++ b/hydro/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/CMakeLists.txt
@@ -6,8 +6,7 @@ add_library(hydro_routing_reservoirs_hybrid STATIC
 
 add_dependencies(hydro_routing_reservoirs_hybrid hydro_routing_reservoirs)
 
-target_include_directories(hydro_routing_reservoirs_hybrid
+target_link_libraries(hydro_routing_reservoirs_hybrid
         PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
+        netCDF::netcdff
 )

--- a/hydro/Routing/Reservoirs/RFC_Forecasts/CMakeLists.txt
+++ b/hydro/Routing/Reservoirs/RFC_Forecasts/CMakeLists.txt
@@ -9,8 +9,7 @@ add_dependencies(hydro_routing_reservoirs_rfc
         hydro_routing_reservoirs_levelpool
 )
 
-target_include_directories(hydro_routing_reservoirs_rfc
+target_link_libraries(hydro_routing_reservoirs_rfc
         PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
+        netCDF::netcdff
 )

--- a/hydro/nudging/CMakeLists.txt
+++ b/hydro/nudging/CMakeLists.txt
@@ -10,10 +10,6 @@ target_link_libraries(hydro_nudging PRIVATE
         hydro_mpp
         hydro_data_rec
         hydro_orchestrator
+        netCDF::netcdff
 )
 
-target_include_directories(hydro_nudging
-        PRIVATE
-        ${netCDF_INCLUDE_DIRS}
-        ${netCDF-Fortran_INCLUDE_DIRS}
-)


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: netCDF, cmake, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The current iteration of the cmake build uses the old-style of finding modules.  This limits the usability of transitive properties as well as the native netCDF cmake build which provide imported targets.

See https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#find-modules for more information on module writing.

Solution:
Augment the output of the provided find module to supply an imported target that fully describes the netCDF library. Additionally, in rewriting how targets in WRF reference netCDF remove unnecessary linking to the library. Ensure the provided import target and flags of the find module matches the netCDF[-Fortran].cmake.in outputs verbatim thus emulating the native netCDF build for additional robustness.

LIST OF MODIFIED FILES: 
M       CMakeLists.txt
M       cmake/modules/FindnetCDF-Fortran.cmake
M       cmake/modules/FindnetCDF.cmake
M       external/CMakeLists.txt
M       external/RSL_LITE/CMakeLists.txt
M       external/atm_ocn/CMakeLists.txt
M       external/esmf_time_f90/CMakeLists.txt
M       external/fftpack/fftpack5/CMakeLists.txt
M       external/io_adios2/CMakeLists.txt
M       external/io_esmf/CMakeLists.txt
M       external/io_grib1/CMakeLists.txt
M       external/io_grib1/MEL_grib1/CMakeLists.txt
M       external/io_grib1/WGRIB/CMakeLists.txt
M       external/io_grib1/grib1_util/CMakeLists.txt
M       external/io_grib2/bacio-1.3/CMakeLists.txt
M       external/io_grib2/g2lib/CMakeLists.txt
M       external/io_grib_share/CMakeLists.txt
M       external/io_netcdf/CMakeLists.txt
M       external/io_netcdfpar/CMakeLists.txt


RELEASE NOTE: 
Restructure netCDF find modules to use modern import target
