### PR TITLE
Ensure clearing of data handle upon freeing

### DIFF
--- a/frame/module_io.F
+++ b/frame/module_io.F
@@ -1283,14 +1283,14 @@ SUBROUTINE wrf_ioclose ( DataHandle, Status )
 !</DESCRIPTION>
   USE module_state_description
   IMPLICIT NONE
-  INTEGER ,       INTENT(IN)  :: DataHandle
-  INTEGER ,       INTENT(OUT) :: Status
+  INTEGER ,       INTENT(INOUT) :: DataHandle
+  INTEGER ,       INTENT(OUT)   :: Status
 #include "wrf_status_codes.h"
-  INTEGER, EXTERNAL           :: use_package
-  LOGICAL, EXTERNAL           :: wrf_dm_on_monitor, multi_files, use_output_servers_for
-  INTEGER                     :: io_form
-  LOGICAL                     :: for_out
-  INTEGER                     :: Hndl
+  INTEGER, EXTERNAL             :: use_package
+  LOGICAL, EXTERNAL             :: wrf_dm_on_monitor, multi_files, use_output_servers_for
+  INTEGER                       :: io_form
+  LOGICAL                       :: for_out
+  INTEGER                       :: Hndl
 
   CALL wrf_debug( DEBUG_LVL, 'module_io.F: in wrf_ioclose' )
 
@@ -2087,13 +2087,14 @@ SUBROUTINE free_handle ( DataHandle )
 !</PRE>
 !</DESCRIPTION>
   IMPLICIT NONE
-  INTEGER, INTENT(IN)    :: DataHandle
+  INTEGER, INTENT(INOUT)    :: DataHandle
   INTEGER i
   IF ( .NOT. is_inited ) THEN
     CALL wrf_error_fatal( 'free_handle: not initialized' )
   ENDIF
   IF ( DataHandle .GE. 1 .AND. DataHandle .LE. MAX_WRF_IO_HANDLE ) THEN
     wrf_io_handles(DataHandle) = -999319
+    DataHandle = 0
   ENDIF
   RETURN
 END SUBROUTINE free_handle


### PR DESCRIPTION
Certain parts of the code were not properly clearing data handles stored in `grid` variable, and this change makes any call to `close_dataset` always clear the value.

TYPE: bug fix

KEYWORDS: io, data_handle

DESCRIPTION OF CHANGES:
Problem:
As the code is written right now, responsibility of tracking of data handles is spread across the code base:
* module_io.F handles the global list and what is available
* autogenerated code clears grid % *_oid values
* written code must also manage clearing old oid values
* and so on...

For example, this issue is made evident when using the subroutine `med_read_qna_emissions()` which does not appropriately clear the grid % auxinput17_oid. While this may be seen as an issue with this specific code segment, the design of IO data handle management has lead to easily mismanaged data handles being kept around after freeing.

Solution:
While a full code refactor of all occurrences of clearing data handles would be ideal, the simplest and most concise fix is to have the `free_handle` subroutine clear the data handle each time it is called. This resolves the bug and DOES NOT (or rather should not) affect the code in any negative way. As any call to `free_handle` effectively relinquishes ownership of that data handle it should ALWAYS be assumed that the data handle passed in *can* and *should* be cleared, even if subsequently reacquired as that would potentially acquire a different data handle.

TESTS CONDUCTED: 
1. Verified reproducible error that revealed this issue to be resolved when implementing these changes