### PR TITLE
Fix errant line contiuation syntax in chem code

### DIFF
--- a/chem/module_input_chem_data.F
+++ b/chem/module_input_chem_data.F
@@ -3843,8 +3843,8 @@ SUBROUTINE bdy_chem_value_top_pv ( chem,xlat,         &
 
     REAL, DIMENSION(ims:ime,kms:kme,jms:jme,num_chem ),  &
                intent(INOUT) :: chem
-    REAL, DIMENSION( ims:ime , jms:jme ),   intent(IN)   :: xlat     ! for determination of O3/PV p\
-roportionality constant
+    REAL, DIMENSION( ims:ime , jms:jme ),   intent(IN)   :: xlat     ! for determination of O3/PV proportionality constant
+
     REAL                  :: pv2o3_con   ! for determination of O3/PV proportionality constant
     REAL, DIMENSION(ims:ime , kms:kme , jms:jme), intent(IN) :: pv,pb,p
     REAL   :: preshPa


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: syntax

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
There is invalid Fortran syntax for line continuation in the chem code. More sensitive compilers catch this as an error during the CMake build as files are not sanitized as much compared to the make build.

Solution:
Change the lines to be a single line. 

ISSUE: 
#2214 

TESTS CONDUCTED: 
1. Recreated issue noted in #2214 using Intel OneAPI compilers and testing code modifications to pass compilation successfully.

