### PR TITLE
Upgrade and bug fixes in ADIOS2 (IO=14)

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -732,13 +732,13 @@ while ( <CONFIGURE_DEFAULTS> )
     if ( $sw_adios2_path ) 
       { $_ =~ s/CONFIGURE_WRFIO_ADIOS2/wrfio_adios2/g ; 
         $_ =~ s:CONFIGURE_ADIOS2_FLAG:-DADIOS2: ;
-        if ( -d "$sw_adios2_path/lib" )
-          {
-            $adios2_libdir = "$sw_adios2_path/lib" ;
-          }
-        elsif ( -d "$sw_adios2_path/lib64" )
+        if ( -d "$sw_adios2_path/lib64" )
           {
             $adios2_libdir = "$sw_adios2_path/lib64" ;
+          }
+        elsif ( -d "$sw_adios2_path/lib" )
+          {
+            $adios2_libdir = "$sw_adios2_path/lib" ;
           }
         else
           {
@@ -1120,13 +1120,13 @@ while ( <ARCH_PREAMBLE> )
     if ( $sw_adios2_path ) 
       { $_ =~ s/CONFIGURE_WRFIO_ADIOS2/wrfio_adios2/g ; 
         $_ =~ s:CONFIGURE_ADIOS2_FLAG:-DADIOS2: ;
-        if ( -d "$sw_adios2_path/lib" )
-          {
-            $adios2_libdir = "$sw_adios2_path/lib" ;
-          }
-        elsif ( -d "$sw_adios2_path/lib64" )
+        if ( -d "$sw_adios2_path/lib64" )
           {
             $adios2_libdir = "$sw_adios2_path/lib64" ;
+          }
+        elsif ( -d "$sw_adios2_path/lib" )
+          {
+            $adios2_libdir = "$sw_adios2_path/lib" ;
           }
         else
           {

--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -732,13 +732,13 @@ while ( <CONFIGURE_DEFAULTS> )
     if ( $sw_adios2_path ) 
       { $_ =~ s/CONFIGURE_WRFIO_ADIOS2/wrfio_adios2/g ; 
         $_ =~ s:CONFIGURE_ADIOS2_FLAG:-DADIOS2: ;
-        if ( -d "$sw_adios2_path/lib64" )
-          {
-            $adios2_libdir = "$sw_adios2_path/lib64" ;
-          }
-        elsif ( -d "$sw_adios2_path/lib" )
+        if ( -d "$sw_adios2_path/lib" )
           {
             $adios2_libdir = "$sw_adios2_path/lib" ;
+          }
+        elsif ( -d "$sw_adios2_path/lib64" )
+          {
+            $adios2_libdir = "$sw_adios2_path/lib64" ;
           }
         else
           {
@@ -1120,13 +1120,13 @@ while ( <ARCH_PREAMBLE> )
     if ( $sw_adios2_path ) 
       { $_ =~ s/CONFIGURE_WRFIO_ADIOS2/wrfio_adios2/g ; 
         $_ =~ s:CONFIGURE_ADIOS2_FLAG:-DADIOS2: ;
-        if ( -d "$sw_adios2_path/lib64" )
-          {
-            $adios2_libdir = "$sw_adios2_path/lib64" ;
-          }
-        elsif ( -d "$sw_adios2_path/lib" )
+        if ( -d "$sw_adios2_path/lib" )
           {
             $adios2_libdir = "$sw_adios2_path/lib" ;
+          }
+        elsif ( -d "$sw_adios2_path/lib64" )
+          {
+            $adios2_libdir = "$sw_adios2_path/lib64" ;
           }
         else
           {

--- a/doc/README.adios2
+++ b/doc/README.adios2
@@ -1,27 +1,40 @@
-The ADIOS2 I/O option in WRF improves I/O at scale, as well as enabling in-situ processing and code-coupling capabilities.
+The ADIOS2 I/O option in WRF improves I/O scalability, as well as enabling in-situ processing and code-coupling capabilities.
 
 USAGE:
-The ADIOS2 I/O option for history and/or restart file is enabled by setting one of the following:
+The ADIOS2 I/O option for history and/or restart files is enabled by setting one of the following:
 io_form_history = 14
 io_form_restart = 14
 
-Additionally, the ADIOS2 I/O implementation allows for optional configuration that can be appended to the namelist.input:
+The ADIOS2 I/O option can be enabled for input and/or boundary file as well.
+io_form_input    = 14
+io_form_boundary = 14
+
+Note:
+1. During our testing with 'io_form_boundary = 14', the exception 'BeginStep() is called a second time without an intervening EndStep()' is thrown when running real.exe.
+   However, the outputs seem to be correct, and upon inspection, the BeginStep() and EndStep() are properly called in order.
+2. When running wrf.exe with 'io_form_boundary = 14', the exception 'IO wrfbdy_d01 declared twice' may be thrown.
+   Nevertheless, this can be safely ignored since a vacant I/O name such as 'wrfbdy_d01_1' will be used in substitution.
+
+Furthermore, the ADIOS2 I/O implementation supports optional configurations that can be appended to the namelist.input:
  &namelist_adios2
- adios2_compression_enable = .true.,
- adios2_blosc_compressor = "lz4",
- adios2_numaggregators = 0,
+   adios2_compression_enable = .true.,
+   adios2_blosc_compressor = "lz4",
+   adios2_blosc_clevel = 9,
+   adios2_numaggregators = 0,
  /
 
-- ADIOS2 compression is enabled by default but can be disabled with the adios2_compression_enable parameter.
-- Different Blosc compression codecs are available: lz4 (default), lz4hc, blosclz, zstd, zlib. 
-  The ideal compression codec depends on the platform architecture as well as required compression ratios.
-- adios2_numaggregators is the number of aggregator ranks (and resulting sub-files created). This number can greatly affect write times, and is the primary tuning knob in ADIOS2. 
-  By default this is set to 0, which is an alias for a single aggregator per compute node, which is found to be a good option at large process counts,
+- ADIOS2 compression is enabled by default but can be disabled with the 'adios2_compression_enable' parameter.
+- Different Blosc compression codecs are available: lz4 (default), lz4hc, blosclz, zstd, zlib.
+  The ideal compression codec depends on the platform architecture.
+  Experimentation with the compression level 'adios2_blosc_clevel', ranging from 1 to 9, may be useful as well.
+- 'adios2_numaggregators' is the number of aggregator ranks (and resulting sub-files created). This number can greatly affect write times, and is the primary tuning knob in ADIOS2.
+  By default, this is set to 0, which is an alias for a single aggregator per compute node, which is found to be a good option at large process counts,
   as file system contention is minimized while removing inter-node communication that is seen in MPI-I/O based approaches.
-  Alternatively, this can be set to any number between 1 and the number of processes participating in the computation. 
-  Using adios2_numaggregators set to the number of participating processes (or larger) essentially achieves file-per-process I/O which is highly performant at lower process/node counts. 
+  Alternatively, this can be set to any number between 1 and the number of processes participating in the computation.
+  Using adios2_numaggregators set to the number of participating processes (or larger) essentially achieves file-per-process I/O which is highly performant at lower process/node counts.
+  For moderate process/node counts, using a divisible value between sqrt(num_proc)/2 and sqrt(num_proc) may be optimal.
 
-As ADIOS2 is "Step-based" approach (to resemble actual production of data in "steps"), optimal performance is achieved when history outputs are appended to the same file. 
+As ADIOS2 is "Step-based" approach (to resemble actual production of data in "steps"), optimal performance is achieved when history outputs are appended to the same file.
 This is achieved in WRF by setting the frames_per_outfile namelist.input parameter to a large number.
 
 As ADIOS2 generates data in its own file format (BP3/4/5), post-processing scripts will need to altered to use the ADIOS2 read API.
@@ -34,13 +47,16 @@ WRF is configured for use with ADIOS2 by setting the $ADIOS2 environment variabl
 ADIOS2 installation should be configured for MPI and Blosc, and requires a version of ADIOS2 >= v2.8.0.
 
 ADVANCED:
-In general ADIOS2 parameters can be set using an XML file (see ADIOS2 documentation for more details). 
-But as transformation parameters (like compression) must be specified in the XML on a per-variable basis, which in WRF can be hundreds of variables, this is not feasible. 
+In general ADIOS2 parameters can be set using an XML file (see ADIOS2 documentation for more details).
+But as transformation parameters (like compression) must be specified in the XML on a per-variable basis, which in WRF can be hundreds of variables, this is not feasible.
 Therefore compression is hardcoded in the WRF-ADIOS2 implementation, but with the compression controlled by the aforementioned namelist.input parameters.
 That being said, additional features in ADIOS2 like SST for in-situ processing, and node-local burst buffer write capabilities are enabled by using an XML file (named adios2.xml,
-and should be placed in the run directory).
-The ADIOS2 "io name" in the XML should be set to the name of the file that would be written to the disk, and frames_per_outfile should be set to a large number,
-to enforce all of the data to use the same ADIOS2 "io name".
+and must be placed in the run directory).
+
+In the XML file, the ADIOS2 "io name" is the WRF filename, i.e., the files that would be read/written to the disk.
+You may set 'frames_per_outfile' to a large number to enforce all of the data to use the same ADIOS2 "io name".
+Otherwise, you may have to write a script for generating the XML file, duplicating read/write parameters for all filenames.
+
 When using the ADIOS2 SST file engine (e.g. for in-situ processing), the parameter SpeculativePreloadMode should be set to "OFF", to prevent ADIOS2 preemptively sending unneeded data to the data consumer.
 
 Example adios2.xml for node-local burst buffer functionality:


### PR DESCRIPTION
(Previously #2174 ) Upgrade and bug fixes in ADIOS2 (io_form=14)

TYPE: bug fix, enhancement

KEYWORDS: ADIOS2, compression, blosc compressor, blosc clevel, operator defined twice, IO declare twice, lib64

SOURCE: Somrath Kanoksirirath (NCR, ThaiSC)

DESCRIPTION OF CHANGES:
Problem:
1. 'Compressor operator defined twice' exception thrown when having more than one domains, causing no compression in subsequent files. (#2167)
2. Segmentation fault when running wrf.exe with 'adios2_compressoin_enable = .true.' when WRF is compiled using Intel oneAPI (ifx) or Cray Fortan compiler, for example. Note: this error is not found when using ifort.
3. New/future blosc compressor (for 'adios2_blosc_compressor') cannot be used since the accepted list is hard coded.
4. Add 'adios2_blosc_clevel' in &namelist_adios2 for adjusting blosc compression level
5. 'IO wrfbdy_d01 declared twice' exception thrown when running wrf.exe using 'io_form_boundary = 14'
6. Error/Warning messages do not state which adios2 function is causing the problem
7. '-ladios2_fortran_mpi' and/or '-ladios2_fortran' library not found when ADIOS2 having both /lib and /lib64

Solution:
1. Use 'adios2_inquire_operator' to check and reuse the existing 'Compressor' operator. Note: ADIOS2 operator needs to have an unique name under the same ADIOS2 IO.
2. Remove 'if (DH%compress_operator%name .ne. 'Compressor') then' condition which accessing the name before the operator is defined in subsequent lines. Note: the fix mentioned in #2167 was not taken account of this issue.
3. Remove the hard coded check. When the compressor is not supported, let the exception from ADIOS2 propagates up and return with a more meaningful error message.
4. Add 'adios2_blosc_clevel' to Register/registry.io_boilerplate. Use 'adios2_set_operation_parameter' to add this feature to the compress operator. Update doc/README.adios2.
5. Find and use a vacant IO name by iterating 'filename_<n>' and provide a heads-up to user. Note: ADIOS2 IO needs to have an unique name under the same ADIOS2 program-wide interface.
6. Edit error/warning messages making them more meaningful.
7. Edit arch/Config.pl to make it use /lib64, where the shared libraries are reside, if the directory exists before use /lib

ISSUE: Fixes #2167 and more

LIST OF MODIFIED FILES:
M Registry/registry.io_boilerplate
M arch/Config.pl
M doc/README.adios2
M external/io_adios2/wrf_io.F90

TESTS CONDUCTED:
1. Similar tests as in #2167 were conducted using Intel classic (ifort), Intel oneAPI (ifx) and Cray Fortran (ftn) compilers (using DM+SM option) on a HPE Cray EX system.
2. Additional tests, where ADIOS2 is also used for wrfbdy and wrfinput to run real.exe and wrf.exe, were conducted. The program run and complete successfully but with some warnings from ADIOS2 as mentioned in README.adios2.
3. The restart run  also works properly.

RELEASE NOTE:
Upgrade and bug fixes in ADIOS2 (io_form=14)