### PR TITLE
hydro bugfix: correctly handle lake_option=3 / no DA case, WRF-Hydro PR#808

### DIFF
--- a/hydro/OrchestratorLayer/config.F90
+++ b/hydro/OrchestratorLayer/config.F90
@@ -759,9 +759,13 @@ contains
     nlst(did)%SOLVEG_INITSWC = SOLVEG_INITSWC
     nlst(did)%reservoir_obs_dir = "testDirectory"
 
-    if ((lake_option == 3) .and. (reservoir_persistence_usgs .or. reservoir_persistence_usace .or. reservoir_rfc_forecasts)) then
-      reservoir_type_specified = .TRUE.
-      lake_option = 1
+    if (lake_option == 3) then
+      if (reservoir_persistence_usgs .or. reservoir_persistence_usace .or. reservoir_rfc_forecasts) then
+         reservoir_type_specified = .TRUE.
+      else
+         print *, "WARNING: lake_option = 3 (Reservoir DA), but no specific DA option was enabled. Setting lake_option to 1."
+      end if
+      lake_option = 1      ! set to 1 either way
     end if
 
     if (lake_option == -99) then


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: hydro, bugfix, lake_option, reservoir DA

SOURCE: Soren Rasmussen, internal hydro group

DESCRIPTION OF CHANGES:
Problem: If lake_option was set to 3 (Reservoir DA) but no Reservoir DA flags were set to .true. the internal lake_option was not set to [levelpool/off/passthrough] and a cryptic error resulted. 

Solution: NCAR/wrf_hydro_nwm_public#808 This fix now prints an error message and reverts the value to Level Pool if no DA option is selected.


LIST OF MODIFIED FILES: 
```
M       hydro/OrchestratorLayer/config.F90
```

TESTS CONDUCTED: 
1. Do mods fix problem? Yes, tested in the WRF-Hydro model. WRF builds with GNU
3. Are the Jenkins tests all passing? Yes

RELEASE NOTE: Hydro reservoir drainage area (DA) lake option bugfix
