### PR TITLE
Suppress MYNN-EDMF verify checkout command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ wrf : framework_only
 	   echo "NoahMP submodule files populating WRF directories" ; \
 	   echo "------------------------------------------------------------------------------" ; \
 	fi
-	if [ \( ! -f phys/module_bl_mynnedmf.F \) -o \
+	@if [ \( ! -f phys/module_bl_mynnedmf.F \) -o \
 	    \( ! -f phys/module_bl_mynnedmf_common.F \) -o \
 	    \( ! -f phys/module_bl_mynnedmf_common.F \) ] ; then \
 	  echo " " ; \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: make, verbose

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The MYNN-EDMF checkout status check commands in the make build were being output all the time regardless of status causing the `echo` error line to be verbosely printed out along with the actual status.

Solution:
Suppress the verbose output of the subshell command using the make command prefix `@`

TESTS CONDUCTED: 
1. Recompilation with the change no longer produces unwanted output
