### PR TITLE
Fix floating point exception in phys/module_mp_radar.F when debugging with -D

### DIFF
--- a/phys/module_mp_radar.F
+++ b/phys/module_mp_radar.F
@@ -49,8 +49,10 @@ MODULE module_mp_radar
       REAL, PUBLIC:: xam_r, xbm_r, xmu_r, xobmr
       REAL, PUBLIC:: xam_s, xbm_s, xmu_s, xoams, xobms, xocms
       REAL, PUBLIC:: xam_g, xbm_g, xmu_g, xoamg, xobmg, xocmg
-      REAL, PUBLIC:: xam_h, xbm_h, xmu_h, xoamh, xobmh, xocmh
+      REAL, PUBLIC:: xmu_h, xoamh, xobmh, xocmh
       REAL, PUBLIC:: xorg2, xosg2, xogg2, xohg2
+      REAL, PUBLIC:: xam_h = 0. ! Prevents fpe in debugging
+      REAL, PUBLIC:: xbm_h = 0. ! Prevents fpe in debugging
 
       INTEGER, PARAMETER, PUBLIC:: slen = 20
       CHARACTER(len=slen), PUBLIC::                                     &
@@ -222,9 +224,13 @@ CONTAINS
       xoamg = 1./xam_g
       xobmg = 1./xbm_g
       xocmg = xoamg**xobmg
-      xoamh = 1./xam_h
-      xobmh = 1./xbm_h
-      xocmh = xoamh**xobmh
+!     If statement prevents floating point exceptions in mp schemes
+!     which do not initialise the below
+      if ((xam_h .gt. 0.) .and. (xbm_h .gt. 0.)) then
+         xoamh = 1./xam_h
+         xobmh = 1./xbm_h
+         xocmh = xoamh**xobmh
+      endif
 
 
       end subroutine radar_init


### PR DESCRIPTION
Prevent floating point exception in phys/module_mp_radar.F when debugging with -D related to new variables in UDM scheme.

TYPE: bug fix

KEYWORDS: debug, radar, microphysics, UDM, -D

SOURCE: Jack Bartlett (Imperial College London)

DESCRIPTION OF CHANGES:
Problem:
Lines 225 and 226 in phys/module_mp_radar.F trigger a floating point exception when debugging with option -D and using any microphysics scheme which calls `radar_init` except the UDM scheme because `xam_h` and `xbm_h` are not initialised in any other microphysics scheme.

Solution:
Initialise `xam_h` and `xbm_h` at 0 and check if they have been given a value greater than 0 before finding their reciprocals.

ISSUE: For use when this PR closes an issue.
Fixes #2248

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
phys/module_mp_radar.F

TESTS CONDUCTED: 
Only tested by trying `mp_physics=8` with debugging option -D and the new fixes (which previously triggered a fpe).
