### PR TITLE
Removed unnecessary factor in computation of dry air density in modul…

### DIFF
--- a/chem/module_chem_utilities.F
+++ b/chem/module_chem_utilities.F
@@ -78,7 +78,7 @@ CONTAINS
 
       p_phy(i,k,j) = p(i,k,j) + pb(i,k,j)
       t_phy(i,k,j) = (t(i,k,j)+t0)*(p_phy(i,k,j)/p1000mb)**rcp
-      rho(i,k,j) = 1./alt(i,k,j)*(1.+moist(i,k,j,P_QV))
+      rho(i,k,j) = 1./alt(i,k,j) !*(1.+moist(i,k,j,P_QV))
       u_phy(i,k,j) = 0.5*(u(i,k,j)+u(i+1,k,j))
       v_phy(i,k,j) = 0.5*(v(i,k,j)+v(i,k,j+1))
 


### PR DESCRIPTION
Removed unnecessary factor in computation of dry air density in module_chem_utilities.F

TYPE: bug fix

KEYWORDS: WRF-Chem, dry air density

SOURCE: NOAA GSL, Alexander Ukhov (KAUST)

DESCRIPTION OF CHANGES:
Problem:
It was found that dry air density was miscalculated.

Solution:
Removed unnecessary factor. Simulations before and after did not show any significant difference, as expected.



![before_and_after](https://github.com/user-attachments/assets/276b2ce7-7fe1-409e-be0f-18113161de3f)

LIST OF MODIFIED FILES:
M chem/module_chem_utilities.F

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Fixed calculation of dry air density in module_chem_utilities.F. The bug had a very minor effect.