### PR TITLE
A fix for NTU microphysics

### DIFF
--- a/phys/module_mp_ntu.F
+++ b/phys/module_mp_ntu.F
@@ -5692,7 +5692,6 @@
             VTNRG = SQRT(VTN0*VTN0+0.04*VTNR*VTNG)
             VTARG = SQRT(VTAX*VTAX+0.04*VTAR*VTAG)
             RHOGW = (QG1D+QR1D)/(QG1D/RHOG+QR1D/RHOW+ISMALL)
-            RATIO = (RHOGW/DNGRM)**THRD
             STOKE = (RHOW*ABS(VTQ0)*MVDR**2.)/(9.*MUA*MVDG)
             STOKE = MAX(1.5,MIN(10.,STOKE))
             ERG   = 5.5E-1*LOG10(2.51*STOKE)                            ! parameterization based on Cober and List, 1993 [JAS]
@@ -5705,6 +5704,7 @@
                DNGRM = 3.E2*(-5.E5*MVDR*0.6*VTQRG/TC1D)**0.44
             ENDIF
             DNGRM = MIN(MAX(DNGRM,RHOIMIN),RHOG0)
+            RATIO = (RHOGW/DNGRM)**THRD
             IF (MVDG.GE.2.E-4.AND.MVDG.GE.MVDR) THEN
                QRMrg = QRMR1*ERG*VTQRG*NG1D*(GG3*GR4+2.*GG2*GR5+GR6)
                NRMrg = NRMR1*ERG*VTNRG*NG1D*(GG3+2.*GG2*GR2+GR3)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: NTU mp, Floating-point exception

SOURCE: Tzu-Chin Tsai of CWA and internal

DESCRIPTION OF CHANGES:
Problem:
Running the model with ifx compiler gives a floating-point exception error.

Solution:
A fix is identified to fix the error.

LIST OF MODIFIED FILES:
M     phys/module_mp_ntu.F

TESTS CONDUCTED: 
1. With the fix, the code runs well again.
2. Are the Jenkins tests all passing?

RELEASE NOTE: This PR fixes a floating-point exception error identified by ifx, the Intel-oneapi compiler.