### PR TITLE
Add quotes to optimization flags exceptions in CMake

### DIFF
--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -160,7 +160,7 @@ set_source_files_properties(
                             DIRECTORY ${PROJECT_SOURCE_DIR}
                             PROPERTIES
                             COMPILE_OPTIONS_OPTIMIZATION
-                              $<$<COMPILE_LANGUAGE:Fortran>:${WRF_FCNOOPT}>
+                              "$<$<COMPILE_LANGUAGE:Fortran>:${WRF_FCNOOPT}>"
                             )
 
 install( 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, syntax

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
With certain compilers, the optimization flags reduction were not being substituted correctly and the generator expression was left with partial original syntax.

Solution:
Double quote the expression to mirror all other uses of the categorical flag control and expand the expression.

TESTS CONDUCTED: 
1. Tested on Derecho with Intel oneAPI
