### PR TITLE
Use a temp pass through errhandler for trivial errors causing abort

### DIFF
--- a/frame/collect_on_comm.c
+++ b/frame/collect_on_comm.c
@@ -55,8 +55,8 @@ get_datatype_from_typesize( int *typesize )
   // MPI critically aborts on trivial errors caused by this call so replace error
   // handler temporarily
   ierr = MPI_Comm_create_errhandler( &temp_errhandler, &errhandler );
-  ierr = MPI_Errhandler_get( MPI_COMM_WORLD, &previous );
-  ierr = MPI_Errhandler_set( MPI_COMM_WORLD, errhandler );
+  ierr = MPI_Comm_get_errhandler( MPI_COMM_WORLD, &previous );
+  ierr = MPI_Comm_set_errhandler( MPI_COMM_WORLD, errhandler );
 
   /* handle different sized data types appropriately. */
   ierr = MPI_Type_match_size (MPI_TYPECLASS_REAL, *typesize, &dtype);
@@ -71,7 +71,7 @@ get_datatype_from_typesize( int *typesize )
   }
 
   // Reinstate the previous error handler and clear ours
-  ierr = MPI_Errhandler_set( MPI_COMM_WORLD, previous );
+  ierr = MPI_Comm_set_errhandler( MPI_COMM_WORLD, previous );
   ierr = MPI_Errhandler_free( &errhandler );
 
   return dtype;


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: mpi, quilting, comm

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2157 added changes to match an appropriate `MPI_Datatype` to a specific `typesize` during `col_on_comm()` and `dst_on_comm()`. This relies on `MPI_Type_match_size()` to query MPI about the equivalent MPI definition for a particular datatype size. There are safety checks to query `MPI_TYPECLASS_INTEGER` if `MPI_TYPECLASS_REAL` fails. 

However, when given a datatype size that does not match a possible `MPI_TYPECLASS_REAL` value (e.g. 1 byte where no real exists for single byte) instead of getting a failure via return code the query is treated as a critical failure and fully aborts the program. As the query does not rely on critical process handling _and_ since there already exists adequate checks to abort if no sufficient value is found, this preemptive abort is unnecessary. 

Solution:
Temporarily install a pass through errhandler that does not modify the return code but also does not abort. Allow the if statements of finding a correct `MPI_Datatype` to abort if deemed necessary. Additionally, once the checks are complete, reinstate any previous errhandler and free our pass through handle.

ISSUE: 
#2225 

TESTS CONDUCTED: 
1. Tested the stability of this call to handle correct and incorrect types various times while constantly replacing the error handler.

RELEASE NOTE: 
In collect_on_comm.c, use a temporary pass through errhandler to allow MPI_Type_match_size to fail correctly with error code rather than fully abort the program.
