### PR TITLE
Fix CMake build for TEMPO

### DIFF
--- a/phys/CMakeLists.txt
+++ b/phys/CMakeLists.txt
@@ -432,6 +432,16 @@ target_sources(
                   MYNN-EDMF/module_bl_mynnedmf.F90
                   MYNN-EDMF/WRF/module_bl_mynnedmf_common.F90
                   MYNN-EDMF/WRF/module_bl_mynnedmf_driver.F90
+
+                  # TEMPO
+                  TEMPO/src/module_mp_tempo_cfgs.F90
+                  TEMPO/src/module_mp_tempo_params.F90
+                  TEMPO/src/module_mp_tempo_utils.F90
+                  TEMPO/src/module_mp_tempo_diags.F90
+                  TEMPO/src/module_mp_tempo_ml.F90
+                  TEMPO/src/module_mp_tempo_aerosols.F90
+                  TEMPO/src/module_mp_tempo_main.F90
+                  TEMPO/src/module_mp_tempo_driver.F90
                   )
 
 


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: cmake

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
New files were added with PR #2270, but were not added to the CMake build

Solution:
Fix the CMake build issue caused by PR #2270