### PR TITLE
Rework the dependency linking of hydro CMake compilation

### DIFF
--- a/hydro/CPL/WRF_cpl/CMakeLists.txt
+++ b/hydro/CPL/WRF_cpl/CMakeLists.txt
@@ -14,6 +14,8 @@ add_dependencies(hydro_wrf_cpl
         MPI::MPI_Fortran
 )
 
+target_link_libraries( hydro_wrf_cpl PRIVATE hydro_driver )
+
 target_include_directories(hydro_wrf_cpl
         PRIVATE
         $<TARGET_PROPERTY:${PROJECT_NAME}_Core,Fortran_MODULE_DIRECTORY>

--- a/hydro/Data_Rec/CMakeLists.txt
+++ b/hydro/Data_Rec/CMakeLists.txt
@@ -5,3 +5,4 @@ add_library(hydro_data_rec STATIC
         module_RT_data.F90
         module_namelist.F90
 )
+target_link_libraries( hydro_data_rec PRIVATE hydro_mpp )

--- a/hydro/Debug_Utilities/CMakeLists.txt
+++ b/hydro/Debug_Utilities/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_library(hydro_debug_utils STATIC
         debug_dump_variable.F90
 )
+target_link_libraries( hydro_debug_utils PRIVATE hydro_mpp )

--- a/hydro/HYDRO_drv/CMakeLists.txt
+++ b/hydro/HYDRO_drv/CMakeLists.txt
@@ -8,8 +8,7 @@ target_link_libraries(hydro_driver PUBLIC
         hydro_data_rec
         hydro_routing
         hydro_debug_utils
-        PRIVATE
-          netCDF::netcdff
+        netCDF::netcdff
 )
 
 if(WRF_HYDRO_NUDGING STREQUAL "1")

--- a/hydro/IO/CMakeLists.txt
+++ b/hydro/IO/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(hydro_netcdf_layer STATIC
 )
 
 target_link_libraries(hydro_netcdf_layer
+        PUBLIC
         MPI::MPI_Fortran
         netCDF::netcdff
 )

--- a/hydro/MPP/CMakeLists.txt
+++ b/hydro/MPP/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(hydro_mpp STATIC
         hashtable.F90
 )
 
-target_link_libraries(hydro_mpp MPI::MPI_Fortran)
+target_link_libraries(hydro_mpp PUBLIC MPI::MPI_Fortran)
 target_include_directories(hydro_mpp PUBLIC
         ${MPI_Fortran_MODULE_DIR}
 )

--- a/hydro/Routing/CMakeLists.txt
+++ b/hydro/Routing/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(hydro_routing STATIC
 )
 
 target_link_libraries(hydro_routing
+       PRIVATE
        MPI::MPI_Fortran
        netCDF::netcdff
        hydro_mpp

--- a/hydro/utils/CMakeLists.txt
+++ b/hydro/utils/CMakeLists.txt
@@ -18,3 +18,4 @@ add_library(hydro_utils STATIC
         module_version.F90
         module_hydro_stop.F90
 )
+target_link_libraries(hydro_utils PRIVATE MPI::MPI_Fortran)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, hydro

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Some dependencies were not being fully satisfied and were implicit / partially fulfilled by subsequent compilation. In compilers that could tolerate these situations the hydro folder would compile successfully.

However, for compilers where dependencies are enforced (i.e. symbols resloved at compile time even within Fortran submodules), compilation would fail. 

Solution:
To account for situations where compilers require all module dependencies be resolved, dependencies between the hydro libraries and the transitive link properties were reworked to propagate dependencies up the chain correctly.

TESTS CONDUCTED: 
1. Tested building hydro with Intel oneAPI ifx 2024.2.1

RELEASE NOTE: 
Fixed failed compilation with Intel oneAPI by reworking the dependency linking of hydro CMake compilation
