### PR TITLE
Fix typo in cmake find netCDF causing failure on blank responses

### DIFF
--- a/cmake/modules/FindnetCDF.cmake
+++ b/cmake/modules/FindnetCDF.cmake
@@ -66,9 +66,9 @@ else()
 
   foreach( NC_QUERY ${netCDF_QUERY_YES_OPTIONS} )
     execute_process( COMMAND ${NETCDF_PROGRAM} --has-${NC_QUERY} OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE netCDF_${NC_QUERY}_LOWERCASE )
-    if ( NOT "${netCDF-Fortran_${NF_QUERY}_LOWERCASE}" )
+    if ( NOT "${netCDF_${NC_QUERY}_LOWERCASE}" )
       # might be empty
-      set( netCDF-Fortran_${NF_QUERY}_LOWERCASE no )
+      set( netCDF_${NC_QUERY}_LOWERCASE no )
     endif()
     string( TOUPPER ${NC_QUERY}                     NC_QUERY_UPPERCASE )
     string( TOUPPER ${netCDF_${NC_QUERY}_LOWERCASE} NC_ANSWER_UPPERCASE )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: netcdf, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Certain versions of netCDF with particular configurations return a blank when queried with `nc-config`. To prevent a null argument expansion in CMake we should check for variable emptiness and if empty assume the queried feature is not present. There is a typo copied from the FindnetCDF-Fortran.cmake module causing this check to never get exercised leading to failed configuration due to syntax errors.

Solution:
Correct the typo to reference the netCDF variables rather than the netCDF-Fortran ones.

TESTS CONDUCTED: 
1. Tested against netCDF 4.7.2 without szlib (`--has-szlib ->    `)

RELEASE NOTE: Bug fix in CMake FindnetCDF.cmake for empty --has-* nc-config fields
