### PR TITLE
Include mp_physics=88 in TEMPO error print message

### DIFF
--- a/dyn_em/module_initialize_real.F
+++ b/dyn_em/module_initialize_real.F
@@ -2744,7 +2744,8 @@ integer::oops1,oops2
                  .OR. (config_flags%mp_physics .EQ. TEMPO .AND. config_flags%tempo_aerosolaware .EQ. 1) &
                  .OR. config_flags%mp_physics .EQ. RCON_MP_SCHEME) .and. &
                      config_flags%wif_input_opt .EQ. 0 ) THEN
-               CALL wrf_error_fatal ('wif_input_opt=0 but mp_physics=28 or mp_physics=29' )
+               CALL wrf_error_fatal ( & 
+               'wif_input_opt=0 but mp_physics=28, 29, or 88' )
             END IF if_thompsonaero_3d
 
 !=========================================================================================


### PR DESCRIPTION
TYPE: text only

KEYWORDS: TEMPO, mp_physics=88, module_initialize_real, print, error

SOURCE: Internal

DESCRIPTION OF CHANGES:
Problem:
Previously-added code to module_initialize_real checked to ensure if using TEMPO microphysics (option 88) with tempo_hailware=1 and tempo_aerosolaware=1, without setting  wif_input_opt=1, the model stopped with a fatal error. However, the error message only implied the user set mp_physics to 28 or 29.

Solution:
Included mp_physics=88 in the error message

LIST OF MODIFIED FILES: 
M     dyn_em/module_initialize_real.F

TESTS CONDUCTED: 
1. Mods fix the problem. Running real.exe now gives an error message that includes an mp_physics=88 (TEMPO) setting.
2. The Jenkins tests are all passing with text only change.
