### PR TITLE
fix typo

### DIFF
--- a/phys/module_diag_functions.F
+++ b/phys/module_diag_functions.F
@@ -1166,7 +1166,7 @@ CONTAINS
     !  -----------------
     real                :: tdK      !~ Dewpoint temperature ( K )
     real                :: tC       !~ Temperature ( C )
-    real                :: tdC      !~ Dewpoint temperature ( K )
+    real                :: tdC      !~ Dewpoint temperature ( C )
     real                :: svapr    !~ Saturation vapor pressure ( Pa )
     real                :: vapr     !~ Ambient vapor pressure ( Pa )
     real                :: gamma    !~ Dummy term


### PR DESCRIPTION
Fix unit label typo for WetBulbTemp dewpoint temperature (C vs K)

TYPE: text only

KEYWORDS: WRF, diagnostics, WetBulbTemp, unit label, dewpoint, documentation

SOURCE: Yuxuan Xie (IGSNRR, CAS)

DESCRIPTION OF CHANGES:
Problem:
The WetBulbTemp utility variable tdC was documented with the wrong unit (K) in a comment, inconsistent with its Celsius usage.

Solution:
Update the unit in the comment to C in phys/module_diag_functions.F.

LIST OF MODIFIED FILES: 
M phys/module_diag_functions.F

TESTS CONDUCTED: 
1. Comment-only fix; no runtime test required.
2. Not run (documentation-only change).

RELEASE NOTE: Corrected the WetBulbTemp dewpoint temperature unit label to Celsius in diagnostics comments.
