### PR TITLE
Add dependent files to custom command call to enable recompilation timestamp check

### DIFF
--- a/cmake/c_preproc.cmake
+++ b/cmake/c_preproc.cmake
@@ -29,6 +29,7 @@ macro( wrf_c_preproc_fortran )
   # Generate compile command and file outputs
   set( WRF_PP_F_OUTPUT   )
   set( WRF_PP_F_COMMANDS )
+  set( WRF_PP_F_DEPENDS  )
   foreach( WRF_PP_F_SOURCE_FILE  ${WRF_PP_F_SOURCES} )
     get_filename_component( WRF_PP_F_INPUT_SOURCE           ${WRF_PP_F_SOURCE_FILE} REALPATH )
     get_filename_component( WRF_PP_F_INPUT_SOURCE_FILE_ONLY ${WRF_PP_F_SOURCE_FILE} NAME     )
@@ -51,6 +52,10 @@ macro( wrf_c_preproc_fortran )
     list( 
           APPEND WRF_PP_F_OUTPUT
           ${WRF_PP_F_OUTPUT_FILE}
+          )
+    list(
+          APPEND WRF_PP_F_DEPENDS
+          ${WRF_PP_F_INPUT_SOURCE}
           )
     
     # # Tell all targets that eventually use this file that it is generated - this is useful if this macro is used in a
@@ -78,7 +83,7 @@ macro( wrf_c_preproc_fortran )
                       COMMAND ${CMAKE_COMMAND} -E  make_directory ${WRF_PP_F_OUTPUT_DIR}
                       ${WRF_PP_F_COMMANDS}
                       COMMENT "Preprocessing ${WRF_PP_F_TARGET_NAME}"
-                      DEPENDS ${WRF_PP_F_DEPENDENCIES}
+                      DEPENDS ${WRF_PP_F_DEPENDENCIES} ${WRF_PP_F_DEPENDS}
                       )
 
   add_custom_target(

--- a/cmake/m4_preproc.cmake
+++ b/cmake/m4_preproc.cmake
@@ -23,6 +23,7 @@ macro( wrf_m4_preproc_fortran )
   # Generate compile command and file outputs
   set( WRF_PP_M4_OUTPUT   )
   set( WRF_PP_M4_COMMANDS )
+  set( WRF_PP_M4_DEPENDS  )
   foreach( WRF_PP_M4_SOURCE_FILE  ${WRF_PP_M4_SOURCES} )
     get_filename_component( WRF_PP_M4_INPUT_SOURCE           ${WRF_PP_M4_SOURCE_FILE} REALPATH )
     get_filename_component( WRF_PP_M4_INPUT_SOURCE_FILE_ONLY ${WRF_PP_M4_SOURCE_FILE} NAME     )
@@ -45,6 +46,10 @@ macro( wrf_m4_preproc_fortran )
     list( 
           APPEND WRF_PP_M4_OUTPUT
           ${WRF_PP_M4_OUTPUT_FILE}
+          )
+    list( 
+          APPEND WRF_PP_M4_DEPENDS
+          ${WRF_PP_M4_INPUT_SOURCE}
           )
     
     # # Tell all targets that eventually use this file that it is generated - this is useful if this macro is used in a
@@ -72,7 +77,7 @@ macro( wrf_m4_preproc_fortran )
                       COMMAND ${CMAKE_COMMAND} -E  make_directory ${WRF_PP_M4_OUTPUT_DIR}
                       ${WRF_PP_M4_COMMANDS}
                       COMMENT "Preprocessing ${WRF_PP_M4_TARGET_NAME}"
-                      DEPENDS ${WRF_PP_M4_DEPENDENCIES}
+                      DEPENDS ${WRF_PP_M4_DEPENDENCIES} ${WRF_PP_M4_DEPENDS}
                       )
 
   add_custom_target(


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
With the new CMake build, if a file that gets manually preprocessed prior to compilation is edited it will not trigger preprocessing again and thus skip recompilation for those edits.

Solution:
Add the original source file to the list of `DEPENDS` files when adding the custom command. This will add the appropriate make checks to compare timestamps between the original source file and the output results, triggering recompilation.

TESTS CONDUCTED: 
1. Tested recompilation of `wrf_io.F90` as a file that undergoes C and M4 preprocessing.

