### PR TITLE
add local variables for TKE and EL in Shinhong PBL

### DIFF
--- a/phys/module_bl_shinhong.F
+++ b/phys/module_bl_shinhong.F
@@ -358,6 +358,8 @@
             pi3d_hv(i,k) = pi3d(i,k,j)
             dz8w_hv(i,k) = dz8w(i,k,j)
             rthraten_hv(i,k) = rthraten(i,k,j)
+            tke_hv(i,k) = tke(i,k,j)
+            el_hv(i,k) = el(i,k,j)
          end do
       end do
 


### PR DESCRIPTION
 	modified:   module_bl_shinhong.F

Allocate the local variables 

TYPE: Bug fix

KEYWORDS: 

DESCRIPTION OF CHANGES:
Problem:
TKE valeus are unrealistic in tke diagnostics

Solution:
The 3D TKE and EL are allocated in module_bl_shinhong.F

ISSUE: For use when this PR closes an issue.
Fixes #123

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
