### PR TITLE
Fix dust optical averaging mass index

### DIFF
--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -4157,7 +4157,7 @@ END subroutine optical_prep_modal_soa_vbs
                        (ref_index_nh4no3 * mass_no3 / dens_no3) +  &
                        (ref_index_nh4no3 * mass_nh4 / dens_nh4) +  &
                        (ref_index_oin    * mass_oin / dens_oin) +  &
-                       (lwref_index_dust(ns)    * mass_oin / dens_dust)  +  &
+                       (lwref_index_dust(ns)    * mass_soil / dens_dust)  +  &
                        (lwref_index_oc(ns)     * mass_oc  / dens_oc) +   &
                        (lwref_index_nacl(ns)   * mass_na  / dens_na) +   &
                        (lwref_index_nacl(ns)   * mass_cl  / dens_cl) +   &


### PR DESCRIPTION
Fixed GOCART longwave aerosol refractive-index mixing.

TYPE: bug fix

KEYWORDS: WRF-Chem, GOCART, aerosol optics, longwave radiation, refractive index, dust

SOURCE: Alexander Ukhov (KAUST)

DESCRIPTION OF CHANGES:

Problem:
The GOCART aerosol optical preparation routine had an inconsistency in the longwave shell refractive-index calculation.

The longwave dust contribution in the shell refractive-index blend used mass_oin with dens_dust. In optical_prep_gocart, mass_oin represents the non-dust inorganic aerosol mass, while GOCART dust (DUST_1 ... DUST_5) is redistributed into mass_soil. The corresponding shortwave shell blend and the full-particle longwave blend both use mass_soil for the dust contribution.

Solution:
Updated the longwave shell refractive-index blend in optical_prep_gocart to use mass_soil for the dust refractive-index contribution.

LIST OF MODIFIED FILES:
M chem/module_optical_averaging.F

TESTS CONDUCTED:

Ran WRF-Chem GOCART (chem_opt=301) aerosol optical calculations before and after the correction.

Instantaneous 550 nm AOD before and after the GOCART longwave refractive-index correction. 
Diagnostic plots show that the impact on instantaneous 550 nm AOD is small, with spatial differences generally within a few percent. This is expected because the fix is in the longwave refractive-index mixing and does not directly target the shortwave 550 nm AOD diagnostic.

<img width="4860" height="2040" alt="clear_sky_dust_optical_averaging_bug_aod_550nm_instant_response_2016-07" src="https://github.com/user-attachments/assets/ed1781f9-7098-4adf-a051-8f95410bad8b" />

The radiative diagnostics show a clearer response for a selected strong-response time, 2016-07-31_08:00:00. The corrected calculation changes clear-sky dust radiative effects at TOA, BOA, and in the atmospheric column.  The atmospheric column dust forcing is mainly positive where dust loading is large.  The percent differences are spatially localized but demonstrate that the longwave refractive-index inconsistency can affect instantaneous domain-averaged heating rates and clear-sky dust forcing diagnostics even when AOD changes are modest.

<img width="4860" height="4500" alt="clear_sky_dust_optical_averaging_bug_column_forcing_2016-07" src="https://github.com/user-attachments/assets/7da3b98e-4b34-480b-b7a1-956fb14d4f0e" />

<img width="4860" height="4500" alt="clear_sky_dust_optical_averaging_bug_toa_forcing_2016-07" src="https://github.com/user-attachments/assets/0903bebd-03fd-490c-ba0b-fa3aaaa44ae6" />

<img width="4860" height="4500" alt="clear_sky_dust_optical_averaging_bug_boa_forcing_2016-07" src="https://github.com/user-attachments/assets/6d35ede4-efbd-4caf-85d6-d5a74d768dde" />

The corrected calculation produces localized changes in clear-sky dust radiative effects. In the inspected case, the BOA net dust forcing is mostly negative because SW surface dimming dominates the weak positive LW surface effect. The atmospheric-column forcing is mostly positive because SW atmospheric domain-averaged heating dominates weak LW cooling. TOA forcing is spatially mixed, with positive and negative regions depending on surface/background conditions and dust loading.

The correction produces localized changes in domain-averaged LW/SW heating rates and in TOA, BOA, and column dust forcing, with the strongest response at 2016-07-31_08:00:00 UTC.

The domain-averaged LW dust heating-rate contribution is negative, the SW contribution is positive and dominates the net atmospheric heating-rate profile,

<img width="3600" height="4140" alt="clear_sky_dust_optical_averaging_bug_heating_rate_instant_response_2016-07" src="https://github.com/user-attachments/assets/bc07329d-09c6-41bc-88be-943c975a74f7" />

RELEASE NOTE:
Fixed a GOCART aerosol longwave optical-property mixing inconsistency in WRF-Chem.