### PR TITLE
updating the MYNN-EDMF pointer and adding 5 optional 2D arrays for do…

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1155,6 +1155,11 @@ state   real   maxwidth         ij     misc        1         -      h         "m
 state   real   ztop_plume       ij     misc        1         -      h         "ztop_plume"       "Height of tallest plume"               "m"
 state   real   excess_h         ij     misc        1         -      h         "excess_h"         "Max heat excess of plume initialization" "K"
 state   real   excess_q         ij     misc        1         -      h         "excess_q"         "Max moisture excess of plume initialization" "kg/kg"
+state   real   maxMF_dd         ij     misc        1         -      h         "maxMF_dd"         "Maximum mass-flux of downdrafts"       "m/s * area"
+state   real   maxwidth_dd      ij     misc        1         -      h         "maxwidth_dd"      "Maximum downdraft width"               "m"
+state   real   maxtkeprod       ij     misc        1         -      h         "maxtkeprod"       "Maximum tke production by clout top cooling" "m2/s2/hr"
+state   real   cldtop_cooling   ij     misc        1         -      h         "cldtop_cooling"   "Radiative cooling at cloud top"        "K/hr"
+state   real   ent_eff          ij     misc        1         -      h         "ent_eff"          "Entrainment efficiency for cloud tops" "unitless"
 
 #FogDES variables
 state   real   fgdp             ij     misc        1         -      -        "fgdp"                "Accumulated fog deposition"    "mm"
@@ -3236,8 +3241,8 @@ package   kepsscheme     bl_pbl_physics==17          -             scalar:tke_ad
 package   mrfscheme      bl_pbl_physics==99          -             -
 
 package   tkebudget      tke_budget==1               -             state:qSHEAR,qBUOY,qDISS,qWT,dqke
-package   mynn_dmp_edmf1 bl_mynn_edmf==1             -             state:ztop_plume,maxmf,maxwidth,excess_h,excess_q
-package   mynn_dmp_edmf2 bl_mynn_edmf==2             -             state:ztop_plume,maxmf,maxwidth,excess_h,excess_q
+package   mynn_dmp_edmf1 bl_mynn_edmf==1             -             state:ztop_plume,maxmf,maxwidth,excess_h,excess_q,maxmf_dd,maxwidth_dd,maxtkeprod,cldtop_cooling,ent_eff
+package   mynn_dmp_edmf2 bl_mynn_edmf==2             -             state:ztop_plume,maxmf,maxwidth,excess_h,excess_q,maxmf_dd,maxwidth_dd,maxtkeprod,cldtop_cooling,ent_eff
 package   mynn_3Doutput1 bl_mynn_output==1           -             state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
 package   mynn_3Doutput2 bl_mynn_output==2           -             state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
 package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl,qi_bl

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1293,7 +1293,9 @@ BENCH_START(pbl_driver_tim)
      &        ,qcg=grid%qcg, grav_settling=config_flags%grav_settling     &
 !    &        ,K_m=grid%K_m, K_h=grid%K_h, K_q=grid%K_q                   &
      &        ,vdfg=grid%vdfg,maxwidth=grid%maxwidth,maxMF=grid%maxmf     &
-     &        ,ztop_plume=grid%ztop_plume                                 &
+     &        ,ztop_plume=grid%ztop_plume,maxmf_dd=grid%maxmf_dd          &
+     &        ,maxtkeprod=grid%maxtkeprod,maxwidth_dd=grid%maxwidth_dd    &
+     &        ,cldtop_cooling=grid%cldtop_cooling,ent_eff=grid%ent_eff    &
      &        ,excess_h=grid%excess_h,excess_q=grid%excess_q              &    
      &        ,spp_pbl=config_flags%spp_pbl                               &
      &        ,pattern_spp_pbl=grid%pattern_spp_pbl                       &

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -64,6 +64,8 @@ CONTAINS
                  ,vdfg                                             &
                  ,maxwidth,maxMF,ztop_plume                        &
                  ,excess_h,excess_q                                &
+                 ,maxmf_dd,maxwidth_dd,maxtkeprod                  &
+                 ,cldtop_cooling,ent_eff                           &
                  ,spp_pbl,pattern_spp_pbl                          &
               ! EEPS
                  ,pek,pep,pek_adv,pep_adv                          &
@@ -615,8 +617,9 @@ CONTAINS
    REAL, DIMENSION( ims:ime , jms:jme ), OPTIONAL,              &
         &    INTENT(INOUT)::                               vdfg
    REAL, OPTIONAL, DIMENSION( ims:ime , jms:jme ),              &
-        &    INTENT(OUT) ::           maxwidth,maxMF,ztop_plume,&
-                                              excess_h,excess_q
+        &    INTENT(OUT) ::          maxwidth,maxMF,ztop_plume, &
+                    maxmf_dd,maxtkeprod,cldtop_cooling,ent_eff, &
+                                 maxwidth_dd,excess_h,excess_q
 
     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ),     &
            INTENT(INOUT) ::         qnwfa_curr,qnifa_curr,qnbca_curr
@@ -1728,7 +1731,9 @@ CONTAINS
                    &sub_thl3D=sub_thl3D,sub_sqv3D=sub_sqv3D,             &
                    &det_thl3D=det_thl3D,det_sqv3D=det_sqv3D,             &
                    &maxwidth=maxwidth,maxMF=maxMF,                       &
-                   &ztop_plume=ztop_plume,                               &
+                   &ztop_plume=ztop_plume,maxmf_dd=maxmf_dd,             &
+                   &maxtkeprod=maxtkeprod,cldtop_cooling=cldtop_cooling, &
+                   &ent_eff=ent_eff,maxwidth_dd=maxwidth_dd,             &
                    &excess_h=excess_h,excess_q=excess_q,                 &
                    &RTHRATEN=RTHRATEN,                                   &
                    &bl_mynn_tkeadvect=bl_mynn_tkeadvect,                 &

--- a/run/README.namelist
+++ b/run/README.namelist
@@ -802,8 +802,10 @@ use_rap_aero_icbc                   = .false.   ! Set to .true. to ingest real-t
  bl_mynn_edmf_tke (max_dom)          = 0,  ! default; = 1 activates TKE transport in MYNN mass-flux scheme 
                                             (assuming bl_mynn_edmf > 0)
                                        0    no TKE transport (default);1: activate TKE transport
- bl_mynn_output (max_dom)            = 0,  ! do not output extra arrays
-                                       1    allocate and output extra 3D arrays from MYNN PBL
+ bl_mynn_edmf_dd (max_dom)	     = 0,  ! default = 0; 1 activates downdraft component in MYNN
+ bl_mynn_output (max_dom)            = 0,  ! default = 0; do not output extra arrays
+                                           ! =1:allocate and output extra 3D arrays from MYNN PBL for mass flux updrafts
+				           ! =2:allocate and output extra 3D arrays from MYNN PBL for mass flux downdrafts
  bl_mynn_mixscalars (max_dom)        = 0   ! off, 1: activate mixing of scalars
  bl_mynn_mixqt (max_dom)             = 0   ! mixing moisture species separately, 1: mixing total water
 


### PR DESCRIPTION
This PR provides a significant update to the downdraft component of the MYNN-EDMF with minor tweaks elsewhere. This submodule update to WRF will be the same version added to the community version of MPAS next. 

TYPE: enhancement

KEYWORDS: MYNN-EDMF, downdrafts, clouds

SOURCE: Joseph Olson (NOAA/GSL)

DESCRIPTION OF CHANGES:
Problem:

1. The downdraft component forced by cloud-top cooling, which has only been lightly tested. 
2. There was also an analytical method for specifying a profile of tke production forced by cloud-top cooling. This has also received limited testing.

Solution:

1. Blend the downdrafts with the analytical profile specification of TKE production to provide one fairly well tested option.
2. Extend the analytical profile method to single-layer fog as well as clouds aloft that are decoupled from the surface. This allows this method to be used in tandem (and consistently) with the downdraft component.
3. Add 5 2d diagnostic variables that have been extremely useful in developing the downdraft component.
4. Related to forecasting clouds in the marine boundary layer, change the max for qnwfa in the common file to have no impact above the marine pbl while still limiting it to reasonable values within the marine pbl--a useful hack to not allow the poor qnwfa specifications from the climatology to create excessive fog over cold coastal waters (i.e., near NY and Boston).

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status release-v4.8.0` to get formatted list)
M       Registry/Registry.EM_COMMON
M       dyn_em/module_first_rk_step_part1.F
M       phys/MYNN-EDMF
M       phys/module_pbl_driver.F
M       run/README.namelist

TESTS CONDUCTED: 
1. Do mods fix problem? Yes. How can that be demonstrated, and was that test conducted? Case studies, with all debug flags used.
5. Are the Jenkins tests all passing?

RELEASE NOTE: The update to the MYNN-EDMF includes a significant revision to the downdraft component, which has undergone development specifically for improving the over-forecasting of fog over cold SSTs.
