### PR TITLE
CMake set release flags properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if ( DEFINED CMAKE_TOOLCHAIN_FILE )
   # include( ${WRF_CONFIG} )
 endif()
 
+# Import default flags now, get rid of any imported release flag
+# we will handle that ourselves with WRF_FCOPTIM/WRF_FCNOOPT
+set( CMAKE_Fortran_FLAGS_RELEASE "" CACHE STRING "" FORCE )
+set( CMAKE_C_FLAGS_RELEASE       "" CACHE STRING "" FORCE )
+
 # list( APPEND CMAKE_MODULE_PATH         )
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/ ${PROJECT_SOURCE_DIR}/cmake/modules )
 

--- a/cmake/template/arch_config.cmake
+++ b/cmake/template/arch_config.cmake
@@ -15,10 +15,10 @@ set( CMAKE_Fortran_FLAGS_INIT    "{SFC_FLAGS} {FCBASEOPTS} {BYTESWAPIO}" )
 set( CMAKE_C_FLAGS_INIT          "{SCC_FLAGS} {CFLAGS_LOCAL}" )
 
 # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG_INIT.html
-set( CMAKE_Fortran_FLAGS_Debug_INIT    "{FCDEBUG}" )
-set( CMAKE_Fortran_FLAGS_Release_INIT  "" )
-set( CMAKE_C_FLAGS_Debug_INIT    "" )
-set( CMAKE_C_FLAGS_Release_INIT  "" )
+set( CMAKE_Fortran_FLAGS_DEBUG_INIT    "{FCDEBUG}" )
+set( CMAKE_Fortran_FLAGS_RELEASE_INIT  "" )
+set( CMAKE_C_FLAGS_DEBUG_INIT          "" )
+set( CMAKE_C_FLAGS_RELEASE_INIT        "" )
 
 # Project specifics now
 set( WRF_MPI_Fortran_FLAGS  "{DM_FC_FLAGS}"   )

--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -155,6 +155,8 @@ target_sources(
 # Disable optimizations on these files always
 set_source_files_properties(
                             ${nl_dyn_source}
+                            module_comm_nesting_dm.F
+                            DIRECTORY ${PROJECT_SOURCE_DIR}
                             PROPERTIES
                             COMPILE_OPTIONS_OPTIMIZATION
                               $<$<COMPILE_LANGUAGE:Fortran>:${WRF_FCNOOPT}>


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, flags, optimization

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
To feed initial flags into the cmake build, a toolchain file is used. 

However, for particular build configurations, namely release and debug, despite the configuration being "Release" and "Debug", respectively, the corresponding `CMAKE_<LANG>_FLAGS_<CONFIG>_INIT` has the configuration name capitalized. 

Additionally, these initial flags supplement the starting flags and do not override any inherited flags that CMake automatically appends. This can cause issues with certain compilers where subsequent flags that normally should supersede previously listed options are ignored. As an example, using nvfortran/pgi the following will cause forced optimization, which is not viable for some files within WRF : 
https://forums.developer.nvidia.com/t/nvfortran-reducing-optimation-level-by-multiple-on-does-not-work/191825
https://forums.developer.nvidia.com/t/how-to-override-pgccs-optimization-flag/136275

Finally, certain files do not have optimization overridden even if it were to work correctly

Solution:
Ensure correct variable name in toolchain file to provide initial starting flags, and wipe CMake-injected release flags to avoid significant deviation from provided optimization flags. Add proper directory scope to files that need these reduced optimizations. 


TESTS CONDUCTED: 
1. Tested with CMake build on Derecho selecting nvhpc/pgi compiler stanzas

RELEASE NOTE: Override CMake-injected optimization flags in favor of the flags set by the build system and provided stanza information.
