### PR TITLE
fix a vectorization option in AOCC stanza

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -2092,9 +2092,8 @@ RWORDSIZE       =       CONFIGURE_RWORDSIZE
 
 AMDARCH         =       -march=znver3
 AMDMATHLIB      =       -fveclib=AMDLIBM
-AMDLDFLAGS      =       -Wl,-mllvm -Wl,-enable-loop-reversal -Wl,-mllvm -Wl,-enable-gather -Wl,-mllvm -Wl,-vectorize-noncontigous-memory-aggressively
+AMDLDFLAGS      =       -Wl,-mllvm -Wl,-enable-loop-reversal -Wl,-mllvm -Wl,-enable-gather -Wl,-mllvm -Wl,-vectorize-non-contiguous-memory-aggressively
 AMDFCFLAGS      =
-
 PROMOTION       =       #-fdefault-real-8
 ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM -DRPC_TYPES=2
 CFLAGS_LOCAL    =       -w -c -m64 -Ofast -ffast-math $(AMDARCH)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: AOCC, vectorization

SOURCE: Will Hatheway

DESCRIPTION OF CHANGES:
Problem:
The AOCC stanza in arch/configure.defaults contains a misspelled LLVM optimizer option. This PR provides the fix.

LIST OF MODIFIED FILES:
M     arch/configure.defaults

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
