### PR TITLE
CMake Fix ideal compilation

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options    ( "${PROJECT_COMPILE_OPTIONS}"     )
 add_compile_definitions( "${PROJECT_COMPILE_DEFINITIONS}" )
 
 # First make true executables
-if ( ${WRF_CORE} STREQUAL "PLUS" OR ${WRF_CASE} STREQUAL "EM_REAL" )
+if ( ${WRF_CORE} STREQUAL "PLUS" OR ${WRF_CORE} STREQUAL "ARW" )
   
   add_executable( 
                   wrf


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, ideal

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2089 introduced the ability to compile WRFPLUS, however it inadvertently removed the compilation of `wrf[.exe]` from any configurations that weren't `PLUS` or 'EM_REAL`. Thus, the ideal cases under `ARW` core but not `EM_REAL` no longer compiled the `wrf` target, effectively breaking compilation for any ideal cases.

Solution:
Adjust the logic to compile the `wrf` executable for `ARW` or `PLUS` cores.

ISSUE: For use when this PR closes an issue.
Fixes #2224 

TESTS CONDUCTED: 
1. Tested fixes to ensure em_real, ideal, chem, and plus configurations all compile correctly again.

RELEASE NOTE: 
CMake bug fix to ensure ideal cases compile correctly again.