### PR TITLE
updating MYNN-EDMF pointer and removing icloud_bl package

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -1157,7 +1157,7 @@ state   real   excess_h         ij     misc        1         -      h         "e
 state   real   excess_q         ij     misc        1         -      h         "excess_q"         "Max moisture excess of plume initialization" "kg/kg"
 state   real   maxMF_dd         ij     misc        1         -      h         "maxMF_dd"         "Maximum mass-flux of downdrafts"       "m/s * area"
 state   real   maxwidth_dd      ij     misc        1         -      h         "maxwidth_dd"      "Maximum downdraft width"               "m"
-state   real   maxtkeprod       ij     misc        1         -      h         "maxtkeprod"       "Maximum tke production by clout top cooling" "m2/s2/hr"
+state   real   maxtkeprod       ij     misc        1         -      h         "maxtkeprod"       "Maximum tke production by cloud top cooling" "m2/s2/hr"
 state   real   cldtop_cooling   ij     misc        1         -      h         "cldtop_cooling"   "Radiative cooling at cloud top"        "K/hr"
 state   real   ent_eff          ij     misc        1         -      h         "ent_eff"          "Entrainment efficiency for cloud tops" "unitless"
 
@@ -3229,7 +3229,7 @@ package   ysuscheme      bl_pbl_physics==1           -             -
 package   myjpblscheme   bl_pbl_physics==2           -             state:tke_pbl,el_pbl
 package   gfsscheme      bl_pbl_physics==3           -             -
 package   qnsepblscheme  bl_pbl_physics==4           -             state:tke_pbl,el_pbl,massflux_EDKF,entr_EDKF,detr_EDKF,thl_up,thv_up,rv_up,rt_up,rc_up,u_up,v_up,frac_up,rc_mf
-package   mynnpblscheme  bl_pbl_physics==5           -             scalar:qke_adv;state:qke,sh3d,sm3d,tsq,qsq,cov,el_pbl,tke_pbl
+package   mynnpblscheme  bl_pbl_physics==5           -             scalar:qke_adv;state:qke,sh3d,sm3d,tsq,qsq,cov,cldfra_bl,qc_bl,qi_bl,el_pbl,tke_pbl
 package   acmpblscheme   bl_pbl_physics==7           -             -
 package   boulacscheme   bl_pbl_physics==8           -             state:el_pbl,tke_pbl,wu_tur,wv_tur,wt_tur,wq_tur
 package   camuwpblscheme bl_pbl_physics==9           -             state:tauresx2d,tauresy2d,tpert2d,qpert2d,wpert2d,tke_pbl,smaw3d,wsedl3d,turbtype3d
@@ -3245,7 +3245,6 @@ package   mynn_dmp_edmf1 bl_mynn_edmf==1             -             state:ztop_pl
 package   mynn_dmp_edmf2 bl_mynn_edmf==2             -             state:ztop_plume,maxmf,maxwidth,excess_h,excess_q,maxmf_dd,maxwidth_dd,maxtkeprod,cldtop_cooling,ent_eff
 package   mynn_3Doutput1 bl_mynn_output==1           -             state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
 package   mynn_3Doutput2 bl_mynn_output==2           -             state:edmf_a,edmf_w,edmf_thl,edmf_qt,edmf_ent,edmf_qc,sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
-package   pbl_cloud      icloud_bl==1                -             state:cldfra_bl,qc_bl,qi_bl
 
 package   sms_3dtke      km_opt==5                   -             state:gamu,gamv,nlflux,dlk,l_diss,elmin,xkmv_meso
 

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -1271,7 +1271,6 @@ BENCH_START(pbl_driver_tim)
      &        ,tke_budget=config_flags%tke_budget                         &
      &        ,bl_mynn_cloudpdf=config_flags%bl_mynn_cloudpdf             &
      &        ,bl_mynn_mixlength=config_flags%bl_mynn_mixlength           &
-     &        ,icloud_bl=config_flags%icloud_bl                           &
      &        ,qc_bl=grid%qc_bl,qi_bl=grid%qi_bl,cldfra_bl=grid%cldfra_bl &
      &        ,bl_mynn_edmf=config_flags%bl_mynn_edmf                     &
               ,bl_mynn_edmf_dd=config_flags%bl_mynn_edmf_dd               &

--- a/phys/module_pbl_driver.F
+++ b/phys/module_pbl_driver.F
@@ -51,7 +51,7 @@ CONTAINS
                  ,dqke,qWT,qSHEAR,qBUOY,qDISS,tke_budget           &
                  ,bl_mynn_closure,bl_mynn_cloudpdf                 &
                  ,bl_mynn_mixlength                                &
-                 ,icloud_bl,qc_bl,qi_bl,cldfra_bl                  &
+                 ,qc_bl,qi_bl,cldfra_bl                            &
                  ,bl_mynn_edmf,bl_mynn_edmf_dd                     &
                  ,bl_mynn_edmf_mom,bl_mynn_edmf_tke                &
                  ,bl_mynn_mixscalars,bl_mynn_mixaerosols           &
@@ -605,7 +605,6 @@ CONTAINS
                                      bl_mynn_cloudmix,         &
                                      bl_mynn_mixqt,            &
                                      bl_mynn_ess,              &
-                                     icloud_bl,                &
                                      tke_budget
 
    REAL, OPTIONAL, INTENT(IN)  :: bl_mynn_closure
@@ -1740,7 +1739,6 @@ CONTAINS
                    &tke_budget=tke_budget,                               &
                    &bl_mynn_cloudpdf=bl_mynn_cloudpdf,                   &
                    &bl_mynn_mixlength=bl_mynn_mixlength,                 &
-                   &icloud_bl=icloud_bl,                                 &
                    &bl_mynn_edmf=bl_mynn_edmf,                           &
                    &bl_mynn_edmf_dd=bl_mynn_edmf_dd,                     &
                    &bl_mynn_edmf_mom=bl_mynn_edmf_mom,                   &


### PR DESCRIPTION
This PR makes the MYNN-EDMF in WRF consistent with the ongoing PR to get the MYNN-EDMF into MPAS.

TYPE: update MYNN-EDMF pointer, feature removed

KEYWORDS: MYNN-EDMF, icloud_bl

SOURCE: Joseph Olson (NOAA-GSL)

DESCRIPTION OF CHANGES:
Problem:
1. Need to sync the versions of the MYNN-EDMF linked to WRF and MPAS
2. "icloud_bl" is not used in MPAS. Instead, the coupling of the MYNN-EDMF clouds to the radiation uses a different flag (config_radt_cld_scheme = "cld_fraction_mynn") in the cloudiness driver. In WRF, icloud_bl is still used to determine the coupling to radiation, but we no longer need to use icloud_bl to allocate the subgrid cloud arrays (qc_bl, qi_bl, and cldfra_bl). They are now moved to the MYNN-EDMF package. This just simplifies the code and we no longer need to pipe icloud_bl into the MYNN-EDMF scheme.

Solution:
Update the MYNN-EDMF pointer and remove the additional icloud_bl-related package.

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
M Registry/Registry.EM_COMMON
M dyn_em/module_first_rk_step_part1.F
M phys/MYNN-EDMF
M phys/module_pbl_driver.F