### PR TITLE
only memory leak related

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -2001,6 +2001,7 @@ endif
 #endif
 
 DEALLOCATE(z_at_q)
+DEALLOCATE(dz8w)
 
    IF (config_flags%p_lev_diags == PRESS_DIAGS ) THEN
     CALL wrf_debug ( 200 , ' PLD: pressure level diags' )

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -356,10 +356,20 @@ SUBROUTINE calc_ts( grid )
    ALLOCATE ( earth_u_profile(grid%max_ts_level), earth_v_profile(grid%max_ts_level) )
 #endif
 
-   IF ( grid%ntsloc_domain .LE. 0 ) RETURN
+   IF ( grid%ntsloc_domain .LE. 0 ) THEN
+#if ( EM_CORE == 1 )
+       DEALLOCATE(earth_u_profile, earth_v_profile)
+#endif
+       RETURN
+   END IF
 
 #if ((EM_CORE == 1) && (DA_CORE != 1))
-   IF ( grid%dfi_opt /= DFI_NODFI .AND. grid%dfi_stage /= DFI_FST ) RETURN
+   IF ( grid%dfi_opt /= DFI_NODFI .AND. grid%dfi_stage /= DFI_FST ) THEN
+#if ( EM_CORE == 1 )
+       DEALLOCATE(earth_u_profile, earth_v_profile)
+#endif
+       RETURN
+   END IF
 #endif
 
    n = grid%next_ts_time


### PR DESCRIPTION
Fix memory leak relate allocate array again before deallocate call

TYPE: bug fix,

KEYWORDS: Memory Leak

SOURCE: Charlie Li - Software developer from lakes environmental canada

DESCRIPTION OF CHANGES:
Problem:
the change in wrf_timeseries.F and start_em.F are memory leak detected when use PGI option:
-g -O0 -traceback -Mchkptr -Mbounds -Ktrap=fp -Msave -tp=px
It will failed for: "0: ALLOCATE: array already allocated"

1. dyn_em/start_em.F
ALLOCATE(dz8w(IMS:IME,KMS:KME,JMS:JME),STAT=I) ; dz8w = 0.

miss logic to deallocate dz8w
2../share/wrf_timeseries.F

SUBROUTINE calc_ts( grid )

#if ( EM_CORE == 1 )
PRINT *, "ALLOCATE WILL call in wrf_timeseries.F at line 356: ALLOCATE ( earth_u_profile(grid%max_ts_level), earth_v_profile(grid%max_ts_level) )"
ALLOCATE ( earth_u_profile(grid%max_ts_level), earth_v_profile(grid%max_ts_level) )
PRINT *, "ALLOCATE called in wrf_timeseries.F at line 356: ALLOCATE ( earth_u_profile(grid%max_ts_level), earth_v_profile(grid%max_ts_level) )"
#endif

IF ( grid%ntsloc_domain .LE. 0 ) RETURN

#if ((EM_CORE == 1) && (DA_CORE != 1))
IF ( grid%dfi_opt /= DFI_NODFI .AND. grid%dfi_stage /= DFI_FST ) RETURN
#endif

when it return, it didn't free memory for earth_u_profile and earth_v_profile if EM_CORE  == 1

Solution:
Just in source code add code to free memory related

ISSUE: For use when this PR closes an issue.
Fixes #123

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
share/wrf_timeseries.F
dyn_em/start_em.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
