### PR TITLE
Add PnetCDF Non-blocking APIs to Perform I/O

### DIFF
--- a/Registry/registry.io_boilerplate
+++ b/Registry/registry.io_boilerplate
@@ -37,6 +37,7 @@ rconfig   logical self_test_domain        namelist,time_control		1              
 rconfig   character  history_outname   namelist,time_control		1  "wrfout_d<domain>_<date>"     -     "name of history outfile"  ""      ""
 rconfig   character  history_inname    namelist,time_control		1  "wrfhist_d<domain>_<date>"    -     "name of history infile"  ""      ""
 rconfig   logical    use_netcdf_classic   namelist,time_control         1              .false. -     "use_netcdf_classic"           ""      ""
+rconfig   logical    enable_pnetcdf_bput  namelist,time_control     1                  .false. -     "enable_pnetcdf_bput"          ""      ""
 
 rconfig   integer history_interval_d      namelist,time_control		max_domains    0       h     "history_interval_d"       ""      "DAYS"
 rconfig   integer history_interval_h      namelist,time_control		max_domains    0       h     "history_interval_h"       ""      "HOURS"

--- a/external/io_pnetcdf/ext_pnc_put_dom_ti.code
+++ b/external/io_pnetcdf/ext_pnc_put_dom_ti.code
@@ -103,7 +103,7 @@ IF ( ncd_ok_to_put_dom_ti( DataHandle ) ) THEN
       return
     endif
   elseif (DH%FileStatus == WRF_FILE_OPENED_FOR_WRITE) then
-    stat = NFMPI_REDEF(DH%NCID)
+    call try_redef(DH, stat)
     call netcdf_err(stat,Status)
     if(Status /= WRF_NO_ERR) then
       write(msg,*) &

--- a/external/io_pnetcdf/field_routines.F90
+++ b/external/io_pnetcdf/field_routines.F90
@@ -33,7 +33,7 @@
 !*  Date:    October 6, 2000
 !*
 !*----------------------------------------------------------------------------
-subroutine ext_pnc_RealFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
+subroutine ext_pnc_RealFieldIO(Coll,IO,NCID,VarID,VStart,VCount,EnableBput,Data,Status)
   use wrf_data_pnc
   use ext_pnc_support_routines
   implicit none
@@ -45,16 +45,21 @@ subroutine ext_pnc_RealFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   integer                     ,intent(in)    :: VarID
   integer ,dimension(NVarDims),intent(in)    :: VStart
   integer ,dimension(NVarDims),intent(in)    :: VCount
+  logical                     ,intent(in)    :: EnableBput
   real, dimension(*)          ,intent(inout) :: Data
   integer                     ,intent(out)   :: Status
   integer                                    :: stat
 !local
   integer(KIND=MPI_OFFSET_KIND), dimension(NVarDims)    :: VStart_mpi, VCount_mpi
+  integer :: BputReqID
   VStart_mpi = VStart
   VCount_mpi = VCount
 
   if(IO == 'write') then
-    if(Coll)then
+    if(EnableBput)then
+      ! Calling non-blocking buffered-version API
+      stat = NFMPI_BPUT_VARA_REAL(NCID,VarID,VStart_mpi,VCount_mpi,Data,BputReqID)
+    else if(Coll)then
       stat = NFMPI_PUT_VARA_REAL_ALL(NCID,VarID,VStart_mpi,VCount_mpi,Data)
     else
       stat = NFMPI_PUT_VARA_REAL(NCID,VarID,VStart_mpi,VCount_mpi,Data)
@@ -74,7 +79,7 @@ subroutine ext_pnc_RealFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   return
 end subroutine ext_pnc_RealFieldIO
 
-subroutine ext_pnc_DoubleFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
+subroutine ext_pnc_DoubleFieldIO(Coll,IO,NCID,VarID,VStart,VCount,EnableBput,Data,Status)
   use wrf_data_pnc
   use ext_pnc_support_routines
   implicit none
@@ -86,16 +91,21 @@ subroutine ext_pnc_DoubleFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   integer                     ,intent(in)    :: VarID
   integer ,dimension(NVarDims),intent(in)    :: VStart
   integer ,dimension(NVarDims),intent(in)    :: VCount
+  logical                     ,intent(in)    :: EnableBput
   real*8                      ,intent(inout) :: Data
   integer                     ,intent(out)   :: Status
   integer                                    :: stat
 !local
   integer(KIND=MPI_OFFSET_KIND), dimension(NVarDims)    :: VStart_mpi, VCount_mpi
+  integer :: BputReqID
   VStart_mpi = VStart
   VCount_mpi = VCount
 
   if(IO == 'write') then
-    if(Coll)then
+    if(EnableBput)then
+      ! Calling non-blocking buffered-version API
+      stat = NFMPI_BPUT_VARA_DOUBLE(NCID,VarID,VStart_mpi,VCount_mpi,Data,BputReqID)
+    else if(Coll)then
       stat = NFMPI_PUT_VARA_DOUBLE_ALL(NCID,VarID,VStart_mpi,VCount_mpi,Data)
    else
       stat = NFMPI_PUT_VARA_DOUBLE(NCID,VarID,VStart_mpi,VCount_mpi,Data)
@@ -115,7 +125,7 @@ subroutine ext_pnc_DoubleFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   return
 end subroutine ext_pnc_DoubleFieldIO
 
-subroutine ext_pnc_IntFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
+subroutine ext_pnc_IntFieldIO(Coll,IO,NCID,VarID,VStart,VCount,EnableBput,Data,Status)
   use wrf_data_pnc
   use ext_pnc_support_routines
   implicit none
@@ -127,16 +137,21 @@ subroutine ext_pnc_IntFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   integer                     ,intent(in)    :: VarID
   integer ,dimension(NVarDims),intent(in)    :: VStart
   integer ,dimension(NVarDims),intent(in)    :: VCount
+  logical                     ,intent(in)    :: EnableBput
   integer                     ,intent(inout) :: Data
   integer                     ,intent(out)   :: Status
   integer                                    :: stat
 !local
   integer(KIND=MPI_OFFSET_KIND), dimension(NVarDims)    :: VStart_mpi, VCount_mpi
+  integer :: BputReqID
   VStart_mpi = VStart
   VCount_mpi = VCount
 
   if(IO == 'write') then
-    if(Coll)then
+    if(EnableBput)then
+      ! Calling non-blocking buffered-version API
+      stat = NFMPI_BPUT_VARA_INT(NCID,VarID,VStart_mpi,VCount_mpi,Data,BputReqID)
+    else if(Coll)then
       stat = NFMPI_PUT_VARA_INT_ALL(NCID,VarID,VStart_mpi,VCount_mpi,Data)
     else
       stat = NFMPI_PUT_VARA_INT(NCID,VarID,VStart_mpi,VCount_mpi,Data)
@@ -156,7 +171,7 @@ subroutine ext_pnc_IntFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   return
 end subroutine ext_pnc_IntFieldIO
 
-subroutine ext_pnc_LogicalFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
+subroutine ext_pnc_LogicalFieldIO(Coll,IO,NCID,VarID,VStart,VCount,EnableBput,Data,Status)
   use wrf_data_pnc
   use ext_pnc_support_routines
   implicit none
@@ -168,6 +183,7 @@ subroutine ext_pnc_LogicalFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   integer                                         ,intent(in)    :: VarID
   integer,dimension(NVarDims)                     ,intent(in)    :: VStart
   integer,dimension(NVarDims)                     ,intent(in)    :: VCount
+  logical                                         ,intent(in)    :: EnableBput
   logical,dimension(VCount(1),VCount(2),VCount(3)),intent(inout) :: Data
   integer                                         ,intent(out)   :: Status
   integer,dimension(:,:,:),allocatable                           :: Buffer
@@ -175,6 +191,7 @@ subroutine ext_pnc_LogicalFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
   integer                                                        :: i,j,k
 !local
   integer(KIND=MPI_OFFSET_KIND), dimension(NVarDims)    :: VStart_mpi, VCount_mpi
+  integer :: BputReqID
   VStart_mpi = VStart
   VCount_mpi = VCount
 
@@ -197,7 +214,10 @@ subroutine ext_pnc_LogicalFieldIO(Coll,IO,NCID,VarID,VStart,VCount,Data,Status)
         enddo
       enddo
     enddo
-    if(Coll)then
+    if(EnableBput)then
+      ! Calling non-blocking buffered-version API
+      stat = NFMPI_BPUT_VARA_INT(NCID,VarID,VStart_mpi,VCount_mpi,Buffer,BputReqID)
+    else if(Coll)then
       stat = NFMPI_PUT_VARA_INT_ALL(NCID,VarID,VStart_mpi,VCount_mpi,Buffer)
    else
       stat = NFMPI_PUT_VARA_INT(NCID,VarID,VStart_mpi,VCount_mpi,Buffer)

--- a/external/io_pnetcdf/wrf_io.F90
+++ b/external/io_pnetcdf/wrf_io.F90
@@ -687,6 +687,7 @@ subroutine FieldIO(IO,DataHandle,DateStr,Starts,Length,MemoryOrder &
   integer                                   :: NDim
   integer,dimension(NVarDims)               :: VStart
   integer,dimension(NVarDims)               :: VCount
+  type(wrf_data_handle)      ,pointer       :: DH
 
   call GetTimeIndex(IO,DataHandle,DateStr,TimeIndex,Status)
   if(Status /= WRF_NO_ERR) then
@@ -704,19 +705,21 @@ VCount(:) = 1
   VCount(1:NDim) = Length(1:NDim)
   VStart(NDim+1) = TimeIndex
   VCount(NDim+1) = 1
+  DH => WrfDataHandles(DataHandle)
+
   select case (FieldType)
     case (WRF_REAL)
-      call ext_pnc_RealFieldIO    (WrfDataHandles(DataHandle)%Collective, &
-                                   IO,NCID,VarID,VStart,VCount,XField,Status)
+      call ext_pnc_RealFieldIO    (DH%Collective,IO,NCID,VarID,&
+                            VStart,VCount,DH%BputEnabled,XField,Status)
     case (WRF_DOUBLE)
-      call ext_pnc_DoubleFieldIO  (WrfDataHandles(DataHandle)%Collective, &
-                                   IO,NCID,VarID,VStart,VCount,XField,Status)
+      call ext_pnc_DoubleFieldIO  (DH%Collective,IO,NCID,VarID,&
+                            VStart,VCount,DH%BputEnabled,XField,Status)
     case (WRF_INTEGER)
-      call ext_pnc_IntFieldIO     (WrfDataHandles(DataHandle)%Collective, &
-                                   IO,NCID,VarID,VStart,VCount,XField,Status)
+      call ext_pnc_IntFieldIO     (DH%Collective,IO,NCID,VarID,&
+                            VStart,VCount,DH%BputEnabled,XField,Status)
     case (WRF_LOGICAL)
-      call ext_pnc_LogicalFieldIO (WrfDataHandles(DataHandle)%Collective, &
-                                   IO,NCID,VarID,VStart,VCount,XField,Status)
+      call ext_pnc_LogicalFieldIO (DH%Collective,IO,NCID,VarID,&
+                            VStart,VCount,DH%BputEnabled,XField,Status)
       if(Status /= WRF_NO_ERR) return
     case default
 !for wrf_complex, double_complex

--- a/external/io_pnetcdf/wrf_io.F90
+++ b/external/io_pnetcdf/wrf_io.F90
@@ -1479,6 +1479,20 @@ subroutine ext_pnc_ioclose(DataHandle, Status)
     return
   endif
 
+  ! Detach bput buffer before file close
+  if (DH%BputEnabled) then
+    stat = NFMPI_BUFFER_DETACH(DH%NCID)
+
+    ! check error
+    call netcdf_err(stat,Status)
+    if(Status /= WRF_NO_ERR) then
+      write(msg,*) 'NetCDF error in ext_pnc_ioclose: buffer detach ',__FILE__,', line', __LINE__
+      call wrf_debug ( WARN , TRIM(msg))
+      return
+    endif
+    DH%BputEnabled = .false.
+  endif
+
   stat = NFMPI_CLOSE(DH%NCID)
   call netcdf_err(stat,Status)
   if(Status /= WRF_NO_ERR) then

--- a/external/io_pnetcdf/wrf_io.F90
+++ b/external/io_pnetcdf/wrf_io.F90
@@ -930,6 +930,32 @@ subroutine ext_pnc_bput_set_buffer_size(hndl, bput_buffer_size)
   endif
 end subroutine ext_pnc_bput_set_buffer_size
 
+! ext_pnc_bput_wait:
+! Flush all cached reqs to the file. Wait/block till finished.
+subroutine ext_pnc_bput_wait(hndl)
+  use wrf_data_pnc
+  use ext_pnc_support_routines
+  use pnetcdf
+  implicit none
+  include 'wrf_status_codes.h'
+  integer, INTENT(IN)  :: hndl
+  type(wrf_data_handle), pointer :: DH
+  integer :: ierr, status, dummy(0)
+
+  call GetDH(hndl,DH,ierr)
+  if (DH%BputEnabled) then
+    ierr = NFMPI_WAIT_ALL(DH%NCID, NF_REQ_ALL, dummy, dummy)
+
+    ! check error
+    call netcdf_err(ierr,status)
+    if(status /= WRF_NO_ERR) then
+      write(msg,*) 'NetCDF error in ',__FILE__,', line', __LINE__
+      call wrf_debug(WARN, TRIM(msg))
+      return
+    endif
+  endif
+end subroutine ext_pnc_bput_wait
+
 subroutine ext_pnc_open_for_read(DatasetName, Comm1, Comm2, SysDepInfo, DataHandle, Status)
   use wrf_data_pnc
   use ext_pnc_support_routines

--- a/frame/module_io.F
+++ b/frame/module_io.F
@@ -71,6 +71,19 @@ MODULE module_io
     RETURN
   END FUNCTION io_form_for_stream
 
+! BputSetBufferSize:
+! Set the buffer size used by PnetCDF bput calls.
+SUBROUTINE BputSetBufferSize(fid, bput_buffer_size)
+  INTEGER, INTENT(IN) :: fid
+  INTEGER(KIND=8), INTENT(IN) :: bput_buffer_size
+  INTEGER :: Hndl, Hopened
+  LOGICAL :: for_out
+#ifdef PNETCDF
+  call get_handle(Hndl, Hopened, for_out, fid)
+  call ext_pnc_bput_set_buffer_size(Hndl, bput_buffer_size)
+#endif
+END SUBROUTINE BputSetBufferSize
+
 !--- ioinit
 
 SUBROUTINE wrf_ioinit( Status )

--- a/frame/module_io.F
+++ b/frame/module_io.F
@@ -39,6 +39,8 @@ MODULE module_io
                                                 ! are_bdys_distributed, bdys_are_distributed and
                                                 ! bdys_not_distributed routines access this flag
   CHARACTER*256 extradims
+  INTEGER(kind=8) :: bput_buffer_size_history = -1
+  INTEGER(kind=8) :: bput_buffer_size_restart = -1
 
 !<DESCRIPTION>
 !<PRE>

--- a/frame/module_io.F
+++ b/frame/module_io.F
@@ -98,6 +98,27 @@ SUBROUTINE BputWait(fid)
 #endif
 END SUBROUTINE BputWait
 
+! An helper routine to call enddef for PnetCDF and NetCDF(PAR).
+! So that define mode is only entered once. (This is an optimization)
+! Currently the optimization is only implemented for PnetCDF.
+SUBROUTINE wrf_enddef(fid)
+  INTEGER, INTENT(IN) :: fid
+  INTEGER :: Hndl, io_form, status
+  LOGICAL :: for_out
+  INTEGER, EXTERNAL           :: use_package
+
+  call get_handle(Hndl, io_form, for_out, fid)
+
+  SELECT CASE (use_package(io_form))
+
+#ifdef PNETCDF
+    CASE(io_pnetcdf)
+      call ext_pnc_enddef(Hndl, status)
+#endif
+
+  ENDSELECT
+END SUBROUTINE wrf_enddef
+
 !--- ioinit
 
 SUBROUTINE wrf_ioinit( Status )

--- a/frame/module_io.F
+++ b/frame/module_io.F
@@ -84,6 +84,18 @@ SUBROUTINE BputSetBufferSize(fid, bput_buffer_size)
 #endif
 END SUBROUTINE BputSetBufferSize
 
+! BputWait:
+! Flush all cached reqs to the file. Wait/block till finished.
+SUBROUTINE BputWait(fid)
+  INTEGER, INTENT(IN) :: fid
+  INTEGER :: Hndl, Hopened
+  LOGICAL :: for_out
+#ifdef PNETCDF
+  call get_handle(Hndl, Hopened, for_out, fid)
+  call ext_pnc_bput_wait(Hndl)
+#endif
+END SUBROUTINE BputWait
+
 !--- ioinit
 
 SUBROUTINE wrf_ioinit( Status )

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -1596,3 +1596,210 @@ endif
     RETURN
   END SUBROUTINE traverse_statevars_debug
 
+  ! BputCalcBufferSize:
+  ! Calculate the buffer size needed by PnetCDF bput calls.
+  ! The buffer size should equal the total amount of writes (excluding headers)
+  SUBROUTINE BputCalcBufferSize(grid, switch, totalSize)
+    USE module_domain_type, ONLY : fieldlist
+    USE module_domain
+    USE module_io
+    IMPLICIT NONE
+    INTEGER, PARAMETER :: DateStrLen = 19
+    TYPE(domain), INTENT(IN) :: grid
+    INTEGER, INTENT(IN) :: switch ! history files or restart files
+    INTEGER(kind=8), INTENT(INOUT):: totalSize ! the buffer size to return
+    ! temp variables
+    INTEGER :: gridSize = 0, typeSize = 4
+    INTEGER :: newSwitch, itrace
+    TYPE(fieldlist), POINTER :: p
+#ifdef PNETCDF
+    IF (totalSize > -1) THEN ! size already calculated, no need to repeat.
+      RETURN
+    ENDIF
+    p => grid%head_statevars%next
+
+    ! init variables
+    newSwitch = switch
+    totalSize = 0
+    ! The following codes are borrowed from share/output_wrf.F: subroutine "output_wrf"
+    !
+    ! The subroutine "output_wrf" is to write each variable to file. The implementation
+    ! logic of "output_wrf" is that:
+    !
+    !   Iterate over all variables (do while loop):
+    !       Some "if" conditions:
+    !           write/output the variable (of size amoutX) to file
+    !       End IF
+    !   End loop.
+    !
+    ! This subroutine "BputCalcBufferSize" is to return the buffer size (i.e. the total
+    ! amount of writes). The logic here is to replace "write/output the variable to file"
+    ! in the original logic with "increment total size":
+    !
+    !   totalSize = 0
+    !   Iterate over all variables (do while loop):
+    !       Some "if" conditions:
+    !           totalSize = totalSize + amoutX
+    !       End IF
+    !   End loop.
+    DO WHILE ( ASSOCIATED( p ) )
+      IF ( p%ProcOrient .NE. 'X' .AND. p%ProcOrient .NE. 'Y' ) THEN
+        IF (p%Ndim .EQ. 0)  THEN
+          IF ((p%Restart.AND.switch.EQ.restart_only).OR.on_stream(p%streams,newSwitch)) THEN
+            IF ( in_use_for_config(grid%id,TRIM(p%VarName)) ) THEN
+              ! increment totalSize
+              CALL BputInqSizeOfType(p%Type, typeSize)
+              totalSize = totalSize + typeSize ! grid szie=1 when p%Ndim == 0
+            ENDIF
+          ENDIF
+        ELSE IF (p%Ndim .EQ. 1) THEN
+          IF ((p%Restart.AND.switch.EQ.restart_only).OR.on_stream(p%streams,newSwitch)) THEN
+            IF ( in_use_for_config(grid%id,TRIM(p%VarName)) ) THEN
+              IF (switch.EQ.restart_only.OR.p%Ntl/100.EQ.mod(p%Ntl,100)) THEN
+                ! increment totalSize
+                CALL BputCalcGridSize(p, gridSize) ! calculate grid size
+                IF (gridSize >= 0) THEN
+                  CALL BputInqSizeOfType(p%Type, typeSize)
+                  totalSize = totalSize + gridSize * typeSize
+                ENDIF
+              ENDIF
+            ENDIF
+          ENDIF
+        ELSE IF (p%Ndim .EQ. 2) THEN
+          IF ((p%Restart.AND.switch.EQ.restart_only).OR.on_stream(p%streams,newSwitch)) THEN
+            IF ( in_use_for_config(grid%id,TRIM(p%VarName)) .AND.  &
+              ( .NOT. p%subgrid_x .OR. (p%subgrid_x .AND. grid%sr_x .GT. 0) ) .AND. &
+              ( .NOT. p%subgrid_y .OR. (p%subgrid_y .AND. grid%sr_y .GT. 0) )       &
+            ) THEN
+              IF (switch.EQ.restart_only.OR.p%Ntl/100.EQ.mod(p%Ntl,100)) THEN
+                ! increment totalSize
+                CALL BputCalcGridSize(p, gridSize) ! calculate grid size
+                IF (gridSize >= 0) THEN
+                  CALL BputInqSizeOfType(p%Type, typeSize)
+                  totalSize = totalSize + gridSize * typeSize
+                ENDIF
+              ENDIF
+            ENDIF
+          ENDIF
+        ELSE IF (p%Ndim .EQ. 3) THEN
+          IF ((p%Restart.AND.switch.EQ.restart_only).OR.on_stream(p%streams,newSwitch)) THEN
+            IF ( in_use_for_config(grid%id,TRIM(p%VarName)) .AND.  &
+              ( .NOT. p%subgrid_x .OR. (p%subgrid_x .AND. grid%sr_x .GT. 0) ) .AND. &
+              ( .NOT. p%subgrid_y .OR. (p%subgrid_y .AND. grid%sr_y .GT. 0) )       &
+            ) THEN
+              IF (switch.EQ.restart_only.OR.p%Ntl/100.EQ.mod(p%Ntl,100)) THEN
+                ! increment totalSize
+                CALL BputCalcGridSize(p, gridSize) ! calculate grid size
+                IF (gridSize >= 0) THEN
+                  CALL BputInqSizeOfType(p%Type, typeSize)
+                  totalSize = totalSize + gridSize * typeSize
+                ENDIF
+              ENDIF
+            ENDIF
+          ENDIF
+        ELSE IF (p%Ndim .EQ. 4 .AND. p%scalar_array ) THEN
+          IF (switch.EQ.restart_only.OR.p%Ntl/100.EQ.mod(p%Ntl,100)) THEN
+            DO itrace = PARAM_FIRST_SCALAR , p%num_table(grid%id)
+              IF ((p%Restart.AND.switch.EQ.restart_only).OR.on_stream(p%streams_table(grid%id,itrace)%stream,newSwitch)) THEN
+                ! increment totalSize
+                CALL BputCalcGridSize(p, gridSize) ! calculate grid size
+                IF (gridSize >= 0) THEN
+                  CALL BputInqSizeOfType(p%Type, typeSize)
+                  totalSize = totalSize + gridSize * typeSize
+                ENDIF
+              ENDIF
+            ENDDO
+          ENDIF
+        ENDIF
+      ENDIF
+      p => p%next
+    ENDDO
+    ! MPI Process 0 also needs to write to a variable called TimesVariable.
+    ! This variable has fix length 19 (DateStrLen). (external/io_pnetcdf/wrf_io.F90: GetTimeIndex)
+    ! Here we give 19 (DateStrLen) extra bytes to all MPI processes instead
+    ! of just giving to process 0, so that we can skip MPI rank check here to
+    ! simplify the implementation.
+    totalSize = totalSize + DateStrLen
+    contains
+    ! BputCalcGridSize:
+    ! Returns the size of the grid.
+    ! For example,  if it is a 2D 30 x 40 grid, then return size=1200 (=30x40).
+    ! if it is a 3D 10 x 30 x 40 grid, then return size=12000 (=10x30x40).
+    SUBROUTINE BputCalcGridSize(ptr, sizeOut)
+      USE module_domain_type, ONLY : fieldlist
+      TYPE(fieldlist), INTENT(INOUT), POINTER :: ptr
+      INTEGER, INTENT(OUT) :: sizeOut
+      INTEGER :: ndim, ierr=0
+      ! Whether it is a 0D/1D/2D/3D grid.
+      CALL BputInqDim(TRIM(ptr%MemoryOrder), ndim, ierr)
+      IF (ierr < 0) THEN
+        sizeOut = -1
+        return
+      ENDIF
+      ! ptr%sp[i] and prt%ep[i] store the start and end position of
+      ! grid along the i^th dimension, both sides inclusive.
+      sizeOut = 0
+      IF (ndim .EQ. 0) THEN
+        sizeOut = 1
+      ELSE IF (ndim .EQ. 1) THEN
+        IF (ptr%ep1 - ptr%sp1 >= 0) &
+        sizeOut = (ptr%ep1 - ptr%sp1 + 1)
+      ELSE IF (ndim .EQ. 2) THEN
+        IF (ptr%ep1 - ptr%sp1 >= 0 .AND. ptr%ep2 - ptr%sp2 >= 0) &
+        sizeOut = (ptr%ep1 - ptr%sp1 + 1) * (ptr%ep2 - ptr%sp2 + 1)
+      ELSE IF (ndim .EQ. 3) THEN
+        IF (ptr%ep1 - ptr%sp1 >= 0 .AND. ptr%ep2 - ptr%sp2 >= 0 .AND. ptr%ep3 - ptr%sp3 >= 0) &
+        sizeOut = (ptr%ep1 - ptr%sp1 + 1) * (ptr%ep2 - ptr%sp2 + 1) * (ptr%ep3 - ptr%sp3 + 1)
+      ENDIF
+      return
+    END SUBROUTINE BputCalcGridSize
+    ! BputInqSizeOfType:
+    ! Returns: how many bytes needed for one variable having this type.
+    SUBROUTINE BputInqSizeOfType(Type, Size)
+      CHARACTER*1, INTENT(IN) :: Type
+      INTEGER, INTENT(OUT) :: Size
+      ! LOGICAL :: temp_logical
+      REAL :: temp_real
+      REAL*8 :: temp_double
+
+      Size = 1
+      IF (Type .EQ. 'r') THEN
+        Size = SIZEOF(temp_real)
+      ELSE IF (Type .EQ. 'd') THEN
+        Size = SIZEOF(temp_double)
+      ELSE IF (Type .EQ. 'i') THEN
+        Size = SIZEOF(Size)
+      ELSE IF (Type .EQ. 'l') THEN
+        Size = SIZEOF(Size) ! integer is used for logic type
+      ENDIF
+      RETURN
+    END SUBROUTINE BputInqSizeOfType
+    ! BputInqDim:
+    ! Returns the number of dimension of the grid
+    ! i.e. whether it is a 0D/1D/2D/3D grid.
+    ! implementation is borrowed from external/io_pnetcdf/wrf_io.F90: GetDim
+    SUBROUTINE BputInqDim(MemoryOrder,NDim,Status)
+      CHARACTER*(*) ,INTENT(IN)  :: MemoryOrder
+      INTEGER       ,INTENT(OUT) :: NDim
+      INTEGER       ,INTENT(OUT) :: Status
+      CHARACTER*3                :: MemOrd
+      CALL lower_case(MemoryOrder,MemOrd) ! Convert to lower case
+      SELECT CASE (MemOrd)
+        CASE ('xyz','xzy','yxz','yzx','zxy','zyx','xsz','xez','ysz','yez')
+          NDim = 3
+        CASE ('xy','yx','xs','xe','ys','ye', 'cc')
+          NDim = 2
+        CASE ('z','c')
+          NDim = 1
+        CASE ('0')  ! NDim=0 for scalars.  TBH:  20060502
+          NDim = 0
+        CASE default
+          print *, 'memory order = ',MemOrd,'  ',MemoryOrder
+          Status = -1
+          return
+        END SELECT
+      Status = 0
+      RETURN
+    END SUBROUTINE BputInqDim
+#endif
+  END SUBROUTINE BputCalcBufferSize

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -103,6 +103,13 @@
 
     LOGICAL, EXTERNAL :: wrf_dm_on_monitor
 
+    ! bput_enabled is used to determine if non-blocking pnetcdf （bput） should be used for PnetCDF.
+    ! to use non-blocking bput:
+    !       1) enable_pnetcdf_bput = .true. in namelist.input
+    !       2) io_form_history=11 or io_form_restart=11 (or both=11) in namelist.input
+    !       3) not a dryrun
+    LOGICAL :: bput_enabled
+
     WRITE(wrf_err_message,*)'output_wrf: begin, fid = ',fid
     CALL wrf_debug( 300 , wrf_err_message )
 
@@ -1005,6 +1012,24 @@ endif
     IF ( (first_input   .LE. switch .AND. switch .LE. last_input) .OR. &
          (first_history .LE. switch .AND. switch .LE. last_history ) .OR. &
           switch .EQ. restart_only    ) THEN
+
+      bput_enabled = grid%enable_pnetcdf_bput .AND. (.NOT.dryrun)
+      ! Calculate and set bput buffer size for history files.
+      IF (switch .EQ. history_only) THEN
+        bput_enabled = bput_enabled .AND. (grid%io_form_history == 11)
+        IF (bput_enabled) THEN
+          CALL BputCalcBufferSize(grid, switch, bput_buffer_size_history)
+          call BputSetBufferSize(fid, bput_buffer_size_history)
+        ENDIF
+      ! Calculate and set bput buffer size for restart files.
+      ELSE IF (switch .EQ. restart_only) THEN
+        bput_enabled = bput_enabled .AND. (grid%io_form_restart == 11)
+        IF (bput_enabled) THEN
+          CALL BputCalcBufferSize(grid, switch, bput_buffer_size_restart)
+          call BputSetBufferSize(fid, bput_buffer_size_restart)
+        ENDIF
+      ENDIF
+
       newswitch = switch
       p => grid%head_statevars%next
       CALL wrf_start_io_timestep(fid, ierr)
@@ -1534,6 +1559,10 @@ endif
       IF (adjust) THEN
         current_date = current_date_save
       ENDIF
+    ENDIF
+
+    IF (bput_enabled) THEN
+      call BputWait(fid) ! wait till all PnetCDF bput calls (on this file) are finished.
     ENDIF
 
 #if ( (EM_CORE == 1) && (DA_CORE != 1) )

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -1009,6 +1009,10 @@ endif
     ENDIF
 #endif
 
+    IF (.NOT. dryrun) THEN
+      call wrf_enddef(fid)
+    ENDIF
+
     IF ( (first_input   .LE. switch .AND. switch .LE. last_input) .OR. &
          (first_history .LE. switch .AND. switch .LE. last_history ) .OR. &
           switch .EQ. restart_only    ) THEN

--- a/var/build/da_name_space.pl
+++ b/var/build/da_name_space.pl
@@ -196,4 +196,5 @@ wrf_get_dom_ti_integer
 is_this_data_ok_to_use
 check_which_switch
 med_read_qna_emissions
+BputCalcBufferSize
 ###########################################################################################


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: parallel I/O, PnetCDF, non-blocking APIs, requests aggregation

SOURCE: Zanhua Huang (Northwestern University), Wei-keng Liao (Northwestern University, @wkliao)

DESCRIPTION OF CHANGES:
Problem:
We found that using [PnetCDF non-blocking APIs](https://parallel-netcdf.github.io/wiki/CombiningOperations.html) can improve the parallel I/O performance noticeably over the original blocking APIs used in WRF. A paper discussing the performance of PnetCDF non-blocking APIs with WRF is [I/O in WRF: A Case Study in Modern Parallel I/O Techniques](https://doi.org/10.1145/3581784.3613216)

Solution:
We added a new I/O option to enable PnetCDF non-blocking APIs. If users specify `enable_pnetcdf_bput` to `.true.` in the namelist, and also specify io_form to PnetCDF for history and/or restart file (io_form = 11), then PnetCDF non-blocking APIs will be used.

When PnetCDF non-blocking APIs are enabled, the write calls to WRF variables are first buffered in the memory, and flushed to file until the end of each time step.


LIST OF MODIFIED FILES:
1. Registry/registry.io_boilerplate
1. external/io_pnetcdf/ext_pnc_put_dom_ti.code
1. external/io_pnetcdf/field_routines.F90
1. external/io_pnetcdf/wrf_io.F90
1. frame/module_io.F
1. share/output_wrf.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
We conducted the performance evaluation on a WRF single-domain [benchmark](https://akirakyle.github.io/WRF_benchmarks/) with a grid size of 1900x1300 on Cori at NERSC. The performance improvement of using PnetCDF non-blocking APIs is presented in the paper mentioned above.
3. Are the Jenkins tests all passing? Not tested

RELEASE NOTE: Support PnetCDF non-blocking APIs to increase parallel I/O performance of PnetCDF. Zanhua Huang, Kaiyuan Hou, Ankit Agrawal, Alok Choudhary, Robert Ross, and Wei-Keng Liao. 2023. I/O in WRF: A Case Study in Modern Parallel I/O Techniques. In Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis (SC '23). Association for Computing Machinery, New York, NY, USA, Article 94, 1–13. https://doi.org/10.1145/3581784.3613216
