### PR TITLE
Fix missing dependencies for new dynamic lightning scheme

### DIFF
--- a/main/depend.common
+++ b/main/depend.common
@@ -2531,6 +2531,9 @@ module_microphysics_driver.o: \
 	module_mp_cammgmp_driver.o \
 	module_irrigation.o \
 	module_mp_fast_sbm.o \
+	module_calc_lpi_new.o \
+	module_ltng_pe.o \
+	module_ltng_strokes.o \
 	../frame/module_driver_constants.o \
 	../frame/module_state_description.o \
 	../frame/module_wrf_error.o \


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: make, dependencies

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
PR #2276 added some new modules that were not included as dependencies in `main/depend.common`

Solution:
Add the new files to the dependencies for the `module_microphysics_driver` object rule

TESTS CONDUCTED: 
1. Tested compilation of idealized cases using `-j 1`