### PR TITLE
Remove inaccurate error message regarding ghg_input

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -984,6 +984,8 @@
                    ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME       )   .OR.  &
                    ( model_config_rec % ra_sw_physics(i) .EQ. RRTMG_SWSCHEME_FAST  ) ) ) ) THEN
                ! This is OK, no way would a negation have been understandable!
+            ELSE IF ( model_config_rec % ra_sw_physics(i) == 0 ) THEN
+                    model_config_rec%ghg_input=0
             ELSE
                oops = oops + 1
             END IF


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ghg_input, idealized, no radiation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
Most idealized cases have radiation options turned off, which causes the following error message to inaccurately print to the rsl files when ideal.exe is run:

ERROR: ghg_input available only for these radiation schemes: CAM, RRTM, RRTMG, RRTMG_fast
           And the LW and SW schemes must be reasonably paired together:
           OK = CAM LW with CAM SW
           OK = RRTM, RRTMG LW or SW, RRTMG_fast LW or SW may be mixed

Solution:
In share/module_check_a_mundo.F, add code to ensure that when radiation is turned off, not only does the message not print, but the namelist value for ghg_input is set to 0, as well. 

LIST OF MODIFIED FILES: 
M    share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Code compiles okay and no longer prints the message for idealized cases (tested with em_quarter_ss).
2. The Jenkins tests are all passing.

RELEASE NOTE: This PR fixes an erroneous print for using ghg_input when no radiation option is selected, mostly from idealized cases.