### PR TITLE
Fix the bug: TUV photolysis is inactive if simulation starts on 1st Jan

### DIFF
--- a/chem/module_ftuv_driver.F
+++ b/chem/module_ftuv_driver.F
@@ -1308,10 +1308,11 @@ include 'netcdf.inc'
 !-----------------------------------------------------------------------------
 !     set solar distance factor
 !-----------------------------------------------------------------------------
-         if( curjulday /= julday ) then
-            curjulday = julday
-            call sundis( curjulday, esfact )
-         endif
+         ! osipov fix the bug. Always calc the distance. Testing for 0 results in True on 1 Jan, keeps the sfact=0 and shutsdown the photolysis for entire day
+         !if( curjulday /= julday ) then
+         curjulday = julday
+         call sundis( curjulday, esfact )
+         !endif
 
       end subroutine ftuv_timestep_init
 

--- a/chem/module_phot_tuv.F
+++ b/chem/module_phot_tuv.F
@@ -341,10 +341,11 @@ any_daylight: &
 !-----------------------------------------------------------------------------
 !     set solar distance factor
 !-----------------------------------------------------------------------------
-     if( curjulday /= julday ) then
-       curjulday = julday
-       esfact = sundis( julday )
-     endif
+     ! osipov fix the bug. Always calc the distance. Testing for 0 results in True on 1 Jan, keeps the sfact=0 and shutsdown the photolysis for entire day
+     !if( curjulday /= julday ) then
+     curjulday = julday
+     esfact = sundis( julday )
+     !endif
      if( .not. config_flags%scale_o3_to_grnd_exo_coldens ) then
        if( config_flags%scale_o3_to_du_at_grnd ) then
          dobsi = max( 0.,config_flags%du_at_grnd )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: TUV, distance to the sun, 1 January, Julian day

SOURCE: Sergey Osipov (KAUST)

DESCRIPTION OF CHANGES:
Problem:
TUV and FTUV fail to initialize the distance to the Sun properly if the simulation starts on 1 Jan. The multiplication factor remains uninitialized at 0, which zeros out photolysis rate calculations (see line 745 @ module_phot_tuv.F. On the next day, the distance is recalculated normally and photolysis rates are calculated properly.

Solution:
Given that the calculation of sun distance is trivial, the if check was disabled

LIST OF MODIFIED FILES: 
chem/module_phot_tuv.F
chem/module_ftuv_driver.F

TESTS CONDUCTED: 
 The Jenkins tests are all passing.

RELEASE NOTE: This PR fixed a bug where TUV and FTUV fail to initialize the distance to the Sun properly if the simulation starts on 1 Jan.