### PR TITLE
CMake Correctly set generated property on autogen source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required( VERSION 3.20 )
-cmake_policy( SET CMP0118 NEW )
+cmake_minimum_required( VERSION 3.19 )
 
 enable_language( C )
 enable_language( CXX )

--- a/cmake/c_preproc.cmake
+++ b/cmake/c_preproc.cmake
@@ -60,19 +60,13 @@ macro( wrf_c_preproc_fortran )
     # # It keeps getting better lol
     # # https://gitlab.kitware.com/cmake/cmake/-/issues/18399
     # # We could use cmake 3.20+ and CMP0118, but this allows usage from 3.18.6+
-    # TL;DR - This doesn't work despite all documentation stating otherwise, need to use CMP0118
-    # set_source_files_properties(
-    #                             ${WRF_PP_F_OUTPUT_FILE}
-    #                             ${WRF_PP_F_TARGET_DIRECTORY}
-    #                             PROPERTIES
-    #                               GENERATED TRUE
-    #                             )
     set_source_files_properties(
                                 ${WRF_PP_F_OUTPUT_FILE}
                                 DIRECTORY ${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
                                 ${WRF_PP_F_TARGET_DIRECTORY}
                                 PROPERTIES
                                   Fortran_PREPROCESS OFF
+                                  GENERATED          TRUE
                                 )
     # message( STATUS "File ${WRF_PP_F_SOURCE_FILE} will be preprocessed into ${WRF_PP_F_OUTPUT_FILE}" )
 

--- a/cmake/m4_preproc.cmake
+++ b/cmake/m4_preproc.cmake
@@ -54,19 +54,13 @@ macro( wrf_m4_preproc_fortran )
     # # It keeps getting better lol
     # # https://gitlab.kitware.com/cmake/cmake/-/issues/18399
     # # We could use cmake 3.20+ and CMP0118, but this allows usage from 3.18.6+
-    # TL;DR - This doesn't work despite all documentation stating otherwise, need to use CMP0118
-    # set_source_files_properties(
-    #                             ${WRF_PP_M4_OUTPUT_FILE}
-    #                             ${WRF_PP_M4_TARGET_DIRECTORY}
-    #                             PROPERTIES
-    #                               GENERATED TRUE
-    #                             )
     set_source_files_properties(
                                 ${WRF_PP_M4_OUTPUT_FILE}
                                 DIRECTORY ${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
                                 ${WRF_PP_M4_TARGET_DIRECTORY}
                                 PROPERTIES
                                   Fortran_PREPROCESS OFF
+                                  GENERATED          TRUE
                                 )
     # message( STATUS "File ${WRF_PP_M4_SOURCE_FILE} will be preprocessed into ${WRF_PP_M4_OUTPUT_FILE}" )
 

--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -102,7 +102,8 @@ endif()
 target_sources(
                 ${PROJECT_NAME}_Core
                 PRIVATE
-                  ${WRF_INCLUDE_FILES}
+                  module_internal_header_util.F
+
 
                   module_configure.F
                   module_driver_constants.F

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -165,6 +165,15 @@ add_custom_target(
                     ${allocs_source}
                   )
 
+set_source_files_properties(
+                            ${CMAKE_BINARY_DIR}/frame/module_state_description.F
+                            ${dealloc_source}
+                            ${allocs_source}
+                            DIRECTORY ${PROJECT_SOURCE_DIR}
+                            PROPERTIES
+                              GENERATED TRUE
+                            )
+
 target_sources(
                 ${PROJECT_NAME}_Core
                 PRIVATE


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: autogeneration, compilation, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Currently the CMake build system minimum version is limited by the automated scoping of generated property on certain source files. This in combination of `CMP0118` requires usage of CMake >3.20

Solution:
Set the generated property at the correct scope for source file usage. Lower the minimum required version to reflect this change. Note that CMake 3.18.6 is not used as there are features from 3.19 in use that, while could be implemented by hand, would take more effort to remove than the gained benefit. 

TESTS CONDUCTED: 
1. Combined with #2125, #2130, and #2131 this was tested on the latest patch of each unique minor release of CMake since v3.19.8. The full list of tested versions is as follows:
v3.19.8
v3.20.6
v3.21.7
v3.22.6
v3.23.5
v3.24.4
v3.25.3
v3.26.6
v3.27.9
v3.28.6
v3.29.8
v3.30.5
v3.31.0

RELEASE NOTE: 
Set the generated property on autogen source code explicitly in CMake and allow for lowered minimum CMake version of v3.19 
