### PR TITLE
Inconsistency in dimensionality in heat flux evaluation within slab model is rectified.

### DIFF
--- a/phys/module_sf_slab.F
+++ b/phys/module_sf_slab.F
@@ -407,7 +407,7 @@ CONTAINS
                 ESG=SVP1*EXP(SVP2*(TG0(I)-SVPT0)/(TG0(I)-SVP3))
                 QSG=EP2*ESG/(PSFC(I)-ESG)
                 THG=TSK(I)*(100./PSFC(I))**ROVCP
-                HFX(I)=FLHC(I)*(THG-THX(I))
+                HFX(I)=FLHC(I)*CAPG(I)*(THG-THX(I))
                 QFX(I)=FLQC(I)*(QSG-QX(I))
                 LH(I)=QFX(I)*XLV
         QS(I)=HFX(I)+QFX(I)*XLV                                
@@ -440,7 +440,7 @@ CONTAINS
                     -SVP3))                                                      
                 QSG=EP2*ESG/(PS-ESG)                                             
 !     UPDATE FLUXES FOR NEW GROUND TEMPERATURE                                   
-                HFXT=FLHC(I)*(THG-THX(I))                                     
+                HFXT=FLHC(I)*CAPG(I)*(THG-THX(I))                                    
                 QFXT=FLQC(I)*(QSG-QX(I))
                 QS(I)=HFXT+QFXT*XLV                                
 !     SUM HFX AND QFX OVER SOIL TIMESTEPS                                        


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: Slab model, sensible heat flux, heat capacity. skin temperature, thermal balance 

SOURCE: Parag Joshi (Brookhaven National Laboratory)

DESCRIPTION OF CHANGES:
Problem: The sensible heat flux evaluation in the slab model is incorrect. The flux is missing the factor of thermal capacity.

Solution: The error is fixed following the formulation and verified by evaluating the dimensions post corrections. 

ISSUE: For use when this PR closes an issue.
Fixes #123

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: 
1. No test is performed for quantifying the impact of the error. 

RELEASE NOTE: The sensible heat flux evaluation turned out to be dimensionally inconsistent which led to the incorrect evaluation of the ground temperature. Following the formulation (Link: https://journals.ametsoc.org/view/journals/apme/21/11/1520-0450_1982_021_1594_ahrmot_2_0_co_2.xml), refer to the equations 5a and 11 of the article in the link, the error is highlighted. 
