### PR TITLE
Add explicit casts to mismatched pointer types in rsl_lite

### DIFF
--- a/external/RSL_LITE/c_code.c
+++ b/external/RSL_LITE/c_code.c
@@ -484,12 +484,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( (long *)buf, (long *)p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie, 
+            F_PACK_LINT ( (long *)buf, (long *)(p+yp_curs), imemord, &js, &je, &ks, &ke, &is, &ie, 
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( (int * )buf, (int * )p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )(p+yp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
 	  }
@@ -505,12 +505,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = IMAX(ips-shw) ; ie = IMIN(ipe+shw) ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( (long *)p+yp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)(p+yp_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT ( (int * )p+yp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )(p+yp_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
 	  }
@@ -538,12 +538,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( (long *)buf, (long *)p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT ( (long *)buf, (long *)(p+ym_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( (int * )buf, (int * )p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )(p+ym_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
   	  }
@@ -559,12 +559,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = IMAX(ips-shw) ; ie = IMIN(ipe+shw) ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( (long *)p+ym_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)(p+ym_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT ( (int * )p+ym_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )(p+ym_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
 	  }
@@ -596,12 +596,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( (long *)buf, (long *)p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT ( (long *)buf, (long *)(p+xp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( (int * )buf, (int * )p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )(p+xp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
 	  }
@@ -617,12 +617,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = ipe+recvbegp  ; ie = is + recvwp - 1 ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( (long *)p+xp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)(p+xp_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT ( (int * )p+xp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )(p+xp_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
 	  }
@@ -652,12 +652,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( (long *)buf, (long *)p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT ( (long *)buf, (long *)(p+xm_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( (int * )buf, (int * )p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )(p+xm_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
 	  }
@@ -673,12 +673,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           ie = ips-recvbegm ; is = ie - recvwm + 1 ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( (long *)p+xm_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)(p+xm_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
           } 
           else if ( typesize == 4 ) {
-            F_UNPACK_INT ( (int * )p+xm_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )(p+xm_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
 	  }

--- a/external/RSL_LITE/c_code.c
+++ b/external/RSL_LITE/c_code.c
@@ -484,12 +484,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie, 
+            F_PACK_LINT ( (long *)buf, (long *)p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie, 
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
 	  }
@@ -505,12 +505,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = IMAX(ips-shw) ; ie = IMIN(ipe+shw) ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( p+yp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)p+yp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT ( p+yp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )p+yp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
 	  }
@@ -538,12 +538,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( buf, p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT ( (long *)buf, (long *)p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( buf, p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
   	  }
@@ -559,12 +559,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = IMAX(ips-shw) ; ie = IMIN(ipe+shw) ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( p+ym_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)p+ym_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT ( p+ym_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )p+ym_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
 	  }
@@ -596,12 +596,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( buf, p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT ( (long *)buf, (long *)p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( buf, p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
 	  }
@@ -617,12 +617,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = ipe+recvbegp  ; ie = is + recvwp - 1 ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( p+xp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)p+xp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT ( p+xp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )p+xp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
 	  }
@@ -652,12 +652,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_PACK_LINT ( buf, p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT ( (long *)buf, (long *)p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT ( buf, p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT ( (int * )buf, (int * )p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
 	  }
@@ -673,12 +673,12 @@ RSL_LITE_PACK ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           ie = ips-recvbegm ; is = ie - recvwm + 1 ;
           if ( typesize == 8 ) {
-            F_UNPACK_LINT ( p+xm_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT ( (long *)p+xm_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
           } 
           else if ( typesize == 4 ) {
-            F_UNPACK_INT ( p+xm_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT ( (int * )p+xm_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
 	  }

--- a/external/RSL_LITE/c_code.c
+++ b/external/RSL_LITE/c_code.c
@@ -780,12 +780,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_UNPACK_LINT_AD ( p+yp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie, 
+            F_UNPACK_LINT_AD ( (long *)(p+yp_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie, 
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT_AD ( p+yp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT_AD ( (int * )(p+yp_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
 	  }
@@ -801,12 +801,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = IMAX(ips-shw) ; ie = IMIN(ipe+shw) ;
           if ( typesize == 8 ) {
-            F_PACK_LINT_AD ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT_AD ( (long *)buf, (long *)(p+yp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT_AD ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT_AD ( (int * )buf, (int * )(p+yp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             yp_curs += wcount*typesize ;
 	  }
@@ -834,12 +834,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_UNPACK_LINT_AD ( p+ym_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT_AD ( (long *)(p+ym_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT_AD ( p+ym_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT_AD ( (int * )(p+ym_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
   	  }
@@ -855,12 +855,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = IMAX(ips-shw) ; ie = IMIN(ipe+shw) ;
           if ( typesize == 8 ) {
-            F_PACK_LINT_AD ( buf, p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT_AD ( (long *)buf, (long *)(p+ym_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT_AD ( buf, p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT_AD ( (int * )buf, (int * )(p+ym_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             ym_curs += wcount*typesize ;
 	  }
@@ -892,12 +892,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_UNPACK_LINT_AD ( p+xp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT_AD ( (long *)(p+xp_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT_AD ( p+xp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT_AD ( (int * )(p+xp_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
 	  }
@@ -913,12 +913,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           is = ipe+recvbegp  ; ie = is + recvwp - 1 ;
           if ( typesize == 8 ) {
-            F_PACK_LINT_AD ( buf, p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT_AD ( (long *)buf, (long *)(p+xp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_PACK_INT_AD ( buf, p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT_AD ( (int * )buf, (int * )(p+xp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xp_curs += wcount*typesize ;
 	  }
@@ -948,12 +948,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
 	    MPI_Abort(MPI_COMM_WORLD, 99) ;
           }
           if ( typesize == 8 ) {
-            F_UNPACK_LINT_AD ( p+xm_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_LINT_AD ( (long *)(p+xm_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                 &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
           }
 	  else if ( typesize == 4 ) {
-            F_UNPACK_INT_AD ( p+xm_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_UNPACK_INT_AD ( (int * )(p+xm_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                                &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
 	  }
@@ -969,12 +969,12 @@ RSL_LITE_PACK_AD ( int * Fcomm0, char * buf , int * shw0 ,
           ks = kps           ; ke = kpe ;
           ie = ips-recvbegm ; is = ie - recvwm + 1 ;
           if ( typesize == 8 ) {
-            F_PACK_LINT_AD ( buf, p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_LINT_AD ( (long *)buf, (long *)(p+xm_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                   &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
           } 
           else if ( typesize == 4 ) {
-            F_PACK_INT_AD ( buf, p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+            F_PACK_INT_AD ( (int * )buf, (int * )(p+xm_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                                  &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
             xm_curs += wcount*typesize ;
 	  }

--- a/external/RSL_LITE/period.c
+++ b/external/RSL_LITE/period.c
@@ -169,12 +169,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( (long *)buf, (long *)p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)(p+xp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( (int * )buf, (int * )p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )(p+xp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
 	}
@@ -188,12 +188,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         is = ipe           ; ie = ipe+shw-1+stag ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( (long *)p+xp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)(p+xp_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( (int * )p+xp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )(p+xp_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
 	}
@@ -219,12 +219,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( (long *)buf, (long *)p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)(p+xm_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( (int * )buf, (int * )p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )(p+xm_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
 	}
@@ -238,12 +238,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         is = ips-shw       ; ie = ips-1           ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( (long *)p+xm_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)(p+xm_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( (int * )p+xm_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )(p+xm_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
 	}
@@ -274,12 +274,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( (long *)buf, (long *)p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)(p+yp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( (int * )buf, (int * )p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )(p+yp_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
 	}
@@ -293,12 +293,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         js = jpe           ; je = jpe+shw-1+stag ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( (long *)p+yp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)(p+yp_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( (int * )p+yp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )(p+yp_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
 	}
@@ -324,12 +324,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( (long *)buf, (long *)p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)(p+ym_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( (int * )buf, (int * )p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )(p+ym_curs), imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
 	}
@@ -343,12 +343,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         js = jps-shw       ; je = jps-1           ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( (long *)p+ym_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)(p+ym_curs), (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( (int * )p+ym_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )(p+ym_curs), (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
 	}

--- a/external/RSL_LITE/period.c
+++ b/external/RSL_LITE/period.c
@@ -169,12 +169,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( buf, p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( buf, p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )p+xp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
 	}
@@ -188,12 +188,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         is = ipe           ; ie = ipe+shw-1+stag ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( p+xp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)p+xp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( p+xp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )p+xp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xp_curs += wcount*typesize ;
 	}
@@ -219,12 +219,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( buf, p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( buf, p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )p+xm_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
 	}
@@ -238,12 +238,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         is = ips-shw       ; ie = ips-1           ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( p+xm_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)p+xm_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( p+xm_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )p+xm_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           xm_curs += wcount*typesize ;
 	}
@@ -274,12 +274,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
 	}
@@ -293,12 +293,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         js = jpe           ; je = jpe+shw-1+stag ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( p+yp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)p+yp_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( p+yp_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )p+yp_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           yp_curs += wcount*typesize ;
 	}
@@ -324,12 +324,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
 	  MPI_Abort(MPI_COMM_WORLD, 98) ;
         }
         if ( typesize == 8 ) {
-          F_PACK_LINT ( buf, p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_LINT ( (long *)buf, (long *)p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                         &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_PACK_INT ( buf, p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_PACK_INT ( (int * )buf, (int * )p+ym_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
                                        &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
 	}
@@ -343,12 +343,12 @@ void RSL_LITE_PACK_PERIOD ( int* Fcomm0, char * buf , int * shw0 , int * typesiz
         ks = kps           ; ke = kpe ;
         js = jps-shw       ; je = jps-1           ;
         if ( typesize == 8 ) {
-          F_UNPACK_LINT ( p+ym_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_LINT ( (long *)p+ym_curs, (long *)buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                           &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
         } else
 	if ( typesize == 4 ) {
-          F_UNPACK_INT ( p+ym_curs, buf, imemord, &js, &je, &ks, &ke, &is, &ie,
+          F_UNPACK_INT ( (int * )p+ym_curs, (int * )buf, imemord, &js, &je, &ks, &ke, &is, &ie,
                                          &jms,&jme,&kms,&kme,&ims,&ime, &wcount ) ;
           ym_curs += wcount*typesize ;
 	}

--- a/external/RSL_LITE/rsl_lite.h
+++ b/external/RSL_LITE/rsl_lite.h
@@ -161,7 +161,7 @@
 
 
 #define RSL_MALLOC(T,N)  (T *)rsl_malloc(__FILE__,__LINE__,(sizeof(T))*(N))
-#define RSL_FREE(P)      rsl_free(&(P))
+#define RSL_FREE(P)      rsl_free((char **)&(P))
 
 char * buffer_for_proc ( int P, int size, int code ) ;
 int buffer_size_for_proc( int P, int code );


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: gcc14, compilation, c99

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
From #2047 :
Compilation of WRF v4.6.0 fails with GCC 14 due to new standard changes

> Type checking on pointer types (-Werror=incompatible-pointer-types)
> GCC no longer allows implicitly casting all pointer types to all other pointer types. This behavior is now restricted to the void * type and its qualified variations.
> 
> To fix compilation errors resulting from that, you can add the appropriate casts, and maybe consider using void * in more places (particularly for old programs that predate the introduction of void * into the C language).
> 
> Programs that do not carefully track pointer types are likely to contain aliasing violations, so consider building with -fno-strict-aliasing. (Whether casts are written manually or performed by GCC automatically does not make a difference in terms of strict aliasing violations.)
> 
> A frequent source of incompatible function pointer types involves callback functions that have more specific argument types (or less specific return types) than the function pointer they are assigned to. For example, old code which attempts to sort an array of strings might look like this: 
```
#include <stddef.h>
#include <stdlib.h>
#include <string.h>

int
compare (char **a, char **b)
{
  return strcmp (*a, *b);
}

void
sort (char **array, size_t length)
{
  qsort (array, length, sizeof (*array), compare);
}
```
Example of failure : 
```
/home/aislas/wrf-model/wrf/external/RSL_LITE/c_code.c: In function ‘rsl_lite_pack_’:
/home/aislas/wrf-model/wrf/external/RSL_LITE/c_code.c:487:27: error: passing argument 1 of ‘f_pack_lint_’ from incompatible pointer type [-Wincompatible-pointer-types]
  487 |             F_PACK_LINT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
      |                           ^~~
      |                           |
      |                           char *
In file included from /home/aislas/wrf-model/wrf/external/RSL_LITE/c_code.c:31:
/home/aislas/wrf-model/wrf/external/RSL_LITE/rsl_lite.h:200:25: note: expected ‘long int *’ but argument is of type ‘char *’
  200 | void F_PACK_LINT (long *inbuf, long *outbuf, int* memorder, int* js, int* je, int* ks, int* ke, int* is, int* ie, int* jms, int* jme, int* kms, int* kme, int* ims, int* ime, int* curs);
      |                   ~~~~~~^~~~~
/home/aislas/wrf-model/wrf/external/RSL_LITE/c_code.c:487:33: error: passing argument 2 of ‘f_pack_lint_’ from incompatible pointer type [-Wincompatible-pointer-types]
  487 |             F_PACK_LINT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
      |                                ~^~~~~~~~
      |                                 |
      |                                 char *
/home/aislas/wrf-model/wrf/external/RSL_LITE/rsl_lite.h:200:38: note: expected ‘long int *’ but argument is of type ‘char *’
  200 | void F_PACK_LINT (long *inbuf, long *outbuf, int* memorder, int* js, int* je, int* ks, int* ke, int* is, int* ie, int* jms, int* jme, int* kms, int* kme, int* ims, int* ime, int* curs);
      |                                ~~~~~~^~~~~~
/home/aislas/wrf-model/wrf/external/RSL_LITE/c_code.c:492:26: error: passing argument 1 of ‘f_pack_int_’ from incompatible pointer type [-Wincompatible-pointer-types]
  492 |             F_PACK_INT ( buf, p+yp_curs, imemord, &js, &je, &ks, &ke, &is, &ie,
      |                          ^~~
      |                          |
      |                          char *
/home/aislas/wrf-model/wrf/external/RSL_LITE/rsl_lite.h:201:23: note: expected ‘int *’ but argument is of type ‘char *’
  201 | void F_PACK_INT (int *inbuf, int *outbuf, int* memorder, int* js, int* je, int* ks, int* ke, int* is, int* ie, int* jms, int* jme, int* kms, int* kme, int* ims, int* ime, int* curs);
      |                  ~~~~~^~~~~
```

Error was reproduced AlmaLinux release 9.4 with GCC 14.1.0

Solution:
Use explicit type casting

ISSUE: 
Fixes #2047 

TESTS CONDUCTED: 
1. Tested on GCC 14.1.0
