### PR TITLE
When write_hist_at_0h_rst=.true., will now apply to user-def streams

### DIFF
--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -110,6 +110,15 @@ SUBROUTINE med_before_solve_io ( grid , config_flags )
      !  output history at beginning of restart even if alarm is not ringing
      CALL med_hist_out ( grid , HISTORY_ALARM, config_flags )
      CALL WRFU_AlarmRingerOff( grid%alarms( HISTORY_ALARM ), rc=rc )
+!----------------------------------------------------------------------
+! Write history for other streams at restart - James Ruppert - October 2024
+!----------------------------------------------------------------------
+      DO ialarm = first_auxhist, last_auxhist
+         IF  ( (config_flags%restart) .AND. ( currTime .EQ. startTime ) .AND. ( config_flags%write_hist_at_0h_rst )) THEN
+            !  output history at beginning of restart
+            CALL med_hist_out ( grid , ialarm, config_flags )
+         ENDIF
+      ENDDO
    ENDIF
 
    IF( WRFU_AlarmIsRinging( grid%alarms( INPUTOUT_ALARM ), rc=rc ) ) THEN

--- a/share/mediation_integrate.F
+++ b/share/mediation_integrate.F
@@ -114,10 +114,8 @@ SUBROUTINE med_before_solve_io ( grid , config_flags )
 ! Write history for other streams at restart - James Ruppert - October 2024
 !----------------------------------------------------------------------
       DO ialarm = first_auxhist, last_auxhist
-         IF  ( (config_flags%restart) .AND. ( currTime .EQ. startTime ) .AND. ( config_flags%write_hist_at_0h_rst )) THEN
-            !  output history at beginning of restart
-            CALL med_hist_out ( grid , ialarm, config_flags )
-         ENDIF
+      !  output history at beginning of restart
+         CALL med_hist_out ( grid , ialarm, config_flags )
       ENDDO
    ENDIF
 


### PR DESCRIPTION
TYPE: bug fix/enhancement

KEYWORDS: wrf, wrfv4, restart, output streams

SOURCE: James Ruppert (University of Oklahoma)

DESCRIPTION OF CHANGES:
Problem:
When running WRF from as a restart, the option write_hist_at_0h_rst would only apply to the default history stream. Now, when this option is set to true, it will also apply to special user-defined streams. This is required to maintain a consistent number of output time steps per file with multiple time steps writing to a single file, which is often preferred for multiple-day runs.

Solution:
Added an additional loop over history streams with CALL med_hist_out when the following condition is met:
IF ( (config_flags%restart) .AND. ( currTime .EQ. startTime ) .AND. ( config_flags%write_hist_at_0h_rst ))

LIST OF MODIFIED FILES:
share/mediation_integrate.F

TESTS CONDUCTED: 
1. Verified that this change works: when option is set to true, history write-out at first time step of a restart now applies to both the default history stream and a user-defined stream (tested with stream 7).
2. None of the Jenkins tests appear to fail.

RELEASE NOTE:
When the namelist option write_hist_at_0h_rst is set to .true. under &time_control, history write-out will now be conducted for the first time step for both the 0th stream (wrfout* files) and any special user-defined streams being implemented.