### PR TITLE
Fix in KPP compilation during integration edit to use correct make variable

### DIFF
--- a/chem/KPP/util/write_decomp/Makefile
+++ b/chem/KPP/util/write_decomp/Makefile
@@ -28,7 +28,7 @@ all:
 	$(MAKE) comp
 	./write_decomp.exe
 	$(MAKE) integr_edit
-	./integr_edit.exe $(MECH) module_kpp_$(MECH)_Integr.F decomp_$(MODEL).inc $(MODEL)_new
+	./integr_edit.exe $(MECH) module_kpp_$(MECH)_Integr.F decomp_$(MECH).inc $(MECH)_new
 	$(MAKE) clean 
 
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: make, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2018 introduced CMake compilation of the chem and KPP code. In order to do that certain helper programs created during the compilation process were reworked. The KPP mechanism integration edit program, `integr_edit.exe` was changed to take in explicit arguments for the files to read and write. However, the edits to the makefile that control this call use an invalid variable `$(MODEL)` where `$(MECH)` should be used instead. 

Solution:
Use the appropriate `$(MECH)` variable to construct command line arguments to `intergr_edit.exe`

ISSUE: 
#2216

TESTS CONDUCTED: 
1. Recreated the issues noted in #2216, though not limited to the intel compilers. Diagnosed as segfault due to reading of nonexistent file from null expansion of bad make variable. Fixed and recompiled successfully.
