### PR TITLE
Update how fogdes identifies land use type

### DIFF
--- a/phys/module_sf_fogdes.F
+++ b/phys/module_sf_fogdes.F
@@ -105,6 +105,7 @@ CONTAINS
 !JOE-end
 
 ! Local variables
+   CHARACTER*512 :: message
    INTEGER :: i,j
    REAL    :: lad, spcfct, vegh, ftmp1, ftmp2, dp_fog, lwc
    CHARACTER (LEN=25) :: land_use_type, lu_fogdes
@@ -116,7 +117,8 @@ CONTAINS
    ELSEIF (mminlu .eq. 'USGS') THEN ! includes lake category
      land_use_type = 'USGS'
    ELSE
-     PRINT *, 'Unknown landuse category (sf_fogdes.F): num_land_cat=',nlcat
+     write ( message, * ) "Unknown land category for grav_settling (sf_fogdes.f) Landuse type = ",mminlu," and number of land categories= ",nlcat
+     CALL wrf_error_fatal ( message ) 
      STOP
    END IF
 

--- a/phys/module_sf_fogdes.F
+++ b/phys/module_sf_fogdes.F
@@ -117,7 +117,7 @@ CONTAINS
    ELSEIF (mminlu .eq. 'USGS') THEN ! includes lake category
      land_use_type = 'USGS'
    ELSE
-     write ( message, * ) "Unknown land category for grav_settling (sf_fogdes.f) Landuse type = ",mminlu," and number of land categories= ",nlcat
+     write ( message, * ) "Unknown land category for grav_settling (sf_fogdes.F) Landuse type = ",mminlu," and number of land categories= ",nlcat
      CALL wrf_error_fatal ( message ) 
      STOP
    END IF

--- a/phys/module_sf_fogdes.F
+++ b/phys/module_sf_fogdes.F
@@ -13,7 +13,7 @@ CONTAINS
 
   SUBROUTINE sf_fogdes(&
                vdfg,fgdp,dfgdp,ivgtyp,lai,wspd,qc_curr,            &
-               dtbl,rho,dz8w,grav_settling,nlcat,                  &
+               dtbl,rho,dz8w,grav_settling,nlcat,mminlu,           &
                ids,ide, jds,jde, kds,kde,                          &
                ims,ime, jms,jme, kms,kme,                          &
                its,ite, jts,jte, kts,kte                           &
@@ -81,7 +81,7 @@ CONTAINS
                                                ,ids,ide,jds,jde,kds,kde
 
    INTEGER, INTENT(IN)                       :: grav_settling,nlcat
-
+   CHARACTER (LEN=*), INTENT(IN)::  mminlu
    INTEGER,DIMENSION( ims:ime , jms:jme ),INTENT(INOUT)       :: ivgtyp
 
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
@@ -111,9 +111,9 @@ CONTAINS
 
 !------------------------------------------------------------------
 
-   IF     ((nlcat .eq. 20).or.(nlcat .eq. 21)) THEN ! includes lake category
+   IF     (mminlu .eq. 'MODIFIED_IGBP_MODIS_NOAH') THEN ! includes lake category
      land_use_type = 'MODIS'
-   ELSEIF ((nlcat .eq. 24).or.(nlcat .eq. 28)) THEN ! includes lake category
+   ELSEIF (mminlu .eq. 'USGS') THEN ! includes lake category
      land_use_type = 'USGS'
    ELSE
      PRINT *, 'Unknown landuse category (sf_fogdes.F): num_land_cat=',nlcat

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2509,7 +2509,7 @@ CONTAINS
 
            CALL sf_fogdes(                                  &
                 vdfg,fgdp,dfgdp,ivgtyp,lai,wspd,qc_curr,    &
-                dtbl,rho,dz8w,grav_settling,nlcat,          &
+                dtbl,rho,dz8w,grav_settling,nlcat,mminlu,   &
                 ids,ide, jds,jde, kds,kde,                  &
                 ims,ime, jms,jme, kms,kme,                  &
                 i_start(ij),i_end(ij),                      &


### PR DESCRIPTION
Fix fog des (grav_settling) for LCZ dataset 

TYPE: bug fix

KEYWORDS: grav_setting, LCZ

SOURCE: Adam Dury (WeatherQuest)

DESCRIPTION OF CHANGES:
Problem:
WRF crashes when grav_settling is greater than 0 and wudapt_lcz = 1 due to the historical code using hard coded values for land categories to detect which land use type is being used. This isn't the case now so needed to update to use a variable with actual land use category type so the grav_settling code would work when wudapt_lcz was turned on and the nlcat wasnt the same for each land use type.

Solution:
Changed the if statements to use mminlu rather than nlcat so that the grav_settling option knows what land use dataset is being used. Corrected the error message to go into rsl.error files rather than rsl.out files

LIST OF MODIFIED FILES: 
phys/module_sf_fogdes.f
phys/module_surface_driver.f

TESTS CONDUCTED: 
1. Tested with wudapt_lcz on and off with all option of grav_settling.
2. The Jenkins tests are all passing.

RELEASE NOTE: Updated grav_settling code to better recognize the land use type so it doesn't crash. Also update the error message if it does crash to go into the rsl.error files rather than rsl.out files.
