### PR TITLE
Compilation Tests for ARW

### DIFF
--- a/.ci/wrf_compilation_tests-make.json
+++ b/.ci/wrf_compilation_tests-make.json
@@ -25,7 +25,7 @@
         "base_env_numprocs"      : [ "-e", "NUM_PROCS=16" ],
         "very_last_modules"       : [ "netcdf" ],
         ".*gnu.*::test_modules"   : [ "gcc" ],
-        ".*intel(?!-llvm).*::test_modules" : [ "intel-classic" ],
+        ".*intel-classic.*::test_modules" : [ "intel-classic" ],
         ".*intel-llvm.*::test_modules"     : [ "intel-oneapi" ],
         ".*pgi.*::test_modules"   : [ "nvhpc" ],
         ".*dm.*::test_mpi_module" : [ "cray-mpich" ]

--- a/.ci/wrf_compilation_tests-make.json
+++ b/.ci/wrf_compilation_tests-make.json
@@ -65,5 +65,123 @@
         "dependencies" : { "dm" : "afterany" }
       }
     }
+  },
+  "make-intel-classic" :
+  {
+    "hsn.de.hpc"  :
+    {
+      "timelimit" : "00:40:00"
+    },
+    "steps" :
+    {
+      "serial" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "13" ]
+      },
+      "sm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "14" ],
+        "dependencies" : { "serial" : "afterany" }
+      }
+    }
+  },
+  "make-intel-classic-mpi" :
+  {
+    "hsn.de.hpc"  :
+    {
+      "timelimit" : "00:40:00"
+    },
+    "steps" :
+    {
+      "dm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "15" ]
+      },
+      "dm+sm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "16" ],
+        "dependencies" : { "dm" : "afterany" }
+      }
+    }
+  },
+  "make-intel-llvm" :
+  {
+    "hsn.de.hpc"  :
+    {
+      "timelimit" : "00:40:00"
+    },
+    "steps" :
+    {
+      "serial" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "76" ]
+      },
+      "sm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "77" ],
+        "dependencies" : { "serial" : "afterany" }
+      }
+    }
+  },
+  "make-intel-llvm-mpi" :
+  {
+    "hsn.de.hpc"  :
+    {
+      "timelimit" : "00:40:00"
+    },
+    "steps" :
+    {
+      "dm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "78" ]
+      },
+      "dm+sm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "79" ],
+        "dependencies" : { "dm" : "afterany" }
+      }
+    }
+  },
+  "make-pgi" :
+  {
+    "steps" :
+    {
+      "serial" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "1" ]
+      },
+      "sm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "2" ],
+        "dependencies" : { "serial" : "afterany" }
+      }
+    }
+  },
+  "make-pgi-mpi" :
+  {
+    "steps" :
+    {
+      "dm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "3" ]
+      },
+      "dm+sm" :
+      {
+        "command"      : ".ci/tests/build.sh",
+        "arguments"    : [ "-c", "4" ],
+        "dependencies" : { "dm" : "afterany" }
+      }
+    }
   }
 }

--- a/.ci/wrf_compilation_tests-make.json
+++ b/.ci/wrf_compilation_tests-make.json
@@ -17,12 +17,12 @@
       "queue"      : "main",
       "hpc_arguments"  : 
       {
-        "node_select" : { "-l " : { "select"       : 1, "ncpus" : 16 } },
+        "node_select" : { "-l " : { "select"       : 1, "ncpus" : 8 } },
         "priority"    : { "-l " : { "job_priority" : "economy"       } }
       },
       "arguments"  : 
       {
-        "base_env_numprocs"      : [ "-e", "NUM_PROCS=16" ],
+        "base_env_numprocs"      : [ "-e", "NUM_PROCS=8" ],
         "very_last_modules"       : [ "netcdf" ],
         ".*gnu.*::test_modules"   : [ "gcc" ],
         ".*intel-classic.*::test_modules" : [ "intel-classic" ],
@@ -32,156 +32,48 @@
       }
     }
   },
-  "make-gnu" :
-  {
-    "steps" :
-    {
-      "serial" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "32" ]
-      },
-      "sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "33" ],
-        "dependencies" : { "serial" : "afterany" }
-      }
-    }
+
+  "make-gnu-serial" : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "32" ] } } },
+  "make-gnu-sm"     : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "33" ] } } },
+  "make-gnu-dm"     : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "34" ] } } },
+  "make-gnu-dm+sm"  : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "35" ] } } },
+  
+  "make-intel-classic-serial" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "13" ] } }
   },
-  "make-gnu-mpi" :
-  {
-    "steps" :
-    {
-      "dm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "34" ]
-      },
-      "dm+sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "35" ],
-        "dependencies" : { "dm" : "afterany" }
-      }
-    }
+  "make-intel-classic-sm" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "14" ] } }
   },
-  "make-intel-classic" :
-  {
-    "hsn.de.hpc"  :
-    {
-      "timelimit" : "00:40:00"
-    },
-    "steps" :
-    {
-      "serial" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "13" ]
-      },
-      "sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "14" ],
-        "dependencies" : { "serial" : "afterany" }
-      }
-    }
+  "make-intel-classic-dm" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "15" ] } }
   },
-  "make-intel-classic-mpi" :
-  {
-    "hsn.de.hpc"  :
-    {
-      "timelimit" : "00:40:00"
-    },
-    "steps" :
-    {
-      "dm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "15" ]
-      },
-      "dm+sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "16" ],
-        "dependencies" : { "dm" : "afterany" }
-      }
-    }
+  "make-intel-classic-dm+sm" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "16" ] } }
   },
-  "make-intel-llvm" :
-  {
-    "hsn.de.hpc"  :
-    {
-      "timelimit" : "00:40:00"
-    },
-    "steps" :
-    {
-      "serial" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "76" ]
-      },
-      "sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "77" ],
-        "dependencies" : { "serial" : "afterany" }
-      }
-    }
+
+  "make-intel-llvm-serial" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "76" ] } }
   },
-  "make-intel-llvm-mpi" :
-  {
-    "hsn.de.hpc"  :
-    {
-      "timelimit" : "00:40:00"
-    },
-    "steps" :
-    {
-      "dm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "78" ]
-      },
-      "dm+sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "79" ],
-        "dependencies" : { "dm" : "afterany" }
-      }
-    }
+  "make-intel-llvm-sm" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "77" ] } }
   },
-  "make-pgi" :
-  {
-    "steps" :
-    {
-      "serial" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "1" ]
-      },
-      "sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "2" ],
-        "dependencies" : { "serial" : "afterany" }
-      }
-    }
+  "make-intel-llvm-dm" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "78" ] } }
   },
-  "make-pgi-mpi" :
-  {
-    "steps" :
-    {
-      "dm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "3" ]
-      },
-      "dm+sm" :
-      {
-        "command"      : ".ci/tests/build.sh",
-        "arguments"    : [ "-c", "4" ],
-        "dependencies" : { "dm" : "afterany" }
-      }
-    }
-  }
+  "make-intel-llvm-dm+sm" : {
+    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "79" ] } }
+  },
+
+  "make-pgi-serial" : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "1" ] } } },
+  "make-pgi-sm"     : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "2" ] } } },
+  "make-pgi-dm"     : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "3" ] } } },
+  "make-pgi-dm+sm"  : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "4" ] } } }
 }

--- a/.ci/wrf_compilation_tests-make.json
+++ b/.ci/wrf_compilation_tests-make.json
@@ -39,41 +39,53 @@
   "make-gnu-dm+sm"  : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "35" ] } } },
   
   "make-intel-classic-serial" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "13" ] } }
   },
   "make-intel-classic-sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "14" ] } }
   },
   "make-intel-classic-dm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "15" ] } }
   },
   "make-intel-classic-dm+sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "16" ] } }
   },
 
   "make-intel-llvm-serial" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "76" ] } }
   },
   "make-intel-llvm-sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "77" ] } }
   },
   "make-intel-llvm-dm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "78" ] } }
   },
   "make-intel-llvm-dm+sm" : {
-    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "79" ] } }
   },
 
-  "make-pgi-serial" : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "1" ] } } },
-  "make-pgi-sm"     : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "2" ] } } },
-  "make-pgi-dm"     : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "3" ] } } },
-  "make-pgi-dm+sm"  : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "4" ] } } }
+  "make-pgi-serial" : {
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "1" ] } }
+  },
+  "make-pgi-sm"     : {
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "2" ] } }
+  },
+  "make-pgi-dm"     : {
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "3" ] } }
+  },
+  "make-pgi-dm+sm"  : {
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:30:00" } },
+    "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "4" ] } }
+  }
 }

--- a/.ci/wrf_compilation_tests-make.json
+++ b/.ci/wrf_compilation_tests-make.json
@@ -39,36 +39,36 @@
   "make-gnu-dm+sm"  : { "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "35" ] } } },
   
   "make-intel-classic-serial" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "13" ] } }
   },
   "make-intel-classic-sm" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "14" ] } }
   },
   "make-intel-classic-dm" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "15" ] } }
   },
   "make-intel-classic-dm+sm" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "16" ] } }
   },
 
   "make-intel-llvm-serial" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "76" ] } }
   },
   "make-intel-llvm-sm" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "77" ] } }
   },
   "make-intel-llvm-dm" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "78" ] } }
   },
   "make-intel-llvm-dm+sm" : {
-    "hsn.de.hpc" : { "timelimit" : "00:40:00" },
+    "submit_options" : { "hsn.de.hpc" : { "timelimit" : "00:40:00" } },
     "steps" : { "build" : { "command" : ".ci/tests/build.sh", "arguments" : [ "-c", "79" ] } }
   },
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,22 @@ jobs:
             tpool : 1
             mkdirs : true
             tests :
-              - make-gnu
-              - make-gnu-mpi
-              - make-intel-classic
-              - make-intel-classic-mpi
-              - make-intel-llvm
-              - make-intel-llvm-mpi
-              - make-pgi
-              - make-pgi-mpi
+              - make-gnu-serial
+              - make-gnu-sm
+              - make-gnu-dm
+              - make-gnu-dm+sm
+              - make-intel-classic-serial
+              - make-intel-classic-sm
+              - make-intel-classic-dm
+              - make-intel-classic-dm+sm
+              - make-intel-llvm-serial
+              - make-intel-llvm-sm
+              - make-intel-llvm-dm
+              - make-intel-llvm-dm+sm
+              - make-pgi-serial
+              - make-pgi-sm
+              - make-pgi-dm
+              - make-pgi-dm+sm
               # add new compilation tests here
 
     uses : ./.github/workflows/test_workflow.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
             tests :
               - make-gnu
               - make-gnu-mpi
+              - make-intel-classic
+              - make-intel-classic-mpi
+              - make-intel-llvm
+              - make-intel-llvm-mpi
+              - make-pgi
+              - make-pgi-mpi
               # add new compilation tests here
 
     uses : ./.github/workflows/test_workflow.yml

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -87,6 +87,7 @@ jobs:
           -t   ${{ join( fromJson( inputs.tests ), ' ' ) }}  \
           -a "${{ inputs.account }}"                         \
           -p ${{ inputs.pool}} -tp ${{ inputs.tpool }}       \
+          -jn ${{ github.event_name == 'push' && github.ref_name || github.event.number }}-${{ inputs.id }} \
           ${{ inputs.args }} $ALT_DIRS
 
 
@@ -129,8 +130,8 @@ jobs:
         # *documented* functionality doesn't work as expected. Wow, bravo
         # can't use ${{ env. }} as somehow this combination of matrix->reusable workflow->call step is too complex
         # and expands to nothing
-        name: ${{ github.event_name == 'push' && 'master' || github.event.number }}-${{ inputs.id }}_logfiles
-        path: ${{ inputs.archive }}/${{ github.event_name == 'push' && 'master' || github.event.number }}/${{ inputs.id }}/
+        name: ${{ github.event_name == 'push' && github.ref_name || github.event.number }}-${{ inputs.id }}_logfiles
+        path: ${{ inputs.archive }}/${{ github.event_name == 'push' && github.ref_name || github.event.number }}/${{ inputs.id }}/
 
     # As noted in ci.yml, this will need to be moved to a separate workflow with pull_request_target
     # and strictly controlled usage of the GH token

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -69,12 +69,12 @@ jobs:
       if  : ${{ inputs.mkdirs }}
       id  : cpTestDirs
       run : |
-        for testDir in ${{ join( fromJson( inputs.tests ), ' ' ) }}; do
-          echo "Creating duplicate directory for $testDir"
-          # Remove if it exists to get a fresh start
-          rm -rf $testDir
-          cp -Rp main/ $testDir
-        done
+        # Remove if it exists to get a fresh start
+        rm -rf ${{ join( fromJson( inputs.tests ), ' ' ) }}
+
+        echo "Creating duplicate directory for ${{ join( fromJson( inputs.tests ), ' ' ) }}"
+        # Copy 4 at a time max
+        time printf "%s\n" $tests | xargs -i -P 4 cp -Rp main/ {}
 
     - name: Test ${{ inputs.name }}
       id  : runTest

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -69,11 +69,14 @@ jobs:
       if  : ${{ inputs.mkdirs }}
       id  : cpTestDirs
       run : |
-        # Remove if it exists to get a fresh start
-        rm -rf ${{ join( fromJson( inputs.tests ), ' ' ) }}
+        # Limit parallel ops to 4 at a time to not thrash login nodes
 
-        echo "Creating duplicate directory for ${{ join( fromJson( inputs.tests ), ' ' ) }}"
-        # Copy 4 at a time max
+        # Remove if it exists to get a fresh start
+        echo "Cleaning old test directories..."
+        tests="${{ join( fromJson( inputs.tests ), ' ' ) }}"
+        time printf "%s\n" $tests | xargs -i -P 4 rm -rf {}
+
+        echo "Creating duplicate directory for $tests"
         time printf "%s\n" $tests | xargs -i -P 4 cp -Rp main/ {}
 
     - name: Test ${{ inputs.name }}


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: testing, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The testing frameworks (github actions nor Jenkins) don't run a wide array of compilation tests per compiler family commonly available.

Solution:
Use the github actions / hpc-workflows testing framework to run serial, sm, dm, and dm+sm for GNU, Intel Classic & OneAPI, and PGI/nvhpc on Derecho. Tests will run collectively in one node in parallel to maximize core hour allocations.

TESTS CONDUCTED: 
1. Tests can be run locally on Derecho by using the .ci/hpc-workflows runner.py to launch all tests as separate jobs, but this is inefficient and not exactly as the tests run. To emulate the tests as done in the github actions workflow use the additional `args` set in the respective testSet of .github/workflows/.ci.yml and provide alternate directories from which to compile. This can be facilitated via :
* clone WRF branch that features these changes into `<dir>`
*  list names of tests you want space-delimited in variable, e.g. `export tests="make-gnu-serial make-gnu-dm"`
* create copy test dirs with something like `printf "%s\n" $tests | xargs -i -P 4 cp -Rp <dir> {}`
* Create alt dirs run locations from test definitions. In this case one directory up from each, this can be done with `export altDirs=$( printf "../%s/.ci " $tests )` (note the extra space!)
* launch tests using runner and join args along with `-alt $altDirs`
* Final command should look like 
```
<dir>/.ci/hpc-workflows/.ci/runner.py <dir>/.ci/wrf_compilation_tests-make.json -t $tests -a <account> -p <num parallel> -tp 1 -j='{"node_select":{"-l ":{"select":1}}}' -jn <job name> -alt $altDirs
```
