### PR TITLE
bug fix for TEMPO and aer_opt=3 combination

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3101,7 +3101,7 @@ package   nssl_graupelvol nssl_density_on==1           -             scalar:qvol
 package   nssl_hailvol    nssl_density_on==2           -             scalar:qvolg,qvolh
 package   nssl_ssat_out   nssl_ssat_output==1          -             state:ssat
 package   nssl_ssati_out  nssl_ssat_output==2          -             state:ssat,ssati
-package   tempo_aerosol   tempo_aerosolaware==1        -             scalar:qnc,qnwfa,qnifa;state:qnwfa2d,qnifa2d
+package   tempo_aerosol   tempo_aerosolaware==1        -             scalar:qnc,qnwfa,qnifa;state:qnwfa2d,qnifa2d,taod5503d,taod5502d
 package   tempo_hail      tempo_hailaware==1           -             scalar:qng,qvolg
 
 package   radar_refl      compute_radar_ref==1         -             state:refl_10cm,refd_max

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2560,6 +2560,18 @@
      END DO
 
 !-----------------------------------------------------------------------
+!  If aer_opt=3 and TEMPO (mp_physics=88), need to use tempo_aerosolaware = 1
+!-----------------------------------------------------------------------
+     DO i = 1, model_config_rec % max_dom
+       IF ( model_config_rec%mp_physics(i) .EQ. TEMPO .AND. model_config_rec%aer_opt .EQ. 3 .AND. &
+            model_config_rec%tempo_aerosolaware .EQ. 0) THEN
+          model_config_rec%tempo_aerosolaware = 1
+          wrf_err_message = '--- WARNING: For TEMPO & aer_opt=3, tempo_aerosolaware must = 1'
+          CALL wrf_debug ( 0, TRIM( wrf_err_message ) )  
+       END IF
+     END DO
+       
+!-----------------------------------------------------------------------
 !  Set aer_fire_emit_opt for Thompson-MP-Aero (mp_physics=28) AND rcon mp (mp_physics=29)
 !-----------------------------------------------------------------------
      DO i = 1, model_config_rec % max_dom


### PR DESCRIPTION
This PR fixes a crash when TEMPO is run in combination with aer_opt=3

TYPE: bug fix

KEYWORDS: TEMPO, aer_opt=3

SOURCE: Joseph Olson (NOAA-GSL)

DESCRIPTION OF CHANGES:
Problem:
Model crashes because two arrays are left unallocated

Solution:

1. Include taod5503d and taod5502d in the tempo_aerosolaware package
2. Add a safety check in module_check_a_mundo.F to guard against misconfigurations

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status develop` to get formatted list)
M       Registry/Registry.EM_COMMON
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. Do mods fix problem? Yes. Testing in single case study.
2. Are the Jenkins tests all passing?
