### PR TITLE
Shortwave radiation balance at the wall missing reflected direct and diffuse radiation reflection from the wall terms. 

### DIFF
--- a/phys/module_sf_bem.F
+++ b/phys/module_sf_bem.F
@@ -889,7 +889,7 @@ use module_wrf_error
        uroof=(uout(n+1)**2+vout(n+1)**2)**0.5
       deltat=tpv-tair(n+1)
     hf=2.5*(40./100.*uroof)**(0.5)
-    hc=9.842*abs(deltat)**(1./3.)/(7.283-abs(cos(tiltangle)))
+    hc=9.482*abs(deltat)**(1./3.)/(7.238-abs(cos(tiltangle)))
     hup=sqrt(hc**2.+(hf)**2.)
     hc=1.810*abs(deltat)**(1./3.)/(1.382+abs(cos(tiltangle)))
     hdown=sqrt(hc**2.+(hf)**2.)

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1184,7 +1184,7 @@ USE module_model_constants, ONLY :  piconst
           
        CALL TDFCND (DF1,SMR(KZ), QUARTZ, SMCMAX )
        DF1 = DF1 * EXP(-2.0 * SHDFAC)  
-       RGR = EPSV*(RX-SIG*(TGRP**4.)/60.)
+       RGR = EPSV*(RX-SIG*(TA**4.)/60.)
        RGRR= (SGR+RGR) * 697.7 * 60.
        RCH = RHOO*CPP*CHGR
        RR1 = EPSV*(TA**4) * 6.48E-8 / (PS* CHGR) + 1.0
@@ -1727,7 +1727,7 @@ ENDIF
         PSIM=ALOG((Z+Z0)/Z0) &
             -ALOG((X+1.)**2.*(X**2.+1.)) &
             +2.*ATAN(X) &
-            +ALOG((X+1.)**2.*(X0**2.+1.)) &
+            +ALOG((X0+1.)**2.*(X0**2.+1.)) &
             -2.*ATAN(X0)
         FAIH=1./SQRT(1.-16.*XXX)
         PSIH=ALOG((Z+Z0)/Z0)+0.4*B1 &

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -66,7 +66,6 @@ USE module_model_constants, ONLY :  piconst
    REAL, ALLOCATABLE, DIMENSION(:) :: TRLEND_TBL, TBLEND_TBL, TGLEND_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: AKANDA_URBAN_TBL
 !for BEP
-
    ! MAXDIRS :: The maximum number of street directions we're allowed to define
    INTEGER, PARAMETER :: MAXDIRS = 3
    ! MAXHGTS :: The maximum number of building height bins we're allowed to define
@@ -3160,13 +3159,13 @@ SUBROUTINE SFCDIF_URB (ZLM,Z0,THZ0,THLM,SFCSPD,AKANDA,AKMS,AKHS,RLMO,CD,ZT_OUT,V
 ! LECH'S SURFACE FUNCTIONS
 ! ----------------------------------------------------------------------
       PSLMU (ZZ)= -0.96* log (1.0-4.5* ZZ)
-      PSLMS (ZZ)= ZZ * RRIC -2.076* (1. -1./ (ZZ +1.))
+      PSLMS (ZZ)= (ZZ/RFC) -2.076* (1. -1./ (ZZ +1.))
       PSLHU (ZZ)= -0.96* log (1.0-4.5* ZZ)
 
 ! ----------------------------------------------------------------------
 ! PAULSON'S SURFACE FUNCTIONS
 ! ----------------------------------------------------------------------
-      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. -1./ (ZZ +1.))
+      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. - exp(-1.2 * ZZ))
       PSPMU (XX)= -2.* log ( (XX +1.)*0.5) - log ( (XX * XX +1.)*0.5)   &
      &        +2.* ATAN (XX)                                            &
      &- PIHF

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -60,11 +60,6 @@ Description of namelist variables
                                      = 10,      ! GRIB2 format
                                      = 11,      ! pnetCDF format
  ncd_nofill                          = .true.,  ! only a single write, not the write/read/write sequence
- frames_per_emissfile                = 12,      ! number of times in each chemistry emission file.
- io_style_emiss                      = 1,       ! style to use for the chemistry emission files.
-                                                ! 0 = Do not read emissions from files.
-                                                ! 1 = Cycle between two 12 hour files (set frames_per_emissfile=12)
-                                                ! 2 = Dated files with length set by frames_per_emissfile
  debug_level                         = 0, 	! 50,100,200,300 values give increasing prints
  diag_print                          = 0, 	! print out time series of model diagnostics
                                                   0 = no print
@@ -89,20 +84,20 @@ To choose between SI and WPS input to real for EM core:
  auxinput1_inname                    = "met_em.d<domain>.<date>"             ! Input to real from WPS (default since 3.0)
                                      = "wrf_real_input_em.d<domain>.<date>"  ! Input to real from SI
 
-Other output options:
+Other output options: Note all auxhist[1-24], auxinput[2-24] interval variables are domain dependent
 
- auxhist2_outname                    = "rainfall" ! file name for extra output! if not specified,
-                                                    auxhist2_d<domain>_<date> will be used
+ auxhist9_outname                    = "rainfall" ! file name for extra output! if not specified,
+                                                    auxhist9_d<domain>_<date> will be used
                                                     also note that to write variables in output other
                                                     than the history file requires Registry.EM file change
- auxhist2_interval (max_dom)         = 10,      ! interval in minutes
- io_form_auxhist2                    = 2,       ! output in netCDF
- frames_per_auxhist2                 = 1000,    ! number of output times in this file
+ auxhist9_interval (max_dom)         = 10,      ! interval in minutes
+ io_form_auxhist9                    = 2,       ! output in netCDF
+ frames_per_auxhist9                 = 1000,    ! number of output times in this file
 
 For SST updating (used only with sst_update=1):
  
  auxinput4_inname                    = "wrflowinp_d<domain>" 
- auxinput4_interval                  = 360      ! minutes generally matches time given by interval_seconds
+ auxinput4_interval (max_dom)        = 360      ! minutes generally matches time given by interval_seconds
  io_form_auxinput4                   = 2        ! IO format
 
  nwp_diagnostics                     = 0        ! set to = 1 to add 7 history-interval max diagnostic fields
@@ -112,7 +107,7 @@ For additional regional climate surface fields
  output_diagnostics                  = 0        ! set to = 1 to add 36 surface diagnostic arrays (max/min/mean/std)
  auxhist3_outname                    = 'wrfxtrm_d<domain>_<date>' ! file name for added diagnostics
  io_form_auxhist3                    = 2        ! netcdf
- auxhist3_interval                   = 1440     ! minutes between outputs (1440 gives daily max/min)
+ auxhist3_interval (max_dom)         = 1440     ! minutes between outputs (1440 gives daily max/min)
  frames_per_auxhist3                 = 1        ! output times per file
                                                   Note: do restart only at multiple of auxhist3_intervals
 
@@ -138,13 +133,13 @@ Additional settings when running WRFVAR:
  inputout_interval (max_dom)         = 180,     ! interval in minutes when writing input-formatted data 
  input_outname                       = 'wrfinput_d<domain>_<date>' ! you may change the output file name
  inputout_begin_y (max_dom)          = 0
- inputout_begin_mo                   = 0
+ inputout_begin_m                    = 0
  inputout_begin_d (max_dom)          = 0
  inputout_begin_h (max_dom)          = 3
  inputout_begin_m (max_dom)          = 0
  inputout_begin_s (max_dom)          = 0
  inputout_end_y (max_dom)            = 0
- inputout_end_mo                     = 0
+ inputout_end_m                      = 0
  inputout_end_d (max_dom)            = 0
  inputout_end_h (max_dom)            = 12
  inputout_end_m (max_dom)            = 0
@@ -495,7 +490,7 @@ Namelist variables for controlling the adaptive time step option:
                                        For NSSL 1-moment schemes, intercept and particle densities can be set for snow, 
                                        graupel, hail, and rain. For the 1- and 2-moment schemes, the shape parameters 
                                        for graupel and hail can be set.
-                                       PLEASE SEE README.NSSLmp for options affecting the NSSL scheme
+                                       PLEASE SEE doc/README.NSSLmp for options affecting the NSSL scheme
                                      = 17, 19, 21, 22: Legacy NSSL-MP options: see README.NSSLmp for equivalent settings with 18
                                      = 24, WSM 7-class scheme (separate hail and graupel categories)
                                      = 26, WDM 7-class scheme (separate hail and graupel categories)
@@ -874,9 +869,6 @@ Namelist variables for controlling the adaptive time step option:
                                      = 3, for small grid distances (DX < 5 km)
  nsas_dx_factor                      = 0, ! default option
                                      = 1,   NSAS grid-distance dependent option
- ntiedtke_dx_opt                     = 0, default option
-                                     = 1, new Tiedtke grid-distance dependent option (scale-aware)
-                                          when grid size falls below 15 km
  For KF-CuP scheme: recommended to use with cu_rad_feedback
  shallowcu_forced_ra(max_dom)        radiative impact of shallow Cu by a prescribed maximum cloud fraction
                                      = .false., option off, default

--- a/share/output_wrf.F
+++ b/share/output_wrf.F
@@ -40,6 +40,10 @@
             mp_physics, ra_lw_physics, ra_sw_physics, sf_sfclay_physics, &
             sf_surface_physics, bl_pbl_physics, cu_physics, hypsometric_opt, sf_lake_physics, &
             use_theta_m, use_maxw_level, use_trop_level,hybrid_opt, gwd_opt
+#if ( WRF_CMAQ == 1 )
+    INTEGER wrf_cmaq_option
+    LOGICAL direct_sw_feedback
+#endif
     INTEGER swint_opt, aer_type,aer_aod550_opt,aer_angexp_opt,aer_ssa_opt,aer_asy_opt, aer_opt
     REAL    aer_aod550_val,aer_angexp_val,aer_ssa_val,aer_asy_val,etac
     REAL    khdif, kvdif, swrad_scat, dampcoef,radt,bldt,cudt
@@ -88,6 +92,7 @@
     CHARACTER*80  char_junk
     CHARACTER(LEN=256) :: MMINLU
     INTEGER    ibuf(1)
+    LOGICAL    lbuf(1)
     REAL       rbuf(1)
     TYPE(WRFU_TimeInterval) :: bdy_increment
     TYPE(WRFU_Time)         :: next_time, currentTime, startTime
@@ -138,6 +143,10 @@
     call nl_get_khdif              ( grid%id,  khdif              )
     call nl_get_kvdif              ( grid%id,  kvdif              )
     call nl_get_mp_physics         ( grid%id,  mp_physics         )
+#if ( WRF_CMAQ == 1 )
+    call nl_get_wrf_cmaq_option    ( grid%id,  wrf_cmaq_option    )
+    call nl_get_direct_sw_feedback ( grid%id,  direct_sw_feedback )
+#endif
     call nl_get_ra_lw_physics      ( grid%id,  ra_lw_physics      )
     call nl_get_ra_sw_physics      ( grid%id,  ra_sw_physics      )
     call nl_get_sf_sfclay_physics  ( grid%id,  sf_sfclay_physics  )
@@ -347,7 +356,8 @@
     CALL wrf_put_dom_ti_char ( fid , 'START_DATE', TRIM(start_date) , ierr )
     IF ( switch .EQ. input_only) THEN
        CALL wrf_put_dom_ti_char ( fid , 'SIMULATION_START_DATE', TRIM(start_date) , ierr )
-    ELSE IF ( ( switch .EQ. restart_only ) .OR. ( switch .EQ. history_only ) ) THEN
+    ELSE IF ( ( switch .EQ. restart_only ) .OR. ( switch .EQ. history_only ) .OR.  &
+              ( ( switch .GE. auxhist1_only ) .AND. ( switch .LE. auxhist24_only ) ) ) THEN
        CALL nl_get_simulation_start_year   ( 1, simulation_start_year   )
        CALL nl_get_simulation_start_month  ( 1, simulation_start_month  )
        CALL nl_get_simulation_start_day    ( 1, simulation_start_day    )
@@ -552,7 +562,8 @@ endif
        END IF
     END IF
 
-    IF (switch .EQ. history_only) THEN
+    IF ( ( switch .EQ. history_only ) .OR.  &
+         ( ( switch .GE. auxhist1_only ) .AND. ( switch .LE. auxhist24_only ) ) ) THEN
        CALL    wrf_put_dom_ti_integer( fid, 'SKEBS_ON'           , config_flags%skebs_on           , 1, ierr )
        IF ( config_flags%skebs_on .NE. 0 )  THEN
           CALL wrf_put_dom_ti_real   ( fid, 'TOT_BACKSCAT_PSI'   , config_flags%tot_backscat_psi   , 1, ierr )
@@ -623,6 +634,13 @@ endif
     CALL wrf_put_dom_ti_real    ( fid , 'KHDIF' ,  rbuf , 1 , ierr )
     rbuf(1) = kvdif
     CALL wrf_put_dom_ti_real    ( fid , 'KVDIF' ,  rbuf , 1 , ierr )
+#if ( WRF_CMAQ == 1 )
+    ibuf(1) = wrf_cmaq_option
+    CALL wrf_put_dom_ti_integer ( fid , 'WRF_CMAQ_OPTION' ,  ibuf , 1 , ierr )
+    lbuf(1) = direct_sw_feedback
+! Note the code will turn logical T/F to integer 1/0 in the output
+    CALL wrf_put_dom_ti_logical ( fid , 'DIRECT_SW_FEEDBACK' ,  lbuf , 1 , ierr )
+#endif
     ibuf(1) = mp_physics
     CALL wrf_put_dom_ti_integer ( fid , 'MP_PHYSICS' ,  ibuf , 1 , ierr )
     ibuf(1) = ra_lw_physics
@@ -672,7 +690,8 @@ endif
     CALL wrf_put_dom_ti_integer ( fid, 'DISTRIBUTED_AHE_OPT', config_flags%distributed_ahe_opt, 1, ierr)
 #endif
 
-      IF ( switch .EQ. history_only ) THEN
+      IF ( ( switch .EQ. history_only ) .OR.  &
+           ( ( switch .GE. auxhist1_only ) .AND. ( switch .LE. auxhist24_only ) ) ) THEN
       CALL wrf_put_dom_ti_integer ( fid, 'SHCU_PHYSICS',     config_flags%shcu_physics , 1 , ierr )
       CALL wrf_put_dom_ti_integer ( fid, 'MFSHCONV',         config_flags%mfshconv , 1 , ierr )
       CALL wrf_put_dom_ti_integer ( fid, 'FEEDBACK', feedback , 1 , ierr )
@@ -800,7 +819,7 @@ endif
       CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_Y',         ntasks_y                  , 1 , ierr )
       CALL wrf_put_dom_ti_integer   ( fid, 'NTASKS_TOTAL',     ntasks_x*ntasks_y         , 1 , ierr )
 
-      ENDIF ! history_only
+      ENDIF ! history_only and aux history
 
 #if (WRF_CHEM == 1 && WRF_KPP == 1)
       IF ( switch == auxhist9_only .and. config_flags%irr_opt /= 0 ) THEN
@@ -812,6 +831,7 @@ endif
 #if (EM_CORE == 1) && ( DA_CORE != 1)
       IF ( ( switch .EQ. input_only   ) .OR. &
            ( switch .EQ. history_only ) .OR. &
+           ( ( switch .GE. auxhist1_only ) .AND. ( switch .LE. auxhist24_only ) ) .OR. &
            ( switch .EQ. restart_only ) ) THEN
          IF ( grid%this_is_an_ideal_run ) THEN
             CALL wrf_put_dom_ti_char ( fid , 'SIMULATION_INITIALIZATION_TYPE', "IDEALIZED DATA" , ierr )

--- a/var/da/da_radar/da_get_innov_vector_radar.inc
+++ b/var/da/da_radar/da_get_innov_vector_radar.inc
@@ -275,7 +275,6 @@ END IF
       allocate (avg_qrn(tot_h_index,tot_z_index))
       allocate (avg_qds(tot_h_index,tot_z_index))
       allocate (avg_qws(tot_h_index,tot_z_index))
-      allocate (avg_qws(tot_h_index,tot_z_index))
       allocate (avg_qgr(tot_h_index,tot_z_index))
       allocate (ave_rho(tot_h_index,tot_z_index))
 
@@ -379,7 +378,7 @@ END IF
          end do
       end do   !bottom-top
       if (rootproc) close(hydro_weight_unit)
-      if (rootproc) call da_get_unit(hydro_weight_unit)
+      if (rootproc) call da_free_unit(hydro_weight_unit)
    end if   !! use_radar_rhv .and. radar_rhv_opt == 2
 
    do n=iv%info(radar)%n1,iv%info(radar)%n2


### PR DESCRIPTION
@cenlinhe 
In this pull request, we corrected the shortwave radiation balance at the wall, particularly the reflected direct and diffuse radiation reaching the wall. A couple of terms that represent contribution from the reflected radiation from walls were absent in the code. We followed the formulations (equation 8 from Kusaka at. al. (2001))and corrected the shortwave radiation balance. 
 
TYPE: Bug fix

KEYWORDS: Shortwave radiation balance, reflected radiation, shadowing effect, single-layer urban canopy model (SLUCM), direct and diffuse radiation.

SOURCE: Parag Joshi, Katia Lamer (Brookhaven National Laboratory)

DESCRIPTION OF CHANGES:
Problem:
The single-layer urban canopy model missed a couple of terms that represent the direct and diffuse radiation reaching at a wall reflected from the other wall. It leads to an inaccurate calculation of the shortwave radiation at the walls.  

Solution:
Mathematical formulation by Kusaka et. al. (2001) was followed to verify the equations used in the SLUCM module in WRF. The equations are corrected. 

ISSUE: For use when this PR closes an issue.
Fixes #123

LIST OF MODIFIED FILES: module_sf_urban.F

TESTS CONDUCTED: 
1. No tests has been conducted yet. 

RELEASE NOTE: Contribution from the reflected direct and diffuse shortwave radiation from the wall was missing in the code. Present pull request fix the error which leads to underestimation of SWR at the wall.  