### PR TITLE
Update Orographic Gravity Drag scheme option 1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/NCAR/fire_behavior.git
 [submodule "phys/physics_mmm"]
 	path = phys/physics_mmm
-	url = https://github.com/NCAR/MMM-physics.git
+	url = https://github.com/Songyou184/MMM-physics.git
 [submodule "phys/MYNN-EDMF"]
 	path = phys/MYNN-EDMF
 	url = https://github.com/NCAR/MYNN-EDMF

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1179,6 +1179,7 @@ state   real   OL1              ij     misc        1         -     i012rhd   "OL
 state   real   OL2              ij     misc        1         -     i012rhd   "OL2"                   "NON-DIMENSIONAL EFFECTIVE OROGRAPHIC LENGTH FOR SOUTHERLY FLOW"        ""
 state   real   OL3              ij     misc        1         -     i012rhd   "OL3"                   "NON-DIMENSIONAL EFFECTIVE OROGRAPHIC LENGTH FOR SOUTH-WESTERLY FLOW"   ""
 state   real   OL4              ij     misc        1         -     i012rhd   "OL4"                   "NON-DIMENSIONAL EFFECTIVE OROGRAPHIC LENGTH FOR NORTH-WESTERLY FLOW"   ""
+state   real   ELVMAX           ij     misc        1         -     i012rhd   "ELVMAX"                "MAXIMUM OROGRAPHIC HEIGHT"   "m"
 
 # Additional for GSL gravity wave drag suite
 state   real   DTAUX3D_ls      ikj     misc        1         -     rh        "DTAUX3D_ls"            "LOCAL U GWDO STRESS LARGE-SCALE"   "m s-2"
@@ -2888,6 +2889,8 @@ rconfig   integer damp_opt                namelist,dynamics	1             3     
 rconfig   integer rad_nudge               namelist,dynamics	1             0       irh    "rad_nudge"             ""      ""
 rconfig   integer gwd_opt                 namelist,dynamics     max_domains   0       irh    "gwd_opt"               ""      ""
 rconfig   integer gwd_diags               namelist,dynamics     1             0       irh    "gwd_diags"             "switch to turn on extra gwd diagnostics if available for given gwd_opt"      ""
+rconfig   real    gwd_dx_factor           namelist,dynamics max_domains    2.   rh    "gwd_dx_factor" "effective grid factor for kim gravity wave drag"   ""
+rconfig   logical gwd_if_nonhyd           namelist,dynamics max_domains   .true.  rh   "gwd_if_nonhyd" "non_hydrostatic option for kim gravity wave drag"   ""
 rconfig   real    zdamp                   namelist,dynamics	max_domains    5000.   h    "zdamp"         ""      ""
 rconfig   real    dampcoef                namelist,dynamics     max_domains    0.2     h    "dampcoef"              ""      ""
 rconfig   real    khdif                   namelist,dynamics	max_domains    0       h    "khdif"         ""      ""
@@ -3298,7 +3301,7 @@ package   swintopt2      swint_opt==2               -              state:swdown2
 package   aercuopt       aercu_used==1              -              state:aeromcu,CU_UAF,EFCS,EFIS,EFSS,qr_cu,qs_cu,nc_cu,ni_cu,nr_cu,ns_cu,ccn_cu,aerovar;aerocu:cu_sulfate,cu_seasalt,cu_dust1,cu_dust2,cu_dust3,cu_dust4,cu_phoocar,cu_phiocar,cu_phobcar,cu_phibcar
 
 package   slopeopt       slope_rad==1               -              -
-package   gwd_used_1     gwd_used==1                -              state:oc12d,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4,dtaux3d,dtauy3d,dusfcg,dvsfcg
+package   gwd_used_1     gwd_used==1                -              state:oc12d,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4,elvmax,dtaux3d,dtauy3d,dusfcg,dvsfcg
 package   gwd_used_3     gwd_used==3                -              state:var2dls,oc12dls,oa1ls,oa2ls,oa3ls,oa4ls,ol1ls,ol2ls,ol3ls,ol4ls,var2dss,oc12dss,oa1ss,oa2ss,oa3ss,oa4ss,ol1ss,ol2ss,ol3ss,ol4ss 
 package   gwd_diags_used_3   gwd_diags_used==3      -              state:dtaux3d_ls,dtauy3d_ls,dtaux3d_bl,dtauy3d_bl,dtaux3d_ss,dtauy3d_ss,dtaux3d_fd,dtauy3d_fd,dusfcg_ls,dvsfcg_ls,dusfcg_bl,dvsfcg_bl,dusfcg_ss,dvsfcg_ss,dusfcg_fd,dvsfcg_fd
 package   nogwdopt       gwd_opt==0                 -              -

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1296,13 +1296,16 @@ BENCH_START(pbl_driver_tim)
      &        ,PEK_ADV=scalar(ims,kms,jms,P_pek_adv)                      &!TKEadvection
      &        ,PEP_ADV=scalar(ims,kms,jms,P_pep_adv)                      &!TKEadvection
 !GWD for ARW
-     &        ,GWD_OPT=config_flags%gwd_opt &
-     &        ,gwd_diags=config_flags%gwd_diags &
+     &        ,GWD_OPT=config_flags%gwd_opt                              &
+     &        ,gwd_diags=config_flags%gwd_diags                          &
+     &        ,dx_factor=config_flags%gwd_dx_factor                      &
+     &        ,if_nonhyd=config_flags%gwd_if_nonhyd                      &
      &        ,DTAUX3D=grid%dtaux3d,DTAUY3D=grid%dtauy3d &
      &        ,DUSFCG=grid%dusfcg,DVSFCG=grid%dvsfcg &
      &        ,VAR2D=grid%var2d,OC12D=grid%oc12d     &
      &        ,OA1=grid%oa1,OA2=grid%oa2,OA3=grid%oa3,OA4=grid%oa4        &
      &        ,OL1=grid%ol1,OL2=grid%ol2,OL3=grid%ol3,OL4=grid%ol4        &
+     &        ,elvmax=grid%elvmax                                         &
      &        ,SINA=grid%sina,COSA=grid%cosa                              &
      &        ,dtaux3d_ls=grid%dtaux3d_ls,dtauy3d_ls=grid%dtauy3d_ls      &
      &        ,dtaux3d_bl=grid%dtaux3d_bl,dtauy3d_bl=grid%dtauy3d_bl      &

--- a/phys/module_bl_gwdo.F
+++ b/phys/module_bl_gwdo.F
@@ -18,9 +18,10 @@
                  rublten,rvblten,                                             &
                  dtaux3d,dtauy3d,dusfcg,dvsfcg,                               &
                  var2d,oc12d,oa2d1,oa2d2,oa2d3,oa2d4,ol2d1,ol2d2,ol2d3,ol2d4, &
-                 sina,cosa,znu,znw,p_top,                                     &
+                 elvmax,sina,cosa,znu,znw,p_top,                              &
                  cp,g,rd,rv,ep1,pi,                                           &
                  dt,dx,kpbl2d,itimestep,                                      &
+                 dx_factor,if_nonhyd,                                         &
                  ids,ide, jds,jde, kds,kde,                                   &
                  ims,ime, jms,jme, kms,kme,                                   &
                  its,ite, jts,jte, kts,kte,                                   &
@@ -78,6 +79,8 @@
  integer,intent(in),dimension(ims:ime,jms:jme):: kpbl2d
 
  real(kind=kind_phys),intent(in):: dt,cp,g,rd,rv,ep1,pi
+ real(kind=kind_phys),intent(in):: dx_factor
+ logical             ,intent(in):: if_nonhyd
  real(kind=kind_phys),intent(in),optional:: p_top
 
  real(kind=kind_phys),intent(in),dimension(kms:kme),optional:: &
@@ -90,6 +93,7 @@
                                                                oc12d, &
                                              oa2d1,oa2d2,oa2d3,oa2d4, &
                                              ol2d1,ol2d2,ol2d3,ol2d4, &
+                                                              elvmax, &
                                                            sina,cosa
 
  real(kind=kind_phys),intent(in),dimension(ims:ime,kms:kme,jms:jme):: &
@@ -126,7 +130,7 @@
  integer:: i,j,k
 
  real(kind=kind_phys),dimension(its:ite):: &
-    var2d_hv,oc12d_hv,dx_hv,sina_hv,cosa_hv
+    var2d_hv,oc12d_hv,dx_hv,sina_hv,cosa_hv,elvmax_hv
  real(kind=kind_phys),dimension(its:ite):: &
     oa2d1_hv,oa2d2_hv,oa2d3_hv,oa2d4_hv,ol2d1_hv,ol2d2_hv,ol2d3_hv,ol2d4_hv
  real(kind=kind_phys),dimension(its:ite):: &
@@ -195,6 +199,7 @@
        ol2d2_hv(i) = ol2d2(i,j)
        ol2d3_hv(i) = ol2d3(i,j)
        ol2d4_hv(i) = ol2d4(i,j)
+       elvmax_hv(i) =elvmax(i,j)
     enddo
 
     call bl_gwdo_run(sina=sina_hv,cosa=cosa_hv                &
@@ -211,6 +216,8 @@
                     ,oa2d3=oa2d3_hv, oa2d4=oa2d4_hv           &
                     ,ol2d1=ol2d1_hv, ol2d2=ol2d2_hv           &
                     ,ol2d3=ol2d3_hv, ol2d4=ol2d4_hv           &
+                    ,omax=elvmax_hv                           &
+                    ,dx_factor=dx_factor,if_nonhyd=if_nonhyd  &
                     ,g_=g,cp_=cp,rd_=rd,rv_=rv,fv_=ep1,pi_=pi &
                     ,dxmeter=dx_hv,deltim=dt                  &
                     ,its=its,ite=ite,kte=kte,kme=kte+1        &

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -72,9 +72,10 @@ CONTAINS
                  ,hol, mol, regime                                 &
              ! Optional gravity-wave drag             
                  ,gwd_opt,gwd_diags                                &
+                 ,dx_factor,if_nonhyd                              &
                  ,dtaux3d,dtauy3d                                  &
                  ,dusfcg,dvsfcg,var2d,oc12d                        &
-                 ,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4                  &
+                 ,oa1,oa2,oa3,oa4,ol1,ol2,ol3,ol4,elvmax           &
                  ,sina,cosa                                        &
                  ,dtaux3d_ls,dtauy3d_ls                            &
                  ,dtaux3d_bl,dtauy3d_bl                            &
@@ -736,6 +737,8 @@ CONTAINS
 !
    INTEGER,    OPTIONAL, INTENT(IN)    ::               gwd_opt,gwd_diags
    REAL,       OPTIONAL, INTENT(IN)    ::               p_top
+   REAL,       OPTIONAL, INTENT(IN)    ::               dx_factor
+   logical,    OPTIONAL, INTENT(IN)    ::               if_nonhyd
 !
   real,   dimension( ims:ime, kms:kme, jms:jme )                             , &
           optional                                                           , &
@@ -754,6 +757,7 @@ CONTAINS
   real,   dimension( ims:ime, jms:jme )                                      , &
           optional                                                           , &
              intent(in  )   ::                                          var2d, &
+                                                                       elvmax, &
                                                                         oc12d, &
                                                               oa1,oa2,oa3,oa4, &
                                                               ol1,ol2,ol3,ol4, &
@@ -2162,12 +2166,13 @@ CONTAINS
               ,VAR2D=var2d,OC12D=oc12d                              &
               ,OA2D1=oa1,OA2D2=oa2,OA2D3=oa3,OA2D4=oa4              &
               ,OL2D1=ol1,OL2D2=ol2,OL2D3=ol3,OL2D4=ol4              &
-              ,SINA=sina,COSA=cosa                                  &
+              ,elvmax=elvmax,SINA=sina,COSA=cosa                    &
               ,ZNU=znu,ZNW=znw,P_TOP=p_top                          &
               ,CP=cp,G=g,RD=r_d                                     &
               ,RV=r_v,EP1=ep_1,PI=3.141592653                       &
               ,DT=dtbl,DX=dx2d,KPBL2D=kpbl,ITIMESTEP=itimestep      &
               ,errmsg=errmsg,errflg=errflg                          &
+              ,dx_factor = dx_factor, if_nonhyd = if_nonhyd         &
               ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde      &
               ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme      &
               ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte      )

--- a/wrftladj/module_first_rk_step_part1_ad.F
+++ b/wrftladj/module_first_rk_step_part1_ad.F
@@ -399,6 +399,8 @@ BENCH_START(a_pbl_driver_tim)
      &        ,qcg=grid%qcg, grav_settling=config_flags%grav_settling     &
 !GWD for ARW
      &        ,GWD_OPT=config_flags%gwd_opt &
+     &        ,dx_factor=config_flags%gwd_dx_factor                      &
+     &        ,if_nonhyd=config_flags%gwd_if_nonhyd                      &
      &        ,DTAUX3D=grid%dtaux3d,DTAUY3D=grid%dtauy3d &
      &        ,DTAUX3DB=grid%a_dtaux3d,DTAUY3DB=grid%a_dtauy3d &
      &        ,DUSFCG=grid%dusfcg,DVSFCG=grid%dvsfcg &
@@ -406,6 +408,7 @@ BENCH_START(a_pbl_driver_tim)
      &        ,VAR2D=grid%var2d,OC12D=grid%oc12d     &
      &        ,OA1=grid%oa1,OA2=grid%oa2,OA3=grid%oa3,OA4=grid%oa4        &
      &        ,OL1=grid%ol1,OL2=grid%ol2,OL3=grid%ol3,OL4=grid%ol4        &
+     &        ,elvmax=grid%elvmax                                         &
      &        ,SINA=grid%sina, COSA=grid%cosa                             &
      &        ,MFSHCONV=grid%mfshconv                                     & 
      &        ,MASSFLUX_EDKF=grid%massflux_EDKF                           & 

--- a/wrftladj/module_pbl_driver_ad.F
+++ b/wrftladj/module_pbl_driver_ad.F
@@ -48,9 +48,10 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 &  rmol, ch, qcg, grav_settling, el_mynn, dqke, qwt, qshear, qbuoy, qdiss&
 &  , tke_budget, ids, ide, jds, jde, kds, kde, ims, ime, jms, jme&
 &  , kms, kme, i_start, i_end, j_start, j_end, kts, kte, num_tiles, hol, &
-&  mol, regime, gwd_opt, dtaux3d, dtaux3db, dtauy3d, dtauy3db, dusfcg, &
-&  dusfcgb, dvsfcg, dvsfcgb, var2d, oc12d, oa1, oa2, oa3, oa4, ol1, ol2, &
-&  ol3, ol4, sina,cosa, qv_curr, qv_currb, qc_curr, qr_curr, qi_curr, qs_curr, &
+&  mol, regime, gwd_opt, dx_factor, if_nonhyd, dtaux3d, dtaux3db,        &
+   dtauy3d, dtauy3db, dusfcg, dusfcgb, dvsfcg, dvsfcgb, var2d, oc12d,    &
+   oa1, oa2, oa3, oa4, ol1, ol2, ol3, ol4, elvmax, sina,cosa, qv_curr,   &
+   qv_currb, qc_curr, qr_curr, qi_curr, qs_curr, &
 &  qg_curr, rqvblten, rqvbltenb, rqcblten, rqcbltenb, rqiblten, rqibltenb&
 &  , rqrblten, rqsblten, rqgblten, f_qv, f_qc, f_qr, f_qi, f_qs, f_qg, &
 &  frc_urb2d, a_u_bep, a_v_bep, a_t_bep, a_q_bep, b_u_bep, b_v_bep, &
@@ -428,6 +429,8 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 !
   INTEGER, OPTIONAL, INTENT(IN) :: gwd_opt
   REAL, OPTIONAL, INTENT(IN) :: p_top
+   REAL,       OPTIONAL, INTENT(IN)    ::               dx_factor
+   logical,    OPTIONAL, INTENT(IN)    ::               if_nonhyd
 !
   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT) ::&
 &  dtaux3d, dtauy3d
@@ -439,7 +442,7 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
   REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL :: dusfcgb, dvsfcgb
 !
   REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(IN) :: var2d, &
-&  oc12d, oa1, oa2, oa3, oa4, ol1, ol2, ol3, ol4, sina, cosa
+&  oc12d, oa1, oa2, oa3, oa4, ol1, ol2, ol3, ol4, elvmax, sina, cosa
 ! paj
 !mchen
   REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(IN) :: ctopo, &
@@ -679,10 +682,11 @@ SUBROUTINE A_PBL_DRIVER(itimestep, dt, u_frame, v_frame, bldt, curr_secs&
 &                qv_curr, p3d=p_phy, p3di=p8w, pi3d=pi_phy, z=z, rublten=&
 &                rublten, rvblten=rvblten, dtaux3d=dtaux3d, dtauy3d=&
 &                dtauy3d, dusfcg=dusfcg, dvsfcg=dvsfcg, var2d=var2d, &
-&                oc12d=oc12d, oa2d1=oa1, oa2d2=oa2, oa2d3=oa3, oa2d4=oa4&
-&                , ol2d1=ol1, ol2d2=ol2, ol2d3=ol3, ol2d4=ol4, &
+&                oc12d=oc12d, oa2d1=oa1, oa2d2=oa2, oa2d3=oa3, oa2d4=oa4,&
+&                ol2d1=ol1, ol2d2=ol2, ol2d3=ol3, ol2d4=ol4, elvmax=elvmax,&
 &                SINA=sina,COSA=cosa, znu=znu, &
 &                errmsg= errmsg, errflg=errflg, &
+&                dx_factor = dx_factor, if_nonhyd = if_nonhyd,         &
 &                znw=znw, p_top=p_top, cp=cp, g=g, rd=r_d, rv=&
 &                r_v, ep1=ep_1, pi=3.141592653, dt=dtbl, dx=dx2dtmp, kpbl2d=&
 &                kpbl, itimestep=itimestep, ids=ids, ide=ide, jds=jds, &


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: orographic drag

SOURCE: Songyou Hong (NCAR)

DESCRIPTION OF CHANGES:
YSU GWDO was revised following the study of Hong et al. (2025, WAF), now is called as Korean Integrated Model (KIM) GWDO. KIM GWDO requires additional maximum orography file, "ELVMAX" in WPS. Non-hydrostatic effect of Xu et al. (2024, JAS) was also added (gwd_if_nonhyd=.true., default). Factor for the effective grid spacing was added (gwd_dx_factor=2.0, default).

LIST OF MODIFIED FILES: 
 	m   Registry/Registry.EM_COMMON
 	m   arch/Externals.cfg
 	m   dyn_em/module_first_rk_step_part1.F
 	m   phys/module_bl_gwdo.F
 	m   phys/module_pbl_driver.F

TESTS CONDUCTED: 
1. Tested in MPAS.
2. The Jenkins tests are all passing.

RELEASE NOTE: Orographic gravity drag option gwd_opt = 1 is updated in this PR.  Other added options are gwd_dx_factor = 2 (effective grid size) and gwd_if_nonhyd = .true. (nonhydrostatic effect option). Requires the use of updated WPS.
