### PR TITLE
Bug fix for registry path length checks when doing out-of-source code generation

### DIFF
--- a/tools/reg_parse.c
+++ b/tools/reg_parse.c
@@ -88,6 +88,8 @@
 static int ntracers = 0 ;
 static char tracers[1000][100] ;
 
+#define MAX_PATH 256
+
 int
 pre_parse( char * dir, FILE * infile, FILE * outfile )
 {
@@ -117,10 +119,12 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
     for ( p = inln ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
     if ( !strncmp( p , "include", 7 ) &&  ! ( ifdef_stack_ptr >= 0 && ! ifdef_stack[ifdef_stack_ptr] ) ) {
       FILE *include_fp ;
-      char include_file_name_local_registry[128] ;
-      char include_file_name[128] ;
+      char include_file_name_local_registry[MAX_PATH] ;
+      char include_file_name[MAX_PATH] ;
       p += 7 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
-      if ( strlen( p ) > 127 ) { fprintf(stderr,"Registry warning: invalid include file name: %s\n", p ) ; }
+      fprintf( stderr, "Len : %d\n", strlen( p ) );
+      if ( strlen( p ) > MAX_PATH - 1 ) { fprintf(stderr,"Registry error: include file name too long: %s\n", p ) ; }
+      if ( ( strlen( p ) + strlen( dir ) ) > MAX_PATH - 1 ) { fprintf(stderr,"Registry error: include file name too long when adding path: %s/%s\n", dir, p ) ; }
       else {
         
         sprintf( include_file_name_local_registry, "./Registry/%s", p ) ;
@@ -140,7 +144,7 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
           fclose( include_fp ) ;
         } 
         else {
-          fprintf(stderr,"Registry warning: cannot open %s. Tried %s and %s Ignoring.\n", include_file_name, include_file_name, include_file_name_local_registry ) ;
+          fprintf(stderr,"Registry error: cannot open %s. Tried %s and %s Ignoring.\n", include_file_name, include_file_name, include_file_name_local_registry ) ;
         } 
       }
     }

--- a/tools/reg_parse.c
+++ b/tools/reg_parse.c
@@ -124,7 +124,7 @@ pre_parse( char * dir, FILE * infile, FILE * outfile )
       p += 7 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
       fprintf( stderr, "Len : %d\n", strlen( p ) );
       if ( strlen( p ) > MAX_PATH - 1 ) { fprintf(stderr,"Registry error: include file name too long: %s\n", p ) ; }
-      if ( ( strlen( p ) + strlen( dir ) ) > MAX_PATH - 1 ) { fprintf(stderr,"Registry error: include file name too long when adding path: %s/%s\n", dir, p ) ; }
+      else if ( ( strlen( p ) + strlen( dir ) ) > MAX_PATH - 1 ) { fprintf(stderr,"Registry error: include file name too long when adding path: %s/%s\n", dir, p ) ; }
       else {
         
         sprintf( include_file_name_local_registry, "./Registry/%s", p ) ;


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: registry, path

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #1975 added the ability for registry code to be generated out-of-source. To do this, a provided path is used and prepended to include statements within registry files. The max path length checks to create the search path string in a `char*` does not take into account the combined prepend path + relative file path length. When this happens, no obvious errors occur, but a buffer overflow causes malformed registry code to be used, eventually leading to failed compilation.  

Solution:
Use a max path length that checks both the relative file path length and combined length when using the prepended path. As failure to pass this will result in erroneous code, the error messages have been updated to convey that as well.

TESTS CONDUCTED: 
1. Tested with CMake build using an absolute path greater than ~128. Without these changes the registry code will pass but compilation will fail. With these changes, that path length works and paths > 256 will fail at the registry code generation step.  

RELEASE NOTE: Bug fix for registry path length checks when doing out-of-source code generation
