### PR TITLE
fix for possible undefined zol in sfclayrev

### DIFF
--- a/phys/physics_mmm/sf_sfclayrev.F90
+++ b/phys/physics_mmm/sf_sfclayrev.F90
@@ -378,6 +378,8 @@
 
  do 320 i = its,ite
 !                                                                           
+    zol(i)=0.
+!
     if(br(i).gt.0) then
        if(br(i).gt.250.0) then
           zol(i)=zolri(250.0,za(i),znt(i))


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: sfclayrev, fix possible undefined

SOURCE:  internal reported by Xin-Zhong Liang

DESCRIPTION OF CHANGES:
Problem:
zol(i) can be left undefined in rare case of br(i) = 0.

Solution:
add line to initialize zol(i)=0.

LIST OF MODIFIED FILES: 
M       phys/physics_mmm/sf_sfclayrev.F90

TESTS CONDUCTED: 
1. Only compile tested.
2. The Jenkins tests are all passing.

RELEASE NOTE: Fix for rare undefined zol in sfclayrev.