### PR TITLE
Add Turbulent Orographic Form Drag to SFCLAY

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/NCAR/fire_behavior.git
 [submodule "phys/physics_mmm"]
 	path = phys/physics_mmm
-	url = https://github.com/Songyou184/MMM-physics.git
+	url = https://github.com/NCAR/MMM-physics.git
 [submodule "phys/MYNN-EDMF"]
 	path = phys/MYNN-EDMF
 	url = https://github.com/NCAR/MYNN-EDMF

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/NCAR/fire_behavior.git
 [submodule "phys/physics_mmm"]
 	path = phys/physics_mmm
-	url = https://github.com/NCAR/MMM-physics.git
+	url = https://github.com/Songyou184/MMM-physics.git
 [submodule "phys/MYNN-EDMF"]
 	path = phys/MYNN-EDMF
 	url = https://github.com/NCAR/MYNN-EDMF

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2888,6 +2888,8 @@ rconfig   integer damp_opt                namelist,dynamics	1             3     
 rconfig   integer rad_nudge               namelist,dynamics	1             0       irh    "rad_nudge"             ""      ""
 rconfig   integer gwd_opt                 namelist,dynamics     max_domains   0       irh    "gwd_opt"               ""      ""
 rconfig   integer gwd_diags               namelist,dynamics     1             0       irh    "gwd_diags"             "switch to turn on extra gwd diagnostics if available for given gwd_opt"      ""
+rconfig   logical kim_tofd                namelist,dynamics    max_domains   .true.  rh   "kim_tofd" "turbulent form drag (tofd) option for kim gravity wave drag"   ""
+rconfig   real    tofd_factor             namelist,dynamics    max_domains   .003   rh    "tofd_factor" "factor in  kim tofd scheme"   ""
 rconfig   real    zdamp                   namelist,dynamics	max_domains    5000.   h    "zdamp"         ""      ""
 rconfig   real    dampcoef                namelist,dynamics     max_domains    0.2     h    "dampcoef"              ""      ""
 rconfig   real    khdif                   namelist,dynamics	max_domains    0       h    "khdif"         ""      ""

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -710,6 +710,10 @@ BENCH_START(surf_driver_tim)
 #if ( EM_CORE == 1)
      &        ,LakeMask=grid%LakeMask                                               & !lake
      &        ,restart_flag=restart_flag                                            & !flag showing if is a restart timestep
+! TOFD for KIM gwdo scheme
+     &        ,kim_tofd=config_flags%kim_tofd                                       &
+     &        ,tofd_factor=config_flags%tofd_factor                                 &
+     &        ,VAR2D=grid%var2d                                                     &
 #endif
 ! CLM Varaibles
      &        ,NUMC=grid%numc,NUMP=grid%nump,SABV=grid%sabv,SABG=grid%sabg,         &

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -22,6 +22,7 @@
                       gz1oz0,wspd,br,isfflx,dx,                     &
                       svp1,svp2,svp3,svpt0,ep1,ep2,                 &
                       karman,p1000mb,lakemask,                      &
+                      kim_tofd,tofd_factor,var2d,                   &
                       ids,ide,jds,jde,kds,kde,                      &
                       ims,ime,jms,jme,kms,kme,                      &
                       its,ite,jts,jte,kts,kte,                      &
@@ -44,6 +45,8 @@
  real(kind=kind_phys),intent(in):: ep1,ep2,karman
  real(kind=kind_phys),intent(in):: p1000mb
  real(kind=kind_phys),intent(in):: cp,g,rovcp,r,xlv
+ real(kind=kind_phys),intent(in):: tofd_factor
+ logical,intent(in):: kim_tofd
 
  real(kind=kind_phys),intent(in),dimension(ims:ime,jms:jme):: &
     dx,         &
@@ -52,6 +55,7 @@
     psfc,       &
     tsk,        &
     xland,      &
+    var2d,      &
     lakemask,   &
     water_depth
 
@@ -120,6 +124,7 @@
 
  real(kind=kind_phys),dimension(its:ite):: &
     dx_hv,mavail_hv,pblh_hv,psfc_hv,tsk_hv,xland_hv,water_depth_hv,lakemask_hv
+ real(kind=kind_phys),dimension(its:ite):: var2d_hv
  real(kind=kind_phys),dimension(its:ite,kts:kte):: &
     dz_hv,u_hv,v_hv,qv_hv,p_hv,t_hv
 
@@ -154,6 +159,7 @@
        psfc_hv(i)        = psfc(i,j)
        tsk_hv(i)         = tsk(i,j)
        xland_hv(i)       = xland(i,j)
+       var2d_hv(i)       = var2d(i,j)
        lakemask_hv(i)    = lakemask(i,j)
        water_depth_hv(i) = water_depth(i,j)
 
@@ -209,6 +215,7 @@
                           zol=zol_hv,mol=mol_hv,regime=regime_hv,psim=psim_hv,                     &
                           psih=psih_hv,fm=fm_hv,fh=fh_hv,xland=xland_hv,lakemask=lakemask_hv,      &
                           hfx=hfx_hv,qfx=qfx_hv,tsk=tsk_hv,u10=u10_hv,                             &
+                          varf=var2d_hv,if_kim_tofd=kim_tofd,tofd_factor=tofd_factor,              &
                           v10=v10_hv,th2=th2_hv,t2=t2_hv,q2=q2_hv,flhc=flhc_hv,                    &
                           flqc=flqc_hv,qgh=qgh_hv,qsfc=qsfc_hv,lh=lh_hv,                           &
                           gz1oz0=gz1oz0_hv,wspd=wspd_hv,br=br_hv,isfflx=l_isfflx,dx=dx_hv,         &

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -116,6 +116,10 @@ CONTAINS
      &          ,lakemask                                  & !lake
                 , restart_flag                             & ! restart_flag
 #endif
+! KIM TOFD
+                ,kim_tofd                                            & ! kim tofd
+                ,tofd_factor                                         & ! kim tofd
+                ,var2d                                               & ! kim tofd
             !  cyl ocean variable
                 ,OM_TMP,OM_S,OM_U,OM_V,OM_DEPTH,OM_ML,OM_LON          &
      &          ,OM_LAT,okms,okme,rdx,rdy,msfu,msfv,msft              &
@@ -634,6 +638,9 @@ CONTAINS
    INTEGER, INTENT(IN)::   IFNDSNOWSI
    LOGICAL, INTENT(IN)::   do_bioe
    LOGICAL, INTENT(IN)::   do_meganfile
+! kim tofd
+   REAL,    INTENT(IN)::   tofd_factor
+   LOGICAL, INTENT(IN)::   kim_tofd
 
    INTEGER, INTENT(IN)::   NLCAT, mosaic_lu, mosaic_soil
    INTEGER, INTENT(IN)::   NSCAT
@@ -705,6 +712,9 @@ CONTAINS
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT)::   VEGFRA
 !------fds (06/2010)--------------------------
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT)::   XICE
+!---------------------------------------------
+!------kim tofd (01/2025)--------------------------
+   REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN)::   var2d
 !---------------------------------------------
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT)::   ALBSI
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT)::   ICEDEPTH
@@ -2155,6 +2165,7 @@ CONTAINS
                  gz1oz0,wspd,br,isfflx,dx2d,                         &
                  svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,              &
                  P1000mb,lakemask,                                   &
+                 kim_tofd, tofd_factor, var2d,                       &
                  XICE,SST,TSK_SEA,                                                  &
                  CHS2_SEA,CHS_SEA,CPM_SEA,CQS2_SEA,FLHC_SEA,FLQC_SEA,               &
                  HFX_SEA,LH_SEA,QFX_SEA,QGH_SEA,QSFC_SEA,ZNT_SEA,                   &
@@ -2174,6 +2185,7 @@ CONTAINS
                gz1oz0,wspd,br,isfflx,dx2d,                         &
                svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,              &
                P1000mb,lakemask,                                   &
+               kim_tofd, tofd_factor, var2d,                       &
                ids,ide, jds,jde, kds,kde,                          &
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
@@ -5935,6 +5947,7 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,                                       &
                      P1000,LAKEMASK,                               &
+                     kim_tofd, tofd_factor, var2d,                 &
                      XICE,SST,TSK_SEA,                                                  &
                      CHS2_SEA,CHS_SEA,CPM_SEA,CQS2_SEA,FLHC_SEA,FLQC_SEA,               &
                      HFX_SEA,LH_SEA,QFX_SEA,QGH_SEA,QSFC_SEA,ZNT_SEA,                   &
@@ -5957,6 +5970,8 @@ CONTAINS
      REAL,     INTENT(IN )   ::        SVP1,SVP2,SVP3,SVPT0
      REAL,     INTENT(IN )   ::        EP1,EP2,KARMAN
      REAL,     INTENT(IN )   ::        P1000
+     logical, intent(in )    ::        kim_tofd
+     REAL,     INTENT(IN )   ::        tofd_factor
 
      REAL,     DIMENSION( ims:ime, kms:kme, jms:jme )           , &
                INTENT(IN   )   ::                           dz8w
@@ -5971,6 +5986,7 @@ CONTAINS
                                                             PBLH, &
                                                            XLAND, &
                                                         LAKEMASK, &
+                                                           var2d, &
                                                              TSK
      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                INTENT(OUT  )               ::                U10, &
@@ -6202,6 +6218,7 @@ CONTAINS
                  SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                  KARMAN,                                       &
                  P1000,lakemask,                               &
+                 kim_tofd, tofd_factor, var2d,                 &
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
@@ -6296,6 +6313,7 @@ CONTAINS
                  SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                  KARMAN,                                       &
                  P1000,lakemask,                               &
+                 kim_tofd, tofd_factor, var2d,                 &
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: surface layer, turbulent form drag

SOURCE: Songyou Hong

DESCRIPTION OF CHANGES:
Turbulent form drag (TOFD) was added in computing surface drag (kim_tofd=.true., default). A factor for TOFD was added (tofd_factor=.003, default).

LIST OF MODIFIED FILES:
 	M   arch/Externals.cfg
 	M   dyn_em/module_first_rk_step_part1.F
 	M   phys/module_sf_sfclayrev.F
 	M   phys/module_surface_driver.F

TESTS CONDUCTED: 
The Jenkins tests are all passing.

RELEASE NOTE: This PR adds a scale-aware turbulent orographic form drag option (kim_tofd) in revised MM5 surface layer scheme. The default value for the option is on and it would increase surface drag. Use this new option with care.