### PR TITLE
Correcting a value in equation of time formula for solar radiation

### DIFF
--- a/phys/module_diag_functions.F
+++ b/phys/module_diag_functions.F
@@ -1166,7 +1166,7 @@ CONTAINS
     !  -----------------
     real                :: tdK      !~ Dewpoint temperature ( K )
     real                :: tC       !~ Temperature ( C )
-    real                :: tdC      !~ Dewpoint temperature ( K )
+    real                :: tdC      !~ Dewpoint temperature ( C )
     real                :: svapr    !~ Saturation vapor pressure ( Pa )
     real                :: vapr     !~ Ambient vapor pressure ( Pa )
     real                :: gamma    !~ Dummy term

--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11689,7 +11689,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
          else
 !            da=6.2831853071795862*(julian-1)/365.
 !            eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
-!               -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+!               -0.014615*cos(2*da)-0.040849*sin(2*da))*(229.18)
             xt24 = mod(xtime+radt*0.5,1440.)+eot
             tloctm = gmt + xt24/60. + xlong(i,j)/15.
             hrang = 15. * (tloctm-12.) * degrad

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -3526,7 +3526,7 @@ CONTAINS
 
        da=6.2831853071795862*(julian-1)/365.
        eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
-            -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+            -0.014615*cos(2*da)-0.040849*sin(2*da))*(229.18)
        xt24=mod(xtime,1440.)+eot
        do j=jts,jte
           do i=its,ite

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -907,7 +907,7 @@ SUBROUTINE write_ts( grid )
                                  grid%ts_clw(n,i)
             ELSE
                !!! WRF-Solar diagnostics
-               WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,49(f13.5,1x))')  &
+               WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,50(f13.5,1x))')  &
                                  grid%id, grid%ts_hour(n,i),                &
                                  grid%id_tsloc(i), ix, iy,                  &
                                  grid%ts_t(n,i),                            &


### PR DESCRIPTION


TYPE: bug fix

KEYWORDS: Equation of Time parameter had typo (minor)

SOURCE: internal via MPAS reviewer 

DESCRIPTION OF CHANGES:
Problem:
A number did not match the reference. 

ISSUE: 

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M       phys/module_ra_rrtmg_swf.F (this change applies to a commented out line in this module).
M       phys/module_radiation_driver.F
(note that other files show up but those fixes are already on master)

TESTS CONDUCTED: 
Derecho compilation (option 50)

RELEASE NOTE: minor fix to equation of time (little effect expected).
