### PR TITLE
Default soiltype namelist option

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2502,6 +2502,7 @@ rconfig   integer ideal_xland             namelist,physics	1             1      
 rconfig   real    swrad_scat              namelist,physics	1             1       irh    "SWRAD_SCAT" "SCATTERING FACTOR IN SWRAD"      ""
 rconfig   integer surface_input_source    namelist,physics	1             3       irh    "surface_input_source"          "1=static (fractional), 2=time dependent (dominant), 3=dominant cateogry from metgrid"      ""
 rconfig   integer num_soil_layers         namelist,physics	1             5       irh    "num_soil_layers"               ""      ""
+rconfig   integer     default_soiltype    namelist,physics	1               8      rh       "default_soiltype"              "Soil category used to correct missing values (default 8 : silty clay loam)"      ""
 rconfig   integer num_pft_clm             namelist,physics      1            17       -      "num_pft_clm"                  ""      ""
 rconfig   logical input_pft               namelist,physics      1            .false.   h     "input_pft_flag"         "use input pft instead of USGS"      ""
 rconfig   integer maxpatch                namelist,physics      1            10       irh    "maxpatch"                      ""      ""

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2502,7 +2502,7 @@ rconfig   integer ideal_xland             namelist,physics	1             1      
 rconfig   real    swrad_scat              namelist,physics	1             1       irh    "SWRAD_SCAT" "SCATTERING FACTOR IN SWRAD"      ""
 rconfig   integer surface_input_source    namelist,physics	1             3       irh    "surface_input_source"          "1=static (fractional), 2=time dependent (dominant), 3=dominant cateogry from metgrid"      ""
 rconfig   integer num_soil_layers         namelist,physics	1             5       irh    "num_soil_layers"               ""      ""
-rconfig   integer     default_soiltype    namelist,physics	1               8      rh       "default_soiltype"              "Soil category used to correct missing values (default 8 : silty clay loam)"      ""
+rconfig   integer default_soiltype        namelist,physics	1             8        rh    "default_soiltype"              "Soil category used to correct missing values (default 8 : silty clay loam)"      ""
 rconfig   integer num_pft_clm             namelist,physics      1            17       -      "num_pft_clm"                  ""      ""
 rconfig   logical input_pft               namelist,physics      1            .false.   h     "input_pft_flag"         "use input pft instead of USGS"      ""
 rconfig   integer maxpatch                namelist,physics      1            10       irh    "maxpatch"                      ""      ""

--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -3114,7 +3114,7 @@ integer::oops1,oops2
             DO i = its, MIN(ide-1,ite)
                IF ( skip_middle_points_t ( ids , ide , jds , jde , i , j , em_width , hold_ups ) ) CYCLE
                IF ( grid%landmask(i,j) .GT. 0.5 .AND. grid%isltyp(i,j) .EQ. grid%isoilwater ) THEN
-                  grid%isltyp(i,j) = 8
+                  grid%isltyp(i,j) = config_flags%default_soiltype
                   change_soilw =  change_soilw + 1
                   iforce =  iforce + 1
                ELSE IF ( grid%landmask(i,j) .LT. 0.5 .AND. grid%isltyp(i,j) .NE. grid%isoilwater ) THEN
@@ -3125,10 +3125,17 @@ integer::oops1,oops2
             END DO
          END DO
          IF ( change_soilw .GT. 0 .OR. change_soil .GT. 0 ) THEN
-            WRITE(a_message,FMT='(A,I4,A,I6)' ) &
-                  'forcing artificial silty clay loam at ',iforce,' points, out of ',&
-                  (MIN(ide-1,ite)-its+1)*(MIN(jde-1,jte)-jts+1)
-                  CALL wrf_debug(0,a_message)
+            IF (config_flags%default_soiltype == 8) THEN
+               WRITE(a_message,FMT='(A,I4,A,I6)' ) &
+                     'forcing artificial silty clay loam at ',iforce,' points, out of ',&
+                     (MIN(ide-1,ite)-its+1)*(MIN(jde-1,jte)-jts+1)
+            ELSE
+               WRITE(a_message,FMT='(A,I4,A,I4,A,I6)' ) &
+                     'forcing soil type to the user defined default category (',config_flags%default_soiltype,&
+                     ') at ',iforce,' points, out of ',&
+                     (MIN(ide-1,ite)-its+1)*(MIN(jde-1,jte)-jts+1)
+            ENDIF
+            CALL wrf_debug(0,a_message)
          END IF
 
       END IF

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -941,6 +941,7 @@ Namelist variables for controlling the adaptive time step option:
                                                   = 10: CLM4 landsurface model
                                                   = 2: Pleim-Xu landsurface model
                                                   = 3: SSiB landsurface model
+ default_soiltype                    = 8,   ! soil category applied in land cells where no soil category is defined, default is 8 = silty clay loam
  num_land_cat                        = 21,      ! number of land categories in input data.
                                                   24 - for USGS (default); 20 for MODIS
                                                   28 - for USGS if including lake category

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -487,6 +487,19 @@
       ENDDO
 
 !-----------------------------------------------------------------------
+! Check that default_soiltype is between 1 and 19 and is not water (14)
+!-----------------------------------------------------------------------
+      IF ((model_config_rec % default_soiltype .LT. 1) &
+            .OR. (model_config_rec % default_soiltype .GT. 19) &
+            .OR. (model_config_rec % default_soiltype .EQ. 14)) THEN
+         WRITE (wrf_err_message, FMT='(A,I4,A)') '--- ERROR: invalid default_soiltype category (', model_config_rec % default_soiltype, ')'
+         CALL wrf_message ( wrf_err_message )
+         WRITE (wrf_err_message, FMT='(A)') '--- ERROR: resetting default_soiltype to 8 (silty clay loam)'
+         CALL wrf_message ( wrf_err_message )
+         model_config_rec % default_soiltype = 8
+      END IF
+      
+!-----------------------------------------------------------------------
 ! Check that mosiac option cannot turn on when sf_urban_physics = 2 and 3
 !-----------------------------------------------------------------------
       DO i = 1, model_config_rec % max_dom


### PR DESCRIPTION
Purpose: add a default_soiltype namelist option

TYPE: new feature

KEYWORDS: FEAT: Add a default_soiltype namelist option

SOURCE: Mathieu Landreau (Centrale Nantes)

DESCRIPTION OF CHANGES:
Problem:
When running real.exe, in the land cells where no soiltype is defined in the soil dataset, the type is set to 8=silty clay loam. For high-resolution coastal area simulation, this can represent a certain amount of cells.

Solution:
A namelist option named default_soiltype is added. It is checked (in module_check_a_mundo) that the user-defined value is between 1 and 19 and is not water (19)

LIST OF MODIFIED FILES: 
Registry/Registry.EM_COMMON
dyn_em/module_initialize_real.F
run/README.namelist
share/module_check_a_mundo.F

TESTS CONDUCTED: 
- I realized this few month ago and didn't try again. It is possible to test with a coastal area case.
- It has passed the regression tests.

RELEASE NOTE: A namelist option, default_soiltype, is added to define filled-in land category along water/land boundaries where soil data may be missing.
