### PR TITLE
CMake WRFPLUS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,6 +922,10 @@ if ( ${ENABLE_HYDRO} )
   add_subdirectory( hydro  )
 endif()
 
+if ( ${WRF_CORE} STREQUAL "PLUS" )
+  add_subdirectory( wrftladj )
+endif()
+
 add_subdirectory( dyn_em   )
 
 

--- a/cmake/wrf_case_setup.cmake
+++ b/cmake/wrf_case_setup.cmake
@@ -47,6 +47,51 @@ macro( wrf_setup_targets )
 
 endmacro()
 
+# WRF Macro for adding target symlinks/copies to be run after internal install() code 
+# this allows for alternate naming
+macro( wrf_setup_target_new_name )
+
+  set( options        USE_SYMLINKS )
+  set( oneValueArgs   TARGET DEST_PATH NEW_NAME )
+  set( multiValueArgs )
+
+  cmake_parse_arguments(
+                        WRF_SETUP
+                        "${options}"  "${oneValueArgs}"  "${multiValueArgs}"
+                        ${ARGN}
+                        )
+  set( WRF_SETUP_CMD copy_if_different )
+  if ( ${WRF_SETUP_USE_SYMLINKS} )
+    set( WRF_SETUP_CMD create_symlink )
+  endif()
+
+  # Generate install code for each target
+  # https://stackoverflow.com/a/56528615
+  #!TODO Do we *need* the rm for symlinks beforehand?
+  # get_filename_component( WRF_SETUP_FILE_ONLY $<TARGET_FILE:${WRF_SETUP_TARGET}> NAME
+
+  # If we ever wanted to link or copy things other than binaries we could change this
+  set( WRF_SETUP_INSTALL_LOCATION ${CMAKE_INSTALL_PREFIX}/bin )
+
+  install( 
+          CODE "
+                message( STATUS \"Setting up $<TARGET_FILE_NAME:${WRF_SETUP_TARGET}> via ${WRF_SETUP_CMD} as ${WRF_SETUP_NEW_NAME}\" )
+                execute_process( COMMAND ${CMAKE_COMMAND} -E ${WRF_SETUP_CMD} ${WRF_SETUP_INSTALL_LOCATION}/$<TARGET_FILE_NAME:${WRF_SETUP_TARGET}> ${WRF_SETUP_DEST_PATH}/${WRF_SETUP_NEW_NAME} )
+                "
+          COMPONENT setup
+          )
+  
+  # Add .exe link as well
+  install( 
+          CODE "
+                message( STATUS \"Creating symlink for ${WRF_SETUP_NEW_NAME}.exe\" )
+                execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ${WRF_SETUP_DEST_PATH}/${WRF_SETUP_NEW_NAME} ${WRF_SETUP_DEST_PATH}/${WRF_SETUP_NEW_NAME}.exe )
+                "
+          COMPONENT setup
+          )
+
+endmacro()
+
 # WRF Macro for adding file symlinks/copies to be run after internal install() code
 macro( wrf_setup_files )
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,15 +5,8 @@ add_compile_options    ( "${PROJECT_COMPILE_OPTIONS}"     )
 add_compile_definitions( "${PROJECT_COMPILE_DEFINITIONS}" )
 
 # First make true executables
-if ( ${WRF_CORE} STREQUAL "PLUS" )
-  add_executable(
-                  wrfplus
-                  wrf.F
-                  module_wrf_top.F
-                  )
-  list( APPEND FOLDER_COMPILE_TARGETS wrfplus )
-else()
-  # I believe this is always made if not WRF PLUS or ESMF
+if ( ${WRF_CORE} STREQUAL "PLUS" OR ${WRF_CASE} STREQUAL "EM_REAL" )
+  
   add_executable( 
                   wrf
                   wrf.F
@@ -31,45 +24,47 @@ else()
 #   list( APPEND FOLDER_COMPILE_TARGETS em_wrf_SST_ESMF )
 endif()
 
-# Use case info from higher CMakeLists.txt
-set( MODULE_FILE ${PROJECT_SOURCE_DIR}/dyn_em/module_initialize_${WRF_CASE_MODULE}.F )
+if ( ${WRF_CORE} STREQUAL "ARW" )
 
-if ( ${WRF_CASE} STREQUAL "EM_REAL" )
-  add_executable(
-                  ndown
-                  ndown_em.F
-                  ${MODULE_FILE}
-                  )
-  add_executable(
-                  tc
-                  tc_em.F
-                  ${MODULE_FILE}
-                  )
-  add_executable( 
-                  real
-                  real_em.F
-                  ${MODULE_FILE}
-                )
-  list( APPEND FOLDER_COMPILE_TARGETS ndown tc real )
+  # Use case info from higher CMakeLists.txt
+  set( MODULE_FILE ${PROJECT_SOURCE_DIR}/dyn_em/module_initialize_${WRF_CASE_MODULE}.F )
 
-elseif( NOT ${WRF_GENERAL_IDEAL_CASE} ) # Not general ideal and not real
-  # All others are variants of ideal
-  add_executable( 
-                  ideal
-                  ideal_em.F
-                  ${MODULE_FILE}
-                )
-  list( APPEND FOLDER_COMPILE_TARGETS ideal )
-else()
-  # greater than or equal to general ideal case
-  add_executable( 
-                  ideal
-                  ideal_em.F
-                  ${PROJECT_SOURCE_DIR}/dyn_em/module_initialize_ideal.F
-                )
-  list( APPEND FOLDER_COMPILE_TARGETS ideal )
+  if ( ${WRF_CASE} STREQUAL "EM_REAL" )
+    add_executable(
+                    ndown
+                    ndown_em.F
+                    ${MODULE_FILE}
+                    )
+    add_executable(
+                    tc
+                    tc_em.F
+                    ${MODULE_FILE}
+                    )
+    add_executable( 
+                    real
+                    real_em.F
+                    ${MODULE_FILE}
+                  )
+    list( APPEND FOLDER_COMPILE_TARGETS ndown tc real )
+
+  elseif( NOT ${WRF_GENERAL_IDEAL_CASE} ) # Not general ideal and not real
+    # All others are variants of ideal
+    add_executable( 
+                    ideal
+                    ideal_em.F
+                    ${MODULE_FILE}
+                  )
+    list( APPEND FOLDER_COMPILE_TARGETS ideal )
+  else()
+    # greater than or equal to general ideal case
+    add_executable( 
+                    ideal
+                    ideal_em.F
+                    ${PROJECT_SOURCE_DIR}/dyn_em/module_initialize_ideal.F
+                  )
+    list( APPEND FOLDER_COMPILE_TARGETS ideal )
+  endif()
 endif()
-
 
 foreach ( TARGET ${FOLDER_COMPILE_TARGETS} )
   set_target_properties( 
@@ -154,3 +149,13 @@ wrf_setup_files(
                 DEST_PATH
                   ${CMAKE_INSTALL_PREFIX}/run/
                 )
+
+if ( ${WRF_CORE} STREQUAL "PLUS" )
+  wrf_setup_target_new_name(
+                            TARGET         wrf
+                            DEST_PATH      ${CMAKE_INSTALL_PREFIX}/run
+                            NEW_NAME       wrfplus
+                            USE_SYMLINKS
+
+  )
+endif()

--- a/wrftladj/CMakeLists.txt
+++ b/wrftladj/CMakeLists.txt
@@ -1,0 +1,86 @@
+# WRF CMake Build
+
+
+target_sources(
+                ${PROJECT_NAME}_Core
+                PRIVATE
+                  # Mods MP
+                  module_mp_mkessler.F
+                  module_mp_nconvp.F
+                  # Mods BL
+                  module_bl_surface_drag.F
+                  # Mods CU
+                  module_cu_du.F
+                  # Mods LL
+                  module_linked_list2.F
+                  # Mods PT
+                  mediation_pertmod_io.F
+                  # Dynem mods
+                  module_advect_em_tl.F
+                  module_advect_em_ad.F
+                  module_diffusion_em_tl.F
+                  module_diffusion_em_ad.F
+                  module_small_step_em_tl.F
+                  module_small_step_em_ad.F
+                  module_big_step_utilities_em_tl.F
+                  module_big_step_utilities_em_ad.F
+                  module_em_tl.F
+                  module_em_ad.F
+                  module_bc_em_tl.F
+                  module_bc_em_ad.F
+                  module_first_rk_step_part1_tl.F
+                  module_first_rk_step_part1_ad.F
+                  module_first_rk_step_part2_tl.F
+                  module_first_rk_step_part2_ad.F
+                  module_sfs_nba_tl.F
+                  module_sfs_nba_ad.F
+                  module_sfs_driver_tl.F
+                  module_sfs_driver_ad.F
+                  # Dynem objs
+                  solve_em_tl.F
+                  solve_em_ad.F
+                  start_em_tl.F
+                  start_em_ad.F
+                  # Phys mods
+                  module_bl_gwdo_tl.F
+                  module_bl_gwdo_ad.F
+                  module_bl_surface_drag_tl.F
+                  module_bl_surface_drag_ad.F
+                  module_cu_du_tl.F
+                  module_cu_du_ad.F
+                  module_mp_mkessler_tl.F
+                  module_mp_mkessler_ad.F
+                  module_mp_wsm6r_tl.F
+                  module_mp_wsm6r_ad.F
+                  module_mp_nconvp_tl.F
+                  module_mp_nconvp_ad.F
+                  module_physics_addtendc_tl.F
+                  module_physics_addtendc_ad.F
+                  module_physics_init_tl.F
+                  module_physics_init_ad.F
+                  module_pbl_driver_tl.F
+                  module_pbl_driver_ad.F
+                  module_cumulus_driver_tl.F
+                  module_cumulus_driver_ad.F
+                  module_microphysics_driver_tl.F
+                  module_microphysics_driver_ad.F
+                  module_microphysics_zero_out_tl.F
+                  module_microphysics_zero_out_ad.F
+                  # Share mods
+                  module_adtl_grid_utilities.F
+                  module_bc_tl.F
+                  module_bc_ad.F
+                  # Share objs
+                  jcdfi.F
+                  # Frame objs
+                  adStack.c
+                  adBuffer.F
+                )
+
+set_source_files_properties(
+                            adBuffer.F
+                            TARGET_DIRECTORY ${PROJECT_NAME}_Core
+                            PROPERTIES
+                              Fortran_FORMAT FIXED
+                            )
+


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, wrfplus

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The current CMake build does not build the WRF PLUS core configuration

Solution:
Add the necessary source files to compile WRF PLUS. WRF binary will still be created, but a symlink to `wrfplus.exe` will also be created for backward compatibility
