### PR TITLE
Fix aarch64 GCC build when DM configuration selected

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -2174,7 +2174,7 @@ NETCDFPAR_BUILD	=      CONFIGURE_NETCDFPAR_BUILD
 #ARCH    Linux aarch64, armclang compiler OpenMPI # serial smpar dmpar dm+sm
 #
 DESCRIPTION     =      armclang ($SFC/$SCC): Aarch64
-DMPARALLEL      =
+DMPARALLEL      =      # 1
 OMPCPP          =      -fopenmp
 OMP             =      -fopenmp
 OMPCC           =      -fopenmp

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -2214,7 +2214,7 @@ CC_TOOLS        =      $(SCC) -Wno-implicit-function-declaration -Wno-int-conver
 #ARCH    Linux aarch64, GCC compiler OpenMPI # serial smpar dmpar dm+sm
 #
 DESCRIPTION     =      GCC ($SFC/$SCC): Aarch64
-DMPARALLEL      =
+DMPARALLEL      =      # 1
 OMPCPP          =      -fopenmp
 OMP             =      -fopenmp
 OMPCC           =      -fopenmp


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: make, compilation, dm

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
When a DM (distributed memory) configuration is selected, the configuration phase of the make build will extract the corresponding stanza from `arch/configure.defaults` and modify various variable lines with substitutions or comment removals.

Of particular note is the normally defined `DMPARALLEL = # 1` which is changed to `DMPARALLEL = 1` when DM configurations are selected. This definition  is then used to inform the make build about which pieces of code to compile for DM capabilities. The `Linux aarch64, GCC` stanza does not have this comment (`# 1`) and so the variable ends up blank when DM is selected causing compilation failure.

This issue possibly also exists for the `Linux aarch64, armclang` stanza, however no bug report has been noted for this at the time of this PR. 

Solution:
Add `# 1` to the `DMPARALLEL =` line in the `Linux aarch64, GCC` stanza definition. Likewise, perform the same change in the `Linux aarch64, armclang` stanza definition as well.

TESTS CONDUCTED: 
1. Confirmed with user on forum that this resolved their build issues for the `Linux aarch64, GCC` stanza.
