### PR TITLE
correction for eot calculation for solar radiation

### DIFF
--- a/phys/module_ra_rrtmg_swf.F
+++ b/phys/module_ra_rrtmg_swf.F
@@ -11689,7 +11689,7 @@ write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
          else
 !            da=6.2831853071795862*(julian-1)/365.
 !            eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
-!               -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+!               -0.014615*cos(2*da)-0.040849*sin(2*da))*(229.18)
             xt24 = mod(xtime+radt*0.5,1440.)+eot
             tloctm = gmt + xt24/60. + xlong(i,j)/15.
             hrang = 15. * (tloctm-12.) * degrad

--- a/phys/module_radiation_driver.F
+++ b/phys/module_radiation_driver.F
@@ -3524,9 +3524,9 @@ CONTAINS
        integer :: i,j
        real    :: da,eot,xt24,tloctm,xxlat
 
-       da=6.2831853071795862*(julian-1)/365.
+       da=6.2831853071795862*(julian-0.5)/365.
        eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
-            -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+            -0.014615*cos(2*da)-0.040849*sin(2*da))*(229.18)
        xt24=mod(xtime,1440.)+eot
        do j=jts,jte
           do i=its,ite


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: eot, radiation

SOURCE: internal

DESCRIPTION OF CHANGES:
Fractional year and a parameter used in Equation of Time calculation did match the reference (https://gml.noaa.gov/grad/solcalc/solareqns.PDF). This PR fixes both. 

LIST OF MODIFIED FILES: 
M      phys/module_radiation_driver.F
M      phys/module_ra_rrtmg_swf.F (this line is commented out)

TESTS CONDUCTED: 
1. The eot now matches the reference equation.
2. Are the Jenkins tests all passing?

RELEASE NOTE: This PR fixes fractional year calculation and a parameter used in the equation.