### PR TITLE
Turn off tempo_aerosolaware and tempo_hailaware in Registry

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -2443,8 +2443,8 @@ rconfig   integer  nssl_3moment           namelist,physics      1             0 
 rconfig   integer  nssl_density_on        namelist,physics      1            -1       rh       "NSSL graupel/hail density flag"  ""      ""
 rconfig   integer  nssl_ssat_output       namelist,physics      1             0       rh       "NSSL ssat output flag"  ""      ""
 
-rconfig   integer  tempo_aerosolaware     namelist,physics      1             1       rh       "TEMPO aerosol-aware flag"  ""      ""
-rconfig   integer  tempo_hailaware        namelist,physics      1             1       rh       "TEMPO hail-aware flag"  ""      ""
+rconfig   integer  tempo_aerosolaware     namelist,physics      1             0       rh       "TEMPO aerosol-aware flag"  ""      ""
+rconfig   integer  tempo_hailaware        namelist,physics      1             0       rh       "TEMPO hail-aware flag"  ""      ""
 
 rconfig   integer     CCNTY               namelist,physics      1            2        rh       "Aerosol background type for NTU microphysics"  ""   ""
 


### PR DESCRIPTION
TYPE: text only

KEYWORDS: TEMPO, tempo_aerosolaware, tempo_hailaware

SOURCE: internal

DESCRIPTION OF CHANGES:
Options to use aerosol and 2-mom hail are turned off by default. To turn either of them on, set tempo_aerosolaware = 1 and tempo_hailaware = 1 in &hysics namelist record.

LIST OF MODIFIED FILES: 
M      Registry/Registry.EM_COMMON

TESTS CONDUCTED: 
Are the Jenkins tests all passing?

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
