### PR TITLE
CMake sanitize leading define flag

### DIFF
--- a/arch/configure_reader.py
+++ b/arch/configure_reader.py
@@ -19,6 +19,7 @@ osAndArchAlt  = re.compile( r"^ARCH[ ]+(\w+)[ ]+(\w+)",         re.I )
 referenceVar  = re.compile( r"[$]([(])?(\w+)(?(1)[)])", re.I )
 compileObject = re.compile( r"(\W|^)-c(\W|$)" )
 configureRepl = re.compile( r"(\W|^)CONFIGURE_\w+(\W|$)" )
+defineRepl    = re.compile( r"-D([^ ]+)" )
 
 class Stanza():
   
@@ -164,6 +165,7 @@ class Stanza():
     for keyToSan in self.kvPairs_.keys() :
       self.kvPairs_[ keyToSan ] = configureRepl.sub( r"\1\2", self.kvPairs_[ keyToSan ] ).strip()
       self.kvPairs_[ keyToSan ] = compileObject.sub( r"\1\2", self.kvPairs_[ keyToSan ] ).strip()
+      self.kvPairs_[ keyToSan ] =    defineRepl.sub( r"\1",   self.kvPairs_[ keyToSan ] ).strip()
 
 
     # Now fix certain ones that are mixing programs with flags all mashed into one option


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compilation, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
With the addition of #2088, `ARCH_LOCAL` from the stanza is now being fed into compilation with potential `-D` defines. On versions of CMake <3.26 leading `-D` on defines is not removed from certain function calls like `add_compile_definitions()`. This will pass the configuration stage but will fail to compile when using the defined minimum CMake version of the project.  

Solution:
To simplify the logic, all defines fed into the `wrf_config.cmake` file for the configuration step will be sanitized of leading `-D`. This follows the original design intent where stanza sanitization happens before being fed into CMake, thus allowing the CMake code to focus on configuration of options rather than translation of stanza into usable values.


TESTS CONDUCTED: 
1. Tested configuration and compilation on CMake version v3.20.6

RELEASE NOTE: 
Remove leading -D on defines during stanza reading  to allow older versions of CMake to configure properly.
