### PR TITLE
Shortwave radiation balance at the wall missing reflected direct and diffuse radiation reflection from the wall terms.

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -916,7 +916,7 @@ USE module_model_constants, ONLY :  piconst
        SG1=SX*VFGS*(1.-ALBG)
        SB1=SX*VFWS*(1.-ALBB)
        SG2=SB1*ALBB/(1.-ALBB)*VFGW*(1.-ALBG)
-       SB2=SG1*ALBG/(1.-ALBG)*VFWG*(1.-ALBB)
+       SB2=SG1*ALBG/(1.-ALBG)*VFWG*(1.-ALBB) + SB1*ALBB*VFWW
 
      ELSE                              ! shadow effects model
 
@@ -962,7 +962,7 @@ USE module_model_constants, ONLY :  piconst
        SG1=SD*(RW-SLX)/RW*(1.-ALBG)+SQ*VFGS*(1.-ALBG)
        SB1=SD*SLX/W*(1.-ALBB)+SQ*VFWS*(1.-ALBB)
        SG2=SB1*ALBB/(1.-ALBB)*VFGW*(1.-ALBG)
-       SB2=SG1*ALBG/(1.-ALBG)*VFWG*(1.-ALBB)
+       SB2=SG1*ALBG/(1.-ALBG)*VFWG*(1.-ALBB) + SB1*ALBB*VFWW
 
      END IF
 


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: Shortwave radiation balance, reflected radiation, shadowing effect, single-layer urban canopy model (SLUCM), direct and diffuse radiation.

SOURCE: Parag Joshi, Katia Lamer (Brookhaven National Laboratory)

DESCRIPTION OF CHANGES: 
Problem: The single-layer urban canopy model missed a couple of terms that represent the direct and diffuse radiation reaching at a wall reflected from the other wall. It leads to an inaccurate calculation of the shortwave radiation at the walls.

Solution: Mathematical formulation by Kusaka et. al. (2001) was followed to verify the equations used in the SLUCM module in WRF. The equations are corrected.

More details can be found in this [attachment](https://github.com/user-attachments/files/16800936/Shortwave.radiation_Single.Layer.pdf).

LIST OF MODIFIED FILES: module_sf_urban.F

TESTS CONDUCTED:
1. It compiles.
2. It passes the Jenkins tests.

RELEASE NOTE: 
This PR corrects the shortwave radiation balance at the wall, particularly the reflected direct and diffuse radiation reaching the wall which leads to underestimation of SW radiation at the wall.