### PR TITLE
Moved deallocate statement: error when setting diag_nwp2 = 1 due to memory deallocation 

### DIFF
--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -2001,7 +2001,6 @@ endif
 #endif
 
 DEALLOCATE(z_at_q)
-DEALLOCATE(dz8w)
 
    IF (config_flags%p_lev_diags == PRESS_DIAGS ) THEN
     CALL wrf_debug ( 200 , ' PLD: pressure level diags' )
@@ -2167,6 +2166,7 @@ DEALLOCATE(dz8w)
                ,ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte   )
    ENDIF
 
+DEALLOCATE(dz8w)
 
 !  FIRE
 if(config_flags%ifire.eq.2)then


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: seg fault, diag_nwp2

SOURCE: Menda Chasteen

DESCRIPTION OF CHANGES:
Running with `diag_nwp2 = 1` leads to a segmentation fault related to prematurely deallocating `dz8w` in [start_em.F](https://github.com/wrf-model/WRF/blob/f52c197ed39d12e087d02c50f412d90d418f6186/dyn_em/start_em.F#L2004). This PR fixes the error by moving the deallocate statement to after the `trad_fields` call.

LIST OF MODIFIED FILES:
dyn_em/start_em.F

TESTS CONDUCTED:
The regression tests are all passing.

RELEASE NOTE: This PR fixes a seg fault error due to early deallocation of array dz8w for diag_nwp2=2 option in start_em.F.