### PR TITLE
Fix icefactor calculation for temperature range

### DIFF
--- a/phys/module_diag_hailcast.F
+++ b/phys/module_diag_hailcast.F
@@ -647,7 +647,7 @@ END SUBROUTINE hailcast_diagnostic_driver
        IF (TCA(k).gt.242.155) THEN
            icefactor = 1.
        ELSE IF ((TCA(k).LE.242.155).AND.(TCA(k).GT.235.155)) THEN
-           icefactor = (1-(242.155-TCA(k))/5.)
+           icefactor = (1-(242.155-TCA(k))/7.)
        ELSE
            icefactor = 0.
        ENDIF


### PR DESCRIPTION
Fix incorrect interpolation divisor in HAILCAST icefactor calculation

TYPE: bug fix

KEYWORDS: HAILCAST, hail, icefactor, temperature, interpolation

SOURCE: Naoto Ogawa (independent)

DESCRIPTION OF CHANGES:
Problem:
The HAILCAST icefactor calculation uses a divisor of 5 for a 7 K temperature range from 242.155 K to 235.155 K.

Solution:
Change the divisor from 5 to 7 to make the interpolation consistent with the intended temperature range.

ISSUE:
Fixes #2388

LIST OF MODIFIED FILES:
M phys/module_diag_hailcast.F

TESTS CONDUCTED:
No tests were run locally.

RELEASE NOTE:
Correct the HAILCAST icefactor interpolation over the 242.155 K to 235.155 K temperature range.
