### PR TITLE
CFBM: Refinements in the level set

### DIFF
--- a/phys/module_physics_addtendc.F
+++ b/phys/module_physics_addtendc.F
@@ -2151,8 +2151,7 @@ SUBROUTINE phy_fr_ten(config_flags,rk_step,n_moist,            &
                       ims, ime, jms, jme, kms, kme,              &
                       its, ite, jts, jte, kts, kte               )
 !-----------------------------------------------------------------
-   USE module_state_description, ONLY :                         &
-                   FIRE_SFIRE
+   USE module_state_description, ONLY : FIRE_SFIRE
 !-----------------------------------------------------------------
    IMPLICIT NONE
 !-----------------------------------------------------------------


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: CFBM, fire propagation, default settings

SOURCE: Pedro A. Jimenez (NCAR)

DESCRIPTION OF CHANGES:
Problem:
There are instabilities in the methods used to determine the fire propagation

Solution:
1. We updated the default value of a namelist variable, the pseudo time step coefficient for the level set reinitialization
2. We use the previous ENO method to solve the level set equation

LIST OF MODIFIED FILES: We only updated the hash of the fire_behavior git submodule

TESTS CONDUCTED: 
The Jenkins tests are all passing.

RELEASE NOTE: This PR refined methods for the fire propagation in the CFBM.
