### PR TITLE
Update to latest tempo release

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -544,7 +544,7 @@ state   real    qnn            ikjftb  scalar      1         -     \
 state   real    qnc            ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QNCLOUD"       "cloud water Number concentration" "# kg(-1)"
 state   real    qvolg          ikjftb  scalar      1         -     \
-   i0rhusdf=(bdy_interp:dt)    "QVGRAUPEL"     "Graupel Particle Volume" "m(3) kg(-1)"
+   i0rhusdf=(bdy_interp:dt)    "QVGRAUPEL"     "Graupel Particle Volume" "m(3) kg(-1) or L kg(-1) for TEMPO"
 state   real    qvolh          ikjftb  scalar      1         -     \
    i0rhusdf=(bdy_interp:dt)    "QVHAIL"        "Hail Particle Volume" "m(3) kg(-1)"
 state   real    qzr             ikjftb  scalar      1         -     \


### PR DESCRIPTION
Modification from tempo v3.0.0 to v3.0.4 (that pertain to WRF)

TYPE: enhancement

KEYWORDS: tempo

SOURCE: Anders Jensen NOAA/GSL

DESCRIPTION OF CHANGES:
Bugfixes:
- Bug fix for initialization of precipitation diagnostic

Modifications (mostly for speedup and better memory useage)
- global dt variable was removed and replaced with local variables to prevent parallel compute issues
- 3D diagnostics data type was changed to `intent(inout)` from `intent(out)` to reduce the number of calls to `allocate`
- microphysical process tendencies data type was changed from allocatable to a pointer contiguous in memory for better memory handling and efficiency

ISSUE:
Related to PR #2270