### PR TITLE
Bug fix for missed reflectivity calculation in WSM6 scheme

### DIFF
--- a/phys/module_sf_bem.F
+++ b/phys/module_sf_bem.F
@@ -889,7 +889,7 @@ use module_wrf_error
        uroof=(uout(n+1)**2+vout(n+1)**2)**0.5
       deltat=tpv-tair(n+1)
     hf=2.5*(40./100.*uroof)**(0.5)
-    hc=9.842*abs(deltat)**(1./3.)/(7.283-abs(cos(tiltangle)))
+    hc=9.482*abs(deltat)**(1./3.)/(7.238-abs(cos(tiltangle)))
     hup=sqrt(hc**2.+(hf)**2.)
     hc=1.810*abs(deltat)**(1./3.)/(1.382+abs(cos(tiltangle)))
     hdown=sqrt(hc**2.+(hf)**2.)

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1184,7 +1184,7 @@ USE module_model_constants, ONLY :  piconst
           
        CALL TDFCND (DF1,SMR(KZ), QUARTZ, SMCMAX )
        DF1 = DF1 * EXP(-2.0 * SHDFAC)  
-       RGR = EPSV*(RX-SIG*(TGRP**4.)/60.)
+       RGR = EPSV*(RX-SIG*(TA**4.)/60.)
        RGRR= (SGR+RGR) * 697.7 * 60.
        RCH = RHOO*CPP*CHGR
        RR1 = EPSV*(TA**4) * 6.48E-8 / (PS* CHGR) + 1.0
@@ -1727,7 +1727,7 @@ ENDIF
         PSIM=ALOG((Z+Z0)/Z0) &
             -ALOG((X+1.)**2.*(X**2.+1.)) &
             +2.*ATAN(X) &
-            +ALOG((X+1.)**2.*(X0**2.+1.)) &
+            +ALOG((X0+1.)**2.*(X0**2.+1.)) &
             -2.*ATAN(X0)
         FAIH=1./SQRT(1.-16.*XXX)
         PSIH=ALOG((Z+Z0)/Z0)+0.4*B1 &

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -66,7 +66,6 @@ USE module_model_constants, ONLY :  piconst
    REAL, ALLOCATABLE, DIMENSION(:) :: TRLEND_TBL, TBLEND_TBL, TGLEND_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: AKANDA_URBAN_TBL
 !for BEP
-
    ! MAXDIRS :: The maximum number of street directions we're allowed to define
    INTEGER, PARAMETER :: MAXDIRS = 3
    ! MAXHGTS :: The maximum number of building height bins we're allowed to define
@@ -3160,13 +3159,13 @@ SUBROUTINE SFCDIF_URB (ZLM,Z0,THZ0,THLM,SFCSPD,AKANDA,AKMS,AKHS,RLMO,CD,ZT_OUT,V
 ! LECH'S SURFACE FUNCTIONS
 ! ----------------------------------------------------------------------
       PSLMU (ZZ)= -0.96* log (1.0-4.5* ZZ)
-      PSLMS (ZZ)= ZZ * RRIC -2.076* (1. -1./ (ZZ +1.))
+      PSLMS (ZZ)= (ZZ/RFC) -2.076* (1. -1./ (ZZ +1.))
       PSLHU (ZZ)= -0.96* log (1.0-4.5* ZZ)
 
 ! ----------------------------------------------------------------------
 ! PAULSON'S SURFACE FUNCTIONS
 ! ----------------------------------------------------------------------
-      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. -1./ (ZZ +1.))
+      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. - exp(-1.2 * ZZ))
       PSPMU (XX)= -2.* log ( (XX +1.)*0.5) - log ( (XX * XX +1.)*0.5)   &
      &        +2.* ATAN (XX)                                            &
      &- PIHF

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -60,11 +60,6 @@ Description of namelist variables
                                      = 10,      ! GRIB2 format
                                      = 11,      ! pnetCDF format
  ncd_nofill                          = .true.,  ! only a single write, not the write/read/write sequence
- frames_per_emissfile                = 12,      ! number of times in each chemistry emission file.
- io_style_emiss                      = 1,       ! style to use for the chemistry emission files.
-                                                ! 0 = Do not read emissions from files.
-                                                ! 1 = Cycle between two 12 hour files (set frames_per_emissfile=12)
-                                                ! 2 = Dated files with length set by frames_per_emissfile
  debug_level                         = 0, 	! 50,100,200,300 values give increasing prints
  diag_print                          = 0, 	! print out time series of model diagnostics
                                                   0 = no print
@@ -89,20 +84,20 @@ To choose between SI and WPS input to real for EM core:
  auxinput1_inname                    = "met_em.d<domain>.<date>"             ! Input to real from WPS (default since 3.0)
                                      = "wrf_real_input_em.d<domain>.<date>"  ! Input to real from SI
 
-Other output options:
+Other output options: Note all auxhist[1-24], auxinput[2-24] interval variables are domain dependent
 
- auxhist2_outname                    = "rainfall" ! file name for extra output! if not specified,
-                                                    auxhist2_d<domain>_<date> will be used
+ auxhist9_outname                    = "rainfall" ! file name for extra output! if not specified,
+                                                    auxhist9_d<domain>_<date> will be used
                                                     also note that to write variables in output other
                                                     than the history file requires Registry.EM file change
- auxhist2_interval (max_dom)         = 10,      ! interval in minutes
- io_form_auxhist2                    = 2,       ! output in netCDF
- frames_per_auxhist2                 = 1000,    ! number of output times in this file
+ auxhist9_interval (max_dom)         = 10,      ! interval in minutes
+ io_form_auxhist9                    = 2,       ! output in netCDF
+ frames_per_auxhist9                 = 1000,    ! number of output times in this file
 
 For SST updating (used only with sst_update=1):
  
  auxinput4_inname                    = "wrflowinp_d<domain>" 
- auxinput4_interval                  = 360      ! minutes generally matches time given by interval_seconds
+ auxinput4_interval (max_dom)        = 360      ! minutes generally matches time given by interval_seconds
  io_form_auxinput4                   = 2        ! IO format
 
  nwp_diagnostics                     = 0        ! set to = 1 to add 7 history-interval max diagnostic fields
@@ -112,7 +107,7 @@ For additional regional climate surface fields
  output_diagnostics                  = 0        ! set to = 1 to add 36 surface diagnostic arrays (max/min/mean/std)
  auxhist3_outname                    = 'wrfxtrm_d<domain>_<date>' ! file name for added diagnostics
  io_form_auxhist3                    = 2        ! netcdf
- auxhist3_interval                   = 1440     ! minutes between outputs (1440 gives daily max/min)
+ auxhist3_interval (max_dom)         = 1440     ! minutes between outputs (1440 gives daily max/min)
  frames_per_auxhist3                 = 1        ! output times per file
                                                   Note: do restart only at multiple of auxhist3_intervals
 
@@ -138,13 +133,13 @@ Additional settings when running WRFVAR:
  inputout_interval (max_dom)         = 180,     ! interval in minutes when writing input-formatted data 
  input_outname                       = 'wrfinput_d<domain>_<date>' ! you may change the output file name
  inputout_begin_y (max_dom)          = 0
- inputout_begin_mo                   = 0
+ inputout_begin_m                    = 0
  inputout_begin_d (max_dom)          = 0
  inputout_begin_h (max_dom)          = 3
  inputout_begin_m (max_dom)          = 0
  inputout_begin_s (max_dom)          = 0
  inputout_end_y (max_dom)            = 0
- inputout_end_mo                     = 0
+ inputout_end_m                      = 0
  inputout_end_d (max_dom)            = 0
  inputout_end_h (max_dom)            = 12
  inputout_end_m (max_dom)            = 0
@@ -495,7 +490,7 @@ Namelist variables for controlling the adaptive time step option:
                                        For NSSL 1-moment schemes, intercept and particle densities can be set for snow, 
                                        graupel, hail, and rain. For the 1- and 2-moment schemes, the shape parameters 
                                        for graupel and hail can be set.
-                                       PLEASE SEE README.NSSLmp for options affecting the NSSL scheme
+                                       PLEASE SEE doc/README.NSSLmp for options affecting the NSSL scheme
                                      = 17, 19, 21, 22: Legacy NSSL-MP options: see README.NSSLmp for equivalent settings with 18
                                      = 24, WSM 7-class scheme (separate hail and graupel categories)
                                      = 26, WDM 7-class scheme (separate hail and graupel categories)
@@ -874,9 +869,6 @@ Namelist variables for controlling the adaptive time step option:
                                      = 3, for small grid distances (DX < 5 km)
  nsas_dx_factor                      = 0, ! default option
                                      = 1,   NSAS grid-distance dependent option
- ntiedtke_dx_opt                     = 0, default option
-                                     = 1, new Tiedtke grid-distance dependent option (scale-aware)
-                                          when grid size falls below 15 km
  For KF-CuP scheme: recommended to use with cu_rad_feedback
  shallowcu_forced_ra(max_dom)        radiative impact of shallow Cu by a prescribed maximum cloud fraction
                                      = .false., option off, default

--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -275,7 +275,6 @@ END IF
       allocate (avg_qrn(tot_h_index,tot_z_index))
       allocate (avg_qds(tot_h_index,tot_z_index))
       allocate (avg_qws(tot_h_index,tot_z_index))
-      allocate (avg_qws(tot_h_index,tot_z_index))
       allocate (avg_qgr(tot_h_index,tot_z_index))
       allocate (ave_rho(tot_h_index,tot_z_index))
 
@@ -379,7 +378,7 @@ END IF
          end do
       end do   !bottom-top
       if (rootproc) close(hydro_weight_unit)
-      if (rootproc) call da_get_unit(hydro_weight_unit)
+      if (rootproc) call da_free_unit(hydro_weight_unit)
    end if   !! use_radar_rhv .and. radar_rhv_opt == 2
 
    do n=iv%info(radar)%n1,iv%info(radar)%n2


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: radar reflectivity, WSM6

SOURCE: reported by Gabriel Cassol of Sigma Meteorologia, Brazil, internal

DESCRIPTION OF CHANGES:
Problem:
When moving WSM6 to MMM shared physics directory, the calculation of radar reflectivity was left out.

Solution:
The calculation of radar reflectivity is added back in the WSM6 scheme.

ISSUE: For use when this PR closes an issue.
Fixes #2096

LIST OF MODIFIED FILES: 
M      phys/module_mp_wsm6.F

TESTS CONDUCTED: 
1. The reflectivity is computed now when namelist do_radar_ref is set to 1.
2. Are the Jenkins tests all passing?

RELEASE NOTE: Fixed the bug of missing radar reflectivity in WSM6 scheme when do_radar_ref is set to 1. 
