### PR TITLE
CMake Prepare for alternate core selections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,9 @@ set( WRF_CASE_OPTIONS
       EM_CONVRAD
       EM_SQUALL2D_X
       EM_SQUALL2D_Y
+
+      # No case selected, for situations where we are not compiling ARW
+      NONE
       )
 
 set( WRF_CASE "" CACHE STRING "WRF_CASE" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,11 @@ if ( NOT ${WRF_CORE} IN_LIST WRF_CORE_OPTIONS )
   message( FATAL_ERROR "WRF Core option not recognized : ${WRF_CORE}" )
 endif()
 
+if ( NOT ${WRF_CORE} STREQUAL "ARW" )
+  message( STATUS "All non-ARW Cores requires using pointers in grid state struct" )
+  set( USE_ALLOCATABLES OFF CACHE BOOL "Required by configuration" FORCE )
+endif()
+
 if ( NOT ${WRF_NESTING} IN_LIST WRF_NESTING_OPTIONS )
   message( FATAL_ERROR "WRF Nesting option not recognized : ${WRF_NESTING}" )
 endif()

--- a/arch/configure_reader.py
+++ b/arch/configure_reader.py
@@ -575,8 +575,12 @@ def generateCMakeToolChainFile( cmakeToolChainTemplate, output, stanza, optionsD
 
 def projectSpecificOptions( options, stanzaCfg ) :
   coreOption       = getStringOptionSelection( options.sourceCMakeFile, "WRF_CORE_OPTIONS",    "WRF_CORE"    )
-  nestingOption    = getStringOptionSelection( options.sourceCMakeFile, "WRF_NESTING_OPTIONS", "WRF_NESTING", 1 )
-  caseOption       = getStringOptionSelection( options.sourceCMakeFile, "WRF_CASE_OPTIONS",    "WRF_CASE"    )
+  if coreOption == "ARW" :
+    nestingOption    = getStringOptionSelection( options.sourceCMakeFile, "WRF_NESTING_OPTIONS", "WRF_NESTING", 1 )
+    caseOption       = getStringOptionSelection( options.sourceCMakeFile, "WRF_CASE_OPTIONS",    "WRF_CASE"    )
+  else :
+    nestingOption = "NONE"
+    caseOption    = "NONE"
   
   # These are yes
   yesValues    = [ "yes", "y", "true", "1" ]


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, wrfplus, da

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The current CMake build only works with the em core / ARW in mind and presents a non-intuitive selection when attempting other cores. While these cores are not yet supported in the CMake build, remove these selections sets up the configuration script to be able to present a familiar set of options.

Solution:
Remove normally unselectable options from `configure_new` after selecting non-ARW cores. Put in place stand-in values for these unselected variables.  
