### PR TITLE
fix WRF-CHEM errors for CCE build

### DIFF
--- a/chem/module_mosaic_addemiss.F
+++ b/chem/module_mosaic_addemiss.F
@@ -1641,7 +1641,6 @@ size_loop: &
 
 
 
-END MODULE module_mosaic_addemiss
 
 !----------------------------------------------------------------------
 
@@ -2217,6 +2216,8 @@ END MODULE module_mosaic_addemiss
 
 
 end subroutine mosaic_dust_gocartemis
+
+END MODULE module_mosaic_addemiss
 !===========================================================================
 
 !----------------------------------------------------------------------

--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -4705,19 +4705,19 @@ END subroutine optical_prep_modal_soa_vbs
 ! check for refr and refi outside of lookup table range to prevent unstable extrapolation 'binterp' below
           if (refr < refrtabsw(1,ns)) then
              refr = refrtabsw(1,ns)
-             write(*,*), 'Warning: refr is smaller than lookup table range and reset to minimum bound at SW band ', ns
+             write(*,*) 'Warning: refr is smaller than lookup table range and reset to minimum bound at SW band ', ns
           endif
           if (refr > refrtabsw(prefr,ns)) then
              refr = refrtabsw(prefr,ns)
-             write(*,*), 'Warning: refr is larger than lookup table range and reset to maximum bound at SW band ', ns
+             write(*,*) 'Warning: refr is larger than lookup table range and reset to maximum bound at SW band ', ns
           endif
           if (refi < refitabsw(1,ns)) then
              refi = refitabsw(1,ns)
-             write(*,*), 'Warning: refi is smaller than lookup table range and reset to minimum bound at SW band ', ns
+             write(*,*) 'Warning: refi is smaller than lookup table range and reset to minimum bound at SW band ', ns
           endif
           if (refi > refitabsw(prefi,ns)) then
              refi = refitabsw(prefi,ns)
-             write(*,*), 'Warning: refi is larger than lookup table range and reset to maximum bound at SW band ', ns
+             write(*,*) 'Warning: refi is larger than lookup table range and reset to maximum bound at SW band ', ns
           endif
 
 ! interpolate coefficients linear in refractive index
@@ -4980,19 +4980,19 @@ END subroutine optical_prep_modal_soa_vbs
 ! check for refr and refi outside of lookup table range to prevent unstable extrapolation 'binterp' below
           if (refr < refrtablw(1,ns)) then
              refr = refrtablw(1,ns)
-             write(*,*), 'Warning: refr is smaller than lookup table range and reset to minimum bound at LW band ', ns
+             write(*,*) 'Warning: refr is smaller than lookup table range and reset to minimum bound at LW band ', ns
           endif
           if (refr > refrtablw(prefr,ns)) then
              refr = refrtablw(prefr,ns)
-             write(*,*), 'Warning: refr is larger than lookup table range and reset to maximum bound at LW band ', ns
+             write(*,*) 'Warning: refr is larger than lookup table range and reset to maximum bound at LW band ', ns
           endif
           if (refi < refitablw(1,ns)) then    
              refi = refitablw(1,ns)
-             write(*,*), 'Warning: refi is smaller than lookup table range and reset to minimum bound at LW band ', ns
+             write(*,*) 'Warning: refi is smaller than lookup table range and reset to minimum bound at LW band ', ns
           endif
           if (refi > refitablw(prefi,ns)) then
              refi = refitablw(prefi,ns)
-             write(*,*), 'Warning: refi is larger than lookup table range and reset to maximum bound at LW band ', ns
+             write(*,*) 'Warning: refi is larger than lookup table range and reset to maximum bound at LW band ', ns
           endif
 
 ! interpolate coefficients linear in refractive index


### PR DESCRIPTION
Fix issues found when building WRF-CHEM with CCE compiler

TYPE:  no impact

KEYWORDS: CCE,errors,module_optical_averaging.F,module_mosaic_addemiss.F,Cray

SOURCE: Miroslaw Andrejczuk (HPE)

DESCRIPTION OF CHANGES:
Problem:
There were few errors reported by Cray compiler when building WRF-CHEM code.  In chem/module_optical_averaging.F comma after write statements triggered error when building, and for chem/module_mosaic_addemiss.F compiler complained that because subroutine mosaic_dust_gocartemis has an optional argument an interface to this routine is needed in module itself.

Solution:
Remove commas after write statements in module_optical_averaging.F. Move _END MODULE module_mosaic_addemiss_ statement in the file  to include subroutine mosaic_dust_gocartemis in the module definition.

ISSUE: For use when this PR closes an issue.
Fixes #2252

LIST OF MODIFIED FILES: 
chem/module_mosaic_addemiss.F
chem/module_optical_averaging.F


TESTS CONDUCTED: 
1. With those changes I can build wrf/em_real with CCE 
2. Are the Jenkins tests all passing? Wasn't run

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
