### PR TITLE
Bug fix for overwriting of LCZ urban cells in LU_INDEX with default USGS urban category.

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3154,7 +3154,7 @@ integer::oops1,oops2
                       (grid%ivgtyp(i,j).NE.13 .AND. grid%ivgtyp(i,j).NE.24 .AND. grid%ivgtyp(i,j).NE.25 .AND. grid%ivgtyp(i,j).NE.26 .AND. grid%ivgtyp(i,j).LT.30)) grid%ivgtyp(i,j)=13
               ELSE IF ( MMINLU == "USGS" ) THEN
                   IF ( grid%FRC_URB2D(i,j) .GE. 0.5 .AND.  &
-                       grid%ivgtyp(i,j).NE.1 .AND. grid&ivgtyp(i,j).LT.30) grid%ivgtyp(i,j)=1
+                       grid%ivgtyp(i,j).NE.1 .AND. grid%ivgtyp(i,j).LT.30) grid%ivgtyp(i,j)=1
               ENDIF
 
               IF ( grid%FRC_URB2D(i,j) == 0. ) THEN

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3154,7 +3154,7 @@ integer::oops1,oops2
                       (grid%ivgtyp(i,j).NE.13 .AND. grid%ivgtyp(i,j).NE.24 .AND. grid%ivgtyp(i,j).NE.25 .AND. grid%ivgtyp(i,j).NE.26 .AND. grid%ivgtyp(i,j).LT.30)) grid%ivgtyp(i,j)=13
               ELSE IF ( MMINLU == "USGS" ) THEN
                   IF ( grid%FRC_URB2D(i,j) .GE. 0.5 .AND.  &
-                       grid%ivgtyp(i,j).NE.1 ) grid%ivgtyp(i,j)=1
+                       grid%ivgtyp(i,j).NE.1 .AND. grid&ivgtyp(i,j).LT.30) grid%ivgtyp(i,j)=1
               ENDIF
 
               IF ( grid%FRC_URB2D(i,j) == 0. ) THEN


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: LCZ, USGS

SOURCE: Lukas Pilz (Heidelberg University)

DESCRIPTION OF CHANGES:
Problem:
As shown in #2152, for USGS data the wrfinput LU_INDEX field has major differences to the met_em LU_INDEX field. Cells in LU_INDEX which have LCZ categories (>30) were overwritten with the default USGS urban category (1) where FRC_URB2D > 0.5. 

Solution:
Add a check similar to the MODIS case above.

ISSUE:
Fixes #2152 

LIST OF MODIFIED FILES: 
M    dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. Did local tests, the only differences between wrfinput and met_em which remain are changing LU_INDEX 28 to 16, which is a water body redesignation as to my knowledge.
2. Jenkins tests have passed.

RELEASE NOTE: Bug fix for wrfinput where LCZ urban cells in LU_INDEX were overwritten with default USGS urban category.
