### PR TITLE
Fix typo in confcheck CMakeLists.txt for FSEEKO

### DIFF
--- a/confcheck/CMakeLists.txt
+++ b/confcheck/CMakeLists.txt
@@ -53,7 +53,7 @@ if ( NOT "${FSEEKO64}" )
                   RESULT_VAR             FSEEKO
                   SOURCES                ${PROJECT_SOURCE_DIR}/tools/fseek_test.c
                   OPTIONS
-                    COMPILE_DEFINITINOS -DTEST_FSEEKO -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
+                    COMPILE_DEFINITIONS -DTEST_FSEEKO -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                   MESSAGE                "fseeko not supported, compiling with fseek (caution with large files)"
                   )
 endif()


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, typo

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
There is a typo in the confcheck for arguments that are forwarded to `try_compile()` and `try_run()` functions 

Solution:
Fix the typo

TESTS CONDUCTED: 
1. Tested on Derecho with ifx / oneAPI compilers
