### PR TITLE
Add dzstretch_u and dzbot to namelist.input in test/em_real/

### DIFF
--- a/test/em_real/namelist.input
+++ b/test/em_real/namelist.input
@@ -30,8 +30,10 @@
  max_dom                             = 2,
  e_we                                = 150,    220,
  e_sn                                = 130,    214,
- e_vert                              = 45,     45,
- dzstretch_s                         = 1.1
+ e_vert                              = 48,     48,
+ dzbot                               = 30.
+ dzstretch_s                         = 1.11
+ dzstretch_u                         = 1.10
  p_top_requested                     = 5000,
  num_metgrid_levels                  = 34,
  num_metgrid_soil_levels             = 4,


### PR DESCRIPTION
TYPE: enhancement, no impact, text only

KEYWORDS: vertical coordinate, namelist

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The current namelist.input file only has dzstretch_s. To properly use the auto_levels_opt, dzstretch_u and dzbot should be considered.

Solution:
Add dzstretch_u and dzbot in the namelist. Parameters based on UG.

LIST OF MODIFIED FILES: 
M       test/em_real/namelist.input

TESTS CONDUCTED: 
2. Are the Jenkins tests all passing?

RELEASE NOTE: Add dzstretch_u and dzbot in namelist.input. Users are advised to check UG for other parameters to use.
