### PR TITLE
Bugfix for duplicated allocation and file closing for radar_rhv_opt = 2

### DIFF
--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -275,7 +275,6 @@ END IF
       allocate (avg_qrn(tot_h_index,tot_z_index))
       allocate (avg_qds(tot_h_index,tot_z_index))
       allocate (avg_qws(tot_h_index,tot_z_index))
-      allocate (avg_qws(tot_h_index,tot_z_index))
       allocate (avg_qgr(tot_h_index,tot_z_index))
       allocate (ave_rho(tot_h_index,tot_z_index))
 
@@ -379,7 +378,7 @@ END IF
          end do
       end do   !bottom-top
       if (rootproc) close(hydro_weight_unit)
-      if (rootproc) call da_get_unit(hydro_weight_unit)
+      if (rootproc) call da_free_unit(hydro_weight_unit)
    end if   !! use_radar_rhv .and. radar_rhv_opt == 2
 
    do n=iv%info(radar)%n1,iv%info(radar)%n2


### PR DESCRIPTION
Bugs fix of duplicated allocation and file close in radar_rhv_opt = 2.

TYPE: bug fix

KEYWORDS: radar DA

DESCRIPTION OF CHANGES:
Problem:
Duplicated allocation of avg_qws when choosing radar_rhv_opt = 2.
da_free_unit instead of da_get_unit for closing a file when radar_rhv_opt is equal to 2.

ISSUE: #2077 

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
var/da/da_radar/da_get_innov_vector_radar.inc