### PR TITLE
confcheck results passed to main CMakeLists.txt

### DIFF
--- a/confcheck/CMakeLists.txt
+++ b/confcheck/CMakeLists.txt
@@ -5,6 +5,7 @@ wrf_conf_check(
                 SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_ieee_test.F
                 MESSAGE    "Some IEEE Fortran 2003 features missing, removing usage of these features"
                 )
+set(Fortran_2003_IEEE ${Fortran_2003_IEEE} PARENT_SCOPE)
 
 wrf_conf_check(
                 RUN
@@ -12,6 +13,7 @@ wrf_conf_check(
                 SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_iso_c_test.F
                 MESSAGE    "Some ISO_C Fortran 2003 features missing, removing usage ISO_C and stubbing code dependent on it"
                 )
+set(Fortran_2003_ISO_C ${Fortran_2003_ISO_C} PARENT_SCOPE)
 
 wrf_conf_check(
                 RUN
@@ -19,6 +21,7 @@ wrf_conf_check(
                 SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_flush_test.F
                 MESSAGE    "Standard FLUSH routine Fortran 2003 features missing, checking for alternate Fortran_2003_FFLUSH"
                 )
+set(Fortran_2003_FLUSH ${Fortran_2003_FLUSH} PARENT_SCOPE)
 
 if ( NOT ${Fortran_2003_FLUSH} )
   wrf_conf_check(
@@ -27,6 +30,7 @@ if ( NOT ${Fortran_2003_FLUSH} )
                   SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2003_fflush_test.F
                   MESSAGE    "Standard FFLUSH routine Fortran 2003 features missing, no alternate to FLUSH found, feature stubbed out"
                   )
+  set(Fortran_2003_FFLUSH ${Fortran_2003_FFLUSH} PARENT_SCOPE)
 endif()
 
 wrf_conf_check(
@@ -35,6 +39,7 @@ wrf_conf_check(
                 SOURCES    ${PROJECT_SOURCE_DIR}/tools/fortran_2008_gamma_test.F
                 MESSAGE    "Some Fortran 2003 features missing, removing usage gamma function intrinsic and stubbing code dependent on it"
                 )
+set(Fortran_2003_GAMMA ${Fortran_2003_GAMMA} PARENT_SCOPE)
 
 
 
@@ -46,6 +51,7 @@ wrf_conf_check(
                   COMPILE_DEFINITIONS -DTEST_FSEEKO64 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                 MESSAGE                "fseeko64 not supported, checking alternate fseeko"
                 )
+set(FSEEKO64 ${FSEEKO64} PARENT_SCOPE)
 
 if ( NOT "${FSEEKO64}" )
   wrf_conf_check(
@@ -56,6 +62,7 @@ if ( NOT "${FSEEKO64}" )
                     COMPILE_DEFINITIONS -DTEST_FSEEKO -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -DFILE_TO_TEST="${PROJECT_SOURCE_DIR}/CMakeLists.txt"
                   MESSAGE                "fseeko not supported, compiling with fseek (caution with large files)"
                   )
+  set(FSEEKO ${FSEEKO} PARENT_SCOPE)
 endif()
 
 # Unsure if this is even necessary. Defines littered throughout configure.defaults


### PR DESCRIPTION
Fix for the results of the confchecks not getting passed correctly to the main CMakeLists.txt.

TYPE: bugfix

KEYWORDS: bugfix, CMake, confcheck

SOURCE: Max Balsmeier

DESCRIPTION OF CHANGES:
Problem:
See #2217 

Solution:
The result variables of the confchecks are set with the PARENT_SCOPE attribute in confcheck/CMakeLists.txt.

ISSUE:
Fixes #2217 

LIST OF MODIFIED FILES: confcheck/CMakeLists.txt

TESTS CONDUCTED: 
1. I tested it locally, the confcheck results get passed correctly now.

RELEASE NOTE: Bugfix: CMake confcheck result variables passed correctly to main CMakeLists.txt.
