### PR TITLE
Updating MYNN-SFC

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -882,6 +882,10 @@ module_cu_kfeta.o: \
 	../frame/module_wrf_error.o 
 
 
+module_cu_gfl_wrf.o: \
+	module_cu_gfl_deep.o \
+	module_cu_gfl_sh.o
+
 module_cu_gd.o: \
 
 

--- a/main/depend.common
+++ b/main/depend.common
@@ -882,10 +882,6 @@ module_cu_kfeta.o: \
 	../frame/module_wrf_error.o 
 
 
-module_cu_gfl_wrf.o: \
-	module_cu_gfl_deep.o \
-	module_cu_gfl_sh.o
-
 module_cu_gd.o: \
 
 

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2422,14 +2422,14 @@ CONTAINS
                p3d=p_phy,dz8w=dz8w,th3d=th_phy,rho=rho,              &
                psfc=psfc,chs=chs,chs2=chs2,cqs=cqs,cqs2=cqs2,cpm=cpm,&
                znt=znt,ust=ust,pblh=pblh,mavail=mavail,zol=zol,      &
-               mol=mol,psim=psim,psih=psih,                          &
+               mol=mol,psim=psim,psih=psih,qgh=qgh,                  &
                xland=xland,hfx=hfx,qfx=qfx,lh=lh,tsk=tsk,            &
                flhc=flhc,flqc=flqc,qsfc=qsfc,rmol=rmol,              &
                u10=u10,v10=v10,th2=th2,t2=t2,q2=q2,snowh=snowh,      &
                gz1oz0=gz1oz0,wspd=wspd,br=br,dx=dx2d,                &
                itimestep=itimestep,ch=ch,                            &
                spp_pbl=spp_pbl,pattern_spp_pbl=pattern_spp_pbl,      &
-               xice=XICE,sst=SST,tsk_sea=TSK_SEA,                    &
+               xice=XICE,sst=SST,tsk_sea=TSK_SEA,qgh_sea=QGH_SEA,    &
                chs2_sea=CHS2_SEA,chs_sea=CHS_SEA,cpm_sea=CPM_SEA,    &
                cqs2_sea=CQS2_SEA,flhc_sea=FLHC_SEA,                  &
                flqc_sea=FLQC_SEA,hfx_sea=HFX_SEA,lh_sea=LH_SEA,      &
@@ -2443,7 +2443,8 @@ CONTAINS
                ustm=ustm,ck=ck,cka=cka,cd=cd,cda=cda,                &
                sf_mynn_sfcflux_land=sf_mynn_sfcflux_land,            &
                sf_mynn_sfcflux_water=sf_mynn_sfcflux_water,          &
-               isfflx=isfflx,                                        &
+               isfflx=isfflx,shalwater_z0=shalwater_z0,              &
+               water_depth=water_depth,lakemask=lakemask,            &
                flag_lsm=sf_surface_physics,restart=restart_flag,     &
                errmsg=errmsg,errflg=errflg                           ) 
          ELSE
@@ -2452,7 +2453,7 @@ CONTAINS
                rho3d=rho,psfcpa=psfc,                              &
                chs=chs,chs2=chs2,cqs=cqs,cqs2=cqs2,cpm=cpm,        &
                znt=znt,ust=ust,pblh=pblh,mavail=mavail,zol=zol,    &
-               mol=mol,psim=psim,psih=psih,                        &
+               mol=mol,psim=psim,psih=psih,qgh=qgh,                &
                xland=xland,hfx=hfx,qfx=qfx,lh=lh,tsk=tsk,          &
                flhc=flhc,flqc=flqc,qsfc=qsfc,rmol=rmol,            &
                u10=u10,v10=v10,th2=th2,t2=t2,q2=q2,snowh=snowh,    &
@@ -2466,7 +2467,8 @@ CONTAINS
                ustm=ustm,ck=ck,cka=cka,cd=cd,cda=cda,              &
                sf_mynn_sfcflux_land=sf_mynn_sfcflux_land,          &
                sf_mynn_sfcflux_water=sf_mynn_sfcflux_water,        &
-               isfflx=isfflx,                                      &
+               isfflx=isfflx,shalwater_z0=shalwater_z0,            &
+               water_depth=water_depth,lakemask=lakemask,          &
                flag_lsm=sf_surface_physics,restart=restart_flag,   &
                errmsg=errmsg,errflg=errflg                         )
          ENDIF
@@ -5348,12 +5350,12 @@ CONTAINS
               P3D,dz8w,th3d,rho,                                   &
               PSFC,CHS,CHS2,CQS,CQS2,CPM,                          &
               ZNT,UST,PBLH,MAVAIL,ZOL,MOL,PSIM,PSIH,               &
-              XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QSFC,RMOL,            &
+              XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QSFC,RMOL,QGH,        &
               U10,V10,TH2,T2,Q2,SNOWH,                             &
               GZ1OZ0,WSPD,BR,ISFFLX,DX,                            &
               &itimestep,ch,                                       &
               &spp_pbl,pattern_spp_pbl,                            &
-              XICE,SST,TSK_SEA,                                    &
+              XICE,SST,TSK_SEA,QGH_SEA,                            &
               CHS2_SEA,CHS_SEA,CPM_SEA,CQS2_SEA,FLHC_SEA,FLQC_SEA, &
               HFX_SEA,LH_SEA,QFX_SEA,QSFC_SEA,ZNT_SEA,             &
               TICE2TSK_IF2COLD,XICE_THRESHOLD,                     &
@@ -5362,6 +5364,7 @@ CONTAINS
               its,ite, jts,jte, kts,kte,                           &
               ustm,ck,cka,cd,cda,sf_mynn_sfcflux_land,             &
               sf_mynn_sfcflux_water,flag_lsm,restart,              &
+              shalwater_z0,water_depth,lakemask,                   &
               errmsg,errflg                                        )
 
      USE module_sf_mynnsfc_driver
@@ -5378,7 +5381,8 @@ CONTAINS
      INTEGER,  INTENT(IN )   ::       itimestep, ISFFLX
      INTEGER,  INTENT(IN ), optional ::  sf_mynn_sfcflux_land,    &
                                          sf_mynn_sfcflux_water,   &
-                                         flag_lsm
+                                         flag_lsm,                &
+                                         shalwater_z0
      LOGICAL,  INTENT(IN)    ::        restart
      INTEGER,  INTENT(IN), optional      ::     spp_pbl
      REAL,     DIMENSION( ims:ime, kms:kme, jms:jme ),            &
@@ -5396,6 +5400,8 @@ CONTAINS
      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                INTENT(IN   )               ::             MAVAIL, &
                                                            XLAND, &
+                                                     water_depth, &
+                                                        lakemask, &
                                                             PSFC, &
                                                            SNOWH, &
                                                              TSK, &
@@ -5415,6 +5421,7 @@ CONTAINS
                                                               LH, &
                                                         MOL,RMOL, &
                                                             QSFC, &
+                                                             QGH, &
                                                              ZNT, &
                                                              ZOL, &
                                                              UST, &
@@ -5451,6 +5458,7 @@ CONTAINS
                                                 HFX_SEA,          &
                                                 LH_SEA,           &
                                                 QFX_SEA,          &
+                                                QGH_SEA,          &
                                                 QSFC_SEA,         &
                                                 ZNT_SEA
 
@@ -5472,6 +5480,7 @@ CONTAINS
                  PSIH_SEA,                      PSIH_HOLD,        &
                  PSIM_SEA,                      PSIM_HOLD,        &
                                                 QFX_HOLD,         &
+                                                QGH_HOLD,         &
                                                 CPM_HOLD,         &
                  RMOL_SEA,                      RMOL_HOLD,        &
                  UST_SEA,                       UST_HOLD,         &
@@ -5516,6 +5525,7 @@ CONTAINS
      PSIH_HOLD(its:ite,jts:jte) = PSIH(its:ite,jts:jte)
      PSIM_HOLD(its:ite,jts:jte) = PSIM(its:ite,jts:jte)
      QFX_HOLD(its:ite,jts:jte)  = QFX(its:ite,jts:jte)
+     QGH_HOLD(its:ite,jts:jte)  = QGH(its:ite,jts:jte)
      RMOL_HOLD(its:ite,jts:jte) = RMOL(its:ite,jts:jte)
      UST_HOLD(its:ite,jts:jte)  = UST(its:ite,jts:jte)
      USTM_HOLD(its:ite,jts:jte) = USTM(its:ite,jts:jte)
@@ -5532,7 +5542,7 @@ CONTAINS
                rho3d=rho,psfcpa=psfc,                          &
                chs=chs,chs2=chs2,cqs=cqs,cqs2=cqs2,cpm=cpm,    &
                znt=znt,ust=ust,pblh=pblh,mavail=mavail,zol=zol,&
-               mol=mol,psim=psim,psih=psih,                    &
+               mol=mol,psim=psim,psih=psih,qgh=qgh,            &
                xland=xland,hfx=hfx,qfx=qfx,lh=lh,tsk=tsk_local,&
                flhc=flhc,flqc=flqc,qsfc=qsfc,rmol=rmol,        &
                u10=u10,v10=v10,th2=th2,t2=t2,q2=q2,snowh=snowh,&
@@ -5545,7 +5555,8 @@ CONTAINS
                ustm=ustm,ck=ck,cka=cka,cd=cd,cda=cda,          &
                sf_mynn_sfcflux_land=sf_mynn_sfcflux_land,      &
                sf_mynn_sfcflux_water=sf_mynn_sfcflux_water,    &
-               isfflx=isfflx,                                  &
+               isfflx=isfflx,shalwater_z0=shalwater_z0,        &
+               water_depth=water_depth,lakemask=lakemask,      &
                flag_lsm=flag_lsm,restart=restart,              &
                errmsg=errmsg,errflg=errflg                     )
 
@@ -5585,6 +5596,7 @@ CONTAINS
      PSIH_SEA(its:ite,jts:jte) = PSIH_HOLD(its:ite,jts:jte)
      PSIM_SEA(its:ite,jts:jte) = PSIM_HOLD(its:ite,jts:jte)
      QFX_SEA(its:ite,jts:jte)  = QFX_HOLD(its:ite,jts:jte)
+     QGH_SEA(its:ite,jts:jte)  = QGH_HOLD(its:ite,jts:jte)
      RMOL_SEA(its:ite,jts:jte) = RMOL_HOLD(its:ite,jts:jte)
      UST_SEA(its:ite,jts:jte)  = UST_HOLD(its:ite,jts:jte)
      USTM_SEA(its:ite,jts:jte) = USTM_HOLD(its:ite,jts:jte)
@@ -5597,7 +5609,7 @@ CONTAINS
            qv3d=qv3d,p3d=p3d,dz8w=dz8w,th3d=th3d,rho3d=rho,psfcpa=psfc,        &
            chs=chs_sea,chs2=chs2_sea,cqs=cqs,cqs2=cqs2_sea,cpm=cpm_sea,        &
            znt=znt_sea,ust=ust_sea,pblh=pblh,mavail=mavail_sea,zol=zol_sea,    &
-           mol=mol_sea,psim=psim_sea,psih=psih_sea,                            &
+           mol=mol_sea,psim=psim_sea,psih=psih_sea,qgh=qgh_sea,                &
            xland=xland_sea,hfx=hfx_sea,qfx=qfx_sea,lh=lh_sea,tsk=tsk_sea,      &
            flhc=flhc_sea,flqc=flqc_sea,qsfc=qsfc_sea,rmol=rmol_sea,            &
            u10=u10_sea,v10=v10_sea,th2=th2_sea,t2=t2_sea,q2=q2_sea,snowh=snowh,&
@@ -5631,6 +5643,7 @@ CONTAINS
               psih(i,j)   = psih(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * psih_sea(i,j)
               psim(i,j)   = psim(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * psim_sea(i,j)
               ! QFX  -- wait
+              ! QGH  -- wait
               rmol(i,j)   = rmol(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * rmol_sea(i,j)
               ust(i,j)    = ust(i,j)    * XICE(i,j) + (1.0-XICE(i,j)) * ust_sea(i,j)
               wspd(i,j)   = wspd(i,j)   * XICE(i,j) + (1.0-XICE(i,j)) * wspd_sea(i,j)


### PR DESCRIPTION
The purpose for this PR is to update the refactored MYNN surface layer scheme, which has now been more fully debugged and has been tested in both WRF and MPAS. 

TYPE: enhancement

KEYWORDS: MYNN-SFC version 6.0.0 refactored HRRR

SOURCE: Joseph B. Olson

DESCRIPTION OF CHANGES:
The Main Problem:
This scheme was refactored starting from the CCPP version, which has a few distinctions from WRF/MPAS that required further work to fully integrate into both WRF and MPAS.

Solutions:

1. Corrected the conversions of mixing ratio/specific humidity.
2. added output of variables qgh and cqs, which are needed in some mode frameworks for some configurations
3. Some tuning was done for sf_mynn_sfcflux_land = 1 to work better when initializing off of RAP/HRRR/RRFS and using RUC LSM. If using Noah LSM, it will default to the Chen et al. (variable Czil) approach.
4. Added the infrastructure for bathymetry-dependent z0, which is expected to be compared with other approaches (possibly from WFIP3 data) and possibly tweaked in the near future.
5. Added automated CI testing in "MYNN-SFC/tests", which further help check for code errors for every PR to the MYNN-SFC repository. This helped find a few bugs in relatively unused configurations.


LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M       phys/MYNN-SFC
M       phys/module_surface_driver.F

TESTS CONDUCTED: 
1. Do mods fix problem? Yes, case study testing with debug flags active.
2. Are the Jenkins tests all passing?
