### PR TITLE
Call `project()` before before `enable_language()` in CmakeLists.txt …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required( VERSION 3.20 )
 cmake_policy( SET CMP0118 NEW )
 
+project( WRF )
+
 enable_language( C )
 enable_language( CXX )
 enable_language( Fortran )
 
-project( WRF )
 set( EXPORT_NAME ${PROJECT_NAME} )
 
 if ( DEFINED CMAKE_TOOLCHAIN_FILE )


### PR DESCRIPTION
This change fixes the warning appearing when calling `configure_new` with newer versions of Cmake. 

TYPE: bug fix

KEYWORDS: cmake, configure

SOURCE: Jakub Lewandowski (University of Leeds)

DESCRIPTION OF CHANGES:
Problem:
When calling `configure_new` script with newer versions of Cmake (3.30.5 in my case) warning appears:

```
CMake Warning (dev) at CMakeLists.txt:5 (enable_language):
  project() should be called prior to this enable_language() call.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Solution:
This is easily fixable by calling `project()` before `enable_language()` as the warning suggests.

ISSUE: For use when this PR closes an issue.
n/a

LIST OF MODIFIED FILES: CmakeLists.txt

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted? 
2. Are the Jenkins tests all passing?

I tested the change on my machine and it solved the issue. As the change is very minor it should not cause issues for others.

RELEASE NOTE: Fixed CMake dev warning `project() should be called prior to this enable_language() call` appearing when using `configure_new` script with some newer versions of Cmake.
