### PR TITLE
Correct syntax with explicit function arguments where previously implicit

### DIFF
--- a/external/RSL_LITE/rsl_bcast.c
+++ b/external/RSL_LITE/rsl_bcast.c
@@ -82,7 +82,7 @@ static int destroy_par_info ( p )
 
 static int destroy_list( list, dfcn )
      rsl_list_t ** list ;          /* pointer to pointer to list */
-     int (*dfcn)() ;               /* pointer to function for destroying
+     int (*dfcn)(void *) ;               /* pointer to function for destroying
                                       the data field of the list */
 {
   rsl_list_t *p, *trash ;

--- a/external/RSL_LITE/rsl_bcast.c
+++ b/external/RSL_LITE/rsl_bcast.c
@@ -82,7 +82,7 @@ static int destroy_par_info ( p )
 
 static int destroy_list( list, dfcn )
      rsl_list_t ** list ;          /* pointer to pointer to list */
-     int (*dfcn)(void *) ;               /* pointer to function for destroying
+     int (*dfcn)(void *) ;         /* pointer to function for destroying
                                       the data field of the list */
 {
   rsl_list_t *p, *trash ;

--- a/external/io_grib1/MEL_grib1/pack_spatial.c
+++ b/external/io_grib1/MEL_grib1/pack_spatial.c
@@ -88,7 +88,7 @@ int	pack_spatial (  pt_cnt, bit_cnt, pack_null, fbuff, ppbitstream,
     float max_grid;		/* maximum value in grid */
     float ftemp;		/* temporary float containing grid value */
     unsigned long *pBitstream;
-    unsigned long grib_local_ibm(double local_float);
+    unsigned long grib_local_ibm(double);
     int wordnum;
     int zero_cnt;
     int prec_too_high = 0;

--- a/external/io_grib1/MEL_grib1/pack_spatial.c
+++ b/external/io_grib1/MEL_grib1/pack_spatial.c
@@ -88,7 +88,7 @@ int	pack_spatial (  pt_cnt, bit_cnt, pack_null, fbuff, ppbitstream,
     float max_grid;		/* maximum value in grid */
     float ftemp;		/* temporary float containing grid value */
     unsigned long *pBitstream;
-    unsigned long grib_local_ibm();
+    unsigned long grib_local_ibm(double local_float);
     int wordnum;
     int zero_cnt;
     int prec_too_high = 0;


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: gcc, gcc15, compilation

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
GCC 15 uses newer standards compliance, notably the disallowance of `func()` function declaration as a way to defer true arguments later specified in the function definition. Instead, functions declared as `func()` will be assumed to mean `func(void)` and any other amount of arguments must be explicitly noted in the declaration.

Solution:
Make sure function declarations and definitions match.

ISSUE: For use when this PR closes an issue.
Fixes #2226 

TESTS CONDUCTED: 
1. Built and tested against GCC 15.1.0

RELEASE NOTE: 
Fix compilation with GCC 15 by correcting function declaration syntax to explicitly list function arguments.
