### PR TITLE
Small fixes in README.namelist regarding MYNN scheme

### DIFF
--- a/run/README.namelist
+++ b/run/README.namelist
@@ -781,13 +781,13 @@ use_rap_aero_icbc                   = .false.   ! Set to .true. to ingest real-t
  icloud_bl                                        option to couple the subgrid-scale clouds from the PBL scheme (MYNN only) 
                                                   to radiation schemes 
                                      0:  no coupling; 1: activate coupling to radiation (default)
- bl_mynn_cloudmix (max_dom)          = 0 ! default off; =1 activates mixing of qc and qi in MYNN
+ bl_mynn_cloudmix (max_dom)          activates mixing of qc and qi in MYNN
                                      0: no mixing of qc & qi; 1: mixing activated (default). 
                                         Note qnc and qni are mixed when scalar_pblmix =1.
  bl_mynn_mixlength                   option to change mixing length formulation in MYNN
                                      0: original as in Nakanishi and Niino 2009, 
-                                     1: RAP/HRRR (including BouLac in free atmosphere), 
-                                     2: experimental (default; includes cloud-specific mixing length and a scale-aware mixing 
+                                     1: RAP/HRRR (default; including BouLac in free atmosphere), 
+                                     2: experimental (includes cloud-specific mixing length and a scale-aware mixing 
                                         length, following Ito et al. 2015, BLM). Option 2 has been well tested with 
                                         the edmf options.
  bl_mynn_cloudpdf                    option to switch to different cloud PDFs to represent subgrid clouds


### PR DESCRIPTION
TYPE: bugfix, text only

KEYWORDS: README, namelist, default, MYNN

SOURCE: Max Balsmeier

DESCRIPTION OF CHANGES:
Problem:
The default for namelist bl_mynn_mixlength was wrong and the definition of bl_mynn_cloudmix was not clear for MYNN PBL.

Solution:
The README was fixed and clarified.

LIST OF MODIFIED FILES: run/README.namelist

RELEASE NOTE: Fix and clarification in README.namelist regarding MYNN PBL scheme.
