### PR TITLE
fix units of evaporation for imp_scheme==2 in slucm

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -1032,7 +1032,8 @@ USE module_model_constants, ONLY :  piconst
    IF (IMP_SCHEME==2) then
    IF (FLXHUMRP <= 0.) FLXHUMRP = 0. 
 !  Compute water retention depth from previous time step 
-   DrelR = DrelRP+(RAIN1-FLXHUMRP)*DELT/porimp(IMPR)
+   ! Convert kinematic water flux to evaporation in m/s: multiply flux by rho_air/who_water in SI units
+   DrelR = DrelRP+(RAIN1-FLXHUMRP*RHOO/1000.)*DELT/porimp(IMPR)
    IF (RAIN > 0. .AND. DrelR < DrelRP) DrelR = DrelRP 
   
    IF (DrelR <= 0.) then
@@ -1284,9 +1285,10 @@ ENDIF
    IF (FLXHUMBP <= 0.) FLXHUMBP = 0. 
    IF (FLXHUMGP <= 0.) FLXHUMGP = 0. 
 ! Compute water retention from previous time step for wall and ground
-  DrelB = DrelBP+(RAIN1-FLXHUMBP)*DELT/porimp(IMPB) 
+   ! Convert kinematic water flux to evaporation in m/s: multiply flux by rho_air/who_water in SI units
+  DrelB = DrelBP+(RAIN1-FLXHUMBP*RHOO/1000.)*DELT/porimp(IMPB) 
     IF (RAIN > 0. .AND. DrelB < DrelBP) DrelB = DrelBP 
-  DrelG = DrelGP+(RAIN1-FLXHUMGP)*DELT/porimp(IMPG)  
+  DrelG = DrelGP+(RAIN1-FLXHUMGP*RHOO/1000.)*DELT/porimp(IMPG)  
     IF (RAIN > 0. .AND. DrelG < DrelGP) DrelG = DrelGP 
   
   IF (DrelB <= 0.) then


### PR DESCRIPTION
Fix the conversion of kinematic water vapor flux to evaporation in m/s for water budget in slucm

TYPE: bug fix

KEYWORDS: slucm, urban evaporation, urban physics

SOURCE: Einara Zahn, Princeton University

DESCRIPTION OF CHANGES:
Problem:
Evaporation rate over impervious surfaces was incorrectly computed in SLUCM for option IMP_SCHEME==2. The kinematic vapor flux (kg/kg x m/s) was not converted to evaporation in m/s before entering the water budget equation, leading to wrong update of water storage.

Solution:
Multiplied the kinematic water vapor flux by air density and divided by water density in module_sf_urban.f90, only inside the code block for IMP_SCHEME == 2. The conversion does not affect the default version IMP_SCHEME==1.

ISSUE: For use when this PR closes an issue.
Fixes #2186

LIST OF MODIFIED FILES:  phys/module_sf_urban.F

TESTS CONDUCTED: 
1. Running urban simulations on rainy days, with and without the unit conversion.
2. Jenkins tests have passed.

RELEASE NOTE: Corrected evaporation rate calculation for water budget over impervious surfaces in SLUCM when IMP_SCHEME == 2. Affects available water in impervious surfaces and latent heat flux output in urban simulations with impervious scheme enabled.
