### PR TITLE
CMake Better nf-config libdir detection

### DIFF
--- a/cmake/modules/FindnetCDF-Fortran.cmake
+++ b/cmake/modules/FindnetCDF-Fortran.cmake
@@ -81,9 +81,19 @@ else()
   endforeach()
 
 
-  # A bug in previous netcdf-fortran cmake builds, extract from flibs
-  string( REGEX MATCH "^-L([^ ]*)" netCDF-Fortran_LIBRARY_LINK_LOCATION ${netCDF-Fortran_FLIBS} )
-  set( netCDF-Fortran_LIBRARY_DIR ${CMAKE_MATCH_1} )
+  # A bug in previous netcdf-fortran cmake builds, extract from prefix, flibs, or include in priority order
+  if( NOT "${netCDF-Fortran_PREFIX}" STREQUAL "" )
+    # fall back to the prefix
+    set( netCDF-Fortran_LIBRARY_DIR ${netCDF-Fortran_PREFIX} )
+  elseif ( NOT "${netCDF-Fortran_FLIBS}" STREQUAL "" )
+    # flibs valid
+    string( REGEX MATCH "^-L([^ ]*)" netCDF-Fortran_LIBRARY_LINK_LOCATION ${netCDF-Fortran_FLIBS} )
+    set( netCDF-Fortran_LIBRARY_DIR ${CMAKE_MATCH_1} )
+  else()
+    # fall back EVEN further to include
+    string( REGEX MATCH "^([^ ]*)/include" netCDF-Fortran_LIBRARY_LINK_LOCATION ${netCDF-Fortran_INCLUDE_DIR} )
+    set( netCDF-Fortran_LIBRARY_DIR ${CMAKE_MATCH_1} )
+  endif()
 
   set( netCDF-Fortran_DEFINITIONS  )
   set( netCDF-Fortran_LIBRARIES
@@ -99,6 +109,9 @@ else()
                 netcdff
                 PATHS ${netCDF-Fortran_LIBRARY_DIR}
                 NO_DEFAULT_PATH
+                PATH_SUFFIXES
+                  lib/
+                  lib64/
                 )
 endif()
 
@@ -110,6 +123,7 @@ find_package_handle_standard_args(
                                   netCDF-Fortran
                                   FOUND_VAR netCDF-Fortran_FOUND
                                   REQUIRED_VARS
+                                    netCDF-Fortran_LIBRARY
                                     netCDF-Fortran_INCLUDE_DIRS
                                     netCDF-Fortran_LIBRARIES
                                     netCDF-Fortran_VERSION


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, netcdf, netcdf-fortran, nf-config

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
As nf-config does not provide an equivalent --libdir output we must derive the info ourselves. --flibs provided the info previously, but it may be more practical to use the --prefix output and search suspected suffixes instead as --flibs contains other libraries' link info. 

Solution:
Use output of --prefix from nf-config as the primary source of library dir. To handle the cases where --prefix is empty, we still fall back to --flibs and if that proves insufficient then the as a last resort one directory above the include directory can be used as a substitute for the prefix.

TESTS CONDUCTED: 
1. Tested with netCDF-Fortran v4.6.2, modifying nf-config to emulate fallback if clauses

RELEASE NOTE: Better nf-config libdir detection in CMake build
