### PR TITLE
Add reflectivity calculation back to WSM6 scheme

### DIFF
--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -1,7 +1,7 @@
  module module_mp_wsm6
  use ccpp_kind_types,only: kind_phys
 
- use mp_wsm6,only: mp_wsm6_run
+ use mp_wsm6,only: mp_wsm6_run,refl10cm_wsm6
  use mp_wsm6_effectrad,only: mp_wsm6_effectRad_run
 
 
@@ -230,6 +230,23 @@
            re_snow(i,k,j)  = re_qs_hv(i,k)
         enddo
      enddo
+
+     if (diagflag .and. do_radar_ref == 1) then
+        do i=its,ite
+           do k=kts,kte
+              t1d(k)=th(i,k,j)*pii(i,k,j)
+              p1d(k)=p(i,k,j)
+              qv1d(k)=q(i,k,j)
+              qr1d(k)=qr(i,k,j)
+              qs1d(k)=qs(i,k,j)
+              qg1d(k)=qg(i,k,j)
+           enddo
+           call refl10cm_wsm6 (qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ,kts,kte)
+           do k = kts, kte
+              refl_10cm(i,k,j) = MAX(-35., dBZ(k))
+           enddo
+        enddo
+     endif
 
  enddo
 

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -242,7 +242,7 @@
            enddo
            call refl10cm_wsm6 (qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ,kts,kte)
            do k = kts, kte
-              refl_10cm(i,k,j) = MAX(-35., dBZ(k))
+              refl_10cm(i,k,j) = max(-35., dBZ(k))
            enddo
         enddo
      endif

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -9,7 +9,6 @@
  private
  public:: wsm6
 
-
  contains
 
 

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -243,7 +243,7 @@
            enddo
            call refl10cm_wsm6 (qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ,kts,kte)
            do k = kts, kte
-              refl_10cm(i,k,j) = MAX(-35., dBZ(k))
+              refl_10cm(i,k,j) = max(-35., dBZ(k))
            enddo
         enddo
      endif

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -243,7 +243,7 @@
            enddo
            call refl10cm_wsm6 (qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ,kts,kte)
            do k = kts, kte
-              refl_10cm(i,k,j) = max(-35., dBZ(k))
+              refl_10cm(i,k,j) = MAX(-35., dBZ(k))
            enddo
         enddo
      endif

--- a/phys/module_mp_wsm6.F
+++ b/phys/module_mp_wsm6.F
@@ -9,6 +9,7 @@
  private
  public:: wsm6
 
+
  contains
 
 
@@ -242,7 +243,7 @@
            enddo
            call refl10cm_wsm6 (qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ,kts,kte)
            do k = kts, kte
-              refl_10cm(i,k,j) = max(-35., dBZ(k))
+              refl_10cm(i,k,j) = MAX(-35., dBZ(k))
            enddo
         enddo
      endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: radar reflectivity, WSM6

SOURCE: reported by Gabriel Cassol of Sigma Meteorologia, Brazil, internal

DESCRIPTION OF CHANGES:
Problem:
When moving WSM6 to MMM shared physics directory, the calculation of radar reflectivity was left out.

Solution:
The calculation of radar reflectivity is added back in the WSM6 scheme.

ISSUE: For use when this PR closes an issue.
Fixes https://github.com/wrf-model/WRF/issues/2096

LIST OF MODIFIED FILES:
M phys/module_mp_wsm6.F

TESTS CONDUCTED:

1. The reflectivity is computed now when namelist do_radar_ref is set to 1.
2. The Jenkins tests are all passing.

RELEASE NOTE: Fixed the bug of missing radar reflectivity in WSM6 scheme when do_radar_ref is set to 1.