### PR TITLE
Fix GFL build issues

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -2569,6 +2569,21 @@ module_cu_gf_ctrans.o: \
 	../frame/module_state_description.o 
 
 
+module_cu_gfl_common.o: \
+	ccpp_kind_types.o
+
+
+module_cu_gfl_sh.o: \
+	module_cu_gfl_deep.o \
+	module_cu_gfl_common.o
+
+
+module_cu_gfl_wrf.o: \
+	module_cu_gfl_deep.o \
+	module_cu_gfl_sh.o \
+	ccpp_kind_types.o
+
+
 module_cumulus_driver.o: \
 	../share/module_chem_share.o \
 	module_cu_kf.o \
@@ -2588,6 +2603,10 @@ module_cumulus_driver.o: \
 	module_cu_ntiedtke.o \
 	module_cu_mskf.o \
 	module_cu_kfcup.o \
+	module_cu_gfl_common.o \
+	module_cu_gfl_deep.o \
+	module_cu_gfl_sh.o \
+	module_cu_gfl_wrf.o \
 	../frame/module_state_description.o \
 	../frame/module_configure.o \
 	../frame/module_domain.o \

--- a/phys/CMakeLists.txt
+++ b/phys/CMakeLists.txt
@@ -75,10 +75,6 @@ target_sources(
                   module_cu_camzm_driver.F
                   module_cu_g3.F
                   module_cu_gd.F
-                  module_cu_gf_ctrans.F
-                  module_cu_gf_deep.F
-                  module_cu_gf_sh.F
-                  module_cu_gf_wrfdrv.F
                   module_cu_kf.F
                   module_cu_kfcup.F
                   module_cu_kfeta.F
@@ -432,6 +428,12 @@ target_sources(
                   MYNN-EDMF/module_bl_mynnedmf.F90
                   MYNN-EDMF/WRF/module_bl_mynnedmf_common.F90
                   MYNN-EDMF/WRF/module_bl_mynnedmf_driver.F90
+
+                  # GFL
+                  GFL/module_cu_gfl_deep.F90
+                  GFL/module_cu_gfl_sh.F90
+                  GFL/WRF/module_cu_gfl_common.F90
+                  GFL/WRF/module_cu_gfl_wrf.F90
                   )
 
 

--- a/tools/trigger_test.F
+++ b/tools/trigger_test.F
@@ -1,0 +1,1 @@
+! Add or remove superfluous lines to trigger tests


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: build, make, cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2269 introduced the GFL submodule replacing the older GF implementation. In doing so, the related files' dependencies and additions to both builds was not done completely.

Solution:
Add object dependencies for make build. Remove old file reference and update with new files in cmake build.