### PR TITLE
CMake Add documentation to custom defined properties

### DIFF
--- a/cmake/target_source_properties.cmake
+++ b/cmake/target_source_properties.cmake
@@ -42,12 +42,16 @@ function( define_target_source_properties )
                     SOURCE
                     PROPERTY   ${PROPERTY}
                     # INHERITED # they will be "inherited" via target to source
+                    BRIEF_DOCS "Transitive property from target to file"
+                    FULL_DOCS  "This property can override an existing property derived from a target"
                     )
 
     define_property(
                     TARGET
                     PROPERTY   ${PROPERTY}
                     # INHERITED # they will be "inherited" via target to source
+                    BRIEF_DOCS "Transitive property from target to file"
+                    FULL_DOCS  "This property can be overridden on a per file basis"
                     )
   endforeach()
 endfunction()


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: compilation, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
As noted in #2124, prior to CMake 3.23, when defining custom properties the `BRIEF_DOCS` and `FULL_DOCS` are non-optional arguments. 

Solution:
Add proper documentation to the custom properties to allow minimum CMake version requirements of the project to remain the same.

ISSUE: 
Addresses #2124 

TESTS CONDUCTED: 
1. Tested on CMake v3.20.6

RELEASE NOTE: 
Add documentation to custom properties in CMake to fix compatibility with older versions.
