### PR TITLE
Replace nonstandard isnan() call with value input checks instead

### DIFF
--- a/phys/module_wind_mav.F
+++ b/phys/module_wind_mav.F
@@ -1231,11 +1231,11 @@ MODULE module_wind_mav
       end if
 
       tmp1 = tmp1 / tmp2
-      if ( tmp1 < -1 .or. tmp1 > 1 ) then
-        angle = 0
+      if ( tmp1 < -1.0_8 .or. tmp1 > 1.0_8 ) then
+        angle = 0.
       else
         angle = real(acos(tmp1), kind = 4)
-      endif
+      end if
  
       if (abs(angle) <= sr_angle) then
           ft = .true.

--- a/phys/module_wind_mav.F
+++ b/phys/module_wind_mav.F
@@ -1231,10 +1231,10 @@ MODULE module_wind_mav
       end if
 
       tmp1 = tmp1 / tmp2
-      if ( tmp1 < -1.0_8 .or. tmp1 > 1.0_8 ) then
-        angle = 0.
+      if (tmp1 < -1.0_8 .or. tmp1 > 1.0_8) then
+          angle = 0.
       else
-        angle = real(acos(tmp1), kind = 4)
+          angle = real(acos(tmp1), kind = 4)
       end if
  
       if (abs(angle) <= sr_angle) then

--- a/phys/module_wind_mav.F
+++ b/phys/module_wind_mav.F
@@ -1231,7 +1231,7 @@ MODULE module_wind_mav
       end if
 
       tmp1 = tmp1 / tmp2
-      if ( tmp1 < -1 .or. tmp1 > 1 )
+      if ( tmp1 < -1 .or. tmp1 > 1 ) then
         angle = 0
       else
         angle = real(acos(tmp1), kind = 4)

--- a/phys/module_wind_mav.F
+++ b/phys/module_wind_mav.F
@@ -1230,11 +1230,12 @@ MODULE module_wind_mav
           tmp2 = sign(tmp1,tmp2)
       end if
 
-      angle = real(acos(tmp1/tmp2), kind = 4)
-
-      if (isnan(angle)) then
-         angle = 0.
-      end if
+      tmp1 = tmp1 / tmp2
+      if ( tmp1 < -1 .or. tmp1 > 1 )
+        angle = 0
+      else
+        angle = real(acos(tmp1), kind = 4)
+      endif
  
       if (abs(angle) <= sr_angle) then
           ft = .true.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compilation, nonstandard

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #1944 introduced a nonstandard function call `isnan()` which breaks compilation for compilers which don't support this extension. 

Solution:
A potential alternative is to use the `ieee_is_nan()` call from `ieee_arithmetic`. As there is conditional compilation of this module which requires Fortran 2003 standard, an easier alternative is just to check the input values before calling `acos()`
