### PR TITLE
Corrected end date for em_b_wave  test case 

### DIFF
--- a/test/em_b_wave/namelist.input
+++ b/test/em_b_wave/namelist.input
@@ -11,7 +11,7 @@
  start_second                        = 00,   00,   00,
  end_year                            = 0001, 0001, 0001,
  end_month                           = 01,   01,   01,
- end_day                             = 05,   05,   05,
+ end_day                             = 06,   06,   06,
  end_hour                            = 00,   00,   00,
  end_minute                          = 00,   00,   00,
  end_second                          = 00,   00,   00,


### PR DESCRIPTION
TYPE: no impact directly in the run

KEYWORDS: namelist, end_date, b_wave

SOURCE: Jeronimo Bande (IDING SAS)

DESCRIPTION OF CHANGES:
Problem:
Wrong end date in namelist. Not good for example.

Solution:
Correct  end date of the simulation.

LIST OF MODIFIED FILES: 
test/em_b_wave/namelist.input

TESTS CONDUCTED: 
Jenkins tests are all passing.
