### PR TITLE
Fix core uninitialized values causing undefined behavior

### DIFF
--- a/frame/module_domain_type.F
+++ b/frame/module_domain_type.F
@@ -45,17 +45,17 @@ MODULE module_domain_type
    END TYPE tile_zone
 
    TYPE fieldlist
-      CHARACTER*80    :: VarName
-      CHARACTER*1     :: Type
-      CHARACTER*1     :: ProcOrient  ! 'X' 'Y' or ' ' (X, Y, or non-transposed)
-      CHARACTER*80    :: DataName
-      CHARACTER*80    :: Description
-      CHARACTER*80    :: Units
-      CHARACTER*10    :: MemoryOrder
-      CHARACTER*10    :: Stagger
-      CHARACTER*80    :: dimname1
-      CHARACTER*80    :: dimname2
-      CHARACTER*80    :: dimname3
+      CHARACTER*80    :: VarName     = ''
+      CHARACTER*1     :: Type        = ''
+      CHARACTER*1     :: ProcOrient  = '' ! 'X' 'Y' or ' ' (X, Y, or non-transposed)
+      CHARACTER*80    :: DataName    = ''
+      CHARACTER*80    :: Description = ''
+      CHARACTER*80    :: Units       = ''
+      CHARACTER*10    :: MemoryOrder = ''
+      CHARACTER*10    :: Stagger     = ''
+      CHARACTER*80    :: dimname1    = ''
+      CHARACTER*80    :: dimname2    = ''
+      CHARACTER*80    :: dimname3    = ''
       LOGICAL         :: scalar_array
       LOGICAL         :: boundary_array
       LOGICAL         :: restart


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: uninitialized

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
The domain type `fieldlist` is a derived type used to store state vars within the `grid`. Thus, this type facilitates many of the read, write, and general control of state variables defined within the registry.

Throughout the code, character fields such as `MemoryOrder` are accessed and read to determine branching logic for how a particular state var should be handled. Not all fields are required to be defined within the registry, and this leads to uninitialized values within a newly created instance of `fieldlist`.

Solution:
Rather than correcting the registry generated code that assigns state vars, a better solution is to fix the upstream type definition to always start with initialized default vales.

This fixes sporadic undefined behavior arising from accessing these fields, sometimes resulting in total model crash or indefinite hangs as MPI synchronization calls take different branching logic.