### PR TITLE
Fix line continuation syntax causing problems with certain compilers

### DIFF
--- a/dyn_em/module_big_step_utilities_em.F
+++ b/dyn_em/module_big_step_utilities_em.F
@@ -5733,11 +5733,11 @@ END SUBROUTINE phy_prep_part2
 !                                300                                     ! term 4
 !                    
          IF ( ( config_flags%use_theta_m .EQ. 1 ) .AND. (P_Qv .GE. PARAM_FIRST_SCALAR) ) THEN
-            t_new(i,k,j) =  h_diabatic(i,k,j)*(1. + (R_v/R_d)*qv_diabatic(i,k,j)) + \
-                            mpten*(1. + (R_v/R_d)*qv(i,k,j)) + \
+            t_new(i,k,j) =  h_diabatic(i,k,j)*(1. + (R_v/R_d)*qv_diabatic(i,k,j)) + &
+                            mpten*(1. + (R_v/R_d)*qv(i,k,j)) + &
                             (R_v/R_d)*qvten*th_phy(i,k,j) - T0
             th_phy_m_t0(i,k,j) = (t_new(i,k,j)+T0)/(1.+(R_v/R_d)*qv(i,k,j)) - T0
-            h_diabatic(i,k,j) =  ( mpten*(1. + (R_v/R_d)*qv(i,k,j)) + \
+            h_diabatic(i,k,j) =  ( mpten*(1. + (R_v/R_d)*qv(i,k,j)) + &
                                  (R_v/R_d)*qvten*th_phy(i,k,j) ) / dt
          ELSE
             t_new(i,k,j) = t_new(i,k,j) + mpten


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: syntax, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
dyn_em/module_big_step_utilities_em.F contains nonstandard line continuation symbols that are most likely being ignored by the make build system by the in situ file preprocessing steps. The cmake build does not use sed or standard.exe to preprocess files, so these lines get fed directly to compilers. Fortran compilers that do not support C-style line continuation then fail (nvhpc as an example).

Solution:
Change line continuation characters to standard Fortran.
