### PR TITLE
Change surface layer option for tropical suite

### DIFF
--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -3154,7 +3154,7 @@
             IF ( model_config_rec % ra_lw_physics(i) == -1 ) model_config_rec % ra_lw_physics(i) = RRTMG_LWSCHEME        ! RRTMG LW
             IF ( model_config_rec % ra_sw_physics(i) == -1 ) model_config_rec % ra_sw_physics(i) = RRTMG_SWSCHEME        ! RRTMG SW
             IF ( model_config_rec % bl_pbl_physics(i) == -1 ) model_config_rec % bl_pbl_physics(i) = YSUSCHEME           ! YSU
-            IF ( model_config_rec % sf_sfclay_physics(i) == -1 ) model_config_rec % sf_sfclay_physics(i) = SFCLAYSCHEME  ! MM5
+            IF ( model_config_rec % sf_sfclay_physics(i) == -1 ) model_config_rec % sf_sfclay_physics(i) = SFCLAYREVSCHEME  ! revised MM5
             IF ( model_config_rec % sf_surface_physics(i) == -1 ) model_config_rec % sf_surface_physics(i) = LSMSCHEME   ! Noah
 
          END DO


### PR DESCRIPTION
TYPE:  no impact, text only

KEYWORDS: surface layer option, tropical suite

SOURCE: internal

DESCRIPTION OF CHANGES:
This PR switches the surface layer option in tropical suite from 91 (MM5 option) to 1, the revised MM5 option. The change is consistent with the 'mesoscale-reference' suite physics in MPAS starting from v8.2.0.

LIST OF MODIFIED FILES: 
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
Yes

RELEASE NOTE: This PR changes the surface layer option in tropical suite from old MM5 option (sf_sfclay_physics = 91) to revised MM5 option (sf_sfclay_physics = 1).
