### PR TITLE
Fix mismatch between Timeserie write FMT and actual variable list in WRITE statement

### DIFF
--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -907,7 +907,7 @@ SUBROUTINE write_ts( grid )
                                  grid%ts_clw(n,i)
             ELSE
                !!! WRF-Solar diagnostics
-               WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,49(f13.5,1x))')  &
+               WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,50(f13.5,1x))')  &
                                  grid%id, grid%ts_hour(n,i),                &
                                  grid%id_tsloc(i), ix, iy,                  &
                                  grid%ts_t(n,i),                            &


### PR DESCRIPTION
Fix mismatch in WRF time series WRITE format (with solar_diagnostics option activated).

TYPE: bug fix

KEYWORDS: time series, TS, format, write, wrf solar, solar_diagnostics

SOURCE: Massimo D'Isidoro (ENEA - Italian National Agency for New Technologies, Energy and Sustainable Economic Development)

DESCRIPTION OF CHANGES:
Problem:
When solar diagnostics is activated in namelist.input, the WRF time series output WRITE statement lists 55 variables but the Fortran FMT only specifies 54 fields. This causes the last variable (ts_swddnic2) to be written in a separate record in the output files *.TS , leading to inconsistent time series data.

Solution:
The WRITE statement FMT has been corrected to match all 55 variables, ensuring that they are written on the same record in the TS file.

ISSUE: 
This fixes part of issue #2255

LIST OF MODIFIED FILES: 
M       share/wrf_timeseries.F

TESTS CONDUCTED: 
A WRF run with solar_diagnostics activated, compared to previous version to confirm the fix.

RELEASE NOTE: Corrected a bug in the WRF time series output,  when solar_diagnostics is activated, where the last variable (ts_swddnic2) was written in a separate record. TS files now correctly includes all the 55 variables on the same record.
