### PR TITLE
CMake Fix missing shinhong pbl module

### DIFF
--- a/phys/CMakeLists.txt
+++ b/phys/CMakeLists.txt
@@ -412,6 +412,7 @@ target_sources(
                   # Shared physics
                   physics_mmm/bl_gwdo.F90
                   physics_mmm/bl_ysu.F90
+                  physics_mmm/bl_shinhong.F90
                   physics_mmm/cu_ntiedtke.F90
                   physics_mmm/module_libmassv.F90
                   physics_mmm/mp_radar.F90


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, shinhong, pbl

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2286 added `bl_shinhong.F90` to the MMM-physics repo but only added it to the make build.

Solution:
Add the new file to the CMake build as well.

TESTS CONDUCTED: 
1. Confirmed that after this ARW core builds in cmake