### PR TITLE
Add return statement to GET_LANDUSE() function

### DIFF
--- a/share/landread.c
+++ b/share/landread.c
@@ -640,6 +640,7 @@ int GET_LANDUSE (        float *adx,
     }
   }
   tsCloseTileSet();
+  return 0;
 }
 
 int GET_TERRAIN (        float *adx,


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: landuse

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The `GET_LANDUSE()` function in landread.c when enabled had an implicit return for a non-void function, i.e. it should return an integer to denote status. This results in undefined behavior with an uninitialized return value left to the discretion of the compiler optimization, if it even does auto-initialize returns to some known value.

Solution:
Add a return statement of value `0` to denote success at the very end of the function.

TESTS CONDUCTED: 
1. Originally exposed with option 78 (Intel OneAPI ifx/icx) on derecho. Tested with 1 MPI rank and 36 MPI ranks to ensure landread did not fail where not expected to with these modifications.

RELEASE NOTE: 
Bug fix in landread.c to address undefined behavior by adding an explicit return statement in `GET_LANDUSE()` function
