### PR TITLE
Refactor gfluxp and gfluxm calculations in grav_settling

### DIFF
--- a/phys/module_bl_fogdes.F
+++ b/phys/module_bl_fogdes.F
@@ -118,12 +118,12 @@ CONTAINS
        ELSE
           gfluxm=0.
        ENDIF
-
-       IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-         ! old
+       ! old
+       ! IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
          ! gfluxp=grav_settling2*gno* &
          !       & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
          ! LS added
+      IF ( qc_curr(i,k+1,j) > qcgmin) THEN
           gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
        ELSE
           gfluxp=0.
@@ -136,22 +136,22 @@ CONTAINS
        !print*,"dqc=",dqc(i,k,j)," gfluxm=",gfluxm," gfluxp=",gfluxp
 
        DO k=kts+1,kte-1
-
-          IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
           ! old
+          ! IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
           !   gfluxp=grav_settling2*gno* &
           !         & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
           ! LS added
+          IF ( qc_curr(i,k+1,j) > qcgmin) THEN
              gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
           ELSE
              gfluxp=0.
           ENDIF
-
-          IF (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)) > qcgmin) THEN
           ! old
+          ! IF (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)) > qcgmin) THEN
           !   gfluxm=grav_settling2*gno* &
           !        & (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)))**gpw
           !LS added
+          IF ( qc_curr(i,k,j) > qcgmin) THEN
              gfluxm=grav_settling2*gno*(qc_curr(i,k,j))**gpw
           ELSE
              gfluxm=0.

--- a/phys/module_bl_fogdes.F
+++ b/phys/module_bl_fogdes.F
@@ -119,7 +119,7 @@ CONTAINS
           gfluxm=0.
        ENDIF
 
-         ! LS added
+      
       IF ( qc_curr(i,k+1,j) > qcgmin) THEN
           gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
        ELSE
@@ -133,14 +133,14 @@ CONTAINS
        !print*,"dqc=",dqc(i,k,j)," gfluxm=",gfluxm," gfluxp=",gfluxp
 
        DO k=kts+1,kte-1
-          ! LS added
+          
           IF ( qc_curr(i,k+1,j) > qcgmin) THEN
              gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
           ELSE
              gfluxp=0.
           ENDIF
 
-          !LS added
+          
           IF ( qc_curr(i,k,j) > qcgmin) THEN
              gfluxm=grav_settling2*gno*(qc_curr(i,k,j))**gpw
           ELSE

--- a/phys/module_bl_fogdes.F
+++ b/phys/module_bl_fogdes.F
@@ -120,8 +120,11 @@ CONTAINS
        ENDIF
 
        IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-          gfluxp=grav_settling2*gno* &
-                & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
+         ! old
+         ! gfluxp=grav_settling2*gno* &
+         !       & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
+         ! LS added
+          gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
        ELSE
           gfluxp=0.
        ENDIF
@@ -135,15 +138,21 @@ CONTAINS
        DO k=kts+1,kte-1
 
           IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-             gfluxp=grav_settling2*gno* &
-                   & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
+          ! old
+          !   gfluxp=grav_settling2*gno* &
+          !         & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
+          ! LS added
+             gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
           ELSE
              gfluxp=0.
           ENDIF
 
           IF (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-             gfluxm=grav_settling2*gno* &
-                   & (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)))**gpw
+          ! old
+          !   gfluxm=grav_settling2*gno* &
+          !        & (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)))**gpw
+          !LS added
+             gfluxm=grav_settling2*gno*(qc_curr(i,k,j))**gpw
           ELSE
              gfluxm=0.
           ENDIF

--- a/phys/module_bl_fogdes.F
+++ b/phys/module_bl_fogdes.F
@@ -118,10 +118,7 @@ CONTAINS
        ELSE
           gfluxm=0.
        ENDIF
-       ! old
-       ! IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-         ! gfluxp=grav_settling2*gno* &
-         !       & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
+
          ! LS added
       IF ( qc_curr(i,k+1,j) > qcgmin) THEN
           gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
@@ -136,20 +133,13 @@ CONTAINS
        !print*,"dqc=",dqc(i,k,j)," gfluxm=",gfluxm," gfluxp=",gfluxp
 
        DO k=kts+1,kte-1
-          ! old
-          ! IF (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-          !   gfluxp=grav_settling2*gno* &
-          !         & (.5*(qc_curr(i,k+1,j)+qc_curr(i,k,j)))**gpw
           ! LS added
           IF ( qc_curr(i,k+1,j) > qcgmin) THEN
              gfluxp=grav_settling2*gno*(qc_curr(i,k+1,j))**gpw
           ELSE
              gfluxp=0.
           ENDIF
-          ! old
-          ! IF (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)) > qcgmin) THEN
-          !   gfluxm=grav_settling2*gno* &
-          !        & (.5*(qc_curr(i,k-1,j)+qc_curr(i,k,j)))**gpw
+
           !LS added
           IF ( qc_curr(i,k,j) > qcgmin) THEN
              gfluxm=grav_settling2*gno*(qc_curr(i,k,j))**gpw


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: grav_settling, cloud water budget, upwind scheme, central-difference, cloud top, WRF-SCM

SOURCE: Li Shun (Ocean University of China)

DESCRIPTION OF CHANGES
Problem: 
The `grav_settling` option in `module_bl_fogdes.F` uses a central-difference scheme to compute settling fluxes:
- Downward (loss) flux: `[qc(k) + qc(k-1)] / 2`
- Incoming from above (gain) flux: `[qc(k+1) + qc(k)] / 2`

Under strong gradient conditions at cloud top (`qc(k+1) < qc(k) < qc(k-1)`), this algorithm may cause the net export from layer `k` to exceed its own cloud water amount `qc(k)`, producing unphysical negative values. These negative values are later clipped to zero by the MP scheme, but this "mass loss without phase change" is not recorded by any budget diagnostic variables, thus breaking the cloud water budget closure.

Solution:
Replace the central-difference scheme with an upwind (single-layer) scheme:
- Downward flux uses `qc(k)`
- Incoming flux from above uses `qc(k+1)`

This aligns with the droplet settling calculation in microphysics schemes such as Thompson/P3.

ISSUE
Fixes #2373

LIST OF MODIFIED FILES
M        phys/module_bl_fogdes.F

TESTS CONDUCTED

1. Cloud water budget closure was compared in WRF-SCM with `grav_settling` enabled/disabled. Before the fix, `qcmpac > pladj - praut - pracw` (budget imbalance); after the fix, the two sides are equal, indicating good budget closure.
2. It passed regression tests.

RELEASE NOTE: Fixed a budget imbalance issue in the `grav_settling` option within `module_bl_fogdes.F`. The previous central-difference flux calculation could cause unphysical negative cloud water at cloud top and break mass conservation. The flux is now computed using an upwind (single-layer) scheme, consistent with other microphysics schemes such as Thompson/P3.