### PR TITLE
Bug fix in WDM7

### DIFF
--- a/phys/module_mp_udm.F
+++ b/phys/module_mp_udm.F
@@ -5,8 +5,8 @@
 !! author Songyou Hong [hong@ucar.edu, songyouhong@gmail.com]
 !!
   module module_mp_udm
-   use module_mp_radar
-   use module_gfs_machine , only : kind_phys
+  use module_mp_radar
+  use module_gfs_machine , only : kind_phys
 !
 !-------------------------------------------------------------------------------
 ! parameters for microphysical processes

--- a/phys/module_mp_udm.F
+++ b/phys/module_mp_udm.F
@@ -2533,7 +2533,7 @@ subroutine udm2d(t1, q1                                          &
 !
      do n = 1, niter
        do k = ktop, kts, -1
-         if(qrs(k,i,1)>qrmin) then
+         if(qrs(k,i,1)>0.) then
            denqr(k) = dend(k,i)*qrs(k,i,1)
            denqn(k) = dend(k,i)*ncr(k,i,3)
          else
@@ -2549,13 +2549,8 @@ subroutine udm2d(t1, q1                                          &
        call semi_lagrangian(1,kdim,max(ktop,2),dend(:,i),denfac(:,i),t(:,i),   &
             delz(:,i),vtn(:),denqn(:),qnpath,dtcfl,lat,i)
        do k = ktop, kts, -1
-         if(denqr(k)>qrmin) then
-           qrs(k,i,1) = max(denqr(k)/dend(k,i),0.)
-           ncr(k,i,3) = max(denqn(k)/dend(k,i),0.)
-         else
-           qrs(k,i,1) = 0.0
-           ncr(k,i,3) = 0.0
-         endif
+         qrs(k,i,1) = max(denqr(k)/dend(k,i),0.)
+         ncr(k,i,3) = max(denqn(k)/dend(k,i),0.)
        enddo
 !
        precip_r = qrpath/dtcld + precip_r   ! [kgm-2s-1]

--- a/phys/module_mp_wdm7.F
+++ b/phys/module_mp_wdm7.F
@@ -472,6 +472,7 @@ CONTAINS
         lamdc_tmp
   REAL, DIMENSION( its:ite , kts:kte ) ::                         &
         falkc, work1c, work2c, fallc
+  real, dimension(its:ite,kts:kte)   :: dqr,dnr
   REAL, DIMENSION( its:ite , kts:kte ) ::                         &
         pcact, prevp, psdep, pgdep, phdep, praut, psaut, pgaut,   &
         phaut, pracw, psacw, pgacw, phacw, pgaci, pgacr, pgacs,   &
@@ -830,10 +831,14 @@ CONTAINS
               falkn(i,k) = ncr(i,k,3)*workn(i,k)/mstep(i)
               fall(i,k,1) = fall(i,k,1)+falk(i,k,1)
               falln(i,k) = falln(i,k)+falkn(i,k)
-              qrs(i,k,1) = max(qrs(i,k,1)-(falk(i,k,1)-falk(i,k+1,1)           &
-                          *delz(i,k+1)/delz(i,k))*dtcld/den(i,k),0.)
-              ncr(i,k,3) = max(ncr(i,k,3)-(falkn(i,k)-falkn(i,k+1)*delz(i,k+1) &
-                          /delz(i,k))*dtcld,0.)
+              dqr(i,k) = min(falk(i,k,1)*dtcld/den(i,k),qrs(i,k,1))
+              dqr(i,k+1) = min(falk(i,k+1,1)*delz(i,k+1)/delz(i,k)              &
+                           *dtcld/den(i,k),qrs(i,k+1,1))
+              dnr(i,k) = min(falkn(i,k)*dtcld,ncr(i,k,3))
+              dnr(i,k+1) = min(falkn(i,k+1)*delz(i,k+1)/delz(i,k)*dtcld,        &
+                           ncr(i,k+1,3))
+              qrs(i,k,1) = max(qrs(i,k,1)-dqr(i,k)+dqr(i,k+1),0.)
+              ncr(i,k,3) = max(ncr(i,k,3)-dnr(i,k)+dnr(i,k+1),0.)
             endif
           enddo
         enddo
@@ -1634,15 +1639,18 @@ CONTAINS
 !
 ! pgwet: wet growth of graupel [LFO 43]
 !
-          rs0 = psat*exp(log(ttp/t0c)*xa)*exp(xb*(1.-ttp/t0c))
-          rs0 = min(rs0,0.99*p(i,k))
-          rs0 = ep2*rs0/(p(i,k)-rs0)
-          rs0 = max(rs0,qmin)
-          ghw1 = den(i,k)*hvap*diffus(t(i,k),p(i,k))*(rs0-q(i,k))              &
-               - xka(t(i,k),den(i,k))*(-supcol)
-          ghw2 = den(i,k)*(xlf0+cliq*(-supcol))
-          ghw3 = venfac(p(i,k),t(i,k),den(i,k))*sqrt(sqrt(g*den(i,k)/den0))
-          ghw4 = den(i,k)*(xlf0-cliq*supcol+cice*supcol)
+
+          if(qrs(i,k,4).gt.qcrmin.and.qrs(i,k,3).gt.qcrmin) then
+            rs0 = psat*exp(log(ttp/t0c)*xa)*exp(xb*(1.-ttp/t0c))
+            rs0 = min(rs0,0.99*p(i,k))
+            rs0 = ep2*rs0/(p(i,k)-rs0)
+            rs0 = max(rs0,qmin)
+            ghw1 = den(i,k)*hvap*diffus(t(i,k),p(i,k))*(rs0-q(i,k))            &
+                 - xka(t(i,k),den(i,k))*(-supcol)
+            ghw2 = den(i,k)*(xlf0+cliq*(-supcol))
+            ghw3 = venfac(p(i,k),t(i,k),den(i,k))*sqrt(sqrt(g*den(i,k)/den0))
+            ghw4 = den(i,k)*(xlf0-cliq*supcol+cice*supcol)
+          endif
           if(qrs(i,k,3).gt.qcrmin) then
             if(pgaci(i,k).gt.0.0) then
               egi = exp(0.07*(-supcol))
@@ -1655,6 +1663,13 @@ CONTAINS
                         +ghw4*(pgaci_w(i,k)+pgacs(i,k)))
             pgwet(i,k) = max(pgwet(i,k), 0.0)
           endif
+!
+!  graupel is assumed to increase in density upon reaching wet growth
+!
+         if(pgacw(i,k)+pgacr(i,k)<0.95*pgwet(i,k)) then
+           pgaci(i,k) = 0.0
+           pgacs(i,k) = 0.0
+         endif
 !
 ! phwet: wet growth of hail [LFO 43] 
 !
@@ -1670,6 +1685,14 @@ CONTAINS
                       +prech3*ghw3*rslope(i,k,4)**(2.75)                       &
                       +ghw4*(phaci_w(i,k)+phacs(i,k)))
           phwet(i,k) = max(phwet(i,k), 0.0)
+!
+!  hail is assumed to increase in density upon reaching wet growth
+!
+          if(phacw(i,k)+phacr(i,k)<0.95*phwet(i,k)) then
+            phaci(i,k) = 0.0
+            phacs(i,k) = 0.0
+            phacg(i,k) = 0.0
+          endif
           if(supcol.le.0) then
             xlf = xlf0
 !


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: WDM7, Sedimentation, Hail

SOURCE: Songyou Hong

DESCRIPTION OF CHANGES:
Problem:
Sedimentation of raindrop in WDM7 does not check the mass conservation.
Dry growth of hail needs to be updated.

Solution:
Sedimentation of rain checks the mass conservation.
Dry growth of hail waits for the wet growth of hail.

LIST OF MODIFIED FILES: 
M      phys/module_mp_wdm7.F

TESTS CONDUCTED: 
1. It was tested for 2d-squall2d and results are physically robust.
2. The Jenkins tests are all passing.

RELEASE NOTE: This PR fixes sedimentation calculation and hail physics in WDM7 microphysics.
