### PR TITLE
  Determine MPI Data Types in col_on_comm() & dst_on_comm() to prevent displacements overflow. (Fix for #2156)

### DIFF
--- a/frame/collect_on_comm.c
+++ b/frame/collect_on_comm.c
@@ -36,11 +36,11 @@
 # endif
 #endif
 
-  
+
 int col_on_comm ( int *, int *, void *, int *, void *, int *, int);
 int dst_on_comm ( int *, int *, void *, int *, void *, int *, int);
 
-void 
+void
 COLLECT_ON_COMM ( int * comm, int * typesize ,
                   void * inbuf, int *ninbuf , void * outbuf, int * noutbuf )
 {
@@ -96,7 +96,7 @@ col_on_comm ( int * Fcomm, int * typesize ,
     {
 #ifndef MS_SUA
       fprintf(stderr,"FATAL ERROR: collect_on_comm: noutbuf_loc (%d) > noutbuf (%d)\n",
-		      noutbuf_loc , * noutbuf ) ; 
+		      noutbuf_loc , * noutbuf ) ;
       fprintf(stderr,"WILL NOT perform the collection operation\n") ;
 #endif
       MPI_Abort(MPI_COMM_WORLD,1) ;
@@ -241,4 +241,3 @@ rlim_ ()
 }
 #endif
 #endif
-


### PR DESCRIPTION
Determine MPI Data Types in col_on_comm() & dst_on_comm() to prevent displacements overflow.

TYPE: bug fix

KEYWORDS: prevent displacements overflow in MPI_Gatherv() and MPI_Scatterv() operations

SOURCE: Benjamin Kirk & Negin Sobhani (NSF NCAR / CISL)

DESCRIPTION OF CHANGES:
Problem:
The MPI_Gatherv() and MPI_Scatterv() operations require integer displacements into the communications buffers. Historically everything is passed as an MPI_CHAR, causing these displacements to be larger than otherwise necessary. For large domain sizes this can cause the displace[] offsets to exceed the maximum int, wrapping to negative values.

Solution:
This change introduces additional error checking and then uses the function MPI_Type_match_size() (available since MPI-2.0) to determine a suitable MPI_Datatype given the input *typesize.  The result then is that the displace[] offsets are in terms of data type extents, rather than bytes, and less likely to overflow.

ISSUE: Fixes #2156 

LIST OF MODIFIED FILES: 
M       frame/collect_on_comm.c

TESTS CONDUCTED: 
Failed cases run now.

RELEASE NOTE: 
Determine MPI Data Types in col_on_comm() & dst_on_comm() to prevent displacements overflow.
