### PR TITLE
Bug fix in UDM MP

### DIFF
--- a/phys/module_mp_udm.F
+++ b/phys/module_mp_udm.F
@@ -5,8 +5,8 @@
 !! author Songyou Hong [hong@ucar.edu, songyouhong@gmail.com]
 !!
   module module_mp_udm
-   use module_mp_radar
-   use module_gfs_machine , only : kind_phys
+  use module_mp_radar
+  use module_gfs_machine , only : kind_phys
 !
 !-------------------------------------------------------------------------------
 ! parameters for microphysical processes

--- a/phys/module_mp_udm.F
+++ b/phys/module_mp_udm.F
@@ -2533,7 +2533,7 @@ subroutine udm2d(t1, q1                                          &
 !
      do n = 1, niter
        do k = ktop, kts, -1
-         if(qrs(k,i,1)>qrmin) then
+         if(qrs(k,i,1)>0.) then
            denqr(k) = dend(k,i)*qrs(k,i,1)
            denqn(k) = dend(k,i)*ncr(k,i,3)
          else
@@ -2549,13 +2549,8 @@ subroutine udm2d(t1, q1                                          &
        call semi_lagrangian(1,kdim,max(ktop,2),dend(:,i),denfac(:,i),t(:,i),   &
             delz(:,i),vtn(:),denqn(:),qnpath,dtcfl,lat,i)
        do k = ktop, kts, -1
-         if(denqr(k)>qrmin) then
-           qrs(k,i,1) = max(denqr(k)/dend(k,i),0.)
-           ncr(k,i,3) = max(denqn(k)/dend(k,i),0.)
-         else
-           qrs(k,i,1) = 0.0
-           ncr(k,i,3) = 0.0
-         endif
+         qrs(k,i,1) = max(denqr(k)/dend(k,i),0.)
+         ncr(k,i,3) = max(denqn(k)/dend(k,i),0.)
        enddo
 !
        precip_r = qrpath/dtcld + precip_r   ! [kgm-2s-1]


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: UDM, rain calculation 

SOURCE:  Songyou Hong

DESCRIPTION OF CHANGES:
Problem:
UDM MP occasionally produces unphysical rain rates. 

Solution:
Allow tiny values of rain drops (qr < 1.e-9) to be sedimented 

LIST OF MODIFIED FILES:  
M       module_mp_udm.F

TESTS CONDUCTED: 
1. This PR fixes the issue in 4.8 UDM MP testing.
2. The Jenkins tests are all passing.

RELEASE NOTE: This PR fixes out-of-bound rainfall calculation in UDM microphysics which happens occasionally. 
