### PR TITLE
Bep bem nzu

### DIFF
--- a/README.LluisFB
+++ b/README.LluisFB
@@ -1,8 +1,0 @@
-This is a forked version of WRF dedicated to the bugs and fixes found by 
-Lluís Fita Borrell, UBA/CIMA/IFAECI, Argentina
-
-Following instructions from https://github.com/wrf-model/WRF/wiki/Workflow-for-WRF-Code-Modification
-
-This fork is aimed to contriute to the development of WRF model and used to perform 'Pull requests' when bugs are found and solutions for them are provided.
-
-

--- a/README.LluisFB
+++ b/README.LluisFB
@@ -1,0 +1,8 @@
+This is a forked version of WRF dedicated to the bugs and fixes found by 
+Lluís Fita Borrell, UBA/CIMA/IFAECI, Argentina
+
+Following instructions from https://github.com/wrf-model/WRF/wiki/Workflow-for-WRF-Code-Modification
+
+This fork is aimed to contriute to the development of WRF model and used to perform 'Pull requests' when bugs are found and solutions for them are provided.
+
+

--- a/phys/module_sf_bep_bem.F
+++ b/phys/module_sf_bep_bem.F
@@ -1597,7 +1597,7 @@ do iz= kts,kte
 
 
        
-       do iz=1,nz_um !Compute the outdoor temperature 
+       do iz=1,nzu !Compute the outdoor temperature 
 	 tmp_u(iz)=pt_u(iz)*(pr_u(iz)/p0)**(rcp_u) 
        end do
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: module_sf_bep_bem.F, loop index, debugging-crash

SOURCE: L. Fita (UBA/CIMA/IFAECI)

DESCRIPTION OF CHANGES:
Problem:
The loop index in line 1600 of subroutine module_sf_bep_bem.F should be up to `nzu`, instead of `nz_um`.

Solution:
This PR fixes the index.

ISSUE: For use when this PR closes an issue.
Fixes #2194

LIST OF MODIFIED FILES: 
M       phys/module_sf_bep_bem.F

TESTS CONDUCTED: 
1. Code was modified and recompiled in serial debug mode and it did not crashed
2. The Jenkins tests are all passing.

RELEASE NOTE: This PR fixed a loop index error in bep_bem urban code.
