### PR TITLE
Adding MPI parallelization to CFBM

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -3549,6 +3549,8 @@ halo      HALO_EM_COUPLE_B   dyn_em 48:ph_1,ph_2,w_1,w_2,t_1,t_2,u_1,u_2,v_1,v_2
 period    PERIOD_EM_COUPLE_B dyn_em 3:ph_1,ph_2,w_1,w_2,t_1,t_2,u_1,u_2,v_1,v_2,\
                                        moist,chem,tracer,scalar
 
+halo      HALO_EM_CFBM dyn_em 8:znt,t2,q2,psfc,rainc,rainnc,u10,v10
+
 #cyl for trajectory 
 halo      HALO_EM_F dyn_em  24:muu,muv,mut
 halo      HALO_EM_F_1 dyn_em  24:muus,muvs

--- a/doc/README.cfbm
+++ b/doc/README.cfbm
@@ -9,6 +9,7 @@ This instructs WRF to read the CFBM namelist: namelist.cfbm
 
 In a given WRF simulation, CFBM can only be activated in one domain.
 
+It only works with Lambert-Conformal projections at this time.
 
 This is an example of the namelist.cfbm:
 

--- a/doc/README.cfbm
+++ b/doc/README.cfbm
@@ -14,7 +14,7 @@ This is an example of the namelist.cfbm:
 
  &time
  dt = 2               ! WRF time step [s] for the nest CFBM is active
- interval_output = 2  ! Frequency [Min] saving fire output
+ interval_output = 2  ! Frequency [s] saving fire output
 /
 
  &atm

--- a/doc/README.cfbm
+++ b/doc/README.cfbm
@@ -30,6 +30,5 @@ This is an example of the namelist.cfbm:
  fire_ignition_radius1 = 2000.0,
  fire_ignition_start_time1 = 6.0,
  fire_ignition_end_time1 = 60.0,
- fire_wind_height = 1.0, 
 /
 

--- a/doc/README.cfbm
+++ b/doc/README.cfbm
@@ -9,3 +9,27 @@ This instructs WRF to read the CFBM namelist: namelist.cfbm
 
 In a given WRF simulation, CFBM can only be activated in one domain.
 
+
+This is an example of the namelist.cfbm:
+
+ &time
+ dt = 2               ! WRF time step [s] for the nest CFBM is active
+ interval_output = 2  ! Frequency [Min] saving fire output
+/
+
+ &atm
+ /
+
+ &fire
+ fire_num_ignitions = 1,
+ fire_ignition_ros1 =   1.2,
+ fire_ignition_start_lat1 = 39.68,
+ fire_ignition_start_lon1 = -103.58,
+ fire_ignition_end_lat1 = 39.68,
+ fire_ignition_end_lon1 = -103.58,
+ fire_ignition_radius1 = 2000.0,
+ fire_ignition_start_time1 = 6.0,
+ fire_ignition_end_time1 = 60.0,
+ fire_wind_height = 1.0, 
+/
+

--- a/doc/README.cfbm
+++ b/doc/README.cfbm
@@ -1,0 +1,11 @@
+
+WRF should be compiled with CMake in order to use the Community Fire Behavior model:
+git clone --recurse-submodules https://github.com/wrf-model/WRF
+./configure_new -- -DENABLE_CFBM=ON
+./compile_new
+
+To activate the model you need to set ifire = 1 in the fire block of the WRF namelist.
+This instructs WRF to read the CFBM namelist: namelist.cfbm
+
+In a given WRF simulation, CFBM can only be activated in one domain.
+

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -56,7 +56,7 @@ CONTAINS
 #ifdef DM_PARALLEL
     USE module_dm, ONLY : local_communicator, mytask, ntasks, ntasks_x, ntasks_y, local_communicator_periodic, wrf_dm_maxval
     USE module_comm_dm, ONLY : halo_em_phys_a_sub,halo_em_fdda_sfc_sub,halo_pwp_sub,halo_em_chem_e_3_sub, &
-    halo_em_chem_e_5_sub, halo_em_hydro_noahmp_sub, halo_em_tracer_e_5_sub
+    halo_em_chem_e_5_sub, halo_em_hydro_noahmp_sub, halo_em_tracer_e_5_sub, halo_em_cfbm_sub
 #if ( WRFPLUS == 1 )
     USE module_comm_dm, ONLY : halo_em_phys_a_bl_surf_sub
 #endif
@@ -64,10 +64,11 @@ CONTAINS
     USE module_utility
 
 #ifdef WRF_CFBM
-      ! CFBM
+      ! CFBM modules
     use advance_mod, only : Advance_state
-    use wrf_mod, only : Interp_wrf2dvar_to_cfbm, Interp_wrfwinds_to_cfbm, Provide_atm_feedback
+    use wrf_mod, only : Interp_wrfwinds_to_cfbm, Provide_atm_feedback
     use interp_mod, only : VINTERP_WINDS_FROM_3D_WINDS, VINTERP_WINDS_FROM_10M_WINDS
+    use coupling_mod, only : Interp_horizontal
 #endif
 
     IMPLICIT NONE
@@ -1408,30 +1409,38 @@ BENCH_END(pbl_driver_tim)
 #ifdef WRF_CFBM
        case (1)
            ! Interpolate from Atm to fire grid
-         call Interp_wrf2dvar_to_cfbm (grid%znt, ims, ime, jms, jme, &
+#ifdef DM_PARALLEL
+#     include "HALO_EM_CFBM.inc"
+#endif
+         call Interp_horizontal (grid%znt, grid%fire_state%proj, ims, ime, jms, jme, &
              grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-             grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-             grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fz0)
+             grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+             grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+             grid%fire_state%fz0)
 
-         call Interp_wrf2dvar_to_cfbm (grid%t2, ims, ime, jms, jme, &
+         call Interp_horizontal (grid%t2, grid%fire_state%proj, ims, ime, jms, jme, &
              grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-             grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-             grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fire_t2)
+             grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+             grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+             grid%fire_state%fire_t2)
 
-         call Interp_wrf2dvar_to_cfbm (grid%q2, ims, ime, jms, jme, &
+         call Interp_horizontal (grid%q2, grid%fire_state%proj, ims, ime, jms, jme, &
              grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-             grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-             grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fire_q2)
+             grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+             grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+             grid%fire_state%fire_q2)
 
-         call Interp_wrf2dvar_to_cfbm (grid%psfc, ims, ime, jms, jme, &
+         call Interp_horizontal (grid%psfc, grid%fire_state%proj, ims, ime, jms, jme, &
              grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-             grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-             grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fire_psfc)
+             grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+             grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+             grid%fire_state%fire_psfc)
 
-         call Interp_wrf2dvar_to_cfbm (grid%rainc + grid%rainnc, ims, ime, jms, jme, &
+         call Interp_horizontal (grid%rainc + grid%rainnc, grid%fire_state%proj, ims, ime, jms, jme, &
              grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-             grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-             grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fire_rain)
+             grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+             grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+             grid%fire_state%fire_rain)
 
          Select_vinterp_opt: select case  (grid%cfbm_namelist%wind_vinterp_opt)
            case (VINTERP_WINDS_FROM_3D_WINDS)
@@ -1444,15 +1453,17 @@ BENCH_END(pbl_driver_tim)
                  grid%cfbm_namelist%fire_wind_height, grid%fire_state%uf, grid%fire_state%vf)
 
            case (VINTERP_WINDS_FROM_10M_WINDS)
-             call Interp_wrf2dvar_to_cfbm (grid%u10, ims, ime, jms, jme, &
+             call Interp_horizontal (grid%u10, grid%fire_state%proj, ims, ime, jms, jme, &
                  grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-                 grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-                 grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%uf)
+                 grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+                 grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+                 grid%fire_state%uf)
 
-             call Interp_wrf2dvar_to_cfbm (grid%v10, ims, ime, jms, jme, &
+             call Interp_horizontal (grid%v10, grid%fire_state%proj, ims, ime, jms, jme, &
                  grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-                 grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-                 grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%vf)
+                 grid%fire_state%num_tiles, grid%fire_state%i_start, grid%fire_state%i_end, grid%fire_state%j_start, &
+                 grid%fire_state%j_end, grid%cfbm_namelist%hinterp_opt, grid%fire_state%lats, grid%fire_state%lons, &
+                 grid%fire_state%vf)
 
              call grid%fire_state%Apply_wafs ()
 

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -66,8 +66,8 @@ CONTAINS
 #ifdef WRF_CFBM
       ! CFBM
     use advance_mod, only : Advance_state
-    use wrf_mod, only : Interp_wrf2dvar_to_cfbm, Interp_wrfwinds_to_cfbm
-    use wrf_mod, only : Provide_atm_feedback
+    use wrf_mod, only : Interp_wrf2dvar_to_cfbm, Interp_wrfwinds_to_cfbm, Provide_atm_feedback
+    use interp_mod, only : VINTERP_WINDS_FROM_3D_WINDS, VINTERP_WINDS_FROM_10M_WINDS
 #endif
 
     IMPLICIT NONE
@@ -1433,13 +1433,33 @@ BENCH_END(pbl_driver_tim)
              grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
              grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fire_rain)
 
-         call Interp_wrfwinds_to_cfbm (grid%u_phy, grid%v_phy, grid%z_at_w, ims, ime, kms, kme, jms, jme, &
-             grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
-             grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
-             grid%fire_state%kfds, grid%fire_state%kfde, &
-             grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fz0,  &
-             grid%cfbm_namelist%fire_lsm_zcoupling, grid%cfbm_namelist%fire_lsm_zcoupling_ref, &
-             grid%cfbm_namelist%fire_wind_height, grid%fire_state%uf, grid%fire_state%vf)
+         Select_vinterp_opt: select case  (grid%cfbm_namelist%wind_vinterp_opt)
+           case (VINTERP_WINDS_FROM_3D_WINDS)
+             call Interp_wrfwinds_to_cfbm (grid%u_phy, grid%v_phy, grid%z_at_w, ims, ime, kms, kme, jms, jme, &
+                 grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
+                 grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
+                 grid%fire_state%kfds, grid%fire_state%kfde, &
+                 grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%fz0,  &
+                 grid%cfbm_namelist%fire_lsm_zcoupling, grid%cfbm_namelist%fire_lsm_zcoupling_ref, &
+                 grid%cfbm_namelist%fire_wind_height, grid%fire_state%uf, grid%fire_state%vf)
+
+           case (VINTERP_WINDS_FROM_10M_WINDS)
+             call Interp_wrf2dvar_to_cfbm (grid%u10, ims, ime, jms, jme, &
+                 grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
+                 grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
+                 grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%uf)
+
+             call Interp_wrf2dvar_to_cfbm (grid%v10, ims, ime, jms, jme, &
+                 grid%fire_state%ifms, grid%fire_state%ifme, grid%fire_state%jfms, grid%fire_state%jfme, &
+                 grid%fire_state%ifps, grid%fire_state%ifpe, grid%fire_state%jfps, grid%fire_state%jfpe, &
+                 grid%fire_state%lats, grid%fire_state%lons, grid%fire_state%proj, grid%fire_state%vf)
+
+             call grid%fire_state%Apply_wafs ()
+
+           case default
+             call wrf_error_fatal ('The vertical wind interpolation option does not exist in CFBM')
+
+         end select Select_vinterp_opt
 
          call Advance_state (grid = grid%fire_state, config_flags = grid%cfbm_namelist)
 

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -56,7 +56,7 @@ CONTAINS
 #ifdef DM_PARALLEL
     USE module_dm, ONLY : local_communicator, mytask, ntasks, ntasks_x, ntasks_y, local_communicator_periodic, wrf_dm_maxval
     USE module_comm_dm, ONLY : halo_em_phys_a_sub,halo_em_fdda_sfc_sub,halo_pwp_sub,halo_em_chem_e_3_sub, &
-    halo_em_chem_e_5_sub, halo_em_hydro_noahmp_sub
+    halo_em_chem_e_5_sub, halo_em_hydro_noahmp_sub, halo_em_tracer_e_5_sub
 #if ( WRFPLUS == 1 )
     USE module_comm_dm, ONLY : halo_em_phys_a_bl_surf_sub
 #endif
@@ -1475,6 +1475,12 @@ BENCH_END(pbl_driver_tim)
                grid%rthfrten, grid%rqvfrten)          ! theta and Qv tendencies
            end do
            !$OMP END PARALLEL DO
+
+           if (config_flags%tracer_opt == 3) then
+#ifdef DM_PARALLEL
+#     include "HALO_EM_TRACER_E_5.inc"
+#endif
+           end if
          else
            call wrf_error_fatal ('num_tiles in WRF and CFBM should match')
          endif

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -25,7 +25,7 @@
    USE module_dm, ONLY : wrf_dm_min_real, wrf_dm_max_real
 #endif
    USE module_comm_dm
-   USE module_llxy, ONLY : proj_cassini
+   USE module_llxy, ONLY : proj_cassini, PROJ_LC
    USE module_physics_init
    USE NoahmpGroundwaterInitMod, ONLY: NoahmpGroundwaterInitMain
    USE module_lightning_driver, ONLY : lightning_init
@@ -2256,6 +2256,10 @@ DEALLOCATE(dz8w)
 
        if (abs (grid%dt - grid%cfbm_namelist%dt) > 1.0e-5) then
          call wrf_error_fatal ('CFBM dt should match WRF dt for the fire domain')
+       end if
+
+       if (config_flags%map_proj /= PROJ_LC) then
+         call wrf_error_fatal ('CFBM only supports Lambert Conformal projections at this moment')
        end if
 
          ! Get fire dims

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -146,6 +146,7 @@
               ifms, ifme, jfms, jfme, kfms, kfme, &
               ifps, ifpe, jfps, jfpe, kfps, kfpe
    real :: cen_lat, cen_lon, truelat1, truelat2, stand_lon
+   logical :: is_cfbm_initialized = .false.
 #endif
 
 
@@ -2247,10 +2248,15 @@ DEALLOCATE(dz8w)
        ! Community Fire Behavior model
      case (1)
 #ifdef WRF_CFBM
+       Init_cfbm: if (.not. is_cfbm_initialized) then
 #ifdef DM_PARALLEL
          ! Broadcast the namelist
        call grid%cfbm_namelist%Broadcast_nml (grid%communicator)
 #endif
+
+       if (abs (grid%dt - grid%cfbm_namelist%dt) > 1.0e-5) then
+         call wrf_error_fatal ('CFBM dt should match WRF dt for the fire domain')
+       end if
 
          ! Get fire dims
        call get_ijk_from_subgrid (grid, ifds, ifde, jfds, jfde, kfds, kfde, &
@@ -2287,6 +2293,10 @@ DEALLOCATE(dz8w)
            map_proj = config_flags%map_proj, cen_lat = cen_lat, cen_lon = cen_lon, truelat1 = truelat1, &
            truelat2 = truelat2, stand_lon = stand_lon, nfuel_cat = grid%nfuel_cat, zsf = grid%zsf, &
            dzdxf = grid%dzdxf, dzdyf = grid%dzdyf, communicator = grid%communicator)
+
+         is_cfbm_initialized = .true.
+
+       end if Init_cfbm
 #else
        call wrf_error_fatal ('CFBM requires compilation with CMake')
 #endif

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -146,7 +146,6 @@
               ifms, ifme, jfms, jfme, kfms, kfme, &
               ifps, ifpe, jfps, jfpe, kfps, kfpe
    real :: cen_lat, cen_lon, truelat1, truelat2, stand_lon
-!   integer :: ierr ! To be removed
 #endif
 
 
@@ -2248,11 +2247,9 @@ DEALLOCATE(dz8w)
        ! Community Fire Behavior model
      case (1)
 #ifdef WRF_CFBM
-         ! Broadcast the namelist
 #ifdef DM_PARALLEL
+         ! Broadcast the namelist
        call grid%cfbm_namelist%Broadcast_nml (grid%communicator)
-!       print *, 'grid%cfbm_namelist%fire_num_ignitions = ', grid%cfbm_namelist%fire_num_ignitions
-!       call MPI_Barrier(grid%communicator, ierr)
 #endif
 
          ! Get fire dims

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -20,6 +20,7 @@
    USE module_dm, ONLY : wrf_dm_min_real, wrf_dm_max_real, wrf_dm_maxval, &
         ntasks_x, ntasks_y, &
         local_communicator_periodic, local_communicator, mytask, ntasks
+
 #else
    USE module_dm, ONLY : wrf_dm_min_real, wrf_dm_max_real
 #endif
@@ -2280,7 +2281,7 @@ DEALLOCATE(dz8w)
            sr_x = config_flags%sr_x, sr_y = config_flags%sr_y, &
            map_proj = config_flags%map_proj, cen_lat = cen_lat, cen_lon = cen_lon, truelat1 = truelat1, &
            truelat2 = truelat2, stand_lon = stand_lon, nfuel_cat = grid%nfuel_cat, zsf = grid%zsf, &
-           dzdxf = grid%dzdxf, dzdyf = grid%dzdyf)
+           dzdxf = grid%dzdxf, dzdyf = grid%dzdyf, communicator = grid%communicator)
 #else
        call wrf_error_fatal ('CFBM requires compilation with CMake')
 #endif

--- a/dyn_em/start_em.F
+++ b/dyn_em/start_em.F
@@ -146,6 +146,7 @@
               ifms, ifme, jfms, jfme, kfms, kfme, &
               ifps, ifpe, jfps, jfpe, kfps, kfpe
    real :: cen_lat, cen_lon, truelat1, truelat2, stand_lon
+!   integer :: ierr ! To be removed
 #endif
 
 
@@ -2247,6 +2248,13 @@ DEALLOCATE(dz8w)
        ! Community Fire Behavior model
      case (1)
 #ifdef WRF_CFBM
+         ! Broadcast the namelist
+#ifdef DM_PARALLEL
+       call grid%cfbm_namelist%Broadcast_nml (grid%communicator)
+!       print *, 'grid%cfbm_namelist%fire_num_ignitions = ', grid%cfbm_namelist%fire_num_ignitions
+!       call MPI_Barrier(grid%communicator, ierr)
+#endif
+
          ! Get fire dims
        call get_ijk_from_subgrid (grid, ifds, ifde, jfds, jfde, kfds, kfde, &
                                         ifms, ifme, jfms, jfme, kfms, kfme, &

--- a/share/module_check_a_mundo.F
+++ b/share/module_check_a_mundo.F
@@ -2775,6 +2775,24 @@
       END IF
 
 !-----------------------------------------------------------------------
+! CFBM checks
+!-----------------------------------------------------------------------
+
+      ! CFBM can be active in only one domain
+      oops = 0
+      DO i = 1, model_config_rec % max_dom
+        IF (model_config_rec%ifire(i) == 1) THEN
+          oops = oops + 1
+        END IF
+      END DO
+
+      IF ( oops .GT. 1 ) THEN
+        wrf_err_message = '--- ERROR: CFBM can be active in only one domain'
+        CALL wrf_debug ( 0, TRIM( wrf_err_message ) )
+        count_fatal_error = count_fatal_error + 1
+      END IF
+
+!-----------------------------------------------------------------------
 ! This WRF version does not support trajectories on a global domain
 !-----------------------------------------------------------------------
       IF (  model_config_rec % polar(1) .AND. &


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MPI parallelization with CFBM

SOURCE: Pedro Jimenez (NCAR/RAL)

DESCRIPTION OF CHANGES:
Problem:
MPI parallelization with CFBM only run with 1 MPI task.
It also adds the bilinear interpolation of atmospheric variables in the fire grid.

Solution:
We have allowed for parallelization using multiple MPI tasks.

ISSUE: N/A

LIST OF MODIFIED FILES: 
M       Registry/Registry.EM_COMMON
A       doc/README.cfbm
M       dyn_em/module_first_rk_step_part1.F
M       dyn_em/start_em.F
M       phys/fire_behavior
M       share/module_check_a_mundo.F

TESTS CONDUCTED: 
1. We run test with 1, 2, and 3 MPI tasks and we get bit for bit results
2. Are the Jenkins tests all passing? Yes
    Test Type              | Expected  | Received |  Failed
    = = = = = = = = = = = = = = = = = = = = = = = =  = = = =
    Number of Tests        : 23           24
    Number of Builds       : 60           57
    Number of Simulations  : 158           150        0
    Number of Comparisons  : 95           86        0

    Failed Simulations are: 
    None
    Which comparisons are not bit-for-bit: 
    None

RELEASE NOTE: Allowing for multiple MPI tasks when running the Community Fire Behavior model
