### PR TITLE
fixed defs for adap time step namelist vars in README.namelist

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -405,20 +405,23 @@ Namelist variables for controlling the adaptive time step option:
  use_adaptive_time_step              = .false.  ! T/F use adaptive time stepping.
  step_to_output_time                 = .true.   ! if adaptive time stepping, T/F modify the
                                                   time steps so that the exact history time is reached
- target_cfl(max_dom)                 = 1.2,1.2  ! vertical and horizontal CFL <= to this value implies
-                                                  no reason to reduce the time step, and to increase it
- target_hcfl(max_dom)                = .84,.84  ! horizontal CFL <= to this value implies
- max_step_increase_pct(max_dom)      = 5,51     ! percentage of previous time step to increase, if the
+ target_cfl(max_dom)                 = 1.2,1.2  ! if vertical CFL is <= to this value, it means there
+						  is no reason to reduce the time step, and therefore 
+						  time step is increased
+ target_hcfl(max_dom)                = .84,.84  ! if horizontal CFL <= to this value, it suggests no 
+						  need to reduce time step, and therefore time step 
+						  is increased
+ max_step_increase_pct(max_dom)      = 5,51     ! increase percentage for the previous time step, if the
                                                   max(vert cfl, horiz cfl) <= target_cfl, then the time
-                                                  will increase by max_step_increase_pct. Use something 
-                                                  large for nests (51% suggested)
- starting_time_step(max_dom)         = -1,-1    ! flag = -1 implies use 4*dx (defined in start_em), 
+                                                  will increase by this percentage; use something 
+                                                  much larger for nests (51% suggested, i.e., = 5, 51, 51)
+ starting_time_step(max_dom)         = -1,-1    ! flag = -1 sets time step to 4*dx (defined in start_em), 
                                                   starting_time_step = 100 means the starting time step
                                                   for the coarse grid is 100 s
- max_time_step(max_dom)              = -1,-1    ! flag = -1 implies max time step is 8*dx,
+ max_time_step(max_dom)              = -1,-1    ! flag = -1 sets the max time step to 8*dx,
                                                   max_time_step = 100 means that the time step will not
                                                   exceed 100 s
- min_time_step(max_dom)              = -1,-1    ! flag = -1 implies max time step is 3*dx,
+ min_time_step(max_dom)              = -1,-1    ! flag = -1 sets max time step to 3*dx,
                                                   min_time_step = 100 means that the time step will not
                                                   be less than 100 s
  adaptation_domain                   = 1        ! default, all fine grid domains adaptive dt driven by coarse-grid


### PR DESCRIPTION
TYPE: text only

KEYWORDS: README.namelist, adaptive time step

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Definitions for a few adaptive time step-relative variables in README.namelist weren't comprehensible.

Solution:
Modified the wording to make more sense

LIST OF MODIFIED FILES: 
M   run/README.namelist

TESTS CONDUCTED: 
1. text only
2. Are the Jenkins tests all passing?