### PR TITLE
Fixed the source of the dt=0 error when using adaptive time step  in ideal cases

### DIFF
--- a/dyn_em/adapt_timestep_em.F
+++ b/dyn_em/adapt_timestep_em.F
@@ -287,8 +287,10 @@ RECURSIVE SUBROUTINE adapt_timestep(grid, config_flags)
   num = INT(time_to_bc * precision + 0.5)
   den = precision
   CALL WRFU_TimeIntervalSet(tmpTimeInterval, Sn=num, Sd=den)
-  
-  if ( ( tmpTimeInterval .LT. dtInterval * 2 ) .and. &
+
+if (num .LE. 0) then
+     stepping_to_bc = .false.
+  elseif ( ( tmpTimeInterval .LT. dtInterval * 2 ) .and. &
        ( tmpTimeInterval .GT. dtInterval ) ) then
      dtInterval = tmpTimeInterval / 2
      


### PR DESCRIPTION
Fixed the source of the dt=0 error when using adaptive time step  in ideal cases idealized cases

Restrict the remaining time until the next boundary control to be greater than 0 in order to correct the dtInterval.

TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]

KEYWORDS: adaptative, timestep, ideal

SOURCE:  Jeronimo Bande (IDING SAS)

DESCRIPTION OF CHANGES:
Problem:
The adapt_timestep module is not prepared to handle this kind of idealized case. The algorithm uses the remaining time until the boundary condition is applied, with a counter that resets when the boundary condition is used.

In this idealized case, the counter starts with a value of 10800 (equivalent to 3 hours), but when the supposed boundary condition should occur, it doesn’t, and the counter continues decreasing into negative values, causing the simulation to terminate prematurely.

Solution:
Restrict the remaining time until the next boundary control to be greater than 0 in order to correct the dtInterval.

ISSUE:
Fixes #1560
Fixes #2103
LIST OF MODIFIED FILES: 
/dyn_em/adapt_timestep_em.F

TESTS CONDUCTED: 

RELEASE NOTE: Fix adaptative time step for ideal cases.
