### PR TITLE
Compiler support AOCC

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1975,6 +1975,49 @@ LIB_BUNDLED     = \
                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
 
 #insert new stanza here
+###########################################################
+#ARCH    Linux x86_64 gfortran with flang openmpi #serial smpar dmpar dm+sm
+#
+DESCRIPTION     =       AOCC ($SFC/$SCC): Open MPI
+DMPARALLEL      =       # 1
+OMPCPP          =       # -D_OPENMP
+OMP             =       # -fopenmp
+OMPCC           =       # -fopenmp
+SFC             =       flang
+SCC             =       clang
+CCOMP           =       clang
+DM_FC           =       mpif90
+DM_CC           =       mpicc
+FC              =       flang
+CC              =       clang
+LD              =       $(FC)
+RWORDSIZE       =       CONFIGURE_RWORDSIZE
+PROMOTION       =       #-fdefault-real-8
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DMACOS  -DWRF_USE_CLM
+CFLAGS_LOCAL    =       -w -O3 -c  -DMACOS
+LDFLAGS_LOCAL   =
+CPLUSPLUSLIB    =       
+ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
+FCOPTIM         =       -O2 -ftree-vectorize -funroll-loops
+FCREDUCEDOPT	=       $(FCOPTIM)
+FCNOOPT         =       -O0
+FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
+FORMAT_FIXED    =       -ffixed-form
+FORMAT_FREE     =       -ffree-form -ffree-line-length-none
+FCSUFFIX        =       
+BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
+MODULE_SRCH_FLAG =
+TRADFLAG        =      CONFIGURE_TRADFLAG
+CPP             =      cpp CONFIGURE_CPPFLAGS -xassembler-with-cpp
+AR              =      ar
+ARFLAGS         =      ru
+M4              =      m4 -B 14000
+RANLIB          =      ranlib
+RLFLAGS		=	-c
+CC_TOOLS        =      $(SCC) 
+
 
 ###########################################################
 #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1976,7 +1976,7 @@ LIB_BUNDLED     = \
 
 #insert new stanza here
 ###########################################################
-#ARCH    Linux x86_64 flang with clang compiler #serial smpar dmpar dm+sm
+#ARCH Linux x86_64 i486 i586 i686, flang with clang compiler #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       AOCC ($SFC/$SCC)
 DMPARALLEL      =       # 1
@@ -1986,10 +1986,10 @@ OMPCC           =       # -fopenmp
 SFC             =       flang
 SCC             =       clang
 CCOMP           =       clang
-DM_FC           =       mpif90
-DM_CC           =       mpicc
-FC              =       mpif90
-CC              =       mpicc
+DM_FC           =       mpif90 -f90=$(SFC)
+DM_CC           =       mpicc -cc=$(SCC)
+FC              =       CONFIGURE_FC
+CC              =       CONFIGURE_CC
 LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
 PROMOTION       =       #-fdefault-real-8
@@ -2010,13 +2010,14 @@ FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
-CPP             =      cpp CONFIGURE_CPPFLAGS -xassembler-with-cpp
+CPP             =      /lib/cpp CONFIGURE_CPPFLAGS
 AR              =      ar
 ARFLAGS         =      ru
 M4              =      m4 -B 14000
 RANLIB          =      ranlib
-RLFLAGS		=	-c
-CC_TOOLS        =      $(SCC)
+RLFLAGS		=
+CC_TOOLS        =      $(SCC) 
+
 
 ###########################################################
 #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1978,7 +1978,7 @@ LIB_BUNDLED     = \
 ###########################################################
 #ARCH    Linux x86_64 flang with clang compiler #serial smpar dmpar dm+sm
 #
-DESCRIPTION     =       AOCC ($SFC/$SCC): Open MPI
+DESCRIPTION     =       AOCC ($SFC/$SCC)
 DMPARALLEL      =       # 1
 OMPCPP          =       # -D_OPENMP
 OMP             =       # -fopenmp
@@ -2017,7 +2017,6 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      $(SCC)
-
 
 ###########################################################
 #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1976,7 +1976,7 @@ LIB_BUNDLED     = \
 
 #insert new stanza here
 ###########################################################
-#ARCH    Linux x86_64 gfortran with flang openmpi #serial smpar dmpar dm+sm
+#ARCH    Linux x86_64 flang with clang compiler #serial smpar dmpar dm+sm
 #
 DESCRIPTION     =       AOCC ($SFC/$SCC): Open MPI
 DMPARALLEL      =       # 1
@@ -1988,13 +1988,14 @@ SCC             =       clang
 CCOMP           =       clang
 DM_FC           =       mpif90
 DM_CC           =       mpicc
-FC              =       flang
-CC              =       clang
+FC              =       mpif90
+CC              =       mpicc
+CXX             =       mpicc
 LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
 PROMOTION       =       #-fdefault-real-8
-ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DMACOS  -DWRF_USE_CLM
-CFLAGS_LOCAL    =       -w -O3 -c  -DMACOS
+ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
+CFLAGS_LOCAL    =       -w -O3 -c
 LDFLAGS_LOCAL   =
 CPLUSPLUSLIB    =       
 ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
@@ -2017,6 +2018,9 @@ M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
 CC_TOOLS        =      $(SCC) 
+
+MPI_INC         =      -I/home/virusry/Build_WRF/liba/openmpi/include
+MPI_LIB         =      -I/home/virusry/Build_WRF/liba/openmpi/lib
 
 
 ###########################################################

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -1990,7 +1990,6 @@ DM_FC           =       mpif90
 DM_CC           =       mpicc
 FC              =       mpif90
 CC              =       mpicc
-CXX             =       mpicc
 LD              =       $(FC)
 RWORDSIZE       =       CONFIGURE_RWORDSIZE
 PROMOTION       =       #-fdefault-real-8
@@ -2017,10 +2016,7 @@ ARFLAGS         =      ru
 M4              =      m4 -B 14000
 RANLIB          =      ranlib
 RLFLAGS		=	-c
-CC_TOOLS        =      $(SCC) 
-
-MPI_INC         =      -I/home/virusry/Build_WRF/liba/openmpi/include
-MPI_LIB         =      -I/home/virusry/Build_WRF/liba/openmpi/lib
+CC_TOOLS        =      $(SCC)
 
 
 ###########################################################

--- a/external/io_grib2/bacio-1.3/bacio.v1.3.c
+++ b/external/io_grib2/bacio-1.3/bacio.v1.3.c
@@ -14,7 +14,7 @@
 #ifdef MACOS
 #include <sys/malloc.h>
 #else
-#include <malloc.h>
+#include <stdlib.h>
 #endif
 #include <ctype.h>
 #include <string.h>

--- a/external/io_grib2/bacio-1.3/bacio.v1.3.c
+++ b/external/io_grib2/bacio-1.3/bacio.v1.3.c
@@ -14,7 +14,7 @@
 #ifdef MACOS
 #include <sys/malloc.h>
 #else
-#include <stdlib.h>
+#include <malloc.h>
 #endif
 #include <ctype.h>
 #include <string.h>


### PR DESCRIPTION
# Purpose
Add AOCC flang/clang compiler support for Linux x86_64 architecture with OpenMP capabilities

## TYPE
enhancement

## KEYWORDS
AOCC, flang, clang, compiler, Linux, x86_64, configuration, build system

## SOURCE
Rishi Yadav (Intel - AI Software Engineer)

## DESCRIPTION OF CHANGES

### Problem
The WRF build system lacked support for the AOCC compiler suite (flang Fortran compiler with clang C compiler) on Linux x86_64 architectures, limiting users' ability to leverage this modern, optimized compiler toolchain.

### Solution
Added a new architecture configuration file for Linux x86_64 with AOCC compilers. The configuration specifies:
- `SFC=flang` for Fortran compilation
- `SCC=clang` for C compilation
- Appropriate compiler flags for optimization (`-O2 -ftree-vectorize`)
- Support for OpenMP parallelization
- Proper byte-swapping and Fortran I/O formatting options
- Integration with MPI via `mpif90` and `mpicc` wrappers