### PR TITLE
CMake confcheck switch to try_* functions

### DIFF
--- a/cmake/confcheck.cmake
+++ b/cmake/confcheck.cmake
@@ -1,18 +1,18 @@
 # WRF Macro for adding configuration checks from source file, default is fortran
 # https://cmake.org/cmake/help/latest/module/CheckFortranSourceCompiles.html
 # https://github.com/ufs-community/ufs-weather-model/issues/132
-include( CheckFortranSourceRuns )
-include( CheckFortranSourceCompiles )
-include( CheckCSourceRuns )
-include( CheckCSourceCompiles )
-include( CheckCXXSourceRuns )
-include( CheckCXXSourceCompiles )
+# include( CheckFortranSourceRuns )
+# include( CheckFortranSourceCompiles )
+# include( CheckCSourceRuns )
+# include( CheckCSourceCompiles )
+# include( CheckCXXSourceRuns )
+# include( CheckCXXSourceCompiles )
 
-macro( wrf_conf_check )
+function( wrf_conf_check )
 
   set( options        QUIET RUN REQUIRED )
-  set( oneValueArgs   RESULT_VAR EXTENSION FAIL_REGEX SOURCE MESSAGE SOURCE_TYPE )
-  set( multiValueArgs ADDITIONAL_FLAGS ADDITIONAL_DEFINITIONS ADDITIONAL_INCLUDES ADDITIONAL_LINK_OPTIONS ADDITIONAL_LIBRARIES )
+  set( oneValueArgs   RESULT_VAR MESSAGE )
+  set( multiValueArgs SOURCES OPTIONS )
 
   cmake_parse_arguments(
                         WRF_CFG
@@ -20,102 +20,41 @@ macro( wrf_conf_check )
                         ${ARGN}
                         )
 
-  get_filename_component( WRF_CFG_SOURCE_FILE ${WRF_CFG_SOURCE} REALPATH )  
-  file( READ ${WRF_CFG_SOURCE_FILE} WRF_CFG_CODE )
-
-  # Santize for newlines
-  string( REPLACE "\\n" "\\\\n" WRF_CFG_CODE "${WRF_CFG_CODE}" )
-
-  if ( NOT DEFINED WRF_CFG_SOURCE_TYPE )
-    set( WRF_CFG_SOURCE_TYPE fortran )
+  if ( NOT DEFINED WRF_CFG_BINDIR )
+    set( WRF_CFG_BINDIR ${CMAKE_CURRENT_BINARY_DIR}/confcheck/${WRF_CFG_RESULT_VAR}/ )
   endif()
 
-  if ( DEFINED WRF_CFG_FAIL_REGEX )
-    if ( DEFINED WRF_CFG_RUN )
-      message( WARNING "wrf_conf_check: FAIL_REGEX ignored when running check" )
-    else()
-      set( WRF_CFG_FAIL_REGEX FAIL_REGEX ${WRF_CFG_FAIL_REGEX} )
-    endif()
-  endif()
+  message( STATUS "Performing Check ${WRF_CFG_RESULT_VAR}" )
 
-  if ( DEFINED WRF_CFG_EXTENSION )
-    set( WRF_CFG_EXTENSION SRC_EXT ${WRF_CFG_EXTENSION} )
-  endif()
-
-  # Additional options
-  if ( DEFINED WRF_CFG_QUIET AND ${WRF_CFG_QUIET} )
-    set( CMAKE_REQUIRED_QUIET ${WRF_CFG_QUIET} )
-  endif()
-
-  if ( DEFINED WRF_CFG_ADDITIONAL_FLAGS )
-    set( CMAKE_REQUIRED_FLAGS ${WRF_CFG_ADDITIONAL_FLAGS} )
-  endif()
-
-  if ( DEFINED WRF_CFG_ADDITIONAL_DEFINITIONS )
-    set( CMAKE_REQUIRED_DEFINITIONS ${WRF_CFG_ADDITIONAL_DEFINITIONS} )
-  endif()
-
-  if ( DEFINED WRF_CFG_ADDITIONAL_INCLUDES )
-    set( CMAKE_REQUIRED_INCLUDES ${WRF_CFG_ADDITIONAL_INCLUDES} )
-  endif()
-
-  if ( DEFINED WRF_CFG_ADDITIONAL_LINK_OPTIONS )
-    set( CMAKE_REQUIRED_LINK_OPTIONS ${WRF_CFG_ADDITIONAL_LINK_OPTIONS} )
-  endif()
-
-  if ( DEFINED WRF_CFG_ADDITIONAL_LIBRARIES )
-    set( CMAKE_REQUIRED_LIBRARIES ${WRF_CFG_ADDITIONAL_LIBRARIES} )
-  endif()
-
-  string( TOLOWER "${WRF_CFG_SOURCE_TYPE}" WRF_CFG_SOURCE_TYPE )
   if ( DEFINED WRF_CFG_RUN )
-    if ( ${WRF_CFG_SOURCE_TYPE} STREQUAL "fortran" )
-      check_fortran_source_runs(
-                                "${WRF_CFG_CODE}"
-                                ${WRF_CFG_RESULT_VAR}
-                                ${WRF_CFG_FAIL_REGEX}
-                                ${WRF_CFG_EXTENSION}
-                                )
-    elseif ( ${WRF_CFG_SOURCE_TYPE} STREQUAL "c" )
-      check_c_source_runs(
-                          "${WRF_CFG_CODE}"
-                          ${WRF_CFG_RESULT_VAR}
-                          ${WRF_CFG_FAIL_REGEX}
-                          ${WRF_CFG_EXTENSION}
-                          )
-    elseif ( ${WRF_CFG_SOURCE_TYPE} STREQUAL "cpp" )
-      check_cpp_source_runs(
-                            "${WRF_CFG_CODE}"
-                            ${WRF_CFG_RESULT_VAR}
-                            ${WRF_CFG_FAIL_REGEX}
-                            ${WRF_CFG_EXTENSION}
-                            )
+    try_run( 
+            ${WRF_CFG_RESULT_VAR}
+            WRF_CFG_COMPILE_RESULT_VAR
+            ${WRF_CFG_BINDIR}
+            ${WRF_CFG_SOURCES}
+            ${WRF_CFG_OPTIONS}
+            )
+    if ( ${WRF_CFG_COMPILE_RESULT_VAR} )
+      # Did it run successfully
+      if ( ${${WRF_CFG_RESULT_VAR}} EQUAL 0 )
+        set( ${WRF_CFG_RESULT_VAR} TRUE )
+      endif()
+    else()
+      set( ${WRF_CFG_RESULT_VAR} FALSE )
     endif()
   else()
-    if ( ${WRF_CFG_SOURCE_TYPE} STREQUAL "fortran" )
-      check_fortran_source_compiles(
-                                    "${WRF_CFG_CODE}"
-                                    ${WRF_CFG_RESULT_VAR}
-                                    ${WRF_CFG_EXTENSION}
-                                    )
-    elseif ( ${WRF_CFG_SOURCE_TYPE} STREQUAL "c" )
-      check_c_source_compiles(
-                              "${WRF_CFG_CODE}"
-                              ${WRF_CFG_RESULT_VAR}
-                              ${WRF_CFG_EXTENSION}
-                              )
-    elseif ( ${WRF_CFG_SOURCE_TYPE} STREQUAL "cpp" )
-      check_cpp_source_compiles(
-                                "${WRF_CFG_CODE}"
-                                ${WRF_CFG_RESULT_VAR}
-                                ${WRF_CFG_EXTENSION}
-                                )
-    endif()
+      try_compile(
+                  ${WRF_CFG_RESULT_VAR}
+                  ${WRF_CFG_BINDIR}
+                  SOURCES ${WRF_CFG_SOURCES}
+                  ${WRF_CFG_OPTIONS}
+                  )
   endif()
 
   # If it failed - note that since this is a run/compile test we expect pass/true 
   # to just proceed as normal, but if failure we should do something about it
   if ( NOT ( DEFINED ${WRF_CFG_RESULT_VAR} AND "${${WRF_CFG_RESULT_VAR}}" ) )
+    message( STATUS "Performing Check ${WRF_CFG_RESULT_VAR} - Failure" )
     set( WRF_CFG_MSG_TYPE STATUS )
     if ( DEFINED WRF_CFG_REQUIRED AND ${WRF_CFG_REQUIRED} )
       set( WRF_CFG_MSG_TYPE FATAL_ERROR )
@@ -126,8 +65,12 @@ macro( wrf_conf_check )
     else()
       message( ${WRF_CFG_MSG_TYPE} "${WRF_CFG_RESULT_VAR} marked as required, check failed" )
     endif()
+  else()
+    message( STATUS "Performing Check ${WRF_CFG_RESULT_VAR} - Success" )
   endif()
 
-endmacro()
+  set( ${WRF_CFG_RESULT_VAR} ${${WRF_CFG_RESULT_VAR}} PARENT_SCOPE )
+
+endfunction()
 
 

--- a/confcheck/CMakeLists.txt
+++ b/confcheck/CMakeLists.txt
@@ -2,24 +2,21 @@
 wrf_conf_check(
                 RUN
                 RESULT_VAR Fortran_2003_IEEE
-                SOURCE     ${PROJECT_SOURCE_DIR}/tools/fortran_2003_ieee_test.F
-                EXTENSION  .F
+                SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_ieee_test.F
                 MESSAGE    "Some IEEE Fortran 2003 features missing, removing usage of these features"
                 )
 
 wrf_conf_check(
                 RUN
                 RESULT_VAR Fortran_2003_ISO_C
-                SOURCE     ${PROJECT_SOURCE_DIR}/tools/fortran_2003_iso_c_test.F
-                EXTENSION  .F
+                SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_iso_c_test.F
                 MESSAGE    "Some ISO_C Fortran 2003 features missing, removing usage ISO_C and stubbing code dependent on it"
                 )
 
 wrf_conf_check(
                 RUN
                 RESULT_VAR Fortran_2003_FLUSH
-                SOURCE     ${PROJECT_SOURCE_DIR}/tools/fortran_2003_flush_test.F
-                EXTENSION  .F
+                SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_flush_test.F
                 MESSAGE    "Standard FLUSH routine Fortran 2003 features missing, checking for alternate Fortran_2003_FFLUSH"
                 )
 
@@ -27,8 +24,7 @@ if ( NOT ${Fortran_2003_FLUSH} )
   wrf_conf_check(
                   RUN
                   RESULT_VAR Fortran_2003_FFLUSH
-                  SOURCE     ${PROJECT_SOURCE_DIR}/tools/fortran_2003_fflush_test.F
-                  EXTENSION  .F
+                  SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_fflush_test.F
                   MESSAGE    "Standard FFLUSH routine Fortran 2003 features missing, no alternate to FLUSH found, feature stubbed out"
                   )
 endif()
@@ -36,8 +32,7 @@ endif()
 wrf_conf_check(
                 RUN
                 RESULT_VAR Fortran_2003_GAMMA
-                SOURCE     ${PROJECT_SOURCE_DIR}/tools/fortran_2008_gamma_test.F
-                EXTENSION  .F
+                SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2008_gamma_test.F
                 MESSAGE    "Some Fortran 2003 features missing, removing usage gamma function intrinsic and stubbing code dependent on it"
                 )
 
@@ -45,22 +40,20 @@ wrf_conf_check(
 
 wrf_conf_check(
                 RUN
-                SOURCE_TYPE            C
                 RESULT_VAR             FSEEKO64
-                SOURCE                 ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
-                EXTENSION              .c
-                ADDITIONAL_DEFINITIONS -DTEST_FSEEKO64 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
+                SOURCES                ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
+                OPTIONS
+                  COMPILE_DEFINITIONS -DTEST_FSEEKO64 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                 MESSAGE                "fseeko64 not supported, checking alternate fseeko"
                 )
 
 if ( NOT "${FSEEKO64}" )
   wrf_conf_check(
                   RUN
-                  SOURCE_TYPE            C
                   RESULT_VAR             FSEEKO
-                  SOURCE                 ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
-                  EXTENSION              .c
-                  ADDITIONAL_DEFINITIONS -DTEST_FSEEKO -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
+                  SOURCES                ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
+                  OPTIONS
+                    COMPILE_DEFINITINOS -DTEST_FSEEKO -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                   MESSAGE                "fseeko not supported, compiling with fseek (caution with large files)"
                   )
 endif()


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, configuration

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The configuration checks done by the CMake build use language-specific calls between various functions. This has lead to a rather complex signature that is also limited in scope.

Solution:
Simplify the `wrf_conf_check` calls to make use of CMake's built-in `try_compile()` and `try_run()` functions, forwarding argument to those as necessary. Aside from minor adjustments to the `wrf_conf_check` calls this should appear as a drop-in replacement that provides the same results as before, i.e. no change to the system configuration options detected.
