### PR TITLE
Fix fseek test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,10 +792,13 @@ endif()
 #!TODO Leaving as is in WRF for now but investigate why we don't do this
 # https://stackoverflow.com/a/1035713
 # If fseeko64 succeeds, use that, else check if we can fall back to fseeko, and if not just use fseek
-if ( ${FSEEKO64} )
-  list( APPEND PROJECT_COMPILE_DEFINITIONS FSEEKO64_OK )
-elseif( "${FSEEKO}" )
-  list( APPEND PROJECT_COMPILE_DEFINITIONS FSEEKO_OK )
+if ( "${FSEEKO64}" OR "${FSEEKO}" )
+  list( APPEND PROJECT_COMPILE_DEFINITIONS _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE=1 )
+  if ( "${FSEEKO64}" )
+    list( APPEND PROJECT_COMPILE_DEFINITIONS FSEEKO64_OK )
+  elseif( "${FSEEKO}" )
+    list( APPEND PROJECT_COMPILE_DEFINITIONS FSEEKO_OK )
+  endif()
 else()
   list( APPEND PROJECT_COMPILE_DEFINITIONS FSEEK_OK )
 endif()

--- a/confcheck/CMakeLists.txt
+++ b/confcheck/CMakeLists.txt
@@ -49,7 +49,7 @@ wrf_conf_check(
                 RESULT_VAR             FSEEKO64
                 SOURCE                 ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
                 EXTENSION              .c
-                ADDITIONAL_DEFINITIONS -DTEST_FSEEKO64 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
+                ADDITIONAL_DEFINITIONS -DTEST_FSEEKO64 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                 MESSAGE                "fseeko64 not supported, checking alternate fseeko"
                 )
 
@@ -60,7 +60,7 @@ if ( NOT "${FSEEKO64}" )
                   RESULT_VAR             FSEEKO
                   SOURCE                 ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
                   EXTENSION              .c
-                  ADDITIONAL_DEFINITIONS -DTEST_FSEEKO -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
+                  ADDITIONAL_DEFINITIONS -DTEST_FSEEKO -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                   MESSAGE                "fseeko not supported, compiling with fseek (caution with large files)"
                   )
 endif()

--- a/tools/fseek_test.c
+++ b/tools/fseek_test.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/types.h>
+void
 main()
 {
   FILE *fp ;

--- a/tools/fseek_test.c
+++ b/tools/fseek_test.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/types.h>
-void
+int
 main()
 {
   FILE *fp ;
@@ -44,6 +44,6 @@ main()
     retval = 1 ;
   }
   fclose(fp) ;
-  exit(retval) ;
+  return retval ;
 }
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: fseek, compilation, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The fseek test lacks correct syntax causing false negative reports of feature not existing when newer compiler standards disallow this.

Solution:
Add `int` to the main program in the fseek test. Also to add further robustness in detecting this feature, use the `-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1` generally *nix standard defines.

LIST OF MODIFIED FILES: 
M       CMakeLists.txt
M       confcheck/CMakeLists.txt
M       tools/fseek_test.c

RELEASE NOTE: Fix fseek test