### PR TITLE
Fix incorrect qrn gradient scaling in WRFDA radial velocity adjoint

### DIFF
--- a/var/da/da_radar/da_radial_velocity_adj.inc
+++ b/var/da/da_radar/da_radial_velocity_adj.inc
@@ -4,6 +4,7 @@ subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9,rho)
    ! Purpose: adjoint of da_radial_velocity_lin
    ! History:
    !    08/2017 - bug fix for Vt (Siou-Ying Jiang, CWB, Taiwan)
+   !    06/2026 - bug fix for qrn adjoint gradient scaling (Weiyu Yang, NUIST, China)
    !-----------------------------------------------------------------------
 
    implicit none
@@ -20,7 +21,7 @@ subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9,rho)
    real :: qrrc
    real :: qrn_g, qrn9_g
 
-   qrn_g = qrn *1000. ! kg/kg -> g/kg
+   qrn_g = 0.0        ! Initialize the local adjoint accumulator to 0.0 here
    qrn9_g= qrn9*1000. ! kg/kg -> g/kg
    qrrc = 0.01        ! g/kg
 
@@ -37,7 +38,7 @@ subroutine da_radial_velocity_adj(rv,p,u,v,w,qrn,ps,x,y,z,qrn9,rho)
 
    if (qrn9_g >  qrrc) then
       qrn_g = qrn_g + vt*0.675*alpha*qrn9_g**(-0.875)*rho**0.125
-      qrn   = qrn_g * 0.001  ! g/kg -> kg/kg
+      qrn   = qrn + qrn_g * 1000.  ! Proper adjoint accumulation following the transpose logic (* 1000.0)
    end if
 
    if (trace_use) call da_trace_exit("da_radial_velocity_adj")


### PR DESCRIPTION
Fix incorrect gradient scaling of rain mixing ratio in WRFDA radial velocity adjoint

**TYPE:** 
bug fix

**KEYWORDS:** 
WRFDA, radar, radial velocity, adjoint, tangent linear, gradient, rain mixing ratio

**SOURCE:** 
Weiyu Yang (Nanjing University of Information Science and Technology)

**DESCRIPTION OF CHANGES:**
**Problem:**
In the WRFDA radial velocity tangent linear code, the rain mixing ratio (`qrn`) is scaled by a factor of 1000 (`qrn_g = qrn * 1000.`). According to the strict definition of an adjoint operator (the transpose of the tangent linear operator), the backward propagation of the gradient must also be scaled by 1000 and accumulated. However, the current official adjoint code (`da_radial_velocity_adj.inc`) incorrectly applies an inverse operation (`qrn = qrn_g * 0.001`) instead of the transpose operation. This scales the gradient incorrectly by a factor of $10^{-6}$ compared to the true analytical adjoint, causing the traditional Adjoint Test to fail significantly.

**Solution:**
Modified the source code to strictly follow the mathematical transpose logic of the tangent linear operator:
1. Initialized the local adjoint accumulator `qrn_g` to `0.0`.
2. Replaced the inverse operation with a proper adjoint accumulation: `qrn = qrn + qrn_g * 1000.0`.

**ISSUE:** 
N/A

**LIST OF MODIFIED FILES:** 
M       var/da/da_radar/da_radial_velocity_adj.inc

**TESTS CONDUCTED:** 
1. Conducted an independent Tangent Linear (TL) and Adjoint (AD) test using double-precision (`real*8`). Before the fix, the adjoint test failed because the analytical gradient was scaled by 0.001 instead of 1000. After the fix, the test passed perfectly. The inner products `(Hx)^T * (Hx)` and `x^T * H^T * (Hx)` match exactly up to 15-16 significant digits (the machine precision limit) across perturbation scales from $10^{-1}$ to $10^{-10}$.
2. The code compiles successfully. 

**RELEASE NOTE:** 
Fixed a gradient calculation bug in the WRFDA radial velocity adjoint operator (`da_radial_velocity_adj.inc`). The sensitivities of the rain mixing ratio (`qrn`) were previously scaled incorrectly due to the use of an inverse operation instead of a mathematical transpose operation. This fix ensures the strict accuracy of the adjoint gradient for radar radial velocity assimilation.