### PR TITLE
CMake netCDF Compatibility with WPS

### DIFF
--- a/cmake/template/WRFConfig.cmake.in
+++ b/cmake/template/WRFConfig.cmake.in
@@ -2,8 +2,6 @@
 
 @PACKAGE_INIT@
 
-include( "${CMAKE_CURRENT_LIST_DIR}/@EXPORT_NAME@Targets.cmake" )
-
 set( WRF_VERSION @PROJECT_VERSION@ )
 
 # Options WRF was built with
@@ -50,5 +48,8 @@ find_package( netCDF REQUIRED )
 # Attempt to find zlib packaged with netcdf first
 set( ZLIB_ROOT ${netCDF_PREFIX} )
 find_package( ZLIB   REQUIRED )
+
+
+include( "${CMAKE_CURRENT_LIST_DIR}/@EXPORT_NAME@Targets.cmake" )
 
 check_required_components( "@EXPORT_NAME@_Core" )

--- a/cmake/template/WRFConfig.cmake.in
+++ b/cmake/template/WRFConfig.cmake.in
@@ -35,6 +35,7 @@ set( WRF_BUILD_SBM_FAST                   @BUILD_SBM_FAST@                     )
 set( WRF_SHOW_ALL_VARS_USED               @SHOW_ALL_VARS_USED@                 )
 set( WRF_WRFIO_NCD_NO_LARGE_FILE_SUPPORT  @WRFIO_NCD_NO_LARGE_FILE_SUPPORT@    )
 
+list( PREPEND CMAKE_MODULE_PATH @CMAKE_INSTALL_PREFIX@/share/ )
 
 if ( ${WRF_USE_MPI} )
   find_package( MPI REQUIRED COMPONENTS Fortran C )
@@ -49,6 +50,7 @@ find_package( netCDF REQUIRED )
 set( ZLIB_ROOT ${netCDF_PREFIX} )
 find_package( ZLIB   REQUIRED )
 
+list( POP_FRONT CMAKE_MODULE_PATH )
 
 include( "${CMAKE_CURRENT_LIST_DIR}/@EXPORT_NAME@Targets.cmake" )
 

--- a/cmake/template/WRFConfig.cmake.in
+++ b/cmake/template/WRFConfig.cmake.in
@@ -45,7 +45,8 @@ if ( ${WRF_USE_OPENMP} )
   find_package( OpenMP REQUIRED COMPONENTS Fortran C )
 endif()
 
-find_package( netCDF REQUIRED )
+find_package( netCDF         REQUIRED )
+find_package( netCDF-Fortran REQUIRED )
 # Attempt to find zlib packaged with netcdf first
 set( ZLIB_ROOT ${netCDF_PREFIX} )
 find_package( ZLIB   REQUIRED )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compilation, cmake, netcdf

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2054 changes the netCDF target linking for WRF targets generated through CMake. When used with any other software relying on the package config generated from `cmake/template/WRFConfig.cmake`, there must be a way to find non-CMake supported packages like netCDF. WRF provides these find modules in `<install dir>/share` but does not use them within its own package config. WPS also has a FindnetCDF.cmake and FindnetCDF-Fortran.cmake, but these use the classic variable approach instead of an import target. 

Thus, when building WPS referencing WRF with the changes of #2054, it will use the WPS netCDF find modules instead of WRF's. This will result in an error like:
```
CMake Error at /home/aislas/wrf-model/wrf/install/lib/cmake/WRF/WRFTargets.cmake:111 (set_target_properties):
  The link interface of target "WRF::io_netcdf" contains:

    netCDF::netcdff
```

Solution:
Adjust the generated package config file to use WRF's find modules and give them precedence over WPS for WRF's imported targets specifically.  Additionally, move imported target inclusion to after dependencies have been resolved so that WRF package finding precedence is used.

TESTS CONDUCTED: 
1. Tested with gcc/OpenMPI to build WRF and WPS (v4.6.0) together 
