### PR TITLE
Fixing a scheme-guard bug in urban NbS initialization

### DIFF
--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -3822,8 +3822,7 @@ ENDIF
       XXXR_URB2D(I,J)=0.
       XXXB_URB2D(I,J)=0.
       XXXG_URB2D(I,J)=0.
-      XXXC_URB2D(I,J)=0.
-      XXXVG_URB2D(I,J)=0. ! add in urban-nbs										
+      XXXC_URB2D(I,J)=0.										
 
       IF ( sf_urban_physics == 1 ) THEN
       DRELR_URB2D(I,J) = 0.
@@ -3838,7 +3837,8 @@ ENDIF
       CMCG_URB2D(I,J)  = 0. ! add in urban-nbs										  
       TGR_URB2D(I,J)=TSURFACE0_URB(I,J)+0.
       TVG_URB2D(I,J)=TSURFACE0_URB(I,J)+0.  ! add in urban-nbs
-      TT_URB2D(I,J) =TSURFACE0_URB(I,J)+0.  ! add in urban-nbs														  														  
+      TT_URB2D(I,J) =TSURFACE0_URB(I,J)+0.  ! add in urban-nbs	
+      XXXVG_URB2D(I,J)=0. ! add in urban-nbs	  
       ENDIF
 
       TC_URB2D(I,J)=TSURFACE0_URB(I,J)+0.


### PR DESCRIPTION
**Fixing a scheme-guard bug in urban NbS initialization**

TYPE: bug fix

KEYWORDS: WRF-urban, nature-based solutions

SOURCE: Chenghao Wang (University of Oklahoma)

Problem:
With the new NbS code merged, runs using Noah-MP + SLUCM (`sf_urban_physics=1`) work as expected, but runs using Noah-MP + BEP/BEM (`sf_urban_physics=2/3`) fail. In the failing configurations, the model aborts early with allocator/HDF5 errors such as corrupted double-linked list or malloc-related aborts.

Solution:
We moved `XXXVG_URB2D` initialization into that same SLUCM-only (`sf_urban_physics == 1`) block for consistency with the other NbS fields.
For BEP/BEP+BEM (`sf_urban_physics = 2/3`), NbS SLUCM-only arrays may be unallocated. Writing to an unallocated field can corrupt heap metadata. The corruption may not fail immediately and can later appear as an HDF5/malloc abort (e.g., corrupted double-linked list) when opening `wrfbdy_d01`. This change prevents that invalid write path.

LIST OF MODIFIED FILES: 
M     phys/module_sf_urban.F

TESTS CONDUCTED: 
Successful nested WRF run with NoahMP + BEP/BEM

RELEASE NOTE: Supplementary to PR-2272.