### PR TITLE
CMake improve configure_reader.py script

### DIFF
--- a/arch/configure_reader.py
+++ b/arch/configure_reader.py
@@ -17,7 +17,8 @@ osAndArch     = re.compile( r"^ARCH[ ]+(\w+)[ ]+((?:\w+.*?),|(?:[(].*?[)]))",   
 osAndArchAlt  = re.compile( r"^ARCH[ ]+(\w+)[ ]+(\w+)",         re.I )
 
 referenceVar  = re.compile( r"[$]([(])?(\w+)(?(1)[)])", re.I )
-compileObject = re.compile( r"(\W)-c(\W)" )
+compileObject = re.compile( r"(\W|^)-c(\W|$)" )
+configureRepl = re.compile( r"(\W|^)CONFIGURE_\w+(\W|$)" )
 
 class Stanza():
   
@@ -160,52 +161,9 @@ class Stanza():
     self.dereference( "FCBASEOPTS" )
 
     # Remove rogue compile commands that should *NOT* even be here
-    keysToSanitize = [ 
-                      "ARFLAGS","ARFLAGS",
-                      "CC",
-                      "CFLAGS_LOCAL",
-                      "CFLAGS",
-                      "COMPRESSION_INC",
-                      "COMPRESSION_LIBS",
-                      "CPP",
-                      "CPPFLAGS",
-                      "DM_CC",
-                      "DM_FC",
-                      "ESMF_LDFLAG",
-                      "F77FLAGS",
-                      "FC",
-                      "FCBASEOPTS_NO_G",
-                      "FCBASEOPTS",
-                      "FCOPTIM",
-                      "FCSUFFIX",
-                      "FDEFS",
-                      "FFLAGS",
-                      "FNGFLAGS",
-                      "FORMAT_FIXED",
-                      "FORMAT_FREE",
-                      "LD",
-                      "LDFLAGS_LOCAL",
-                      "LDFLAGS",
-                      "MODULE_SRCH_FLAG",
-                      "RLFLAGS",
-                      "SCC",
-                      "SFC",
-                      "TRADFLAG",
-                      ]
-
-    for keyToSan in keysToSanitize :
-      if keyToSan in self.kvPairs_ :
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_COMP_L", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_COMP_I", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_FC", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_CC", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_FDEFS", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_MPI", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_COMPAT_FLAGS", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_CPPFLAGS", "" )
-        self.kvPairs_[ keyToSan ] = self.kvPairs_[ keyToSan ].replace( "CONFIGURE_TRADFLAG", "" )
-
-        self.kvPairs_[ keyToSan ] = compileObject.sub( r"\1\2", self.kvPairs_[ keyToSan ] ).strip()
+    for keyToSan in self.kvPairs_.keys() :
+      self.kvPairs_[ keyToSan ] = configureRepl.sub( r"\1\2", self.kvPairs_[ keyToSan ] ).strip()
+      self.kvPairs_[ keyToSan ] = compileObject.sub( r"\1\2", self.kvPairs_[ keyToSan ] ).strip()
 
 
     # Now fix certain ones that are mixing programs with flags all mashed into one option


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, configuration

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
In preparation for alternate core compilation, there is need for additional information from the stanzas. Some of these fields include extraneous information to cmake that must be filtered out. The previous version manually listed fields and values to sanitize, but this is brittle when accounting for all stanza types and configurations.

Solution:
Rather than hard-coding the sanitization of stanza fields to be consumed by cmake, a generalized approach is used to allow full use of stanza fields down the line.
